### PR TITLE
Security: Harden nginx configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,7 @@ services:
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./nginx/family-app.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx/security.txt:/etc/nginx/security.txt:ro
       # SSL certs mounted in production (from thedarktower's existing setup)
       - ${SSL_CERT_PATH:-./nginx/certs}:/etc/nginx/certs:ro
     restart: unless-stopped

--- a/nginx/family-app.conf
+++ b/nginx/family-app.conf
@@ -8,6 +8,11 @@ server {
         root /var/www/certbot;
     }
 
+    # Security contact info (also available via HTTPS)
+    location /.well-known/security.txt {
+        alias /etc/nginx/security.txt;
+    }
+
     location / {
         return 301 https://$host$request_uri;
     }
@@ -35,6 +40,18 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
+
+    # HSTS - enforce HTTPS for 1 year, include subdomains, preload-ready
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+
+    # Content Security Policy - Blazor Server + SignalR compatible
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' wss://family.heathdev.me; frame-ancestors 'self';" always;
+
+    # Security contact info
+    location /.well-known/security.txt {
+        alias /etc/nginx/security.txt;
+    }
 
     # Proxy to app container
     location / {

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -23,6 +23,9 @@ http {
     keepalive_timeout 65;
     types_hash_max_size 2048;
 
+    # Hide nginx version in error pages and Server header
+    server_tokens off;
+
     # Gzip compression
     gzip on;
     gzip_vary on;

--- a/nginx/security.txt
+++ b/nginx/security.txt
@@ -1,0 +1,7 @@
+# Family Kitchen Security Contact
+# https://securitytxt.org/
+
+Contact: mailto:security@heathdev.me
+Expires: 2027-01-25T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://family.heathdev.me/.well-known/security.txt


### PR DESCRIPTION
## Summary
Addresses all 5 warnings from bfdonny's security assessment (Grade A).

## Changes

### nginx.conf
- `server_tokens off` — Hide nginx version from error pages and Server header

### family-app.conf
- **Permissions-Policy** — Disable geolocation, microphone, camera APIs
- **HSTS** — 1 year max-age, includeSubDomains, preload-ready
- **Content-Security-Policy** — Blazor Server + SignalR compatible
  - Only allows `wss://` (not `ws://`) for WebSocket connections
  - Restricts script/style/font/img sources appropriately
- **security.txt location** — Serves responsible disclosure contact info

### New Files
- `nginx/security.txt` — RFC 9116 compliant security contact

### docker-compose.yml
- Mount security.txt into nginx container

## Testing
- [ ] Rebuild and deploy: `./docker-build.sh && docker-compose up -d`
- [ ] Verify CSP doesn't break Blazor SignalR connections
- [ ] Verify security.txt accessible at `/.well-known/security.txt`
- [ ] Re-run security scan to confirm warnings resolved

## Notes
- HSTS preload is configured but not yet submitted to hstspreload.org
- CSP allows `unsafe-inline` and `unsafe-eval` for Blazor compatibility