### PR TITLE
feat(recipe-import): add yt-dlp service for YouTube transcript extraction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,12 @@ RUN mkdir -p /app/logs /app/wwwroot/uploads /root/.aspnet/DataProtection-Keys
 # Copy published app
 COPY --from=build /app/publish .
 
+# Install yt-dlp standalone binary (no Python dependency)
+# Pin to a specific release for reproducible builds. Update by changing the version tag.
+ARG YTDLP_VERSION=2025.03.31
+ADD https://github.com/yt-dlp/yt-dlp/releases/download/${YTDLP_VERSION}/yt-dlp_linux /usr/local/bin/yt-dlp
+RUN chmod +x /usr/local/bin/yt-dlp
+
 # Set environment variables
 ENV ASPNETCORE_URLS=http://+:8080
 ENV ASPNETCORE_ENVIRONMENT=Production

--- a/src/FamilyCoordinationApp/Models/YouTube/YouTubeVideoData.cs
+++ b/src/FamilyCoordinationApp/Models/YouTube/YouTubeVideoData.cs
@@ -1,0 +1,20 @@
+namespace FamilyCoordinationApp.Models.YouTube;
+
+/// <summary>
+/// Extracted YouTube video data — metadata plus optional transcript.
+/// Returned by IYtDlpService. Property names are contract — WP-04 references them.
+/// </summary>
+public class YouTubeVideoData
+{
+    public required string VideoId { get; init; }
+    public required string Title { get; init; }
+    public string? Description { get; init; }
+    public double? DurationSeconds { get; init; }
+    public string? Channel { get; init; }
+
+    /// <summary>
+    /// Full transcript text concatenated from subtitle segments.
+    /// Null if no captions are available for the video.
+    /// </summary>
+    public string? Transcript { get; init; }
+}

--- a/src/FamilyCoordinationApp/Models/YouTube/YtDlpMetadata.cs
+++ b/src/FamilyCoordinationApp/Models/YouTube/YtDlpMetadata.cs
@@ -1,0 +1,32 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace FamilyCoordinationApp.Models.YouTube;
+
+/// <summary>
+/// Subset of yt-dlp's --dump-json output needed for recipe extraction.
+/// Only fields required by YtDlpService are mapped.
+/// </summary>
+public class YtDlpMetadata
+{
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    [JsonPropertyName("title")]
+    public string? Title { get; set; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("duration")]
+    public double? Duration { get; set; }
+
+    [JsonPropertyName("channel")]
+    public string? Channel { get; set; }
+
+    [JsonPropertyName("subtitles")]
+    public JsonElement? Subtitles { get; set; }
+
+    [JsonPropertyName("automatic_captions")]
+    public JsonElement? AutomaticCaptions { get; set; }
+}

--- a/src/FamilyCoordinationApp/Services/Interfaces/IYtDlpService.cs
+++ b/src/FamilyCoordinationApp/Services/Interfaces/IYtDlpService.cs
@@ -1,0 +1,13 @@
+using FamilyCoordinationApp.Models.YouTube;
+
+namespace FamilyCoordinationApp.Services.Interfaces;
+
+public interface IYtDlpService
+{
+    /// <summary>
+    /// Extracts video metadata (title, description, duration, channel) and optional transcript
+    /// from a YouTube URL using yt-dlp subprocess.
+    /// Returns null if yt-dlp fails or the URL is invalid.
+    /// </summary>
+    Task<YouTubeVideoData?> ExtractVideoDataAsync(string youtubeUrl, CancellationToken cancellationToken = default);
+}

--- a/src/FamilyCoordinationApp/Services/YtDlpService.cs
+++ b/src/FamilyCoordinationApp/Services/YtDlpService.cs
@@ -1,0 +1,170 @@
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using FamilyCoordinationApp.Models.YouTube;
+using FamilyCoordinationApp.Services.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace FamilyCoordinationApp.Services;
+
+public class YtDlpService : IYtDlpService
+{
+    private const int TimeoutSeconds = 30;
+
+    private readonly ILogger<YtDlpService> _logger;
+
+    public YtDlpService(ILogger<YtDlpService> logger) => _logger = logger;
+
+    public async Task<YouTubeVideoData?> ExtractVideoDataAsync(
+        string youtubeUrl, CancellationToken cancellationToken = default)
+    {
+        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(TimeoutSeconds));
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+        var tempDir = Path.Combine(Path.GetTempPath(), $"ytdlp-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var arguments = BuildArguments(youtubeUrl, tempDir);
+            var (exitCode, stdout) = await ExecuteYtDlpAsync(arguments, linkedCts.Token);
+
+            if (exitCode != 0)
+            {
+                _logger.LogWarning("yt-dlp exited with code {ExitCode} for {Url}", exitCode, youtubeUrl);
+                return null;
+            }
+
+            var metadata = ParseMetadata(stdout);
+            if (metadata?.Id is null || metadata.Title is null)
+            {
+                _logger.LogWarning("yt-dlp returned invalid metadata for {Url}", youtubeUrl);
+                return null;
+            }
+
+            string? transcript = null;
+            var subtitlePath = Path.Combine(tempDir, $"{metadata.Id}.en.srv1");
+            if (File.Exists(subtitlePath))
+            {
+                var srv1Content = await File.ReadAllTextAsync(subtitlePath, linkedCts.Token);
+                transcript = ParseSrv1Transcript(srv1Content);
+            }
+
+            return new YouTubeVideoData
+            {
+                VideoId = metadata.Id,
+                Title = metadata.Title,
+                Description = metadata.Description,
+                DurationSeconds = metadata.Duration,
+                Channel = metadata.Channel,
+                Transcript = transcript
+            };
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogWarning("yt-dlp extraction timed out or was cancelled for {Url}", youtubeUrl);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "yt-dlp extraction failed for {Url}", youtubeUrl);
+            return null;
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    /// <summary>Overridable for testing — runs yt-dlp and returns (exitCode, stdout).</summary>
+    protected virtual async Task<(int ExitCode, string Stdout)> ExecuteYtDlpAsync(
+        string arguments, CancellationToken cancellationToken)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "yt-dlp",
+            Arguments = arguments,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using var process = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to start yt-dlp process");
+
+        var stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+
+        try
+        {
+            await process.WaitForExitAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            try { process.Kill(entireProcessTree: true); } catch { /* best effort */ }
+            throw;
+        }
+
+        return (process.ExitCode, await stdoutTask);
+    }
+
+    /// <summary>
+    /// Builds the yt-dlp argument string for a single call that extracts metadata
+    /// (stdout JSON) and subtitle files (written to tempDir).
+    /// </summary>
+    internal static string BuildArguments(string youtubeUrl, string tempDir)
+    {
+        // Normalize path separator — yt-dlp output templates use forward slashes on all platforms.
+        var outputTemplate = Path.Combine(tempDir, "%(id)s").Replace('\\', '/');
+        return $"--dump-json --write-sub --write-auto-sub --sub-lang en --sub-format srv1 --skip-download -o \"{outputTemplate}\" \"{youtubeUrl}\"";
+    }
+
+    /// <summary>Parses yt-dlp --dump-json stdout into a YtDlpMetadata POCO.</summary>
+    internal static YtDlpMetadata? ParseMetadata(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return null;
+
+        try
+        {
+            return JsonSerializer.Deserialize<YtDlpMetadata>(json);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Parses an srv1 XML subtitle file into a flat transcript string.
+    /// Strips HTML tags (e.g. font elements) and collapses whitespace.
+    /// Returns null if the XML is empty or unparseable.
+    /// </summary>
+    internal static string? ParseSrv1Transcript(string xml)
+    {
+        if (string.IsNullOrWhiteSpace(xml))
+            return null;
+
+        try
+        {
+            var doc = XDocument.Parse(xml);
+            var segments = doc.Descendants("text")
+                .Select(el => StripHtmlTags(el.Value))
+                .Where(s => !string.IsNullOrWhiteSpace(s));
+
+            var joined = string.Join(" ", segments);
+            return string.IsNullOrWhiteSpace(joined) ? null : CollapseWhitespace(joined);
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    private static string StripHtmlTags(string text) =>
+        Regex.Replace(text, "<[^>]+>", string.Empty);
+
+    private static string CollapseWhitespace(string text) =>
+        Regex.Replace(text.Trim(), @"\s+", " ");
+}

--- a/tests/FamilyCoordinationApp.Tests/FamilyCoordinationApp.Tests.csproj
+++ b/tests/FamilyCoordinationApp.Tests/FamilyCoordinationApp.Tests.csproj
@@ -29,4 +29,9 @@
     <ProjectReference Include="..\..\src\FamilyCoordinationApp\FamilyCoordinationApp.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="Fixtures\YtDlp\*.json" CopyToOutputDirectory="Always" />
+    <Content Include="Fixtures\YtDlp\*.srv1" CopyToOutputDirectory="Always" />
+  </ItemGroup>
+
 </Project>

--- a/tests/FamilyCoordinationApp.Tests/Fixtures/YtDlp/no-captions.meta.json
+++ b/tests/FamilyCoordinationApp.Tests/Fixtures/YtDlp/no-captions.meta.json
@@ -1,0 +1,13 @@
+{
+  "id": "noCaptionsVid1",
+  "title": "Simple Roasted Vegetables",
+  "description": "A quick recipe for roasted vegetables with olive oil and herbs.",
+  "duration": 245,
+  "channel": "QuickCookingChannel",
+  "channel_id": "UCfakeChannelId12345",
+  "channel_url": "https://www.youtube.com/channel/UCfakeChannelId12345",
+  "upload_date": "20230101",
+  "view_count": 5432,
+  "subtitles": {},
+  "automatic_captions": {}
+}

--- a/tests/FamilyCoordinationApp.Tests/Fixtures/YtDlp/sample-video.en.srv1
+++ b/tests/FamilyCoordinationApp.Tests/Fixtures/YtDlp/sample-video.en.srv1
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<transcript>
+<text start="4.920" dur="4.960">hey guys how you doing Dave from Cook n</text>
+<text start="9.880" dur="3.240">Share here today we&apos;re making chicken</text>
+<text start="13.120" dur="4.080"><font color="#E5E5E5">teriyaki</font> casserole it&apos;s an all-in-one dish</text>
+<text start="17.200" dur="3.600">Simply Delicious you&apos;re going to love it</text>
+<text start="20.800" dur="4.320">so let&apos;s get going we&apos;re going to begin</text>
+<text start="25.120" dur="4.160">making the teriyaki sauce by combining</text>
+<text start="29.280" dur="3.840">a cup of water with 6 tablespoons of soy sauce</text>
+<text start="33.120" dur="3.200">3 teaspoons of brown sugar</text>
+<text start="36.320" dur="4.080">a couple of tablespoons of cornstarch to give it some thickness</text>
+<text start="40.400" dur="3.680">and some ground black pepper</text>
+<text start="62.400" dur="3.920">now we&apos;re going to put some oil into a preheated pan</text>
+<text start="66.320" dur="4.240">and throw in three chicken breasts cut into strips</text>
+<text start="120.320" dur="3.600">we&apos;re going to add the teriyaki sauce</text>
+<text start="123.920" dur="4.080">to a saucepan and stir it consistently</text>
+<text start="127.920" dur="3.760">while bringing it to a boil until it becomes fairly thick</text>
+<text start="161.280" dur="4.480">transfer this into a casserole dish</text>
+<text start="165.760" dur="3.920">drizzle the remaining teriyaki sauce over the top</text>
+<text start="169.680" dur="4.160">slip this into a 350 degree preheated oven</text>
+<text start="173.840" dur="3.600">for about 20 or 30 minutes</text>
+</transcript>

--- a/tests/FamilyCoordinationApp.Tests/Fixtures/YtDlp/sample-video.meta.json
+++ b/tests/FamilyCoordinationApp.Tests/Fixtures/YtDlp/sample-video.meta.json
@@ -1,0 +1,24 @@
+{
+  "id": "4aZr5hZXP_s",
+  "title": "Chicken Teriyaki Casserole",
+  "description": "Chicken teriyaki casserole is one of my all time favourite dinner recipes. I love recipes like this due to its simplicity. The dish only requires a few simple ingredients such as chicken strips, rice, mixed veggies, and our very own easy teriyaki sauce. You can even make it up the night before, cover it, and slip it in the fridge. The next night put it in the oven for 20 or 30 minutes, and your dinner is ready. Watch the video and give our chicken teriyaki casserole a try. Get the recipe: https://cooknshare.com/recipe/chicken-teriyaki-casserole/",
+  "duration": 189,
+  "channel": "TheCooknShare",
+  "channel_id": "UCm2LsXhRkFHFcWC-jcfbepA",
+  "channel_url": "https://www.youtube.com/channel/UCm2LsXhRkFHFcWC-jcfbepA",
+  "upload_date": "20160925",
+  "view_count": 1847293,
+  "subtitles": {},
+  "automatic_captions": {
+    "en": [
+      {
+        "ext": "srv1",
+        "url": "https://www.youtube.com/api/timedtext?v=4aZr5hZXP_s&lang=en&fmt=srv1"
+      },
+      {
+        "ext": "json3",
+        "url": "https://www.youtube.com/api/timedtext?v=4aZr5hZXP_s&lang=en&fmt=json3"
+      }
+    ]
+  }
+}

--- a/tests/FamilyCoordinationApp.Tests/Services/YtDlpServiceTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/YtDlpServiceTests.cs
@@ -1,0 +1,147 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using FamilyCoordinationApp.Services;
+
+namespace FamilyCoordinationApp.Tests.Services;
+
+public class YtDlpServiceTests
+{
+    private static string FixturePath(string filename) =>
+        Path.Combine("Fixtures", "YtDlp", filename);
+
+    // Fake: overrides process execution to return canned JSON stdout.
+    // Does NOT write subtitle files to disk, so transcript will be null.
+    private sealed class FakeYtDlpService : YtDlpService
+    {
+        private readonly string _stdout;
+
+        public FakeYtDlpService(string stdout, ILogger<YtDlpService> logger)
+            : base(logger) => _stdout = stdout;
+
+        protected override Task<(int ExitCode, string Stdout)> ExecuteYtDlpAsync(
+            string arguments, CancellationToken cancellationToken) =>
+            Task.FromResult((0, _stdout));
+    }
+
+    // Fake: overrides process execution to block until cancellation.
+    private sealed class HangingYtDlpService : YtDlpService
+    {
+        public HangingYtDlpService(ILogger<YtDlpService> logger) : base(logger) { }
+
+        protected override async Task<(int ExitCode, string Stdout)> ExecuteYtDlpAsync(
+            string arguments, CancellationToken cancellationToken)
+        {
+            await Task.Delay(Timeout.Infinite, cancellationToken);
+            return (0, string.Empty); // never reached
+        }
+    }
+
+    // --- Argument construction ---
+
+    [Fact]
+    public void BuildArguments_ContainsMetadataExtractionFlag()
+    {
+        var args = YtDlpService.BuildArguments("https://www.youtube.com/watch?v=test", "/tmp/ytdlp-test");
+
+        args.Should().Contain("--dump-json");
+    }
+
+    [Fact]
+    public void BuildArguments_ContainsSubtitleExtractionFlags()
+    {
+        var args = YtDlpService.BuildArguments("https://www.youtube.com/watch?v=test", "/tmp/ytdlp-test");
+
+        args.Should().Contain("--write-sub");
+        args.Should().Contain("--write-auto-sub");
+        args.Should().Contain("--sub-lang en");
+        args.Should().Contain("--sub-format srv1");
+        args.Should().Contain("--skip-download");
+    }
+
+    // --- JSON deserialization ---
+
+    [Fact]
+    public void ParseMetadata_WithSampleFixture_DeserializesAllFields()
+    {
+        var json = File.ReadAllText(FixturePath("sample-video.meta.json"));
+
+        var metadata = YtDlpService.ParseMetadata(json);
+
+        metadata.Should().NotBeNull();
+        metadata!.Id.Should().Be("4aZr5hZXP_s");
+        metadata.Title.Should().Be("Chicken Teriyaki Casserole");
+        metadata.Duration.Should().BeApproximately(189, 1);
+        metadata.Channel.Should().Be("TheCooknShare");
+        metadata.Description.Should().Contain("teriyaki");
+    }
+
+    // --- srv1 XML parsing ---
+
+    [Fact]
+    public void ParseSrv1Transcript_WithSampleFixture_ReturnsPlainText()
+    {
+        var xml = File.ReadAllText(FixturePath("sample-video.en.srv1"));
+
+        var transcript = YtDlpService.ParseSrv1Transcript(xml);
+
+        transcript.Should().NotBeNullOrEmpty();
+        transcript.Should().Contain("teriyaki");
+    }
+
+    [Fact]
+    public void ParseSrv1Transcript_WithSampleFixture_StripsHtmlTags()
+    {
+        var xml = File.ReadAllText(FixturePath("sample-video.en.srv1"));
+
+        var transcript = YtDlpService.ParseSrv1Transcript(xml);
+
+        transcript.Should().NotContain("<font");
+        transcript.Should().NotContain("</font>");
+        transcript.Should().NotContain("<");
+        transcript.Should().NotContain(">");
+    }
+
+    // --- No-captions fixture ---
+
+    [Fact]
+    public void ParseMetadata_WithNoCaptionsFixture_DeserializesSuccessfully()
+    {
+        var json = File.ReadAllText(FixturePath("no-captions.meta.json"));
+
+        var metadata = YtDlpService.ParseMetadata(json);
+
+        metadata.Should().NotBeNull();
+        metadata!.Id.Should().Be("noCaptionsVid1");
+        metadata.Title.Should().Be("Simple Roasted Vegetables");
+    }
+
+    [Fact]
+    public async Task ExtractVideoDataAsync_NoCaptionsVideo_ReturnsNullTranscript()
+    {
+        var json = File.ReadAllText(FixturePath("no-captions.meta.json"));
+        var service = new FakeYtDlpService(json, Mock.Of<ILogger<YtDlpService>>());
+
+        // FakeYtDlpService returns metadata JSON but writes no subtitle file,
+        // so the service should produce a result with Transcript = null.
+        var result = await service.ExtractVideoDataAsync("https://www.youtube.com/watch?v=noCaptionsVid1");
+
+        result.Should().NotBeNull();
+        result!.VideoId.Should().Be("noCaptionsVid1");
+        result.Transcript.Should().BeNull();
+    }
+
+    // --- Timeout enforcement ---
+
+    [Fact]
+    public async Task ExtractVideoDataAsync_CancellationRequested_ReturnsNull()
+    {
+        var service = new HangingYtDlpService(Mock.Of<ILogger<YtDlpService>>());
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(300));
+
+        var result = await service.ExtractVideoDataAsync(
+            "https://www.youtube.com/watch?v=test", cts.Token);
+
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `YtDlpService` that runs yt-dlp as a subprocess to extract video metadata (title, description, duration, channel) and optional transcript text from a YouTube URL in a single invocation
- Adds `IYtDlpService` interface with `ExtractVideoDataAsync` — the contract WP-04 depends on
- Adds `YouTubeVideoData` and `YtDlpMetadata` POCOs under `Models/YouTube/`
- Installs yt-dlp standalone binary in the Docker runtime stage (pinned to `2025.03.31`, no Python dependency)
- Adds 8 fixture-based and behavioural unit tests covering argument construction, JSON deserialization, srv1 XML parsing, no-captions path, and timeout/cancellation

## Implementation notes

- `YtDlpService` uses a single yt-dlp invocation with `--dump-json --write-sub --write-auto-sub --sub-lang en --sub-format srv1 --skip-download`; metadata arrives via stdout, subtitle file is written to a per-call temp directory
- 30-second timeout is enforced via a linked `CancellationTokenSource`; the process is killed on timeout and `null` is returned
- `BuildArguments`, `ParseMetadata`, and `ParseSrv1Transcript` are `internal static` for direct unit testing (project already exposes internals to the test assembly via `<InternalsVisibleTo>`)
- `ExecuteYtDlpAsync` is `protected virtual` so tests subclass the service to inject canned stdout or simulate a hanging process
- DI registration (`IYtDlpService`) is intentionally deferred to WP-04 to avoid Wave 1 conflicts on `Program.cs`

## Test plan

- [x] `dotnet build src/FamilyCoordinationApp/FamilyCoordinationApp.csproj` — 0 errors
- [x] `dotnet test --filter "FullyQualifiedName~YtDlp"` — 8/8 passed
- [x] Full test suite — 169/169 passed, 0 regressions
- [ ] Docker build + `docker run --rm family-app-test yt-dlp --version` — requires human verification (per spec `execution: review-needed`)