### PR TITLE
fix: override version env var to unblock NuGet gate build

### DIFF
--- a/src/FamilyCoordinationApp/FamilyCoordinationApp.csproj
+++ b/src/FamilyCoordinationApp/FamilyCoordinationApp.csproj
@@ -10,6 +10,8 @@
     <!-- Suppress false positive Razor analyzer warning for MudCheckbox -->
     <!-- See: https://github.com/dotnet/razor/issues/... (known analyzer bug) -->
     <NoWarn>$(NoWarn);RZ10012</NoWarn>
+    <!-- Explicitly override any 'version' env var (e.g. "N/A") that would fail NuGet version parsing -->
+    <Version>1.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/FamilyCoordinationApp.Tests/FamilyCoordinationApp.Tests.csproj
+++ b/tests/FamilyCoordinationApp.Tests/FamilyCoordinationApp.Tests.csproj
@@ -6,6 +6,8 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <!-- Explicitly override any 'version' env var (e.g. "N/A") that would fail NuGet version parsing -->
+    <Version>1.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- `version=N/A` was set as a shell environment variable, picked up by MSBuild as `$(Version)`, causing NuGet to fail with `'N/A' is not a valid version string`
- Added `<Version>1.0.0</Version>` to both `FamilyCoordinationApp.csproj` and `FamilyCoordinationApp.Tests.csproj` so the project property overrides the env var

## Test plan
- [x] `dotnet build src/FamilyCoordinationApp/FamilyCoordinationApp.csproj` — 0 errors
- [x] `dotnet test tests/FamilyCoordinationApp.Tests/FamilyCoordinationApp.Tests.csproj` — 214 passed, 0 failed