### PR TITLE
fix: pin Version=1.0.0 to unblock NuGet restore on Windows

### DIFF
--- a/src/FamilyCoordinationApp/FamilyCoordinationApp.csproj
+++ b/src/FamilyCoordinationApp/FamilyCoordinationApp.csproj
@@ -10,6 +10,8 @@
     <!-- Suppress false positive Razor analyzer warning for MudCheckbox -->
     <!-- See: https://github.com/dotnet/razor/issues/... (known analyzer bug) -->
     <NoWarn>$(NoWarn);RZ10012</NoWarn>
+    <!-- Pin Version to prevent 'N/A' env var from poisoning NuGet restore -->
+    <Version>1.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/FamilyCoordinationApp.Tests/FamilyCoordinationApp.Tests.csproj
+++ b/tests/FamilyCoordinationApp.Tests/FamilyCoordinationApp.Tests.csproj
@@ -6,6 +6,8 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <!-- Pin Version to prevent 'N/A' env var from poisoning NuGet restore -->
+    <Version>1.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- The local build environment has a `version=N/A` environment variable that MSBuild reads as `$(Version)`, causing NuGet.targets to fail with `'N/A' is not a valid version string`
- Added `<Version>1.0.0</Version>` to both `FamilyCoordinationApp.csproj` and `FamilyCoordinationApp.Tests.csproj`; project-file properties override environment variables in MSBuild
- Gate command (`dotnet build && dotnet test`) now passes: 214/214 tests passing

## Test plan

- [ ] `dotnet build src/FamilyCoordinationApp/FamilyCoordinationApp.csproj` exits 0
- [ ] `dotnet test tests/FamilyCoordinationApp.Tests/FamilyCoordinationApp.Tests.csproj` exits 0 (214 passed)