### PR TITLE
fix: override Version in csproj to unblock NuGet restore in worktree env

### DIFF
--- a/src/FamilyCoordinationApp/FamilyCoordinationApp.csproj
+++ b/src/FamilyCoordinationApp/FamilyCoordinationApp.csproj
@@ -10,6 +10,10 @@
     <!-- Suppress false positive Razor analyzer warning for MudCheckbox -->
     <!-- See: https://github.com/dotnet/razor/issues/... (known analyzer bug) -->
     <NoWarn>$(NoWarn);RZ10012</NoWarn>
+    <!-- Explicit version prevents the worktree `version=N/A` env var from
+         propagating through MSBuild into PackageVersion, which causes NuGet
+         restore to fail with "'N/A' is not a valid version string". -->
+    <Version>1.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/FamilyCoordinationApp.Tests/FamilyCoordinationApp.Tests.csproj
+++ b/tests/FamilyCoordinationApp.Tests/FamilyCoordinationApp.Tests.csproj
@@ -6,6 +6,10 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <!-- Explicit version prevents the worktree `version=N/A` env var from
+         propagating through MSBuild into PackageVersion, which causes NuGet
+         restore to fail with "'N/A' is not a valid version string". -->
+    <Version>1.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- The worktree dispatch hooks inject `version=N/A` as an environment variable
- MSBuild imports environment variables as properties, so `$(version)` = "N/A" → `PackageVersion = N/A`
- NuGet.targets fails during restore: `'N/A' is not a valid version string`
- Fix: add `<Version>1.0.0</Version>` explicitly in both `.csproj` files — an explicit property overrides the environment, so restore succeeds regardless of the worktree env var

## Test plan

- [x] `dotnet build src/FamilyCoordinationApp/FamilyCoordinationApp.csproj` — passes (0 errors)
- [x] `dotnet test tests/FamilyCoordinationApp.Tests/FamilyCoordinationApp.Tests.csproj` — 223 passed, 0 failed
- [x] Gate command confirmed green in worktree with `version=N/A` set