### PR TITLE
Chores v1.2 quick wins — equity up-for-grabs visual + inline room-create

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -194,9 +194,9 @@ Phases 8 and 9 were deprecated 2026-02-08. The identified gaps (attribution trac
   - **Room manager** (MEDIUM) — full CRUD surface (rename / icon / delete / reorder — all backed by the existing room API) so rooms can be edited after creation; placement TBD (top-level Settings page vs. a "Manage rooms" view in the chores island). Deferred from the v1.2 quick-wins pass (2026-05-31)
   - **Chore photo display** (LARGE) — upload/store/DTO done (`Chore.PhotoPath`); never rendered (no `<img>` in `ChoreCard.svelte` / room header) — effectively write-only today
   - **Home-page chore card** (LARGE) — `Home.razor` surfaces meals + shopping but zero chore info; `/api/chores/equity` can feed due / overdue / falling-behind counts + a link to `/chores`
-  - **Equity up-for-grabs visual** (SMALL→MEDIUM) — `UpForGrabsCount` already in the equity DTO but rendered only as text; promote to a visual "waiting" element (a full proportional bar needs a new `UnassignedEffortPoints` field)
-  - **Chore icons** (SMALL) — rooms have an `Icon` field + UI; chores have none (parity gap)
-**Note**: distinct from the deprecated Phases 8 & 9 (recipe/meal/shopping polish); this is the chores track.
+  - ~~**Equity up-for-grabs visual** (SMALL→MEDIUM)~~ — DONE (v1.2): `upForGrabsCount` / `fallingBehindCount` promoted from a text line to discrete dashed "outstanding work" entries in `EquityBoard.svelte` (a full proportional bar would still need an `UnassignedEffortPoints` field — deferred)
+  - **Chore icons** (MEDIUM) — chores have no `Icon` field; rooms do (parity gap). NOT a quick win: adding it to the board `ChoreDto` triggers the M9 contract lockstep (`board.json` fixture + `ChoreBoardDtoContractTests` + island `types.ts`) on top of the entity/migration/command/service/projection/endpoint changes. **Folded into the v1.2 handoff** alongside photo display (both render on `ChoreCard.svelte` — one coherent card pass). Reuse the `IconPicker` shipped in the quick-wins pass.
+**Note**: distinct from the deprecated Phases 8 & 9 (recipe/meal/shopping polish); this is the chores track. The v1.2 quick-wins (equity up-for-grabs + inline room-create) shipped 2026-05-31; the LARGE/feature items (photo display, home-page chore card, chore icons, room manager) are the remaining Phase 12 work.
 
 ## Progress
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -190,7 +190,8 @@ Phases 8 and 9 were deprecated 2026-02-08. The identified gaps (attribution trac
 **Goal**: Close the Phase-10 UI seams + chore-board polish surfaced during the v1.1 review (2026-05-31)
 **Depends on**: Phase 11
 **Candidate scope** (grounded against the code, with size estimates):
-  - **Room-create UI** (MEDIUM) — backend `POST /api/rooms` + `RoomService.CreateRoomAsync` exist; no "Add Room" UI in the island
+  - ~~**Room-create UI** (MEDIUM)~~ — DONE (v1.2): inline "+ New room" in the chore add/edit sheets (creates via `POST /api/rooms` + selects, with an icon picker)
+  - **Room manager** (MEDIUM) — full CRUD surface (rename / icon / delete / reorder — all backed by the existing room API) so rooms can be edited after creation; placement TBD (top-level Settings page vs. a "Manage rooms" view in the chores island). Deferred from the v1.2 quick-wins pass (2026-05-31)
   - **Chore photo display** (LARGE) — upload/store/DTO done (`Chore.PhotoPath`); never rendered (no `<img>` in `ChoreCard.svelte` / room header) — effectively write-only today
   - **Home-page chore card** (LARGE) — `Home.razor` surfaces meals + shopping but zero chore info; `/api/chores/equity` can feed due / overdue / falling-behind counts + a link to `/chores`
   - **Equity up-for-grabs visual** (SMALL→MEDIUM) — `UpForGrabsCount` already in the equity DTO but rendered only as text; promote to a visual "waiting" element (a full proportional bar needs a new `UnassignedEffortPoints` field)

--- a/frontend/chores/src/lib/components/EditChoreSheet.svelte
+++ b/frontend/chores/src/lib/components/EditChoreSheet.svelte
@@ -20,8 +20,9 @@
   import type { EffortTier, RecurrenceMode, MemberDto, RoomRollupDto, ChoreDto } from '../types';
   import type { UpdateChoreRequest } from '../api';
   import { boardStore } from '../state.svelte';
-  import { uploadChorePhoto } from '../api';
+  import { uploadChorePhoto, createRoom } from '../api';
   import { showToast } from '../toasts.svelte';
+  import IconPicker from './IconPicker.svelte';
 
   interface Props {
     open: boolean;
@@ -52,6 +53,17 @@
   let localError = $state<string | null>(null);
   let submitting = $state(false);
 
+  // ── Inline "new room" (v1.2 quick win) ─────────────────────────────────────
+  // Create a room without leaving the sheet (the full room manager is deferred —
+  // see ROADMAP Phase 12). Created rooms are merged into the picker chips below
+  // and selected immediately; a later board reload carries them in `rooms`.
+  let createdRooms = $state<RoomRollupDto[]>([]);
+  let showNewRoom = $state(false);
+  let newRoomName = $state('');
+  let newRoomIcon = $state<string>('🧹');
+  let newRoomError = $state<string | null>(null);
+  let creatingRoom = $state(false);
+
   let dialogEl: HTMLDialogElement | null = $state(null);
   let nameInput: HTMLInputElement | null = $state(null);
 
@@ -79,7 +91,49 @@
     { flag: 'saturday', short: 'Sat' },
   ];
 
-  let roomChips = $derived([...rooms].sort((a, b) => a.sortOrder - b.sortOrder));
+  // Picker chips = board rooms + any just-created rooms, deduped by id (the board
+  // copy wins once a reload carries real counts). General (roomId null) renders
+  // separately, so it's excluded here.
+  let roomChips = $derived.by(() => {
+    const byId = new Map<number, RoomRollupDto>();
+    for (const r of createdRooms) if (r.roomId !== null) byId.set(r.roomId, r);
+    for (const r of rooms) if (r.roomId !== null) byId.set(r.roomId, r);
+    return [...byId.values()].sort((a, b) => a.sortOrder - b.sortOrder);
+  });
+
+  async function addNewRoom(): Promise<void> {
+    const trimmed = newRoomName.trim();
+    if (!trimmed) {
+      newRoomError = 'Give the room a name.';
+      return;
+    }
+    if (creatingRoom) return;
+    newRoomError = null;
+    creatingRoom = true;
+    try {
+      const created = await createRoom({ name: trimmed, icon: newRoomIcon });
+      createdRooms = [
+        ...createdRooms,
+        {
+          roomId: created.id,
+          name: created.name,
+          icon: created.icon,
+          photoPath: created.photoPath,
+          sortOrder: created.sortOrder,
+          choreCount: 0,
+          dueCount: 0,
+          status: 'clean',
+        },
+      ];
+      roomId = created.id;
+      newRoomName = '';
+      showNewRoom = false;
+    } catch {
+      newRoomError = "Couldn't create the room — try again.";
+    } finally {
+      creatingRoom = false;
+    }
+  }
 
   /** Derive the cadence + anchorDate from the ChoreDto when pre-filling. */
   function choreToFormState(c: ChoreDto): void {
@@ -339,7 +393,63 @@
               </button>
             {/if}
           {/each}
+          {#if !showNewRoom}
+            <button
+              type="button"
+              class="ch-chip ch-chip-add"
+              onclick={() => {
+                showNewRoom = true;
+                newRoomError = null;
+              }}
+            >
+              ＋ New room
+            </button>
+          {/if}
         </div>
+
+        {#if showNewRoom}
+          <div class="ch-newroom">
+            <IconPicker value={newRoomIcon} onSelect={(i) => (newRoomIcon = i)} label="New room icon" />
+            <div class="ch-newroom-row">
+              <input
+                type="text"
+                bind:value={newRoomName}
+                autocomplete="off"
+                placeholder="Room name (e.g. Garage)"
+                aria-label="New room name"
+                onkeydown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    addNewRoom();
+                  }
+                }}
+              />
+              <button
+                type="button"
+                class="ch-btn-primary ch-newroom-add"
+                onclick={addNewRoom}
+                disabled={creatingRoom || !newRoomName.trim()}
+              >
+                {creatingRoom ? 'Adding…' : 'Add'}
+              </button>
+              <button
+                type="button"
+                class="ch-btn-ghost"
+                onclick={() => {
+                  showNewRoom = false;
+                  newRoomName = '';
+                  newRoomError = null;
+                }}
+                disabled={creatingRoom}
+              >
+                Cancel
+              </button>
+            </div>
+            {#if newRoomError}
+              <p class="ch-sheet-error" role="alert">{newRoomError}</p>
+            {/if}
+          </div>
+        {/if}
       </fieldset>
 
       <fieldset class="ch-field">
@@ -581,6 +691,33 @@
   .ch-chip:hover:not(.active) {
     background: var(--color-action-hover);
     color: var(--color-text);
+  }
+
+  /* Inline "new room" (v1.2) */
+  .ch-chip-add {
+    border-style: dashed;
+  }
+  .ch-newroom {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-top: 10px;
+    padding: 12px;
+    border: 1px dashed var(--color-line-strong);
+    border-radius: var(--radius-sm);
+  }
+  .ch-newroom-row {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+  .ch-newroom-row input[type='text'] {
+    flex: 1;
+    min-width: 140px;
+  }
+  .ch-newroom-add {
+    min-height: 44px;
   }
 
   .ch-hint {

--- a/frontend/chores/src/lib/components/EquityBoard.svelte
+++ b/frontend/chores/src/lib/components/EquityBoard.svelte
@@ -126,9 +126,23 @@
         Even split: {pct(equity.equalSharePct)}% each
       </p>
 
-      <p class="ch-equity-context">
-        Falling behind: {equity.fallingBehindCount} · Up for grabs: {equity.upForGrabsCount}
-      </p>
+      <!-- Outstanding work — discrete entries, distinct from the completed-effort
+           bars above. "Up for grabs" = active chores nobody owns (AssignmentKind.None
+           or a stale claim); "Falling behind" = active chores past due. These are
+           household-level CHORE counts (never a per-person blame label, M12/MN8), and
+           come straight off the equity payload (no board cross-reference). -->
+      <div class="ch-equity-outstanding" aria-label="Outstanding work">
+        <div class="ch-equity-stat" aria-label="{equity.upForGrabsCount} up for grabs">
+          <span class="ch-equity-stat-icon" aria-hidden="true">🙋</span>
+          <span class="ch-equity-stat-count">{equity.upForGrabsCount}</span>
+          <span class="ch-equity-stat-label">up for grabs</span>
+        </div>
+        <div class="ch-equity-stat" aria-label="{equity.fallingBehindCount} falling behind">
+          <span class="ch-equity-stat-icon" aria-hidden="true">⏳</span>
+          <span class="ch-equity-stat-count">{equity.fallingBehindCount}</span>
+          <span class="ch-equity-stat-label">falling behind</span>
+        </div>
+      </div>
     </section>
   {:else}
     <div class="ch-equity-state">
@@ -305,8 +319,34 @@
     border-left: 2px dashed var(--color-text-muted);
   }
 
-  .ch-equity-context {
-    margin: 0;
+  /* ── Outstanding work: up-for-grabs / falling-behind ───────────────────── */
+  /* Discrete entries with a dashed edge (= unclaimed / outstanding) so they read
+     distinctly from the solid completed-effort member bars above. */
+  .ch-equity-outstanding {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .ch-equity-stat {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    padding: 7px 12px;
+    background: var(--color-surface);
+    border: 1px dashed var(--color-line-strong);
+    border-radius: var(--radius-sm);
+  }
+  .ch-equity-stat-icon {
+    font-size: 0.9375rem;
+    line-height: 1;
+  }
+  .ch-equity-stat-count {
+    font-size: 0.9375rem;
+    font-weight: 600;
+    color: var(--color-text);
+    font-variant-numeric: tabular-nums;
+  }
+  .ch-equity-stat-label {
     font-size: 0.8125rem;
     color: var(--color-text-muted);
   }

--- a/frontend/chores/src/lib/components/IconPicker.svelte
+++ b/frontend/chores/src/lib/components/IconPicker.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+  // ───────────────────────────────────────────────────────────────────────
+  // IconPicker (v1.2) — a tiny curated emoji palette, reused by the inline
+  // "new room" form (room icon) and the chore add/edit sheets (chore icon).
+  // Emoji match the island's existing visual language (room rollups already
+  // render emoji icons). Pure presentational: the parent owns `value` and is
+  // notified via `onSelect` — no internal state, no date math.
+  // ───────────────────────────────────────────────────────────────────────
+  interface Props {
+    /** Currently-selected icon (emoji), or null for none. */
+    value: string | null;
+    /** Notified with the picked emoji. */
+    onSelect: (icon: string) => void;
+    /** Optional preset palette override. */
+    icons?: string[];
+    /** Accessible group label. */
+    label?: string;
+  }
+
+  const DEFAULT_ICONS = [
+    '🧹', '🍳', '🛏️', '🚿', '🛋️', '🧺', '🚪', '🌿',
+    '🗑️', '🧽', '🐾', '🚗', '🪴', '🧸', '📦', '🔧',
+  ];
+
+  let { value, onSelect, icons = DEFAULT_ICONS, label = 'Icon' }: Props = $props();
+</script>
+
+<div class="ch-iconpick" role="group" aria-label={label}>
+  {#each icons as icon (icon)}
+    <button
+      type="button"
+      class="ch-iconpick-opt"
+      class:active={value === icon}
+      aria-pressed={value === icon}
+      aria-label={icon}
+      onclick={() => onSelect(icon)}
+    >
+      {icon}
+    </button>
+  {/each}
+</div>
+
+<style>
+  .ch-iconpick {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .ch-iconpick-opt {
+    font: inherit;
+    font-size: 1.125rem;
+    line-height: 1;
+    width: 40px;
+    height: 40px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--color-line-strong);
+    background: transparent;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition:
+      border-color 0.15s,
+      background-color 0.15s,
+      transform 0.1s;
+    -webkit-tap-highlight-color: transparent;
+  }
+  .ch-iconpick-opt:hover:not(.active) {
+    background: var(--color-action-hover);
+  }
+  .ch-iconpick-opt.active {
+    border-color: var(--color-primary);
+    background: var(--color-action-hover);
+    box-shadow: inset 0 0 0 1px var(--color-primary);
+  }
+  .ch-iconpick-opt:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 1px;
+  }
+</style>

--- a/frontend/chores/src/lib/components/QuickAddSheet.svelte
+++ b/frontend/chores/src/lib/components/QuickAddSheet.svelte
@@ -23,6 +23,8 @@
   // ───────────────────────────────────────────────────────────────────────
   import type { EffortTier, RecurrenceMode, MemberDto, RoomRollupDto } from '../types';
   import type { CreateChoreRequest } from '../api';
+  import { createRoom } from '../api';
+  import IconPicker from './IconPicker.svelte';
 
   /** What the parent needs to create the chore + (optionally) attach a photo. */
   export interface QuickAddValue {
@@ -58,6 +60,17 @@
   let photo = $state<File | null>(null);
   let localError = $state<string | null>(null);
 
+  // ── Inline "new room" (v1.2 quick win) ─────────────────────────────────────
+  // Create a room without leaving the sheet (the full room manager is deferred —
+  // see ROADMAP Phase 12). Created rooms merge into the picker chips and are
+  // selected immediately; a later board reload carries them in `rooms`.
+  let createdRooms = $state<RoomRollupDto[]>([]);
+  let showNewRoom = $state(false);
+  let newRoomName = $state('');
+  let newRoomIcon = $state<string>('🧹');
+  let newRoomError = $state<string | null>(null);
+  let creatingRoom = $state(false);
+
   let dialogEl: HTMLDialogElement | null = $state(null);
   let nameInput: HTMLInputElement | null = $state(null);
 
@@ -85,8 +98,49 @@
     { flag: 'saturday', short: 'Sat' },
   ];
 
-  // Rooms sorted by sortOrder; General (roomId null) sorts last by its int.Max.
-  let roomChips = $derived([...rooms].sort((a, b) => a.sortOrder - b.sortOrder));
+  // Picker chips = board rooms + any just-created rooms, deduped by id (the board
+  // copy wins once a reload carries real counts). General (roomId null) renders
+  // separately, so it's excluded here.
+  let roomChips = $derived.by(() => {
+    const byId = new Map<number, RoomRollupDto>();
+    for (const r of createdRooms) if (r.roomId !== null) byId.set(r.roomId, r);
+    for (const r of rooms) if (r.roomId !== null) byId.set(r.roomId, r);
+    return [...byId.values()].sort((a, b) => a.sortOrder - b.sortOrder);
+  });
+
+  async function addNewRoom(): Promise<void> {
+    const trimmed = newRoomName.trim();
+    if (!trimmed) {
+      newRoomError = 'Give the room a name.';
+      return;
+    }
+    if (creatingRoom) return;
+    newRoomError = null;
+    creatingRoom = true;
+    try {
+      const created = await createRoom({ name: trimmed, icon: newRoomIcon });
+      createdRooms = [
+        ...createdRooms,
+        {
+          roomId: created.id,
+          name: created.name,
+          icon: created.icon,
+          photoPath: created.photoPath,
+          sortOrder: created.sortOrder,
+          choreCount: 0,
+          dueCount: 0,
+          status: 'clean',
+        },
+      ];
+      roomId = created.id;
+      newRoomName = '';
+      showNewRoom = false;
+    } catch {
+      newRoomError = "Couldn't create the room — try again.";
+    } finally {
+      creatingRoom = false;
+    }
+  }
 
   function reset() {
     name = '';
@@ -98,6 +152,11 @@
     assigneeUserId = null;
     photo = null;
     localError = null;
+    // Reset the inline new-room form UI (keep createdRooms — a later board reload dedups them).
+    showNewRoom = false;
+    newRoomName = '';
+    newRoomError = null;
+    creatingRoom = false;
   }
 
   $effect(() => {
@@ -294,7 +353,63 @@
               </button>
             {/if}
           {/each}
+          {#if !showNewRoom}
+            <button
+              type="button"
+              class="ch-chip ch-chip-add"
+              onclick={() => {
+                showNewRoom = true;
+                newRoomError = null;
+              }}
+            >
+              ＋ New room
+            </button>
+          {/if}
         </div>
+
+        {#if showNewRoom}
+          <div class="ch-newroom">
+            <IconPicker value={newRoomIcon} onSelect={(i) => (newRoomIcon = i)} label="New room icon" />
+            <div class="ch-newroom-row">
+              <input
+                type="text"
+                bind:value={newRoomName}
+                autocomplete="off"
+                placeholder="Room name (e.g. Garage)"
+                aria-label="New room name"
+                onkeydown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    addNewRoom();
+                  }
+                }}
+              />
+              <button
+                type="button"
+                class="ch-btn-primary ch-newroom-add"
+                onclick={addNewRoom}
+                disabled={creatingRoom || !newRoomName.trim()}
+              >
+                {creatingRoom ? 'Adding…' : 'Add'}
+              </button>
+              <button
+                type="button"
+                class="ch-btn-ghost"
+                onclick={() => {
+                  showNewRoom = false;
+                  newRoomName = '';
+                  newRoomError = null;
+                }}
+                disabled={creatingRoom}
+              >
+                Cancel
+              </button>
+            </div>
+            {#if newRoomError}
+              <p class="ch-sheet-error" role="alert">{newRoomError}</p>
+            {/if}
+          </div>
+        {/if}
       </fieldset>
 
       <fieldset class="ch-field">
@@ -535,6 +650,33 @@
   .ch-chip:hover:not(.active) {
     background: var(--color-action-hover);
     color: var(--color-text);
+  }
+
+  /* Inline "new room" (v1.2) */
+  .ch-chip-add {
+    border-style: dashed;
+  }
+  .ch-newroom {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-top: 10px;
+    padding: 12px;
+    border: 1px dashed var(--color-line-strong);
+    border-radius: var(--radius-sm);
+  }
+  .ch-newroom-row {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+  .ch-newroom-row input[type='text'] {
+    flex: 1;
+    min-width: 140px;
+  }
+  .ch-newroom-add {
+    min-height: 44px;
   }
 
   .ch-hint {


### PR DESCRIPTION
## Chores v1.2 — quick wins (equity up-for-grabs + inline room-create)

Two small, owner-requested polish items surfaced during the v1.1 click-through. Island-only; no backend change.

### What's in
- **Equity up-for-grabs visual** — promoted the muted "Falling behind: X · Up for grabs: Y" text line into two discrete, dashed **outstanding-work entries** (up-for-grabs first), rendered distinctly from the solid completed-effort member bars. Household-level CHORE counts straight off the existing equity payload — no backend change, non-leaderboard framing preserved (M12/MN8).
- **Inline "+ New room"** — adds a reusable `IconPicker` (emoji palette) and an inline new-room form to both `QuickAddSheet` and `EditChoreSheet`. Creates via the existing `POST /api/rooms`, merges the new room into the picker chips (deduped vs the board reload), and selects it. Directly unblocks the reported friction (couldn't assign a chore to a non-existent room, no way to create one).

### Verification
- Island `vite build` 0 errors; `svelte-check` **120 files, 0 errors / 0 warnings**.
- No C# changed → backend suite unaffected (475 green on master). CI will confirm Build & Test + Docker.

### Deferred (tracked in ROADMAP Phase 12)
- **Room manager** (CRUD: rename/icon/delete/reorder; placement TBD — Settings vs. in-chores) — owner wants edit-after-creation; backend API already supports it.
- **Chore icons** — reclassified from "quick win" to a feature: adding `Icon` to the board `ChoreDto` triggers the M9 contract lockstep (`board.json` + `ChoreBoardDtoContractTests` + `types.ts`) on top of entity/migration/command/service/projection/endpoint changes. **Folded into the v1.2 "finish the surface" handoff** alongside photo display (both render on `ChoreCard.svelte` — one coherent card pass); reuses the `IconPicker` shipped here.
- **Chore photo display** + **home-page chore card** — the two LARGE items, in the handoff.

Built on `master` post-#12.
