### PR TITLE
feat(chores-v1.2): chore icons

### DIFF
--- a/frontend/chores/src/lib/api.ts
+++ b/frontend/chores/src/lib/api.ts
@@ -91,6 +91,8 @@ export interface CreateChoreRequest {
   ownerUserId?: number | null;
   assigneeUserId?: number | null;
   photoPath?: string | null;
+  /** Optional emoji/short-code icon; "" or omitted = none. */
+  icon?: string;
 }
 
 /** No assignee — assignment never moves via edit. Carries the version. */
@@ -108,6 +110,8 @@ export interface UpdateChoreRequest {
   version: number;
   /** council C4 — must round-trip so edit-photo works end-to-end. */
   photoPath?: string | null;
+  /** Optional emoji/short-code icon; "" or omitted = none. */
+  icon?: string;
 }
 
 export interface SeedStarterResponse {

--- a/frontend/chores/src/lib/components/ChoreCard.svelte
+++ b/frontend/chores/src/lib/components/ChoreCard.svelte
@@ -122,7 +122,9 @@
 
   <div class="ch-card-main">
     <div class="ch-card-top">
-      <h3 class="ch-card-name">{chore.name}</h3>
+      <h3 class="ch-card-name">
+        {#if chore.icon}<span class="ch-card-icon" aria-hidden="true">{chore.icon}</span>{/if}{chore.name}
+      </h3>
       <span class="ch-pill ch-pill-{tier}" title="Due state: {dueLabel}">{dueLabel}</span>
     </div>
 
@@ -344,6 +346,10 @@
     line-height: 1.3;
     color: var(--color-text);
     overflow-wrap: anywhere;
+  }
+  /* Optional chore icon leads the name (parity with room cards). */
+  .ch-card-icon {
+    margin-right: 6px;
   }
 
   /* ── Dueness pill — tinted by the same colorTier accent ────────────────── */

--- a/frontend/chores/src/lib/components/EditChoreSheet.svelte
+++ b/frontend/chores/src/lib/components/EditChoreSheet.svelte
@@ -42,6 +42,8 @@
   // ── Form state ────────────────────────────────────────────────────────────
   let name = $state('');
   let description = $state('');
+  /** Optional emoji icon; '' = none. Reuses the shared <IconPicker>. */
+  let choreIcon = $state<string>('');
   let cadence = $state<Cadence>('once');
   let intervalDays = $state('3');
   let selectedDays = $state(new Set<string>());
@@ -139,6 +141,7 @@
   function choreToFormState(c: ChoreDto): void {
     name = c.name;
     description = c.description ?? '';
+    choreIcon = c.icon ?? '';
     roomId = c.roomId ?? null;
     effort = c.effortTier;
     ownerUserId = c.ownerUserId ?? null;
@@ -263,6 +266,7 @@
         daysOfWeek: recurrence.daysOfWeek,
         dayOfMonth: null,
         effortTier: effort,
+        icon: choreIcon,
         ownerUserId,
         version: chore.version,
         photoPath: resolvedPhotoPath,
@@ -304,6 +308,22 @@
           placeholder="Any extra detail…"
         />
       </label>
+
+      <fieldset class="ch-field">
+        <legend class="ch-field-label">Icon (optional)</legend>
+        <div class="ch-icon-row">
+          <button
+            type="button"
+            class="ch-chip"
+            class:active={choreIcon === ''}
+            aria-pressed={choreIcon === ''}
+            onclick={() => (choreIcon = '')}
+          >
+            No icon
+          </button>
+          <IconPicker value={choreIcon || null} onSelect={(i) => (choreIcon = i)} label="Chore icon" />
+        </div>
+      </fieldset>
 
       <fieldset class="ch-field">
         <legend class="ch-field-label">How often?</legend>
@@ -665,6 +685,13 @@
   .ch-chip-row {
     display: flex;
     gap: 8px;
+    flex-wrap: wrap;
+  }
+  /* Icon field: the "No icon" chip sits inline with the emoji palette. */
+  .ch-icon-row {
+    display: flex;
+    gap: 8px;
+    align-items: center;
     flex-wrap: wrap;
   }
   .ch-chip {

--- a/frontend/chores/src/lib/components/QuickAddSheet.svelte
+++ b/frontend/chores/src/lib/components/QuickAddSheet.svelte
@@ -49,6 +49,8 @@
   type Cadence = 'once' | 'everyN' | 'days';
 
   let name = $state('');
+  /** Optional emoji icon; '' = none. Reuses the shared <IconPicker>. */
+  let choreIcon = $state<string>('');
   let cadence = $state<Cadence>('once');
   let intervalDays = $state('3'); // string for input coercion; parsed at submit
   let selectedDays = $state(new Set<string>());
@@ -144,6 +146,7 @@
 
   function reset() {
     name = '';
+    choreIcon = '';
     cadence = 'once';
     intervalDays = '3';
     selectedDays = new Set<string>();
@@ -235,6 +238,7 @@
       daysOfWeek: recurrence.daysOfWeek,
       dayOfMonth: null,
       effortTier: effort,
+      icon: choreIcon,
       ownerUserId: null,
       assigneeUserId,
       // Photo is NEVER in the create JSON (council C2) — the parent uploads it
@@ -264,6 +268,22 @@
           placeholder="e.g. Wipe down the counters"
         />
       </label>
+
+      <fieldset class="ch-field">
+        <legend class="ch-field-label">Icon (optional)</legend>
+        <div class="ch-icon-row">
+          <button
+            type="button"
+            class="ch-chip"
+            class:active={choreIcon === ''}
+            aria-pressed={choreIcon === ''}
+            onclick={() => (choreIcon = '')}
+          >
+            No icon
+          </button>
+          <IconPicker value={choreIcon || null} onSelect={(i) => (choreIcon = i)} label="Chore icon" />
+        </div>
+      </fieldset>
 
       <fieldset class="ch-field">
         <legend class="ch-field-label">How often?</legend>
@@ -624,6 +644,13 @@
   .ch-chip-row {
     display: flex;
     gap: 8px;
+    flex-wrap: wrap;
+  }
+  /* Icon field: the "No icon" chip sits inline with the emoji palette. */
+  .ch-icon-row {
+    display: flex;
+    gap: 8px;
+    align-items: center;
     flex-wrap: wrap;
   }
   .ch-chip {

--- a/frontend/chores/src/lib/types.ts
+++ b/frontend/chores/src/lib/types.ts
@@ -34,6 +34,8 @@ export type RoomRollupStatus = 'clean' | 'attention' | 'needsWork';
 export interface ChoreDto {
   id: number;
   name: string;
+  /** Optional emoji/short-code icon (parity with room icons); "" = none. */
+  icon: string;
   description: string | null;
   roomId: number | null;
   recurrenceMode: RecurrenceMode;

--- a/src/FamilyCoordinationApp/Data/Configurations/ChoreConfiguration.cs
+++ b/src/FamilyCoordinationApp/Data/Configurations/ChoreConfiguration.cs
@@ -21,6 +21,12 @@ public class ChoreConfiguration : IEntityTypeConfiguration<Chore>
         builder.Property(c => c.Description)
             .HasMaxLength(2000);
 
+        // Optional emoji/short-code icon (parity with Room.Icon, ~line 21). Non-null;
+        // existing rows backfill to "" via the additive migration's default.
+        builder.Property(c => c.Icon)
+            .IsRequired()
+            .HasMaxLength(30);
+
         // Enums stored as strings (codebase convention).
         builder.Property(c => c.RecurrenceMode)
             .IsRequired()

--- a/src/FamilyCoordinationApp/Data/Entities/Chore.cs
+++ b/src/FamilyCoordinationApp/Data/Entities/Chore.cs
@@ -10,6 +10,9 @@ public class Chore
     public string Name { get; set; } = string.Empty;
     public string? Description { get; set; }
 
+    // Optional emoji/short-code icon (parity with Room.Icon). Empty string = no icon.
+    public string Icon { get; set; } = string.Empty;
+
     // Optional room association (nullable FK -> Room).
     public int? RoomId { get; set; }
 

--- a/src/FamilyCoordinationApp/Endpoints/ChoresEndpoints.cs
+++ b/src/FamilyCoordinationApp/Endpoints/ChoresEndpoints.cs
@@ -630,7 +630,8 @@ public static class ChoresEndpoints
         EffortTier EffortTier,
         int? OwnerUserId,
         int? AssigneeUserId,
-        string? PhotoPath)
+        string? PhotoPath,
+        string? Icon = null)
     {
         public CreateChoreCommand ToCommand() => new(
             Name,
@@ -644,7 +645,8 @@ public static class ChoresEndpoints
             EffortTier,
             OwnerUserId,
             AssigneeUserId,
-            PhotoPath);
+            PhotoPath,
+            Icon ?? string.Empty);
     }
 
     public sealed record UpdateChoreRequest(
@@ -659,7 +661,8 @@ public static class ChoresEndpoints
         EffortTier EffortTier,
         int? OwnerUserId,
         string? PhotoPath,
-        uint Version)
+        uint Version,
+        string? Icon = null)
     {
         public UpdateChoreCommand ToCommand() => new(
             Name,
@@ -672,6 +675,7 @@ public static class ChoresEndpoints
             DayOfMonth,
             EffortTier,
             OwnerUserId,
-            PhotoPath);
+            PhotoPath,
+            Icon ?? string.Empty);
     }
 }

--- a/src/FamilyCoordinationApp/Migrations/20260531184831_AddChoreIcon.Designer.cs
+++ b/src/FamilyCoordinationApp/Migrations/20260531184831_AddChoreIcon.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FamilyCoordinationApp.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FamilyCoordinationApp.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260531184831_AddChoreIcon")]
+    partial class AddChoreIcon
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/FamilyCoordinationApp/Migrations/20260531184831_AddChoreIcon.cs
+++ b/src/FamilyCoordinationApp/Migrations/20260531184831_AddChoreIcon.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FamilyCoordinationApp.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddChoreIcon : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Icon",
+                table: "Chores",
+                type: "character varying(30)",
+                maxLength: 30,
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Icon",
+                table: "Chores");
+        }
+    }
+}

--- a/src/FamilyCoordinationApp/Services/ChoreBoardService.cs
+++ b/src/FamilyCoordinationApp/Services/ChoreBoardService.cs
@@ -99,6 +99,7 @@ public class ChoreBoardService(
     private static ChoreDto ToDto(Chore chore, ChoreDuenessResult dueness, bool isClaimStale) => new(
         chore.ChoreId,
         chore.Name,
+        chore.Icon,
         chore.Description,
         chore.RoomId,
         chore.RecurrenceMode.ToString(),

--- a/src/FamilyCoordinationApp/Services/ChoreCommands.cs
+++ b/src/FamilyCoordinationApp/Services/ChoreCommands.cs
@@ -9,6 +9,7 @@ namespace FamilyCoordinationApp.Services;
 /// </summary>
 /// <param name="Name">Required, non-empty after trim.</param>
 /// <param name="EffortTier">Named effort tier (P3) — drives the default <c>EffortPoints</c> snapshot.</param>
+/// <param name="Icon">Optional emoji/short-code icon (parity with Room.Icon); empty string = none.</param>
 public record CreateChoreCommand(
     string Name,
     string? Description,
@@ -21,7 +22,8 @@ public record CreateChoreCommand(
     EffortTier EffortTier,
     int? OwnerUserId,
     int? AssigneeUserId,
-    string? PhotoPath);
+    string? PhotoPath,
+    string Icon = "");
 
 /// <summary>
 /// Command to update a chore's editable fields (council M11) — the same editable subset as
@@ -39,4 +41,5 @@ public record UpdateChoreCommand(
     int? DayOfMonth,
     EffortTier EffortTier,
     int? OwnerUserId,
-    string? PhotoPath);
+    string? PhotoPath,
+    string Icon = "");

--- a/src/FamilyCoordinationApp/Services/ChoreService.cs
+++ b/src/FamilyCoordinationApp/Services/ChoreService.cs
@@ -56,6 +56,7 @@ public class ChoreService(
                     ChoreId = maxId + 1,
                     Name = cmd.Name.Trim(),
                     Description = string.IsNullOrWhiteSpace(cmd.Description) ? null : cmd.Description.Trim(),
+                    Icon = cmd.Icon ?? string.Empty,
                     RoomId = cmd.RoomId,
                     RecurrenceMode = cmd.RecurrenceMode,
                     IntervalDays = cmd.IntervalDays,
@@ -110,6 +111,7 @@ public class ChoreService(
 
         chore.Name = cmd.Name.Trim();
         chore.Description = string.IsNullOrWhiteSpace(cmd.Description) ? null : cmd.Description.Trim();
+        chore.Icon = cmd.Icon ?? string.Empty;
         chore.RoomId = cmd.RoomId;
         chore.RecurrenceMode = cmd.RecurrenceMode;
         chore.IntervalDays = cmd.IntervalDays;

--- a/src/FamilyCoordinationApp/Services/Dtos/ChoreDtos.cs
+++ b/src/FamilyCoordinationApp/Services/Dtos/ChoreDtos.cs
@@ -27,6 +27,7 @@ public sealed record ChoreBoardDto(
 public sealed record ChoreDto(
     int Id,
     string Name,
+    string Icon,
     string? Description,
     int? RoomId,
     string RecurrenceMode,

--- a/tests/FamilyCoordinationApp.Tests/Fixtures/ChoreBoard/board.json
+++ b/tests/FamilyCoordinationApp.Tests/Fixtures/ChoreBoard/board.json
@@ -3,6 +3,7 @@
     {
       "id": 1,
       "name": "Mop the floor",
+      "icon": "🧹",
       "description": "Use the good mop",
       "roomId": 10,
       "recurrenceMode": "Flexible",
@@ -23,6 +24,7 @@
     {
       "id": 2,
       "name": "Take out trash",
+      "icon": "",
       "description": null,
       "roomId": 10,
       "recurrenceMode": "Fixed",
@@ -43,6 +45,7 @@
     {
       "id": 3,
       "name": "Water the plants",
+      "icon": "🪴",
       "description": "Living room \u002B balcony",
       "roomId": null,
       "recurrenceMode": "Fixed",
@@ -63,6 +66,7 @@
     {
       "id": 4,
       "name": "Fix the squeaky door",
+      "icon": "",
       "description": null,
       "roomId": null,
       "recurrenceMode": "OneOff",

--- a/tests/FamilyCoordinationApp.Tests/Services/ChoreBoardDtoContractTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/ChoreBoardDtoContractTests.cs
@@ -46,6 +46,7 @@ public class ChoreBoardDtoContractTests
             new(
                 Id: 1,
                 Name: "Mop the floor",
+                Icon: "🧹",
                 Description: "Use the good mop",
                 RoomId: 10,
                 RecurrenceMode: "Flexible",
@@ -67,6 +68,7 @@ public class ChoreBoardDtoContractTests
             new(
                 Id: 2,
                 Name: "Take out trash",
+                Icon: "",
                 Description: null,
                 RoomId: 10,
                 RecurrenceMode: "Fixed",
@@ -88,6 +90,7 @@ public class ChoreBoardDtoContractTests
             new(
                 Id: 3,
                 Name: "Water the plants",
+                Icon: "🪴",
                 Description: "Living room + balcony",
                 RoomId: null,
                 RecurrenceMode: "Fixed",
@@ -109,6 +112,7 @@ public class ChoreBoardDtoContractTests
             new(
                 Id: 4,
                 Name: "Fix the squeaky door",
+                Icon: "",
                 Description: null,
                 RoomId: null,
                 RecurrenceMode: "OneOff",
@@ -211,7 +215,7 @@ public class ChoreBoardDtoContractTests
 
         var firstChore = root["chores"]!.AsArray()[0]!.AsObject();
         firstChore.Select(kvp => kvp.Key).Should().BeEquivalentTo(
-            "id", "name", "description", "roomId", "recurrenceMode", "dueState", "colorTier", "nextDueAt",
+            "id", "name", "icon", "description", "roomId", "recurrenceMode", "dueState", "colorTier", "nextDueAt",
             "isClaimStale", "effortTier", "effortPoints", "ownerUserId", "assigneeUserId", "assignmentKind",
             "claimedAt", "lastCompletedAt", "photoPath", "version");
 

--- a/tests/FamilyCoordinationApp.Tests/Services/ChoreServiceTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/ChoreServiceTests.cs
@@ -82,7 +82,8 @@ public class ChoreServiceTests : IDisposable
         EffortTier: EffortTier.Standard,
         OwnerUserId: null,
         AssigneeUserId: assignee,
-        PhotoPath: null);
+        PhotoPath: null,
+        Icon: "🧹");
 
     private async Task<Chore> ReloadAsync(int choreId)
     {
@@ -101,6 +102,7 @@ public class ChoreServiceTests : IDisposable
         chore.HouseholdId.Should().Be(HouseholdId);
         chore.Name.Should().Be("Dishes");
         chore.Description.Should().Be("rinse first");        // trimmed
+        chore.Icon.Should().Be("🧹");
         chore.Status.Should().Be(ChoreStatus.Active);
         chore.EnteredByUserId.Should().Be(Alice);
         chore.EffortPoints.Should().Be(ChoreEffort.PointsFor(EffortTier.Standard));
@@ -238,7 +240,8 @@ public class ChoreServiceTests : IDisposable
             DayOfMonth: null,
             EffortTier: EffortTier.BigJob,
             OwnerUserId: Alice,
-            PhotoPath: null);
+            PhotoPath: null,
+            Icon: "🚿");
 
         var updated = await _service.UpdateChoreAsync(HouseholdId, created.ChoreId, updateCmd, current.Version);
 
@@ -247,6 +250,7 @@ public class ChoreServiceTests : IDisposable
         updated.EffortTier.Should().Be(EffortTier.BigJob);
         updated.EffortPoints.Should().Be(ChoreEffort.PointsFor(EffortTier.BigJob));
         updated.OwnerUserId.Should().Be(Alice);
+        updated.Icon.Should().Be("🚿");                       // icon is editable (unlike the assignment trio)
 
         // Assignment triple untouched by an edit (Bob still holds the claim).
         updated.AssigneeUserId.Should().Be(Bob);


### PR DESCRIPTION
## What

Adds an **optional emoji icon to chores**, closing the Phase-10 parity gap (rooms have `Icon`, chores didn't). Part of **Phase 12 — Chores v1.2 "finish the surface."**

Icon is optional (`""` = none) and renders **leading the chore name** on the card, mirroring how room cards render their icon.

## The vertical slice (M9 lockstep)

**Backend**
- `Chore.Icon` (non-null, `""` default) + `ChoreConfiguration` (`varchar(30)`, required, parity with `Room.Icon`)
- `AddChoreIcon` migration — **additive column, `defaultValue: ""`** backfills existing rows (applies on first request, per this app's migration model)
- `Create/UpdateChoreCommand` gain an **optional** `Icon` param (`= ""`) so existing positional/named call sites stay valid; `ChoreService` sets it on create + update
- `ChoreDto.Icon` (after `Name`) — the board-contract field that cascades. `ChoreBoardService` projection threads it; **`board.json` fixture + `ChoreBoardDtoContractTests` + `ChoreServiceTests` updated in lockstep**
- `ChoresEndpoints` `Create/UpdateChoreRequest` gain `Icon`, threaded via `ToCommand()`

**Island**
- `ChoreDto.icon` (`types.ts`), `Create/UpdateChoreRequest.icon` (`api.ts`)
- `QuickAddSheet` + `EditChoreSheet`: a new **"Icon (optional)"** field reusing the shared `<IconPicker>` (plus a "No icon" chip); `EditChoreSheet` pre-fills from `chore.icon`
- `ChoreCard` renders the icon leading the name

## Verification

- ✅ `dotnet build` (Release) — 0 errors
- ✅ `dotnet test` — **475 passed**, 0 failed (incl. the board contract fixture + new icon round-trip asserts on create/update)
- ✅ `svelte-check` — 0 errors / 0 warnings
- ✅ `vite build` — clean (Docker `chores-node-build` recompiles from source; no committed artifacts)
- ✅ migration confirmed git-tracked (the v1.1 local-green/CI-red trap)

## Scope notes

- **Photo display is intentionally NOT here** — carved out into a dedicated UX/UI design exploration (chores + room photos). This unbundles the planned "one card pass" cleanly; photo will re-touch `ChoreCard`/`RoomsDashboard` as a deliberate design pass.
- Home-page chore card ships as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)