### PR TITLE
fix(deploy): DB-safety guard #3 works non-interactively

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -159,11 +159,25 @@ else
 fi
 
 # (3) Refuse to start on an uninitialized data dir (would trigger a fresh initdb).
-if sudo test -e "$DB_DATA_PATH" && ! sudo test -f "$DB_DATA_PATH/PG_VERSION"; then
-  [[ "${ALLOW_FRESH_DB:-0}" == "1" ]] || die "POSTGRES_DATA_PATH ($DB_DATA_PATH) exists but is not an initialized cluster (no PG_VERSION). Postgres would create a FRESH empty DB. Refusing. If this is a brand-new install, re-run with ALLOW_FRESH_DB=1."
-  log "WARNING: data dir uninitialized but ALLOW_FRESH_DB=1 set — a fresh DB will be created."
+# The host data dir is root-owned, so we can't `sudo test` it: in non-interactive runs (the CI
+# self-hosted deploy, or `ssh host ./deploy.sh`) sudo has no TTY to read a password, and only the
+# specific `sudo docker …` invocations this script uses are NOPASSWD — `sudo test` is NOT, so it
+# fails and the old guard silently "passed". Instead probe the STILL-RUNNING old postgres (same
+# bind mount the new container reuses) via `sudo docker exec` (passwordless, mirrors the backup
+# above) and check PGDATA/PG_VERSION inside it.
+if sudo docker ps --format '{{.Names}}' | grep -qx 'familyapp-postgres'; then
+  if sudo docker exec familyapp-postgres sh -c 'test -f "$PGDATA/PG_VERSION"'; then
+    log "DB safety check passed (live cluster initialized; data dir: $DB_DATA_PATH)"
+  else
+    [[ "${ALLOW_FRESH_DB:-0}" == "1" ]] || die "POSTGRES_DATA_PATH ($DB_DATA_PATH) is mounted but has no PG_VERSION — postgres would create a FRESH empty DB and orphan production data. Refusing. If this is a brand-new install, re-run with ALLOW_FRESH_DB=1."
+    log "WARNING: data dir uninitialized but ALLOW_FRESH_DB=1 set — a fresh DB will be created."
+  fi
+else
+  # No running familyapp-postgres to probe (first deploy on this host, or after `down`); the
+  # pre-deploy backup was skipped for the same reason. Treat as a fresh install — postgres will
+  # initdb a new cluster on first start (matches the original "path doesn't exist yet" behavior).
+  log "DB safety check: no running familyapp-postgres to probe — assuming fresh install (postgres will initdb)."
 fi
-log "DB safety check passed (data dir: $DB_DATA_PATH)"
 
 # ── Deploy ──────────────────────────────────────────────────────────
 log "Deploying containers..."


### PR DESCRIPTION
## Problem

`deploy.sh` guard #3 — *"refuse to start on an uninitialized data dir"* (the guard against postgres silently `initdb`-ing a fresh empty cluster and orphaning prod data) — used `sudo test -e/-f` on the root-owned host data dir:

```bash
if sudo test -e "$DB_DATA_PATH" && ! sudo test -f "$DB_DATA_PATH/PG_VERSION"; then ...
```

In **non-interactive** runs — the **CI self-hosted deploy** and `ssh host ./deploy.sh` — `sudo` has no TTY to read a password, and only the specific `sudo docker …` invocations the script uses are NOPASSWD. `sudo test` is **not**, so it printed `sudo: a terminal is required to read the password`, exited non-zero, the `&&` short-circuited the `if` to false, and the script **silently logged "DB safety check passed" without checking anything.** The guard has effectively been inert on every CI deploy.

(Found while flipping `CHORES_USE_ISLAND=true` to release the chore board — the `sudo: a terminal is required` line surfaced mid-deploy.)

## Fix

Probe the **still-running old postgres** (the same bind mount the new container will reuse) via `sudo docker exec` — which *is* passwordless here (it's exactly what the pre-deploy backup uses) — and check `$PGDATA/PG_VERSION` inside the container:

- **initialized** → pass
- **mounted but no PG_VERSION** → **fail closed** (`die`), preserving the `ALLOW_FRESH_DB=1` override
- **no running postgres** (first deploy / after `down`) → explicit "fresh install" log, proceed (matches the original "path doesn't exist yet" behavior)

## Risk

Low. The **pre-deploy backup (guard #2)** uses `sudo docker exec` and always ran, so prod data was never actually at risk — this just makes the dir guard *actually guard*. No app/code change; CI's .NET build/test is unaffected.

## Validation

Live read-only dry-run of the new logic on the prod host (no deploy triggered):

```
RESULT: PASS (live cluster initialized; data dir: /home/sirm/familyapp-data/postgres)
```

— no sudo password prompt. `bash -n deploy.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)