### PR TITLE
feat(chores-v1.2): photo display + minimal room photo capture

### DIFF
--- a/frontend/chores/src/App.svelte
+++ b/frontend/chores/src/App.svelte
@@ -15,6 +15,7 @@
   import HandOffPicker from './lib/components/HandOffPicker.svelte';
   import DigestSettings from './lib/components/DigestSettings.svelte';
   import Toasts from './lib/components/Toasts.svelte';
+  import PhotoLightbox from './lib/components/PhotoLightbox.svelte';
 
   // ───────────────────────────────────────────────────────────────────────
   // Root of the chores island. Fetches the ONE board payload into the shared
@@ -345,6 +346,9 @@
 />
 
 <Toasts />
+
+<!-- Single shared tap-to-enlarge overlay; opened via showPhoto() from any surface. -->
+<PhotoLightbox />
 
 <style>
   .ch-container {

--- a/frontend/chores/src/lib/components/ChoreCard.svelte
+++ b/frontend/chores/src/lib/components/ChoreCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { ChoreDto, ColorTier, DueState, EffortTier, RecurrenceMode } from '../types';
   import { memberFor } from '../state.svelte';
+  import { showPhoto } from '../lightbox.svelte';
   import MemberAvatar from './MemberAvatar.svelte';
 
   // ───────────────────────────────────────────────────────────────────────
@@ -119,6 +120,32 @@
   aria-busy={pending}
 >
   <div class="ch-card-accent" aria-hidden="true"></div>
+
+  {#if chore.photoPath}
+    <!--
+      Leading photo thumbnail (v1.2). Same-origin served URL (/uploads/…), so
+      `src` works directly. Tap → shared lightbox. Fixed 56px square keeps row
+      height steady regardless of photo orientation; the icon emoji still leads
+      the name. No-photo chores render no thumbnail (unchanged from before).
+    -->
+    <button
+      type="button"
+      class="ch-card-thumb-btn"
+      data-action="photo"
+      onclick={() => showPhoto(chore.photoPath, chore.name)}
+      aria-label="View photo for {chore.name}"
+      title="View photo"
+    >
+      <img
+        class="ch-card-thumb"
+        src={chore.photoPath}
+        alt=""
+        width="56"
+        height="56"
+        loading="lazy"
+      />
+    </button>
+  {/if}
 
   <div class="ch-card-main">
     <div class="ch-card-top">
@@ -322,6 +349,36 @@
     flex-shrink: 0;
     width: 6px;
     background: var(--accent);
+  }
+
+  /* ── Leading photo thumbnail (v1.2) — tap to enlarge ───────────────────── */
+  .ch-card-thumb-btn {
+    flex-shrink: 0;
+    align-self: flex-start;
+    margin: 12px 0 12px 12px;
+    padding: 0;
+    border: none;
+    background: transparent;
+    border-radius: 8px;
+    cursor: zoom-in;
+    line-height: 0;
+    -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation;
+  }
+  .ch-card-thumb {
+    display: block;
+    width: 56px;
+    height: 56px;
+    border-radius: 8px;
+    object-fit: cover;
+    background: var(--color-action-hover);
+  }
+  .ch-card-thumb-btn:hover .ch-card-thumb {
+    filter: brightness(1.04);
+  }
+  .ch-card-thumb-btn:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
   }
 
   .ch-card-main {

--- a/frontend/chores/src/lib/components/EditChoreSheet.svelte
+++ b/frontend/chores/src/lib/components/EditChoreSheet.svelte
@@ -20,7 +20,7 @@
   import type { EffortTier, RecurrenceMode, MemberDto, RoomRollupDto, ChoreDto } from '../types';
   import type { UpdateChoreRequest } from '../api';
   import { boardStore } from '../state.svelte';
-  import { uploadChorePhoto, createRoom } from '../api';
+  import { uploadChorePhoto, createRoom, uploadRoomPhoto } from '../api';
   import { showToast } from '../toasts.svelte';
   import IconPicker from './IconPicker.svelte';
 
@@ -67,6 +67,7 @@
   let showNewRoom = $state(false);
   let newRoomName = $state('');
   let newRoomIcon = $state<string>('🧹');
+  let newRoomPhotoFile = $state<File | null>(null);
   let newRoomError = $state<string | null>(null);
   let creatingRoom = $state(false);
 
@@ -118,13 +119,25 @@
     creatingRoom = true;
     try {
       const created = await createRoom({ name: trimmed, icon: newRoomIcon });
+      // Optional cover photo: upload after create (we now have the room id), then
+      // carry the returned path on the local rollup. A failed upload still keeps
+      // the room — only the photo is skipped (a later board reload reconciles).
+      let createdPhotoPath = created.photoPath;
+      if (newRoomPhotoFile) {
+        try {
+          const up = await uploadRoomPhoto(created.id, newRoomPhotoFile);
+          createdPhotoPath = up.photoPath;
+        } catch {
+          showToast({ message: "Room added, but the photo didn't upload.", kind: 'info' });
+        }
+      }
       createdRooms = [
         ...createdRooms,
         {
           roomId: created.id,
           name: created.name,
           icon: created.icon,
-          photoPath: created.photoPath,
+          photoPath: createdPhotoPath,
           sortOrder: created.sortOrder,
           choreCount: 0,
           dueCount: 0,
@@ -133,6 +146,7 @@
       ];
       roomId = created.id;
       newRoomName = '';
+      newRoomPhotoFile = null;
       showNewRoom = false;
     } catch {
       newRoomError = "Couldn't create the room — try again.";
@@ -476,6 +490,7 @@
                 onclick={() => {
                   showNewRoom = false;
                   newRoomName = '';
+                  newRoomPhotoFile = null;
                   newRoomError = null;
                 }}
                 disabled={creatingRoom}
@@ -483,6 +498,20 @@
                 Cancel
               </button>
             </div>
+            <label class="ch-newroom-photo">
+              <span class="ch-hint">Cover photo (optional)</span>
+              <input
+                type="file"
+                accept="image/*"
+                onchange={(e) => {
+                  const input = e.currentTarget as HTMLInputElement;
+                  newRoomPhotoFile = input.files && input.files.length > 0 ? input.files[0] : null;
+                }}
+              />
+              {#if newRoomPhotoFile}
+                <span class="ch-hint">{newRoomPhotoFile.name}</span>
+              {/if}
+            </label>
             {#if newRoomError}
               <p class="ch-sheet-error" role="alert">{newRoomError}</p>
             {/if}
@@ -786,6 +815,11 @@
   }
   .ch-newroom-add {
     min-height: 44px;
+  }
+  .ch-newroom-photo {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
   }
 
   .ch-hint {

--- a/frontend/chores/src/lib/components/PhotoLightbox.svelte
+++ b/frontend/chores/src/lib/components/PhotoLightbox.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+  // ───────────────────────────────────────────────────────────────────────
+  // PhotoLightbox (v1.2) — the single shared tap-to-enlarge overlay. Reads the
+  // module lightbox store and renders the active photo in a native <dialog>,
+  // the same pattern the sheets use (showModal() + ::backdrop). Tap anywhere
+  // dismisses; Esc closes natively. Mounted ONCE in App.svelte.
+  //
+  // The <dialog> fills the viewport and centers the image so the whole surface
+  // is a dismiss target (matching the zoom-out cursor on the photo).
+  //
+  // ⚠ Never trigger window.alert/confirm here — this is the <dialog> overlay.
+  // ───────────────────────────────────────────────────────────────────────
+  import { lightbox, closePhoto } from '../lightbox.svelte';
+
+  let dialogEl: HTMLDialogElement | null = $state(null);
+  let lb = $derived(lightbox());
+
+  $effect(() => {
+    if (!dialogEl) return;
+    if (lb.src && !dialogEl.open) dialogEl.showModal();
+    else if (!lb.src && dialogEl.open) dialogEl.close();
+  });
+
+  // A photo viewer dismisses on tap anywhere (image or backdrop) — the natural
+  // mobile gesture; Esc also closes via the dialog's native `onclose`.
+  function onClick() {
+    closePhoto();
+  }
+</script>
+
+<dialog
+  bind:this={dialogEl}
+  class="ch-lightbox"
+  onclose={closePhoto}
+  onclick={onClick}
+  aria-label="Enlarged photo"
+>
+  {#if lb.src}
+    <img class="ch-lightbox-img" src={lb.src} alt={lb.alt} />
+  {/if}
+</dialog>
+
+<style>
+  .ch-lightbox {
+    border: none;
+    margin: 0;
+    padding: 0;
+    inset: 0;
+    width: 100vw;
+    max-width: 100vw;
+    height: 100dvh;
+    max-height: 100dvh;
+    background: transparent;
+    display: grid;
+    place-items: center;
+    overflow: hidden;
+  }
+  .ch-lightbox::backdrop {
+    background: rgba(0, 0, 0, 0.82);
+  }
+  .ch-lightbox-img {
+    display: block;
+    max-width: 92vw;
+    max-height: 88dvh;
+    width: auto;
+    height: auto;
+    border-radius: 8px;
+    box-shadow: var(--shadow-4);
+    cursor: zoom-out;
+  }
+</style>

--- a/frontend/chores/src/lib/components/QuickAddSheet.svelte
+++ b/frontend/chores/src/lib/components/QuickAddSheet.svelte
@@ -23,7 +23,8 @@
   // ───────────────────────────────────────────────────────────────────────
   import type { EffortTier, RecurrenceMode, MemberDto, RoomRollupDto } from '../types';
   import type { CreateChoreRequest } from '../api';
-  import { createRoom } from '../api';
+  import { createRoom, uploadRoomPhoto } from '../api';
+  import { showToast } from '../toasts.svelte';
   import IconPicker from './IconPicker.svelte';
 
   /** What the parent needs to create the chore + (optionally) attach a photo. */
@@ -70,6 +71,7 @@
   let showNewRoom = $state(false);
   let newRoomName = $state('');
   let newRoomIcon = $state<string>('🧹');
+  let newRoomPhotoFile = $state<File | null>(null);
   let newRoomError = $state<string | null>(null);
   let creatingRoom = $state(false);
 
@@ -121,13 +123,25 @@
     creatingRoom = true;
     try {
       const created = await createRoom({ name: trimmed, icon: newRoomIcon });
+      // Optional cover photo: upload after create (we now have the room id), then
+      // carry the returned path on the local rollup. A failed upload still keeps
+      // the room — only the photo is skipped (a later board reload reconciles).
+      let createdPhotoPath = created.photoPath;
+      if (newRoomPhotoFile) {
+        try {
+          const up = await uploadRoomPhoto(created.id, newRoomPhotoFile);
+          createdPhotoPath = up.photoPath;
+        } catch {
+          showToast({ message: "Room added, but the photo didn't upload.", kind: 'info' });
+        }
+      }
       createdRooms = [
         ...createdRooms,
         {
           roomId: created.id,
           name: created.name,
           icon: created.icon,
-          photoPath: created.photoPath,
+          photoPath: createdPhotoPath,
           sortOrder: created.sortOrder,
           choreCount: 0,
           dueCount: 0,
@@ -136,6 +150,7 @@
       ];
       roomId = created.id;
       newRoomName = '';
+      newRoomPhotoFile = null;
       showNewRoom = false;
     } catch {
       newRoomError = "Couldn't create the room — try again.";
@@ -158,6 +173,7 @@
     // Reset the inline new-room form UI (keep createdRooms — a later board reload dedups them).
     showNewRoom = false;
     newRoomName = '';
+    newRoomPhotoFile = null;
     newRoomError = null;
     creatingRoom = false;
   }
@@ -418,6 +434,7 @@
                 onclick={() => {
                   showNewRoom = false;
                   newRoomName = '';
+                  newRoomPhotoFile = null;
                   newRoomError = null;
                 }}
                 disabled={creatingRoom}
@@ -425,6 +442,20 @@
                 Cancel
               </button>
             </div>
+            <label class="ch-newroom-photo">
+              <span class="ch-hint">Cover photo (optional)</span>
+              <input
+                type="file"
+                accept="image/*"
+                onchange={(e) => {
+                  const input = e.currentTarget as HTMLInputElement;
+                  newRoomPhotoFile = input.files && input.files.length > 0 ? input.files[0] : null;
+                }}
+              />
+              {#if newRoomPhotoFile}
+                <span class="ch-hint">{newRoomPhotoFile.name}</span>
+              {/if}
+            </label>
             {#if newRoomError}
               <p class="ch-sheet-error" role="alert">{newRoomError}</p>
             {/if}
@@ -704,6 +735,11 @@
   }
   .ch-newroom-add {
     min-height: 44px;
+  }
+  .ch-newroom-photo {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
   }
 
   .ch-hint {

--- a/frontend/chores/src/lib/components/RoomEditSheet.svelte
+++ b/frontend/chores/src/lib/components/RoomEditSheet.svelte
@@ -1,0 +1,345 @@
+<script lang="ts">
+  // ───────────────────────────────────────────────────────────────────────
+  // Edit-room sheet (v1.2 — minimal room manager). A bottom sheet to rename a
+  // room, change its icon, and set/replace/remove its cover photo. Opened from
+  // the Rooms lens drill-in header (real rooms only — never the virtual
+  // General group). The full room manager (reorder / delete) is still deferred.
+  //
+  //  • Photo (council C4 parity with the chore edit-photo flow): if the user
+  //    picks a new file we upload it first (POST /api/rooms/{id}/photo →
+  //    { photoPath }) then send the returned path in the PUT body. To keep the
+  //    existing photo, send the current photoPath unchanged; to remove it, send
+  //    null. No file ever goes in the JSON body.
+  //
+  // A room change is not a chore mutation (no optimistic path), so on success we
+  // refetch the ONE board payload via boardStore.reloadBoard() — the dashboard
+  // cover / drill hero then render the new photo authoritatively.
+  // ───────────────────────────────────────────────────────────────────────
+  import type { RoomRollupDto } from '../types';
+  import type { RoomUpsertRequest } from '../api';
+  import { updateRoom, uploadRoomPhoto } from '../api';
+  import { boardStore } from '../state.svelte';
+  import { showToast } from '../toasts.svelte';
+  import IconPicker from './IconPicker.svelte';
+
+  interface Props {
+    open: boolean;
+    /** The room being edited (a real room — roomId never null). */
+    room: RoomRollupDto | null;
+    onClose: () => void;
+  }
+
+  let { open, room, onClose }: Props = $props();
+
+  // ── Form state ────────────────────────────────────────────────────────────
+  let name = $state('');
+  let roomIcon = $state<string>('🧹');
+  let existingPhotoPath = $state<string | null>(null);
+  let newPhotoFile = $state<File | null>(null);
+  /** Set true to drop the existing photo (sends photoPath null). */
+  let removePhoto = $state(false);
+  let localError = $state<string | null>(null);
+  let submitting = $state(false);
+
+  let dialogEl: HTMLDialogElement | null = $state(null);
+  let nameInput: HTMLInputElement | null = $state(null);
+
+  // Local object-URL preview of a freshly-picked file (revoked on change/close).
+  let previewUrl = $derived(newPhotoFile ? URL.createObjectURL(newPhotoFile) : null);
+
+  function roomToForm(r: RoomRollupDto): void {
+    name = r.name;
+    roomIcon = r.icon || '🧹';
+    existingPhotoPath = r.photoPath;
+    newPhotoFile = null;
+    removePhoto = false;
+    localError = null;
+  }
+
+  $effect(() => {
+    if (!dialogEl) return;
+    if (open && room && !dialogEl.open) {
+      roomToForm(room);
+      dialogEl.showModal();
+      queueMicrotask(() => nameInput?.focus());
+    } else if (!open && dialogEl.open) {
+      dialogEl.close();
+    }
+  });
+
+  // Revoke the object URL when the picked file changes or the sheet unmounts.
+  $effect(() => {
+    const url = previewUrl;
+    return () => {
+      if (url) URL.revokeObjectURL(url);
+    };
+  });
+
+  function onPhotoChange(e: Event) {
+    const input = e.currentTarget as HTMLInputElement;
+    newPhotoFile = input.files && input.files.length > 0 ? input.files[0] : null;
+    if (newPhotoFile) removePhoto = false;
+  }
+
+  async function handleSubmit(e: SubmitEvent) {
+    e.preventDefault();
+    if (submitting || !room || room.roomId === null) return;
+    const trimmed = name.trim();
+    if (!trimmed) {
+      localError = 'Give the room a name.';
+      return;
+    }
+    localError = null;
+    submitting = true;
+    const roomId = room.roomId;
+
+    try {
+      // Resolve the photo: remove → null; new file → upload then use the path;
+      // otherwise keep what's there. A failed upload keeps the existing photo.
+      let resolvedPhotoPath: string | null = existingPhotoPath;
+      if (removePhoto) {
+        resolvedPhotoPath = null;
+      } else if (newPhotoFile) {
+        try {
+          const uploadResult = await uploadRoomPhoto(roomId, newPhotoFile);
+          resolvedPhotoPath = uploadResult.photoPath;
+        } catch {
+          showToast({ message: 'Photo upload failed — saving other changes.', kind: 'info' });
+          resolvedPhotoPath = existingPhotoPath;
+        }
+      }
+
+      const body: RoomUpsertRequest = {
+        name: trimmed,
+        icon: roomIcon,
+        photoPath: resolvedPhotoPath,
+      };
+      await updateRoom(roomId, body);
+      // Refetch so the dashboard cover / drill hero reflect the change.
+      await boardStore.reloadBoard();
+      showToast({ message: 'Room updated.', kind: 'success' });
+      onClose();
+    } catch {
+      localError = "Couldn't save the room — try again.";
+    } finally {
+      submitting = false;
+    }
+  }
+</script>
+
+<dialog bind:this={dialogEl} onclose={onClose} class="ch-sheet">
+  <form method="dialog" onsubmit={handleSubmit}>
+    <header class="ch-sheet-head">
+      <h2>Edit room</h2>
+    </header>
+
+    <div class="ch-sheet-body">
+      <label class="ch-field">
+        <span class="ch-field-label">Room name</span>
+        <input
+          bind:this={nameInput}
+          type="text"
+          bind:value={name}
+          required
+          autocomplete="off"
+          placeholder="e.g. Kitchen"
+        />
+      </label>
+
+      <fieldset class="ch-field">
+        <legend class="ch-field-label">Icon</legend>
+        <IconPicker value={roomIcon} onSelect={(i) => (roomIcon = i)} label="Room icon" />
+      </fieldset>
+
+      <fieldset class="ch-field">
+        <legend class="ch-field-label">Cover photo (optional)</legend>
+        {#if previewUrl}
+          <img class="ch-room-photo-preview" src={previewUrl} alt="New cover preview" />
+          <span class="ch-hint">{newPhotoFile?.name} (will replace the current photo)</span>
+        {:else if existingPhotoPath && !removePhoto}
+          <img class="ch-room-photo-preview" src={existingPhotoPath} alt="Current cover" />
+          <span class="ch-hint">Pick a new file to replace it.</span>
+        {:else if removePhoto}
+          <span class="ch-hint">The cover photo will be removed.</span>
+        {/if}
+        <input type="file" accept="image/*" onchange={onPhotoChange} />
+        {#if existingPhotoPath && !newPhotoFile}
+          <button
+            type="button"
+            class="ch-btn-danger-ghost ch-room-photo-remove"
+            onclick={() => (removePhoto = !removePhoto)}
+          >
+            {removePhoto ? 'Keep current photo' : 'Remove photo'}
+          </button>
+        {/if}
+      </fieldset>
+
+      {#if localError}
+        <p class="ch-sheet-error" role="alert">{localError}</p>
+      {/if}
+    </div>
+
+    <footer class="ch-sheet-actions">
+      <button type="button" class="ch-btn-ghost" onclick={onClose} disabled={submitting}>
+        Cancel
+      </button>
+      <button type="submit" class="ch-btn-primary" disabled={submitting || !name.trim()}>
+        {submitting ? 'Saving…' : 'Save changes'}
+      </button>
+    </footer>
+  </form>
+</dialog>
+
+<style>
+  .ch-sheet {
+    border: none;
+    padding: 0;
+    background: var(--color-surface);
+    color: var(--color-text);
+    box-shadow: var(--shadow-4);
+    width: min(520px, 100vw);
+    max-height: 90vh;
+    margin: auto auto 0;
+    border-radius: var(--radius-md) var(--radius-md) 0 0;
+  }
+  @media (min-width: 600px) {
+    .ch-sheet {
+      margin: auto;
+      border-radius: var(--radius-md);
+    }
+  }
+  .ch-sheet::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+  }
+  .ch-sheet form {
+    display: flex;
+    flex-direction: column;
+    max-height: 90vh;
+  }
+  .ch-sheet-head {
+    padding: 20px 24px 8px;
+  }
+  .ch-sheet-head h2 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 500;
+  }
+  .ch-sheet-body {
+    overflow-y: auto;
+    padding: 8px 24px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+  }
+
+  .ch-field {
+    border: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .ch-field-label {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--color-text-muted);
+    padding: 0;
+  }
+  input[type='text'] {
+    font: inherit;
+    color: inherit;
+    padding: 10px 12px;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    min-height: 44px;
+  }
+  input[type='text']:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -1px;
+    border-color: var(--color-primary);
+  }
+  input[type='file'] {
+    font: inherit;
+    color: var(--color-text-muted);
+    font-size: 0.875rem;
+  }
+
+  .ch-room-photo-preview {
+    width: 100%;
+    max-height: 160px;
+    object-fit: cover;
+    border-radius: var(--radius-sm);
+    background: var(--color-action-hover);
+    display: block;
+  }
+  .ch-room-photo-remove {
+    align-self: flex-start;
+  }
+
+  .ch-hint {
+    margin: 0;
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+  }
+  .ch-sheet-error {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--color-error);
+  }
+
+  .ch-sheet-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 16px 24px calc(20px + env(safe-area-inset-bottom, 0px));
+    border-top: 1px solid var(--color-line);
+  }
+  .ch-btn-ghost,
+  .ch-btn-primary {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    border: none;
+    cursor: pointer;
+    min-height: 44px;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+  }
+  .ch-btn-ghost {
+    background: transparent;
+    color: var(--color-primary);
+  }
+  .ch-btn-ghost:hover:not(:disabled) {
+    background: var(--color-action-hover);
+  }
+  .ch-btn-primary {
+    background: var(--color-primary);
+    color: #fff;
+    box-shadow: var(--shadow-1);
+  }
+  .ch-btn-primary:hover:not(:disabled) {
+    background: var(--color-primary-hover);
+  }
+  .ch-btn-primary:disabled,
+  .ch-btn-ghost:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  .ch-btn-danger-ghost {
+    font: inherit;
+    padding: 8px 16px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    min-height: 40px;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+    background: transparent;
+    color: var(--color-error);
+    border: 1px solid var(--color-error);
+  }
+  .ch-btn-danger-ghost:hover {
+    background: var(--color-action-hover);
+  }
+</style>

--- a/frontend/chores/src/lib/components/RoomsDashboard.svelte
+++ b/frontend/chores/src/lib/components/RoomsDashboard.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import type { RoomGroup } from '../state.svelte';
-  import type { ChoreDto, RoomRollupStatus } from '../types';
+  import type { ChoreDto, RoomRollupDto, RoomRollupStatus } from '../types';
+  import { showPhoto } from '../lightbox.svelte';
   import ChoreCard from './ChoreCard.svelte';
+  import RoomEditSheet from './RoomEditSheet.svelte';
 
   // ───────────────────────────────────────────────────────────────────────
   // Rooms lens (S7) — a rollup dashboard (D9): one card per room (incl. the
@@ -54,34 +56,101 @@
     attention: 'Needs a look',
     needsWork: 'Needs work',
   };
+
+  // ── Room edit (v1.2 minimal room manager) ─────────────────────────────────
+  // Editing is only offered for real rooms (roomId !== null) — never the virtual
+  // General group. RoomEditSheet handles updateRoom + photo upload + board reload.
+  let editOpen = $state(false);
+  let editRoom = $state<RoomRollupDto | null>(null);
+
+  function openEditRoom(rollup: RoomRollupDto): void {
+    editRoom = rollup;
+    editOpen = true;
+  }
+
+  let canEditOpenRoom = $derived((openGroup?.rollup.roomId ?? null) !== null);
 </script>
 
 {#if openGroup}
   <!-- Drill-in: a single room's chore list. -->
   <div class="ch-rooms-drill">
-    <button type="button" class="ch-rooms-back" onclick={backToGrid}>
-      <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
-        <path d="M15 18l-6-6 6-6" fill="none" stroke="currentColor" stroke-width="2" />
-      </svg>
-      All rooms
-    </button>
+    <div class="ch-rooms-drill-bar">
+      <button type="button" class="ch-rooms-back" onclick={backToGrid}>
+        <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+          <path d="M15 18l-6-6 6-6" fill="none" stroke="currentColor" stroke-width="2" />
+        </svg>
+        All rooms
+      </button>
+      {#if canEditOpenRoom}
+        <button type="button" class="ch-rooms-edit" onclick={() => openEditRoom(openGroup.rollup)}>
+          <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
+            <path
+              d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04a1 1 0 0 0 0-1.41l-2.34-2.34a1 1 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+              fill="currentColor"
+            />
+          </svg>
+          Edit room
+        </button>
+      {/if}
+    </div>
 
-    <header class="ch-room-head">
-      <span class="ch-room-icon" aria-hidden="true">{openGroup.rollup.icon}</span>
-      <div class="ch-room-head-text">
-        <h2 class="ch-room-name">{openGroup.rollup.name}</h2>
-        <span class="ch-room-sub">
-          {openGroup.rollup.choreCount}
-          {openGroup.rollup.choreCount === 1 ? 'chore' : 'chores'}
-          {#if openGroup.rollup.dueCount > 0}
-            · {openGroup.rollup.dueCount} need attention
-          {/if}
+    {#if openGroup.rollup.photoPath}
+      <!--
+        Photo'd room → hero band. The emoji still leads the name (operator's
+        hybrid) so identity is anchored even with a cover. Tap the photo to
+        enlarge (shared lightbox); the overlay text is non-interactive.
+      -->
+      <header class="ch-room-hero">
+        <button
+          type="button"
+          class="ch-room-hero-zoom"
+          onclick={() => showPhoto(openGroup.rollup.photoPath, openGroup.rollup.name)}
+          aria-label="View photo for {openGroup.rollup.name}"
+        >
+          <img
+            class="ch-room-hero-img"
+            src={openGroup.rollup.photoPath}
+            alt=""
+            loading="lazy"
+          />
+        </button>
+        <div class="ch-room-hero-overlay" aria-hidden="true">
+          <div class="ch-room-hero-text">
+            <h2 class="ch-room-hero-name">
+              <span class="ch-room-hero-emoji">{openGroup.rollup.icon}</span>
+              {openGroup.rollup.name}
+            </h2>
+            <span class="ch-room-hero-sub">
+              {openGroup.rollup.choreCount}
+              {openGroup.rollup.choreCount === 1 ? 'chore' : 'chores'}
+              {#if openGroup.rollup.dueCount > 0}
+                · {openGroup.rollup.dueCount} need attention
+              {/if}
+            </span>
+          </div>
+          <span class="ch-room-status ch-status-{openGroup.rollup.status}">
+            {STATUS_LABEL[openGroup.rollup.status]}
+          </span>
+        </div>
+      </header>
+    {:else}
+      <header class="ch-room-head">
+        <span class="ch-room-icon" aria-hidden="true">{openGroup.rollup.icon}</span>
+        <div class="ch-room-head-text">
+          <h2 class="ch-room-name">{openGroup.rollup.name}</h2>
+          <span class="ch-room-sub">
+            {openGroup.rollup.choreCount}
+            {openGroup.rollup.choreCount === 1 ? 'chore' : 'chores'}
+            {#if openGroup.rollup.dueCount > 0}
+              · {openGroup.rollup.dueCount} need attention
+            {/if}
+          </span>
+        </div>
+        <span class="ch-room-status ch-status-{openGroup.rollup.status}">
+          {STATUS_LABEL[openGroup.rollup.status]}
         </span>
-      </div>
-      <span class="ch-room-status ch-status-{openGroup.rollup.status}">
-        {STATUS_LABEL[openGroup.rollup.status]}
-      </span>
-    </header>
+      </header>
+    {/if}
 
     {#if openGroup.chores.length > 0}
       <div class="ch-room-cards">
@@ -117,35 +186,42 @@
           aria-label="{group.rollup.name}: {STATUS_LABEL[group.rollup.status]}, {group.rollup
             .choreCount} chores"
         >
-          <span class="ch-room-card-accent" aria-hidden="true"></span>
-          <span class="ch-room-card-body">
-            <span class="ch-room-card-top">
-              <span class="ch-room-card-icon" aria-hidden="true">{group.rollup.icon}</span>
-              <span class="ch-room-card-name">{group.rollup.name}</span>
-            </span>
-            <span class="ch-room-card-meta">
-              <span class="ch-room-status-pill ch-status-{group.rollup.status}">
-                {STATUS_LABEL[group.rollup.status]}
+          {#if group.rollup.photoPath}
+            <!-- Cover image (v1.2). Part of the drill-in button — tapping it opens
+                 the room. The emoji still leads the name below. -->
+            <img class="ch-room-cover" src={group.rollup.photoPath} alt="" loading="lazy" />
+          {/if}
+          <span class="ch-room-card-row">
+            <span class="ch-room-card-accent" aria-hidden="true"></span>
+            <span class="ch-room-card-body">
+              <span class="ch-room-card-top">
+                <span class="ch-room-card-icon" aria-hidden="true">{group.rollup.icon}</span>
+                <span class="ch-room-card-name">{group.rollup.name}</span>
               </span>
-              <span class="ch-room-card-counts">
-                {#if group.rollup.dueCount > 0}
-                  {group.rollup.dueCount} due · {group.rollup.choreCount} total
-                {:else}
-                  {group.rollup.choreCount}
-                  {group.rollup.choreCount === 1 ? 'chore' : 'chores'}
-                {/if}
+              <span class="ch-room-card-meta">
+                <span class="ch-room-status-pill ch-status-{group.rollup.status}">
+                  {STATUS_LABEL[group.rollup.status]}
+                </span>
+                <span class="ch-room-card-counts">
+                  {#if group.rollup.dueCount > 0}
+                    {group.rollup.dueCount} due · {group.rollup.choreCount} total
+                  {:else}
+                    {group.rollup.choreCount}
+                    {group.rollup.choreCount === 1 ? 'chore' : 'chores'}
+                  {/if}
+                </span>
               </span>
             </span>
+            <svg
+              class="ch-room-card-chevron"
+              viewBox="0 0 24 24"
+              width="20"
+              height="20"
+              aria-hidden="true"
+            >
+              <path d="M9 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="2" />
+            </svg>
           </span>
-          <svg
-            class="ch-room-card-chevron"
-            viewBox="0 0 24 24"
-            width="20"
-            height="20"
-            aria-hidden="true"
-          >
-            <path d="M9 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="2" />
-          </svg>
         </button>
       {/each}
     </div>
@@ -156,6 +232,15 @@
     </div>
   {/if}
 {/if}
+
+<RoomEditSheet
+  open={editOpen}
+  room={editRoom}
+  onClose={() => {
+    editOpen = false;
+    editRoom = null;
+  }}
+/>
 
 <style>
   /* ── Status accent (server-computed rollup status; never derived here) ──── */
@@ -177,8 +262,8 @@
   }
   .ch-room-card {
     display: flex;
+    flex-direction: column;
     align-items: stretch;
-    gap: 0;
     text-align: left;
     font: inherit;
     border: 1px solid var(--color-line);
@@ -192,6 +277,21 @@
       box-shadow 0.15s,
       transform 0.1s;
     -webkit-tap-highlight-color: transparent;
+  }
+  /* The accent | body | chevron row; sits below the optional cover image. */
+  .ch-room-card-row {
+    display: flex;
+    align-items: stretch;
+    flex: 1;
+    min-width: 0;
+  }
+  /* Cover image (v1.2) — full-width strip across the top of a photo'd room. */
+  .ch-room-cover {
+    width: 100%;
+    height: 84px;
+    object-fit: cover;
+    display: block;
+    background: var(--color-action-hover);
   }
   .ch-room-card:hover {
     box-shadow: var(--shadow-2);
@@ -305,6 +405,99 @@
     outline: 2px solid var(--color-primary);
     outline-offset: 2px;
     border-radius: var(--radius-sm);
+  }
+  /* Drill-in bar: back (left) + Edit room (right, real rooms only). */
+  .ch-rooms-drill-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+  }
+  .ch-rooms-edit {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font: inherit;
+    font-size: 0.875rem;
+    font-weight: 500;
+    border: 1px solid var(--color-line-strong);
+    background: transparent;
+    color: var(--color-text-muted);
+    padding: 6px 12px;
+    min-height: 36px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+    transition:
+      background-color 0.15s,
+      color 0.15s;
+  }
+  .ch-rooms-edit:hover {
+    background: var(--color-action-hover);
+    color: var(--color-text);
+  }
+  .ch-rooms-edit:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+
+  /* ── Drill-in hero (photo'd room) — emoji-led title overlaid, tap to zoom ── */
+  .ch-room-hero {
+    position: relative;
+    border-radius: var(--radius-md);
+    overflow: hidden;
+  }
+  .ch-room-hero-zoom {
+    display: block;
+    width: 100%;
+    padding: 0;
+    border: none;
+    background: transparent;
+    cursor: zoom-in;
+    line-height: 0;
+    -webkit-tap-highlight-color: transparent;
+  }
+  .ch-room-hero-img {
+    display: block;
+    width: 100%;
+    height: 140px;
+    object-fit: cover;
+    background: var(--color-action-hover);
+  }
+  .ch-room-hero-overlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 12px 14px;
+    background: linear-gradient(to top, rgba(0, 0, 0, 0.62), rgba(0, 0, 0, 0) 70%);
+    pointer-events: none; /* clicks fall through to the zoom button */
+  }
+  .ch-room-hero-text {
+    min-width: 0;
+  }
+  .ch-room-hero-name {
+    margin: 0;
+    font-size: 1.375rem;
+    font-weight: 600;
+    color: #fff;
+    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
+  }
+  .ch-room-hero-emoji {
+    margin-right: 4px;
+  }
+  .ch-room-hero-sub {
+    font-size: 0.8125rem;
+    color: rgba(255, 255, 255, 0.92);
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+  }
+  /* Clean/attention pills need a backing to read on a photo; needsWork stays solid. */
+  .ch-room-hero-overlay .ch-room-status:not(.ch-status-needsWork) {
+    background: rgba(0, 0, 0, 0.4);
+    border-color: rgba(255, 255, 255, 0.5);
+    color: #fff;
   }
   .ch-room-head {
     display: flex;

--- a/frontend/chores/src/lib/lightbox.svelte.ts
+++ b/frontend/chores/src/lib/lightbox.svelte.ts
@@ -1,0 +1,37 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Photo lightbox (v1.2) — a single shared tap-to-enlarge overlay for the
+// chores island. Any surface (the ChoreCard leading thumbnail, the room
+// drill-in hero) calls showPhoto(src, alt) to enlarge a photo; one
+// <PhotoLightbox> mounted in App.svelte renders it as a native <dialog>
+// (showModal() + ::backdrop — Esc closes natively, backdrop click dismisses).
+//
+// Mirrors the toasts store: a module-private `$state` object read via the
+// `lightbox()` accessor and mutated only through the exported helpers. We never
+// export a reassigned `$state` rune directly (Svelte 5 rune rule / CORRECTION).
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface LightboxState {
+  /** The photo URL shown full-size, or null when the lightbox is closed. */
+  src: string | null;
+  /** Alt text for the enlarged image. */
+  alt: string;
+}
+
+const store = $state<LightboxState>({ src: null, alt: '' });
+
+/** The live lightbox state (reactive — read inside markup / effects). */
+export function lightbox(): Readonly<LightboxState> {
+  return store;
+}
+
+/** Open the lightbox on a photo. No-op for a blank/missing src. */
+export function showPhoto(src: string | null | undefined, alt = ''): void {
+  if (!src) return;
+  store.src = src;
+  store.alt = alt;
+}
+
+/** Close the lightbox. */
+export function closePhoto(): void {
+  store.src = null;
+}

--- a/frontend/chores/src/lib/state.svelte.ts
+++ b/frontend/chores/src/lib/state.svelte.ts
@@ -499,6 +499,17 @@ class BoardStore {
     this.refresh = refresh;
   }
 
+  /**
+   * Public board refetch for the room-admin surface (RoomEditSheet + the inline
+   * new-room photo). A room create/edit/photo change is not a chore mutation, so
+   * it has no optimistic path — after it succeeds we refetch the ONE board
+   * payload so the updated rollup (name / icon / photoPath cover) renders
+   * authoritatively. Shares the same loader as liveness + 409 reconcile.
+   */
+  async reloadBoard(): Promise<void> {
+    await this.reconcile();
+  }
+
   /** Is a mutation in flight for this chore? (disable its controls). */
   isPending(choreId: number): boolean {
     return this.pendingChoreIds.has(choreId);


### PR DESCRIPTION
## What

The chores backend has stored chore/room photos since v1.0 (`Chore.PhotoPath`, `Room.PhotoPath`, `/photo` upload routes) but **nothing ever rendered them**. This ships the display + the minimal capture needed to actually set room covers. **Island-only** — no backend, no migration (the API surface was already complete: `updateRoom`, `uploadRoomPhoto`).

## Design pass (operator-confirmed via prototype)

Carved out of the v1.2 bundle as a design-first thread. Built a live prototype in the real island styling, the operator picked:

- **Chore card → leading thumbnail** (56px, tap-to-enlarge — the confirmed lean). Compact on the dense board; no-photo cards unchanged.
- **Rooms → cover image, emoji kept in front of the name** (operator's hybrid: anchors identity so emoji-only rooms don't look bare next to photo'd ones). Dashboard cover + drill-in hero, tap-to-enlarge on the hero.
- **Capture → "add minimal capture too"**: set room photos in-app now, not display-only.

## Changes (all `frontend/chores/`)

- **`PhotoLightbox`** — one shared tap-to-enlarge `<dialog>` (module singleton mirroring the `toasts` store), mounted once in `App`. Tap-anywhere / Esc dismiss; reuses the house `showModal()` + `::backdrop` pattern (no `window.alert/confirm`).
- **`ChoreCard`** — leading 56px thumbnail from `chore.photoPath` (`loading="lazy"`, explicit dims). Icon emoji still leads the name. No-photo cards byte-for-byte as before.
- **`RoomsDashboard`** — cover strip on the dashboard card (inside the drill-in button) + hero band in the drill-in header with the emoji-led title overlaid; tap-to-enlarge on the hero.
- **`RoomEditSheet`** (new — minimal room manager) — "Edit room" in the drill-in header (real rooms only, never General) opens it: edit name / icon / set·replace·remove cover via `updateRoom` + `uploadRoomPhoto`, then `boardStore.reloadBoard()`.
- **Inline "+ New room"** (both chore sheets) — optional cover photo, `uploadRoomPhoto` after create.
- **store** — public `reloadBoard()` for the room-admin surface.

## Verification

- `npm run check` (svelte-check) — **0 errors / 0 warnings**.
- `npm run build` (vite) — clean.
- Live browser verification pending a local Docker image rebuild (island artifacts are baked into the image).

## Still deferred

Full room manager (reorder / delete rooms, a dedicated "+ Add room" on the Rooms lens) remains a Phase-12 follow-up. This adds only what's needed to set & show room covers.