### PR TITLE
fix(chores-v1.2): lightbox click fix stranded after #18 merged early

### DIFF
--- a/frontend/chores/src/lib/components/PhotoLightbox.svelte
+++ b/frontend/chores/src/lib/components/PhotoLightbox.svelte
@@ -41,6 +41,16 @@
 </dialog>
 
 <style>
+  /*
+   * ⚠ Only style `display` on the OPEN dialog. Setting `display` on the bare
+   * `.ch-lightbox` would override the UA `dialog:not([open]) { display: none }`
+   * rule (author > UA), leaving a transparent full-viewport layer on top that
+   * swallows every click when the lightbox is closed. Gate it to [open].
+   */
+  .ch-lightbox[open] {
+    display: grid;
+    place-items: center;
+  }
   .ch-lightbox {
     border: none;
     margin: 0;
@@ -51,8 +61,6 @@
     height: 100dvh;
     max-height: 100dvh;
     background: transparent;
-    display: grid;
-    place-items: center;
     overflow: hidden;
   }
   .ch-lightbox::backdrop {

--- a/scripts/sync-island.ps1
+++ b/scripts/sync-island.ps1
@@ -1,0 +1,57 @@
+#!/usr/bin/env pwsh
+# ─────────────────────────────────────────────────────────────────────────────
+# Fast LOCAL island dev loop.
+#
+# Rebuilds a Svelte island and pushes the fresh bundle straight into the running
+# `familyapp-app` container's static-file dir — NO `dotnet publish`, NO
+# `docker build`, NO container recreate, NO nginx restart. Seconds, not minutes,
+# and it never touches container lifecycle (so it can't wedge the daemon the way
+# a `docker compose up`/recreate can).
+#
+# The island is just static JS/CSS the app serves from
+# /app/wwwroot/islands/<name>/, so copying the new dist over it + a hard-refresh
+# is all that's needed to see a change.
+#
+#   ⚠ EPHEMERAL: the copy lives only in the running container. It is lost on a
+#     container recreate, and it does NOT change the baked image. For a permanent
+#     change (i.e. before a PR / deploy) do a real image build with docker-build.sh.
+#
+# Usage (from anywhere):
+#   pwsh ./scripts/sync-island.ps1                 # syncs the chores island
+#   pwsh ./scripts/sync-island.ps1 shopping-list   # syncs the shopping-list island
+#   pwsh ./scripts/sync-island.ps1 chores -NoBuild # copy existing dist without rebuilding
+# ─────────────────────────────────────────────────────────────────────────────
+param(
+    [string]$Island = "chores",
+    [string]$Container = "familyapp-app",
+    [switch]$NoBuild
+)
+
+$ErrorActionPreference = "Stop"
+$repo = Split-Path $PSScriptRoot -Parent
+$islandDir = Join-Path $repo "frontend/$Island"
+$dist = Join-Path $islandDir "dist"
+
+if (-not (Test-Path $islandDir)) { throw "No island at $islandDir" }
+
+# Fail fast with a clear message if the container isn't up (e.g. daemon wedged).
+$running = (docker ps --filter "name=$Container" --filter "status=running" --format "{{.Names}}")
+if ($running -ne $Container) {
+    throw "Container '$Container' is not running. Start the stack first (docker compose up -d), then re-run."
+}
+
+if (-not $NoBuild) {
+    Write-Host "→ Building '$Island' island (vite)…" -ForegroundColor Cyan
+    Push-Location $islandDir
+    try { npm run build } finally { Pop-Location }
+}
+
+if (-not (Test-Path $dist)) { throw "No build output at $dist — run without -NoBuild first." }
+
+Write-Host "→ Copying dist into ${Container}:/app/wwwroot/islands/$Island/ …" -ForegroundColor Cyan
+docker cp "$dist/." "${Container}:/app/wwwroot/islands/$Island/"
+if ($LASTEXITCODE -ne 0) { throw "docker cp failed." }
+
+Write-Host ""
+Write-Host "✓ '$Island' synced into the running app." -ForegroundColor Green
+Write-Host "  Hard-refresh  http://localhost:8080/$Island   (Ctrl+Shift+R)" -ForegroundColor Green


### PR DESCRIPTION
## Why this exists

PR #18 was merged while its branch was still at the first commit (`6ce43ea`, photo display). The **lightbox click-blocking fix** (`10167c6`) and the dev script (`0660ca3`) were then pushed to that *already-merged* branch, so they never reached master — and the production deploy that ran on the #18 merge shipped the **buggy** version (closed `<dialog>` overlay swallows all clicks in the chores island).

This PR brings the two stranded commits onto master so they deploy.

## Contents (2 commits, 2 files)
- `10167c6` **fix** — gate the PhotoLightbox `<dialog>` layout to `[open]` so the closed dialog falls back to UA `display:none` instead of sitting as an invisible full-viewport layer that eats every click. Verified live in the running app (clicks work; cover/hero/lightbox/room-edit all confirmed).
- `0660ca3` **chore** — `scripts/sync-island.ps1`, the fast local island dev loop.

## Verification
- svelte-check 0/0, vite build clean.
- Verified live in the local Docker stack: interface clickable, room cover + drill-in hero render, tap-to-enlarge lightbox opens/closes, Edit-room + upload/persist endpoints work.