### PR TITLE
feat(chores-v1.2): expand room/chore icon palette

### DIFF
--- a/frontend/chores/src/lib/components/IconPicker.svelte
+++ b/frontend/chores/src/lib/components/IconPicker.svelte
@@ -17,9 +17,29 @@
     label?: string;
   }
 
+  // Curated palette covering the standard household rooms people set up, plus
+  // common chore icons. Grouped by area so a room icon is easy to find.
   const DEFAULT_ICONS = [
-    '🧹', '🍳', '🛏️', '🚿', '🛋️', '🧺', '🚪', '🌿',
-    '🗑️', '🧽', '🐾', '🚗', '🪴', '🧸', '📦', '🔧',
+    // Kitchen & dining
+    '🍳', '🍽️', '🥫', '☕',
+    // Living, media & den
+    '🛋️', '📺', '🔥',
+    // Bedrooms & bath
+    '🛏️', '🚿', '🛁', '🚽',
+    // Kids
+    '🧸', '🍼',
+    // Work & study
+    '💻', '📚',
+    // Entry, closet, storage, stairs & utility
+    '🚪', '🧥', '📦', '🪜', '🔧',
+    // Garage, home & outdoors
+    '🚗', '🏡', '🌳', '🪴', '🌿',
+    // Pets
+    '🐾',
+    // Cleaning & chores
+    '🧹', '🧺', '🧽', '🗑️', '🪟',
+    // Other spaces
+    '🪑', '🏋️',
   ];
 
   let { value, onSelect, icons = DEFAULT_ICONS, label = 'Icon' }: Props = $props();


### PR DESCRIPTION
## What
People are actively setting up rooms, and the icon picker only had 16 options with **no dining room, half-bath, office, mudroom, etc.** Expanded to ~33 icons, **grouped by area** so a room icon is easy to find.

Added (rooms-focused): 🍽️ dining · 🥫 pantry · ☕ breakfast nook · 📺 media · 🔥 den/fireplace · 🛁 bath · 🚽 powder room · 🍼 nursery · 💻 office · 📚 study · 🧥 closet/mudroom · 🪜 basement/attic/stairs · 🏡 home/exterior · 🌳 yard · 🪟 windows · 🪑 seating · 🏋️ gym. All existing chore icons retained.

Shared by the room icon picker (new-room form + RoomEditSheet) and the chore icon picker — one small change, both surfaces benefit.

## Verification
- svelte-check 0/0, vite build clean.
- Previewed live in the local stack (via `scripts/sync-island.ps1`): all new glyphs render, grouping reads well.