### PR TITLE
chore: scrub personal host details from the public repo

### DIFF
--- a/.planning/TODO.md
+++ b/.planning/TODO.md
@@ -230,7 +230,7 @@ docker-compose up
 
 - **Docker Compose:** Full stack (PostgreSQL + app + nginx) works well
 - **Hot Reload:** Requires rebuild - `docker compose build app && docker compose up -d`
-- **Database Access:** `docker exec familyapp-postgres psql -U familyapp -d familyapp`
+- **Database Access:** `docker exec familyapp-postgres psql -U <db-user> -d <db-name>`
 - **Logs:** `docker logs familyapp-app --follow` or `--since 2m`
 - **Browser Console:** Essential for debugging Blazor interactive issues
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ Required env vars (set via `.env` on the server, generated from a secrets manage
 ## Corrections
 <!-- Also see global corrections: D:\Development\data\memory\CORRECTIONS.md -->
 
-- [2026-04-16 UTC] PREPEND `sudo` to docker commands on thedarktower over SSH. Reason: docker socket not in user group.
+- [2026-04-16 UTC] PREPEND `sudo` to docker commands on the production host over SSH. Reason: docker socket not in user group.
 
 <!-- /reflect completed 2026-04-16 UTC -->
 

--- a/deploy-from-windows.ps1
+++ b/deploy-from-windows.ps1
@@ -1,4 +1,9 @@
-# deploy-from-windows.ps1 — Deploy family-coordination-app to darktower from Windows
+# deploy-from-windows.ps1 — Deploy family-coordination-app to the production host from Windows.
+#
+# Configure the target via environment variables (keeps host details out of the repo):
+#   $env:FAMILYAPP_DEPLOY_HOST = "your-ssh-host"   # an SSH Host alias from ~/.ssh/config, or user@host
+#   $env:FAMILYAPP_REMOTE_PATH = "~/familyapp"     # optional; defaults to ~/familyapp
+#
 # Usage:
 #   .\deploy-from-windows.ps1              — Regenerate secrets + recreate containers
 #   .\deploy-from-windows.ps1 --build      — Rebuild Docker image + deploy
@@ -14,20 +19,25 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
-$DarktowerHost = "thedarktower"
-$RemotePath = "~/familyapp"
+
+$DeployHost = $env:FAMILYAPP_DEPLOY_HOST
+if (-not $DeployHost) {
+    Write-Error "Set `$env:FAMILYAPP_DEPLOY_HOST to your SSH host (an alias in ~/.ssh/config, or user@host)."
+    exit 1
+}
+$RemotePath = if ($env:FAMILYAPP_REMOTE_PATH) { $env:FAMILYAPP_REMOTE_PATH } else { "~/familyapp" }
 
 Write-Host "=== Family Coordination App — Remote Deploy ===" -ForegroundColor Cyan
 
 if ($Status) {
-    Write-Host "Checking container status on darktower..."
-    ssh $DarktowerHost "docker ps --filter name=familyapp --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'"
+    Write-Host "Checking container status on the deploy host..."
+    ssh $DeployHost "docker ps --filter name=familyapp --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'"
     exit 0
 }
 
 if ($Down) {
-    Write-Host "Stopping containers on darktower..."
-    ssh $DarktowerHost "cd $RemotePath && ./deploy.sh down"
+    Write-Host "Stopping containers on the deploy host..."
+    ssh $DeployHost "cd $RemotePath && ./deploy.sh down"
     exit 0
 }
 
@@ -38,10 +48,10 @@ if ($Restart) { $flags += "--restart" }
 $flagStr = ($flags -join " ")
 if ($flagStr) {
     Write-Host "Running: deploy.sh $flagStr"
-    ssh $DarktowerHost "cd $RemotePath && ./deploy.sh $flagStr"
+    ssh $DeployHost "cd $RemotePath && ./deploy.sh $flagStr"
 } else {
     Write-Host "Running: deploy.sh (full deploy)"
-    ssh $DarktowerHost "cd $RemotePath && ./deploy.sh"
+    ssh $DeployHost "cd $RemotePath && ./deploy.sh"
 }
 
 Write-Host ""

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,4 +1,4 @@
-# Production override for thedarktower
+# Production override for the self-hosted production host
 services:
   postgres:
     # Override: bind mount from .env instead of named volume


### PR DESCRIPTION
## Why
The repo is public. While no secrets were ever committed (no IP, password, or key), a few files leaked personal infra naming — the production host nickname and a copy-paste DB access command. Low risk, but cleaner to remove.

## Changes
- **`deploy-from-windows.ps1`** — reads the SSH host + remote path from `$env:FAMILYAPP_DEPLOY_HOST` / `$env:FAMILYAPP_REMOTE_PATH` (errors clearly if the host isn't set) instead of hardcoding the host alias.
- **`CLAUDE.md`**, **`docker-compose.prod.yml`** — "thedarktower" → "the production host".
- **`.planning/TODO.md`** — genericized the `psql` access command (drops the literal db user/name).

## Deliberately left alone
- **`.github/workflows/deploy.yml`** — contained no personal identifiers; `~/familyapp` and the `familyapp-*` container names are derived from the project name and only useful to someone already on the box.

## ⚠ Action needed after merge
The deploy helper now requires an env var. Set it once (e.g. in your PowerShell profile):
```powershell
$env:FAMILYAPP_DEPLOY_HOST = "<your-ssh-host>"
```