### PR TITLE
fix(chores): enlarge member avatars + show minder name (feedback #7)

### DIFF
--- a/frontend/chores/src/lib/components/ChoreCard.svelte
+++ b/frontend/chores/src/lib/components/ChoreCard.svelte
@@ -193,10 +193,11 @@
               name={owner.displayName}
               initials={owner.initials}
               pictureUrl={owner.pictureUrl}
-              size={22}
+              size={28}
               relation="Minded by"
             />
             <span class="ch-minder-label">Minder</span>
+            <span class="ch-minder-name">{nameOf(chore.ownerUserId, owner.displayName)}</span>
           </span>
         {/if}
 
@@ -206,7 +207,7 @@
               name={assignee.displayName}
               initials={assignee.initials}
               pictureUrl={assignee.pictureUrl}
-              size={22}
+              size={28}
               relation="Claimed by"
             />
             <span class="ch-claim-label">{nameOf(chore.assigneeUserId, assignee.displayName)}</span>
@@ -217,7 +218,7 @@
               name={assignee.displayName}
               initials={assignee.initials}
               pictureUrl={assignee.pictureUrl}
-              size={22}
+              size={28}
               relation="Assigned to"
             />
             <span class="ch-claim-label">{nameOf(chore.assigneeUserId, assignee.displayName)}</span>
@@ -493,6 +494,10 @@
     font-size: 0.6875rem;
     text-transform: uppercase;
     letter-spacing: 0.04em;
+  }
+  .ch-minder-name {
+    font-weight: 500;
+    color: var(--color-text);
   }
   .ch-claim-label {
     font-weight: 500;


### PR DESCRIPTION
## Feedback #7
> *"The minder user icon should be larger to make it easier to see who it is without having to hover to see name."*

## Cause
The **assignee** already renders the person's name on the card, but the **minder** rendered only a small (22px) avatar + the static word "MINDER" — the name was hover-only.

## Fix (island-only, CSS + markup)
- Bump all three member avatars (minder + claimed/assigned) from 22px → **28px**.
- Render the minder's **name inline** (`nameOf(...)`, so it shows "You" for the current user) next to the "Minder" role label — identifiable at a glance, no hover needed.

## Verification
✅ svelte-check 0/0 + clean build. Visual change — confirmable on a running instance.