### PR TITLE
ux(chores): lead with Chores (home + nav), fix shopping-list row alignment

### DIFF
--- a/src/FamilyCoordinationApp/Components/Layout/NavMenu.razor
+++ b/src/FamilyCoordinationApp/Components/Layout/NavMenu.razor
@@ -22,20 +22,20 @@
         @if (IsExpanded) { <text>Home</text> }
     </MudNavLink>
     
-    <MudNavLink Href="/recipes" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.MenuBook">
-        @if (IsExpanded) { <text>Recipes</text> }
+    <MudNavLink Href="/chores" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.CleaningServices">
+        @if (IsExpanded) { <text>Chores</text> }
     </MudNavLink>
-    
-    <MudNavLink Href="/meal-plan" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.CalendarMonth">
-        @if (IsExpanded) { <text>Meal Plan</text> }
-    </MudNavLink>
-    
+
     <MudNavLink Href="/shoppinglists" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.ShoppingCart">
         @if (IsExpanded) { <text>Shopping Lists</text> }
     </MudNavLink>
 
-    <MudNavLink Href="/chores" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.CleaningServices">
-        @if (IsExpanded) { <text>Chores</text> }
+    <MudNavLink Href="/meal-plan" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.CalendarMonth">
+        @if (IsExpanded) { <text>Meal Plan</text> }
+    </MudNavLink>
+
+    <MudNavLink Href="/recipes" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.MenuBook">
+        @if (IsExpanded) { <text>Recipes</text> }
     </MudNavLink>
 
     <MudDivider Class="my-4" />

--- a/src/FamilyCoordinationApp/Components/Pages/Home.razor
+++ b/src/FamilyCoordinationApp/Components/Pages/Home.razor
@@ -24,109 +24,6 @@
     </div>
 
     <MudGrid Spacing="4">
-        <!-- Today's Meals Card -->
-        <MudItem xs="12" md="6">
-            <MudCard Elevation="2" Class="dashboard-card">
-                <MudCardHeader>
-                    <CardHeaderAvatar>
-                        <MudAvatar Color="Color.Primary" Variant="Variant.Outlined">
-                            <MudIcon Icon="@Icons.Material.Filled.Today" />
-                        </MudAvatar>
-                    </CardHeaderAvatar>
-                    <CardHeaderContent>
-                        <MudText Typo="Typo.h6">Today's Meals</MudText>
-                        <MudText Typo="Typo.body2" Color="Color.Secondary">@DateTime.Today.ToString("MMM d")</MudText>
-                    </CardHeaderContent>
-                    <CardHeaderActions>
-                        <MudIconButton Icon="@Icons.Material.Filled.ArrowForward" Href="/meal-plan" />
-                    </CardHeaderActions>
-                </MudCardHeader>
-                <MudCardContent Class="pt-0">
-                    @if (_todaysMeals.Count == 0)
-                    {
-                        <MudText Color="Color.Secondary" Class="text-center py-4">
-                            No meals planned for today
-                        </MudText>
-                        <div class="text-center">
-                            <MudButton Variant="Variant.Text" Color="Color.Primary" Href="/meal-plan">
-                                Plan something
-                            </MudButton>
-                        </div>
-                    }
-                    else
-                    {
-                        @foreach (var mealGroup in _todaysMeals.GroupBy(m => m.MealType).OrderBy(g => g.Key))
-                        {
-                            <div class="meal-group py-2">
-                                <div class="d-flex align-center gap-2 mb-1">
-                                    <MudIcon Icon="@GetMealTypeIcon(mealGroup.Key)" Size="Size.Small" Color="Color.Secondary" />
-                                    <MudText Typo="Typo.subtitle2" Color="Color.Secondary">@mealGroup.Key</MudText>
-                                </div>
-                                @foreach (var meal in mealGroup)
-                                {
-                                    <div class="meal-item ps-6 py-1">
-                                        <MudText>@GetMealDisplayName(meal)</MudText>
-                                    </div>
-                                }
-                            </div>
-                        }
-                    }
-                </MudCardContent>
-            </MudCard>
-        </MudItem>
-
-        <!-- Shopping List Card -->
-        <MudItem xs="12" md="6">
-            <MudCard Elevation="2" Class="dashboard-card">
-                <MudCardHeader>
-                    <CardHeaderAvatar>
-                        <MudAvatar Color="Color.Secondary" Variant="Variant.Outlined">
-                            <MudIcon Icon="@Icons.Material.Filled.ShoppingCart" />
-                        </MudAvatar>
-                    </CardHeaderAvatar>
-                    <CardHeaderContent>
-                        <MudText Typo="Typo.h6">Shopping List</MudText>
-                        <MudText Typo="Typo.body2" Color="Color.Secondary">
-                            @if (_shoppingListCount > 0)
-                            {
-                                @:@_shoppingListCount items remaining
-                            }
-                            else
-                            {
-                                @:All done!
-                            }
-                        </MudText>
-                    </CardHeaderContent>
-                    <CardHeaderActions>
-                        <MudIconButton Icon="@Icons.Material.Filled.ArrowForward" Href="/shopping-list" />
-                    </CardHeaderActions>
-                </MudCardHeader>
-                <MudCardContent Class="pt-0">
-                    @if (_shoppingListCount == 0)
-                    {
-                        <MudText Color="Color.Secondary" Class="text-center py-4">
-                            Shopping list is empty
-                        </MudText>
-                        <div class="text-center">
-                            <MudButton Variant="Variant.Text" Color="Color.Primary" Href="/shopping-list">
-                                Generate from meal plan
-                            </MudButton>
-                        </div>
-                    }
-                    else
-                    {
-                        <MudProgressLinear Color="Color.Success" 
-                                           Value="@_shoppingListProgress" 
-                                           Class="my-3" 
-                                           Rounded="true" />
-                        <MudText Typo="Typo.caption" Color="Color.Secondary" Class="text-center">
-                            @_shoppingListChecked of @(_shoppingListChecked + _shoppingListCount) items checked
-                        </MudText>
-                    }
-                </MudCardContent>
-            </MudCard>
-        </MudItem>
-
         <!-- Chores Card -->
         <MudItem xs="12" md="6">
             <MudCard Elevation="2" Class="dashboard-card">
@@ -200,6 +97,109 @@
                                 </div>
                             }
                         </div>
+                    }
+                </MudCardContent>
+            </MudCard>
+        </MudItem>
+
+        <!-- Shopping List Card -->
+        <MudItem xs="12" md="6">
+            <MudCard Elevation="2" Class="dashboard-card">
+                <MudCardHeader>
+                    <CardHeaderAvatar>
+                        <MudAvatar Color="Color.Secondary" Variant="Variant.Outlined">
+                            <MudIcon Icon="@Icons.Material.Filled.ShoppingCart" />
+                        </MudAvatar>
+                    </CardHeaderAvatar>
+                    <CardHeaderContent>
+                        <MudText Typo="Typo.h6">Shopping List</MudText>
+                        <MudText Typo="Typo.body2" Color="Color.Secondary">
+                            @if (_shoppingListCount > 0)
+                            {
+                                @:@_shoppingListCount items remaining
+                            }
+                            else
+                            {
+                                @:All done!
+                            }
+                        </MudText>
+                    </CardHeaderContent>
+                    <CardHeaderActions>
+                        <MudIconButton Icon="@Icons.Material.Filled.ArrowForward" Href="/shopping-list" />
+                    </CardHeaderActions>
+                </MudCardHeader>
+                <MudCardContent Class="pt-0">
+                    @if (_shoppingListCount == 0)
+                    {
+                        <MudText Color="Color.Secondary" Class="text-center py-4">
+                            Shopping list is empty
+                        </MudText>
+                        <div class="text-center">
+                            <MudButton Variant="Variant.Text" Color="Color.Primary" Href="/shopping-list">
+                                Generate from meal plan
+                            </MudButton>
+                        </div>
+                    }
+                    else
+                    {
+                        <MudProgressLinear Color="Color.Success" 
+                                           Value="@_shoppingListProgress" 
+                                           Class="my-3" 
+                                           Rounded="true" />
+                        <MudText Typo="Typo.caption" Color="Color.Secondary" Class="text-center">
+                            @_shoppingListChecked of @(_shoppingListChecked + _shoppingListCount) items checked
+                        </MudText>
+                    }
+                </MudCardContent>
+            </MudCard>
+        </MudItem>
+
+        <!-- Today's Meals Card -->
+        <MudItem xs="12" md="6">
+            <MudCard Elevation="2" Class="dashboard-card">
+                <MudCardHeader>
+                    <CardHeaderAvatar>
+                        <MudAvatar Color="Color.Primary" Variant="Variant.Outlined">
+                            <MudIcon Icon="@Icons.Material.Filled.Today" />
+                        </MudAvatar>
+                    </CardHeaderAvatar>
+                    <CardHeaderContent>
+                        <MudText Typo="Typo.h6">Today's Meals</MudText>
+                        <MudText Typo="Typo.body2" Color="Color.Secondary">@DateTime.Today.ToString("MMM d")</MudText>
+                    </CardHeaderContent>
+                    <CardHeaderActions>
+                        <MudIconButton Icon="@Icons.Material.Filled.ArrowForward" Href="/meal-plan" />
+                    </CardHeaderActions>
+                </MudCardHeader>
+                <MudCardContent Class="pt-0">
+                    @if (_todaysMeals.Count == 0)
+                    {
+                        <MudText Color="Color.Secondary" Class="text-center py-4">
+                            No meals planned for today
+                        </MudText>
+                        <div class="text-center">
+                            <MudButton Variant="Variant.Text" Color="Color.Primary" Href="/meal-plan">
+                                Plan something
+                            </MudButton>
+                        </div>
+                    }
+                    else
+                    {
+                        @foreach (var mealGroup in _todaysMeals.GroupBy(m => m.MealType).OrderBy(g => g.Key))
+                        {
+                            <div class="meal-group py-2">
+                                <div class="d-flex align-center gap-2 mb-1">
+                                    <MudIcon Icon="@GetMealTypeIcon(mealGroup.Key)" Size="Size.Small" Color="Color.Secondary" />
+                                    <MudText Typo="Typo.subtitle2" Color="Color.Secondary">@mealGroup.Key</MudText>
+                                </div>
+                                @foreach (var meal in mealGroup)
+                                {
+                                    <div class="meal-item ps-6 py-1">
+                                        <MudText>@GetMealDisplayName(meal)</MudText>
+                                    </div>
+                                }
+                            </div>
+                        }
                     }
                 </MudCardContent>
             </MudCard>

--- a/src/FamilyCoordinationApp/Components/ShoppingList/ShoppingListItemRow.razor
+++ b/src/FamilyCoordinationApp/Components/ShoppingList/ShoppingListItemRow.razor
@@ -19,26 +19,6 @@
 
     <div class="item-content">
         <MudText Typo="Typo.body1" Class="@GetTextClass()">
-            @if (Item.Quantity.HasValue)
-            {
-                <span class="quantity-controls" @onclick:stopPropagation="true">
-                    <MudIconButton Icon="@Icons.Material.Filled.Remove"
-                                   Size="Size.Small"
-                                   OnClick="HandleDecrement"
-                                   aria-label="Decrease quantity"
-                                   Class="quantity-button" />
-                    <span class="quantity">@FormatQuantity(Item.Quantity.Value)</span>
-                    @if (!string.IsNullOrEmpty(Item.Unit))
-                    {
-                        <span class="unit">@Item.Unit</span>
-                    }
-                    <MudIconButton Icon="@Icons.Material.Filled.Add"
-                                   Size="Size.Small"
-                                   OnClick="HandleIncrement"
-                                   aria-label="Increase quantity"
-                                   Class="quantity-button" />
-                </span>
-            }
             <span class="name">@Item.Name</span>
         </MudText>
 
@@ -49,6 +29,30 @@
             </MudText>
         }
     </div>
+
+    @* Quantity stepper is a trailing control (not inline before the name) so every item name
+       shares one left edge — text-only items ("Paper towels") and quantity items ("2 lbs Chicken")
+       line up instead of staggering. Mirrors the Svelte island's ItemRow layout. *@
+    @if (Item.Quantity.HasValue)
+    {
+        <span class="quantity-controls" @onclick:stopPropagation="true">
+            <MudIconButton Icon="@Icons.Material.Filled.Remove"
+                           Size="Size.Small"
+                           OnClick="HandleDecrement"
+                           aria-label="Decrease quantity"
+                           Class="quantity-button" />
+            <span class="quantity">@FormatQuantity(Item.Quantity.Value)</span>
+            @if (!string.IsNullOrEmpty(Item.Unit))
+            {
+                <span class="unit">@Item.Unit</span>
+            }
+            <MudIconButton Icon="@Icons.Material.Filled.Add"
+                           Size="Size.Small"
+                           OnClick="HandleIncrement"
+                           aria-label="Increase quantity"
+                           Class="quantity-button" />
+        </span>
+    }
 
     @if (Item.AddedBy != null)
     {
@@ -222,7 +226,7 @@
         display: inline-flex;
         align-items: center;
         gap: 2px;
-        margin-right: 8px;
+        flex-shrink: 0;
     }
 
     .quantity-button {


### PR DESCRIPTION
## Chores-track UX feedback (prod)

User-requested UX adjustments from production feedback. No backend/API changes.

### 1. Lead with Chores
Chores is the most-used surface, so it now leads every entry point:
- **Home dashboard** cards reordered: **Chores → Shopping List → Today's Meals** (was Meals → Shopping → Chores).
- **Side nav menu**: Home, **Chores**, Shopping Lists, Meal Plan, Recipes.
- **Mobile bottom nav** (was missing Chores entirely): now **Home · Chores · Shopping · Meals · Recipes · Settings** — same Chores-first order as the side nav. On a phone in portrait there was previously *no way* to reach the chore board from the bottom bar.

### 2. Shopping-list row alignment
The quantity stepper rendered **inline before the item name**, so quantity items ("2 lbs Chicken") and text-only items ("Paper towels") started their names at different positions — a jagged column that "looks crazy." The stepper is now a **trailing right-side control**, so every name shares one left edge.

This was the Blazor `ShoppingListItemRow.razor`. The Svelte island's `ItemRow.svelte` already used this layout — this brings the Blazor component to parity.

```
Before                         After
☐ 2 lbs Chicken                ☐ Chicken          [− 2 lbs +]
☐ Paper towels                 ☐ Paper towels
☐ 12 Eggs                      ☐ Eggs             [− 12 +]
```

### Verification
- `dotnet build` ✅ (0 errors)
- Visual/layout changes only; no test impact.
- ⚠️ Worth a real-phone pass (portrait + landscape) on: the new bottom-nav (6 icons — confirm they don't crowd on a ~360px-wide screen), the dashboard card order, and the row alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
