### PR TITLE
fix(ui): add Chores to the mobile bottom nav

### DIFF
--- a/src/FamilyCoordinationApp/Components/Layout/MainLayout.razor
+++ b/src/FamilyCoordinationApp/Components/Layout/MainLayout.razor
@@ -131,26 +131,37 @@
     <MudHidden Breakpoint="Breakpoint.MdAndUp">
         <div class="mobile-bottom-nav">
             <MudPaper Elevation="4" Class="bottom-nav-paper">
+                @* Order mirrors the side NavMenu (Chores-first): Home · Chores · Shopping · Meals · Recipes · Settings. *@
                 <div class="d-flex justify-space-around align-center py-1">
-                    <MudIconButton Icon="@Icons.Material.Filled.Home" 
+                    <MudIconButton Icon="@Icons.Material.Filled.Home"
                                    Color="@(IsCurrentPage("/dashboard") ? Color.Primary : Color.Default)"
                                    Href="/dashboard"
+                                   aria-label="Home"
                                    Size="Size.Medium" />
-                    <MudIconButton Icon="@Icons.Material.Filled.MenuBook" 
-                                   Color="@(IsCurrentPage("/recipes") ? Color.Primary : Color.Default)"
-                                   Href="/recipes"
+                    <MudIconButton Icon="@Icons.Material.Filled.CleaningServices"
+                                   Color="@(IsCurrentPage("/chores") ? Color.Primary : Color.Default)"
+                                   Href="/chores"
+                                   aria-label="Chores"
                                    Size="Size.Medium" />
-                    <MudIconButton Icon="@Icons.Material.Filled.CalendarMonth" 
-                                   Color="@(IsCurrentPage("/meal-plan") ? Color.Primary : Color.Default)"
-                                   Href="/meal-plan"
-                                   Size="Size.Medium" />
-                    <MudIconButton Icon="@Icons.Material.Filled.ShoppingCart" 
+                    <MudIconButton Icon="@Icons.Material.Filled.ShoppingCart"
                                    Color="@(IsCurrentPage("/shopping") ? Color.Primary : Color.Default)"
                                    Href="/shoppinglists"
+                                   aria-label="Shopping lists"
                                    Size="Size.Medium" />
-                    <MudIconButton Icon="@Icons.Material.Filled.Settings" 
+                    <MudIconButton Icon="@Icons.Material.Filled.CalendarMonth"
+                                   Color="@(IsCurrentPage("/meal-plan") ? Color.Primary : Color.Default)"
+                                   Href="/meal-plan"
+                                   aria-label="Meal plan"
+                                   Size="Size.Medium" />
+                    <MudIconButton Icon="@Icons.Material.Filled.MenuBook"
+                                   Color="@(IsCurrentPage("/recipes") ? Color.Primary : Color.Default)"
+                                   Href="/recipes"
+                                   aria-label="Recipes"
+                                   Size="Size.Medium" />
+                    <MudIconButton Icon="@Icons.Material.Filled.Settings"
                                    Color="@(IsCurrentPage("/settings") ? Color.Primary : Color.Default)"
                                    Href="/settings/categories"
+                                   aria-label="Settings"
                                    Size="Size.Medium" />
                 </div>
             </MudPaper>


### PR DESCRIPTION
## Add Chores to the mobile bottom nav

The mobile bottom navigation (`MainLayout`, shown below the `md` breakpoint) had **Home · Recipes · Meal Plan · Shopping · Settings** — but **no Chores link**. On a phone in portrait there was no way to reach the chore board from the bottom bar (reported in prod feedback).

Adds a **Chores** icon (`CleaningServices`, matching the side nav + home card) and reorders the bar to mirror the side `NavMenu`'s Chores-first priority (shipped in #28):

**Home · Chores · Shopping · Meals · Recipes · Settings**

That's 6 icons. The bar uses `justify-space-around`, so they distribute evenly; worth an eyeball on a narrow (~360px) phone to confirm they don't crowd — but 6 icon-buttons is within the usual tolerance.

### Why a separate PR
The fix was originally committed onto the `feat/chores-ux-feedback` branch — but **#28 had already merged** by the time I pushed, so the commit was stranded (new commits on a merged branch never reach master). Re-branched off fresh `master` and cherry-picked the single commit here.

### Verification
- `dotnet build` ✅ (0 errors)
- Markup/layout change only; no test impact.
- ⚠️ Real-phone pass recommended (portrait + landscape): confirm the 6 icons don't crowd and the active-page highlight works on `/chores`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
