### PR TITLE
feat(chores): show the room on chore cards in cross-room lenses

### DIFF
--- a/frontend/chores/src/lib/components/ChoreCard.svelte
+++ b/frontend/chores/src/lib/components/ChoreCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { ChoreDto, ColorTier, DueState, EffortTier, RecurrenceMode } from '../types';
-  import { memberFor } from '../state.svelte';
+  import { memberFor, roomFor } from '../state.svelte';
   import { showPhoto } from '../lightbox.svelte';
   import MemberAvatar from './MemberAvatar.svelte';
 
@@ -26,6 +26,12 @@
     currentUserId: number;
     /** True while a mutation for this chore is in flight (disables controls). */
     pending?: boolean;
+    /**
+     * Show the room locator chip (which room this chore lives in). True for the
+     * cross-room lenses (Needs-attention / Up-for-grabs / Mine); the Rooms lens
+     * passes false since its cards are already grouped under a room header.
+     */
+    showRoom?: boolean;
     onClaim?: (chore: ChoreDto) => void;
     onDrop?: (chore: ChoreDto) => void;
     onComplete?: (chore: ChoreDto) => void;
@@ -38,6 +44,7 @@
     chore,
     currentUserId,
     pending = false,
+    showRoom = true,
     onClaim,
     onDrop,
     onComplete,
@@ -68,6 +75,11 @@
 
   let owner = $derived(memberFor(chore.ownerUserId));
   let assignee = $derived(memberFor(chore.assigneeUserId));
+
+  // ── Room locator (which room this chore lives in) ────────────────────────
+  // Resolved off the board's room rollups. null for roomless chores (General)
+  // or when `showRoom` is off (the Rooms lens, where cards are already grouped).
+  let room = $derived(showRoom ? roomFor(chore.roomId) : null);
 
   let isUnclaimed = $derived(chore.assignmentKind === 'none' || chore.isClaimStale);
   let isClaimed = $derived(chore.assignmentKind === 'claimed' && !chore.isClaimStale);
@@ -160,6 +172,22 @@
     {/if}
 
     <div class="ch-card-meta">
+      {#if room}
+        <span class="ch-tag ch-tag-room" title="Room: {room.name}">
+          {#if room.icon}
+            <span class="ch-tag-room-icon" aria-hidden="true">{room.icon}</span>
+          {:else}
+            <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true">
+              <path
+                d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5A2.5 2.5 0 1 1 12 6.5a2.5 2.5 0 0 1 0 5z"
+                fill="currentColor"
+              />
+            </svg>
+          {/if}
+          {room.name}
+        </span>
+      {/if}
+
       <span class="ch-tag ch-tag-effort" title="Effort: {effortLabel}">
         <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true">
           <path d="M13 2 3 14h7l-1 8 10-12h-7l1-8z" fill="currentColor" />
@@ -466,6 +494,16 @@
   }
   .ch-tag svg {
     flex-shrink: 0;
+  }
+  /* Room locator chip — tinted distinct from the muted effort/recurrence tags
+     so "which room" reads as the card's primary orientation cue. */
+  .ch-tag-room {
+    color: #fff;
+    background: var(--color-primary-soft);
+  }
+  .ch-tag-room-icon {
+    font-size: 0.875rem;
+    line-height: 1;
   }
 
   .ch-card-foot {

--- a/frontend/chores/src/lib/components/RoomsDashboard.svelte
+++ b/frontend/chores/src/lib/components/RoomsDashboard.svelte
@@ -166,6 +166,7 @@
           <ChoreCard
             {chore}
             {currentUserId}
+            showRoom={false}
             pending={isPending(chore.id)}
             {onClaim}
             {onDrop}

--- a/frontend/chores/src/lib/state.svelte.ts
+++ b/frontend/chores/src/lib/state.svelte.ts
@@ -183,6 +183,19 @@ class BoardStore {
     return map;
   });
 
+  /**
+   * roomId → room rollup, for the per-card room locator chip. REAL rooms only —
+   * the virtual General group (roomId === null, roomless chores) is excluded so a
+   * roomless card shows no chip rather than a noisy "General" tag.
+   */
+  roomsById = $derived.by(() => {
+    const map = new Map<number, RoomRollupDto>();
+    for (const r of this.board?.rooms ?? []) {
+      if (r.roomId != null) map.set(r.roomId, r);
+    }
+    return map;
+  });
+
   /** All board chores (empty when unloaded). */
   chores = $derived<ChoreDto[]>(this.board?.chores ?? []);
 
@@ -784,6 +797,16 @@ export const boardStore = new BoardStore();
 export function memberFor(userId: number | null | undefined): MemberDto | null {
   if (userId == null) return null;
   return boardStore.membersById.get(userId) ?? null;
+}
+
+/**
+ * Resolve a room rollup (name + icon) for a chore's roomId, for the per-card
+ * room locator chip. null when the chore is roomless (the virtual General group)
+ * or the roomId is unknown — callers render no chip in that case.
+ */
+export function roomFor(roomId: number | null | undefined): RoomRollupDto | null {
+  if (roomId == null) return null;
+  return boardStore.roomsById.get(roomId) ?? null;
 }
 
 /**


### PR DESCRIPTION
@
## What

Chore cards in the cross-room lenses (**Needs-attention**, **Up for grabs**, **Mine**) now show a **room locator chip** — the room emoji + name leading the card meta row — so you can tell at a glance which room a chore belongs to. The **Rooms** lens is unchanged (its cards are already grouped under a room header, so the chip is suppressed there).

## Why

These lenses interleave chores from every room, but the card gave no indication of *where* a chore lives. Reported need: "the cards need a way to display what room the chore is in."

## How

Pure client-side island change — no API/DTO work. The data was already on the board payload (`ChoreDto.roomId` + `rooms: RoomRollupDto[]`).

- **`state.svelte.ts`** — `roomsById` lookup + `roomFor()` helper (mirrors `memberFor()`). Real rooms only; the virtual **General** group (`roomId: null`) is excluded so roomless cards show *no* chip rather than a noisy "General" tag.
- **`ChoreCard.svelte`** — new `showRoom` prop (default `true`); renders the tinted chip (room emoji, or a map-pin SVG fallback if a room has no icon).
- **`RoomsDashboard.svelte`** — passes `showRoom={false}`.

## Notes

- **Source-only** — island `dist/` is gitignored and rebuilt at Docker build, so this needs an **image rebuild** to reach prod (a plain restart wont pick it up).
- Branched off fresh `master` (not the already-merged `fix/mobile-bottom-nav-chores`) to avoid the stranding trap.

## Verification

- `svelte-check` → 0 errors / 0 warnings
- `vite build` → clean (148 modules)
@