### PR TITLE
fix(chores): one Done catches up an overdue Fixed-schedule chore

### DIFF
--- a/src/FamilyCoordinationApp/Services/ChoreStatusCalculator.cs
+++ b/src/FamilyCoordinationApp/Services/ChoreStatusCalculator.cs
@@ -89,14 +89,16 @@ public class ChoreStatusCalculator
     /// </summary>
     public ChoreDuenessResult Compute(ChoreRecurrenceSnapshot chore, DateTime now, TimeZoneInfo tz)
     {
-        var nextDueAt = ComputeNextDueAt(chore, now, tz);
+        var today = LocalDate(now, tz);
 
         return chore.RecurrenceMode switch
         {
-            RecurrenceMode.Flexible => ComputeFlexible(chore, now, tz, nextDueAt),
-            RecurrenceMode.Fixed => ComputeFixed(chore, now, tz, nextDueAt),
-            RecurrenceMode.OneOff => ComputeOneOff(chore, now, tz, nextDueAt),
-            _ => new ChoreDuenessResult(DueState.NotDue, ColorTier.Fresh, nextDueAt)
+            // Flexible/OneOff derive their next-due independently of the dueness branch; Fixed computes its
+            // state and next-due together (completion-aware slot logic), so it is fully self-contained.
+            RecurrenceMode.Flexible => ComputeFlexible(chore, now, tz, NextDueForFlexible(chore, today, tz)),
+            RecurrenceMode.Fixed => ComputeFixed(chore, now, tz),
+            RecurrenceMode.OneOff => ComputeOneOff(chore, now, tz, NextDueForOneOff(chore, tz)),
+            _ => new ChoreDuenessResult(DueState.NotDue, ColorTier.Fresh, NextDueAt: null)
         };
     }
 
@@ -112,7 +114,9 @@ public class ChoreStatusCalculator
         return chore.RecurrenceMode switch
         {
             RecurrenceMode.Flexible => NextDueForFlexible(chore, today, tz),
-            RecurrenceMode.Fixed => NextDueForFixed(chore, today, tz),
+            // Delegate to the unified Fixed logic so the public next-due never diverges from the dueness it
+            // reports (e.g. a covered slot rolls forward; an overdue slot points at the missed date).
+            RecurrenceMode.Fixed => ComputeFixed(chore, now, tz).NextDueAt,
             RecurrenceMode.OneOff => NextDueForOneOff(chore, tz),
             _ => null
         };
@@ -199,65 +203,118 @@ public class ChoreStatusCalculator
         return LocalMidnightUtc(baseDate, tz);
     }
 
-    // ---- Fixed: interval-from-anchor OR weekly-on-weekday --------------------------------------------
+    // ---- Fixed: interval-from-anchor OR weekly-on-weekday (completion-aware) -------------------------
+    //
+    // A fixed chore is tied to concrete calendar slots (every-N days from an anchor, or specific weekdays).
+    // Dueness is computed against the CURRENT slot — the most recent cadence date on or before today — and
+    // whether a completion has satisfied it:
+    //   • current slot already covered by a completion        -> Scheduled, rolled forward to the next slot
+    //   • current slot is today and not yet done              -> DueToday
+    //   • current slot is in the PAST, not done, and the chore
+    //     has a prior-completion baseline                     -> Overdue (lands in "Falling behind")
+    // A single completion on or after the current slot's date satisfies it and advances to the next future
+    // occurrence — so catching up after several missed slots takes ONE "Done", not one per missed day
+    // (feedback: forgetting the mail for 3 days should not require 3 completions). A never-completed fixed
+    // chore is treated as "new" — never retroactively overdue for a slot that predates it — though it can
+    // still read DueToday on a cadence day.
 
-    private static ChoreDuenessResult ComputeFixed(
-        ChoreRecurrenceSnapshot chore, DateTime now, TimeZoneInfo tz, DateTime? nextDueAt)
+    private static ChoreDuenessResult ComputeFixed(ChoreRecurrenceSnapshot chore, DateTime now, TimeZoneInfo tz)
     {
         var today = LocalDate(now, tz);
+        var (currentSlot, nextSlot) = FixedSlots(chore, today);
 
-        // Weekly-on-weekday (D4-B) — driven by the DaysOfWeek flags.
-        if (chore.DaysOfWeek is { } days && days != ChoreDaysOfWeek.None)
+        DateTime? AsUtc(DateOnly? date) => date is { } d ? LocalMidnightUtc(d, tz) : null;
+
+        // Under-specified fixed chore (no DaysOfWeek, no anchor+interval) => benign Scheduled, no due point.
+        if (currentSlot is null && nextSlot is null)
         {
-            var dueToday = days.HasFlag(ToChoreFlag(today.DayOfWeek));
-            return dueToday
-                ? new ChoreDuenessResult(DueState.DueToday, ColorTier.Due, nextDueAt)
-                : new ChoreDuenessResult(DueState.Scheduled, ColorTier.Fresh, nextDueAt);
+            return new ChoreDuenessResult(DueState.Scheduled, ColorTier.Fresh, NextDueAt: null);
         }
 
-        // Interval-from-anchor (every-N days). Needs both an anchor and a positive interval. Dueness is the
-        // "on-cadence-day vs not" binary (D4): today lands on a cadence multiple => DueToday; otherwise the
-        // chore is simply waiting for its next slot => Scheduled. (Per-completion "missed a slot => overdue"
-        // tracking is not modeled for fixed chores in v1; flexible recurrence carries the decay/overdue model.)
-        if (chore.AnchorDate is { } anchor && chore.IntervalDays is { } interval && interval > 0)
+        // Schedule hasn't started yet (anchor in the future) => waiting on the first occurrence.
+        if (currentSlot is not { } slot)
         {
-            var landsOnCadenceDay = today >= anchor &&
-                                    (today.DayNumber - anchor.DayNumber) % interval == 0;
-
-            return landsOnCadenceDay
-                ? new ChoreDuenessResult(DueState.DueToday, ColorTier.Due, nextDueAt)
-                : new ChoreDuenessResult(DueState.Scheduled, ColorTier.Fresh, nextDueAt);
+            return new ChoreDuenessResult(DueState.Scheduled, ColorTier.Fresh, AsUtc(nextSlot));
         }
 
-        // Under-specified fixed chore (no DaysOfWeek, no anchor+interval) => benign Scheduled.
-        return new ChoreDuenessResult(DueState.Scheduled, ColorTier.Fresh, nextDueAt);
+        // Has the current slot already been satisfied? A completion on or after the slot's LOCAL date covers
+        // it — and because we only ever test the CURRENT slot, one completion clears however many slots have
+        // elapsed since the last one (the catch-up property).
+        var covered = chore.LastCompletedAt is { } last && LocalDate(last, tz) >= slot;
+        if (covered)
+        {
+            return new ChoreDuenessResult(DueState.Scheduled, ColorTier.Fresh, AsUtc(nextSlot));
+        }
+
+        // Pending. Today's occurrence reads DueToday; a past, uncovered occurrence reads Overdue — but only
+        // once the chore has a completion baseline (a brand-new chore is "new", not retroactively behind).
+        if (slot == today)
+        {
+            return new ChoreDuenessResult(DueState.DueToday, ColorTier.Due, AsUtc(today));
+        }
+
+        if (chore.LastCompletedAt is not null)
+        {
+            return new ChoreDuenessResult(DueState.Overdue, ColorTier.Overdue, AsUtc(slot));
+        }
+
+        return new ChoreDuenessResult(DueState.Scheduled, ColorTier.Fresh, AsUtc(nextSlot));
     }
 
-    private static DateTime? NextDueForFixed(ChoreRecurrenceSnapshot chore, DateOnly today, TimeZoneInfo tz)
+    /// <summary>
+    /// The current and next fixed-cadence slots relative to <paramref name="today"/> (local dates).
+    /// <c>Current</c> is the most recent cadence date on or before today (null when the schedule starts in the
+    /// future); <c>Next</c> is the first cadence date strictly after today. Returns (null, null) for an
+    /// under-specified fixed recurrence (e.g. monthly-on-day, which is unsupported here).
+    /// </summary>
+    private static (DateOnly? Current, DateOnly? Next) FixedSlots(ChoreRecurrenceSnapshot chore, DateOnly today)
     {
-        // Weekly-on-weekday: next local date (today inclusive) that matches one of the flagged weekdays.
+        // Weekly-on-weekday (D4-B): scan a 7-day window each way for a flagged weekday. A non-empty flag set
+        // always matches within 7 days, so Current is never null for weekly.
         if (chore.DaysOfWeek is { } days && days != ChoreDaysOfWeek.None)
         {
-            for (var offset = 0; offset < 7; offset++)
+            DateOnly? current = null;
+            for (var back = 0; back < 7; back++)
             {
-                var candidate = today.AddDays(offset);
+                var candidate = today.AddDays(-back);
                 if (days.HasFlag(ToChoreFlag(candidate.DayOfWeek)))
                 {
-                    return LocalMidnightUtc(candidate, tz);
+                    current = candidate;
+                    break;
                 }
             }
 
-            return null; // unreachable: a non-None flag set always matches within 7 days.
+            DateOnly? next = null;
+            for (var fwd = 1; fwd <= 7; fwd++)
+            {
+                var candidate = today.AddDays(fwd);
+                if (days.HasFlag(ToChoreFlag(candidate.DayOfWeek)))
+                {
+                    next = candidate;
+                    break;
+                }
+            }
+
+            return (current, next);
         }
 
-        // Interval-from-anchor: the first cadence multiple >= today.
+        // Interval-from-anchor (every-N days): the cadence is anchor + k·interval (k >= 0).
         if (chore.AnchorDate is { } anchor && chore.IntervalDays is { } interval && interval > 0)
         {
-            var dueDate = FixedDueOnOrAfter(anchor, interval, today);
-            return LocalMidnightUtc(dueDate, tz);
+            if (today < anchor)
+            {
+                // Not started yet — the anchor itself is the first (next) slot, with no current slot.
+                return (null, anchor);
+            }
+
+            var k = (today.DayNumber - anchor.DayNumber) / interval;   // floor => most recent slot <= today
+            var current = anchor.AddDays(k * interval);
+            var next = anchor.AddDays((k + 1) * interval);
+            return (current, next);
         }
 
-        return null;
+        // Under-specified (e.g. DayOfMonth-only) — unsupported here; no slots.
+        return (null, null);
     }
 
     // ---- OneOff: due against AnchorDate, never recurs ------------------------------------------------
@@ -321,19 +378,6 @@ public class ChoreStatusCalculator
     {
         var localMidnight = localDate.ToDateTime(TimeOnly.MinValue, DateTimeKind.Unspecified);
         return TimeZoneInfo.ConvertTimeToUtc(localMidnight, tz);
-    }
-
-    /// <summary>The first cadence date (anchor + k·interval) on or after <paramref name="reference"/>.</summary>
-    private static DateOnly FixedDueOnOrAfter(DateOnly anchor, int interval, DateOnly reference)
-    {
-        var delta = reference.DayNumber - anchor.DayNumber;
-        if (delta <= 0)
-        {
-            return anchor;
-        }
-
-        var k = (delta + interval - 1) / interval; // ceil toward the future
-        return anchor.AddDays(k * interval);
     }
 
     /// <summary>Map a <see cref="System.DayOfWeek"/> to the project's custom <see cref="ChoreDaysOfWeek"/> flag.</summary>

--- a/tests/FamilyCoordinationApp.Tests/Services/ChoreStatusCalculatorTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/ChoreStatusCalculatorTests.cs
@@ -37,11 +37,11 @@ public class ChoreStatusCalculatorTests
     private static ChoreRecurrenceSnapshot Flexible(int? intervalDays, DateTime? lastCompletedAt) =>
         new(RecurrenceMode.Flexible, intervalDays, AnchorDate: null, DaysOfWeek: null, DayOfMonth: null, lastCompletedAt);
 
-    private static ChoreRecurrenceSnapshot FixedEveryN(int intervalDays, DateOnly anchor) =>
-        new(RecurrenceMode.Fixed, intervalDays, anchor, DaysOfWeek: null, DayOfMonth: null, LastCompletedAt: null);
+    private static ChoreRecurrenceSnapshot FixedEveryN(int intervalDays, DateOnly anchor, DateTime? lastCompletedAt = null) =>
+        new(RecurrenceMode.Fixed, intervalDays, anchor, DaysOfWeek: null, DayOfMonth: null, lastCompletedAt);
 
-    private static ChoreRecurrenceSnapshot FixedWeekly(ChoreDaysOfWeek days) =>
-        new(RecurrenceMode.Fixed, IntervalDays: null, AnchorDate: null, days, DayOfMonth: null, LastCompletedAt: null);
+    private static ChoreRecurrenceSnapshot FixedWeekly(ChoreDaysOfWeek days, DateTime? lastCompletedAt = null) =>
+        new(RecurrenceMode.Fixed, IntervalDays: null, AnchorDate: null, days, DayOfMonth: null, lastCompletedAt);
 
     private static ChoreRecurrenceSnapshot OneOff(DateOnly? due, DateTime? lastCompletedAt = null) =>
         new(RecurrenceMode.OneOff, IntervalDays: null, due, DaysOfWeek: null, DayOfMonth: null, lastCompletedAt);
@@ -224,6 +224,120 @@ public class ChoreStatusCalculatorTests
 
         nextDueAt.Should().Be(Utc0(2026, 6, 18)); // Thursday
         nextDueAt!.Value.DayOfWeek.Should().Be(DayOfWeek.Thursday);
+    }
+
+    // ---- Fixed completion-awareness (catch-up + overdue, feedback) ----------------------------------
+    //
+    // A fixed/"Scheduled" chore is computed against its CURRENT slot (most recent cadence date <= today) and
+    // whether a completion satisfied it. One "Done" clears however many slots have elapsed since the last
+    // completion (no per-missed-day marking); a past, uncovered slot with a completion baseline reads Overdue.
+
+    [Fact]
+    public void FixedEveryN_CompletedCurrentSlot_RollsForwardToNextSlot()
+    {
+        // Cadence Jun 1, 6, 11, 16. Completed on the Jun 11 slot; today Jun 13 (between 11 and 16).
+        var anchor = new DateOnly(2026, 6, 1);
+        var chore = FixedEveryN(5, anchor, lastCompletedAt: Utc0(2026, 6, 11, 18));
+        var now = Utc0(2026, 6, 13, 9);
+
+        var result = _calc.Compute(chore, now, Utc);
+
+        result.DueState.Should().Be(DueState.Scheduled);       // current slot satisfied
+        result.ColorTier.Should().Be(ColorTier.Fresh);
+        result.NextDueAt.Should().Be(Utc0(2026, 6, 16));       // rolled forward to the next slot
+    }
+
+    [Fact]
+    public void FixedEveryN_DailyCompletedToday_IsNotDueAgainUntilTomorrow()
+    {
+        // The regression: a daily fixed chore (interval 1) completed today must NOT keep reading DueToday.
+        var anchor = new DateOnly(2026, 6, 1);
+        var chore = FixedEveryN(1, anchor, lastCompletedAt: Utc0(2026, 6, 15, 14));
+        var now = Utc0(2026, 6, 15, 18); // same local day as the completion
+
+        var result = _calc.Compute(chore, now, Utc);
+
+        result.DueState.Should().Be(DueState.Scheduled);
+        result.NextDueAt.Should().Be(Utc0(2026, 6, 16)); // tomorrow, not today
+    }
+
+    [Fact]
+    public void FixedEveryN_MissedPastSlotWithBaseline_IsOverdue()
+    {
+        // Cadence Jun 1, 6, 11, 16. Last done Jun 6; the Jun 11 slot was missed; today Jun 13.
+        var anchor = new DateOnly(2026, 6, 1);
+        var chore = FixedEveryN(5, anchor, lastCompletedAt: Utc0(2026, 6, 6, 12));
+        var now = Utc0(2026, 6, 13, 9);
+
+        var result = _calc.Compute(chore, now, Utc);
+
+        result.DueState.Should().Be(DueState.Overdue);
+        result.ColorTier.Should().Be(ColorTier.Overdue);
+        result.NextDueAt.Should().Be(Utc0(2026, 6, 11)); // points at the missed slot
+    }
+
+    [Fact]
+    public void FixedEveryN_CompletingWhileOverdue_CatchesUpInOneDone()
+    {
+        // Overdue (missed Jun 11). Completing on Jun 13 must clear it and roll to the next FUTURE slot — not
+        // to Jun 11 + interval (which would still be in the past and demand another completion).
+        var anchor = new DateOnly(2026, 6, 1);
+        var now = Utc0(2026, 6, 13, 9);
+
+        var overdue = FixedEveryN(5, anchor, lastCompletedAt: Utc0(2026, 6, 6, 12));
+        _calc.Compute(overdue, now, Utc).DueState.Should().Be(DueState.Overdue);
+
+        var afterDone = overdue with { LastCompletedAt = now };
+        var result = _calc.Compute(afterDone, now, Utc);
+
+        result.DueState.Should().Be(DueState.Scheduled);
+        result.NextDueAt.Should().Be(Utc0(2026, 6, 16)); // next future slot, fully caught up
+    }
+
+    [Fact]
+    public void FixedWeekly_MissedSlotWithBaseline_IsOverdue_ThenOneDoneRollsToNextWeek()
+    {
+        // Mondays. 2026-06-15 is a Monday. Last done the prior Monday (Jun 8); this Monday (Jun 15) missed;
+        // today is Wednesday Jun 17.
+        var now = Utc0(2026, 6, 17, 9); // Wednesday
+        var chore = FixedWeekly(ChoreDaysOfWeek.Monday, lastCompletedAt: Utc0(2026, 6, 8, 12));
+
+        var overdue = _calc.Compute(chore, now, Utc);
+        overdue.DueState.Should().Be(DueState.Overdue);
+        overdue.NextDueAt.Should().Be(Utc0(2026, 6, 15)); // the missed Monday
+
+        // One completion on Wednesday catches up and rolls to next Monday (Jun 22).
+        var afterDone = chore with { LastCompletedAt = now };
+        var result = _calc.Compute(afterDone, now, Utc);
+        result.DueState.Should().Be(DueState.Scheduled);
+        result.NextDueAt.Should().Be(Utc0(2026, 6, 22));
+    }
+
+    [Fact]
+    public void FixedWeekly_NeverCompleted_OffDay_IsNotRetroactivelyOverdue()
+    {
+        // Brand-new Monday chore, today Wednesday Jun 17, never completed: must read Scheduled (waiting for
+        // next Monday), NOT Overdue for the Monday that predates the chore.
+        var now = Utc0(2026, 6, 17, 9); // Wednesday
+        var chore = FixedWeekly(ChoreDaysOfWeek.Monday, lastCompletedAt: null);
+
+        var result = _calc.Compute(chore, now, Utc);
+
+        result.DueState.Should().Be(DueState.Scheduled);
+        result.NextDueAt.Should().Be(Utc0(2026, 6, 22)); // next Monday
+    }
+
+    [Fact]
+    public void FixedWeekly_CompletedTodayOnSlot_RollsToNextWeek()
+    {
+        // Mondays; today is Monday Jun 15 and it was done today => satisfied, next due is the following Monday.
+        var now = Utc0(2026, 6, 15, 16); // Monday
+        var chore = FixedWeekly(ChoreDaysOfWeek.Monday, lastCompletedAt: Utc0(2026, 6, 15, 8));
+
+        var result = _calc.Compute(chore, now, Utc);
+
+        result.DueState.Should().Be(DueState.Scheduled);
+        result.NextDueAt.Should().Be(Utc0(2026, 6, 22));
     }
 
     // ---- OneOff (V2) --------------------------------------------------------------------------------


### PR DESCRIPTION
## The bug

Fixed-recurrence chores (the UI labels these **"Scheduled"**) were **completion-blind**. `ChoreStatusCalculator.ComputeFixed` / `NextDueForFixed` derived due-state purely from the schedule (anchor + interval, or weekday flags) relative to *today* and never read `LastCompletedAt`. Every Fixed unit test was constructed with `LastCompletedAt: null`, so the gap was never exercised.

Consequence: completing a Fixed chore stamped `LastCompletedAt` but changed nothing the board showed. A daily "get the mail" chore read **"Due today" every day — and kept reading due even after you did it.** Sparser schedules that slipped a slot just silently rolled forward, never flagging as behind. Net effect for the user: *"if I forget to get the mail for 3 days then I get it, I shouldn't have to mark it done for each day I missed."*

(Flexible — UI label "Recurring" — already caught up correctly; it decays from `LastCompletedAt`. The bug was specific to Fixed.)

## The fix

Make Fixed dueness **completion-aware**, computed against the **current slot** (the most recent cadence date on or before today):

| Situation | Reads as |
|---|---|
| Current slot already covered by a completion | **Scheduled**, rolled forward to the next slot |
| Current slot is today and not yet done | **Due today** |
| Current slot is in the *past*, uncovered, chore has a prior-completion baseline | **Overdue** (lands in *Falling behind*) |

A single completion on/after the current slot's date satisfies it and advances to the next **future** occurrence — so catching up after several missed slots takes **one** "Done", not one per missed day. This is the **catch up + flag overdue** behavior chosen for the household.

A **never-completed** Fixed chore stays "new" — never retroactively overdue for a slot that predates it.

## Safety / blast radius

- For `LastCompletedAt == null`, the new slot logic reduces to **exactly** the old "is today a cadence day" check, with an **identical `nextDueAt`** — so existing Fixed unit tests and the edit/round-trip **integration** tests are unaffected (verified by analysis + green unit suite).
- All consumers — board, single-chore projection, weekly Discord digest — flow through `Compute()`, so the fix is uniform. The digest now also correctly lists behind Fixed chores.

## Tests

Adds 8 unit tests: covered-slot roll-forward, the **daily-completed-today regression**, overdue escalation (every-N and weekly), one-Done catch-up from overdue, and the no-retroactive-overdue guard for brand-new chores.

```
Passed!  -  Failed: 0, Passed: 37, Skipped: 0  (ChoreStatusCalculatorTests)
```

Build clean; `dotnet format` verify clean.
