### PR TITLE
feat(chores): multi-person chores — co-sign completion gate

### DIFF
--- a/frontend/chores/src/App.svelte
+++ b/frontend/chores/src/App.svelte
@@ -13,6 +13,7 @@
   import QuickAddSheet, { type QuickAddValue } from './lib/components/QuickAddSheet.svelte';
   import EditChoreSheet from './lib/components/EditChoreSheet.svelte';
   import HandOffPicker from './lib/components/HandOffPicker.svelte';
+  import CompleteDialog from './lib/components/CompleteDialog.svelte';
   import DigestSettings from './lib/components/DigestSettings.svelte';
   import Toasts from './lib/components/Toasts.svelte';
   import PhotoLightbox from './lib/components/PhotoLightbox.svelte';
@@ -48,6 +49,8 @@
   let quickAddSubmitting = $state(false);
   let handOffOpen = $state(false);
   let handOffChore = $state<ChoreDto | null>(null);
+  let completeOpen = $state(false);
+  let completeChore = $state<ChoreDto | null>(null);
   let editOpen = $state(false);
   let editChore = $state<ChoreDto | null>(null);
   let digestSettingsOpen = $state(false);
@@ -79,7 +82,21 @@
     store.drop(chore.id);
   }
   function handleComplete(chore: ChoreDto) {
-    store.complete(chore.id);
+    // Multi-person (co-sign) chore → open the participant dialog so the present
+    // member can record who's marking it done (D7). Single-person chore → keep
+    // the exact one-tap Done (unchanged): complete immediately, no dialog.
+    if (chore.requiredCount > 1) {
+      completeChore = chore;
+      completeOpen = true;
+    } else {
+      store.complete(chore.id);
+    }
+  }
+  function handleCompleteSubmit(participantUserIds: number[]) {
+    const chore = completeChore;
+    completeOpen = false;
+    completeChore = null;
+    if (chore) store.complete(chore.id, { participantUserIds });
   }
   function handleHandOff(chore: ChoreDto) {
     handOffChore = chore;
@@ -327,6 +344,18 @@
     handOffChore = null;
   }}
   onSelect={handleHandOffSelect}
+/>
+
+<CompleteDialog
+  open={completeOpen}
+  chore={completeChore}
+  members={store.board?.members ?? []}
+  currentUserId={store.currentUserId}
+  onClose={() => {
+    completeOpen = false;
+    completeChore = null;
+  }}
+  onSubmit={handleCompleteSubmit}
 />
 
 <EditChoreSheet

--- a/frontend/chores/src/lib/api.ts
+++ b/frontend/chores/src/lib/api.ts
@@ -93,6 +93,8 @@ export interface CreateChoreRequest {
   photoPath?: string | null;
   /** Optional emoji/short-code icon; "" or omitted = none. */
   icon?: string;
+  /** Number of distinct contributors required to satisfy the chore (WP-05). Omit or 1 = normal. */
+  requiredCount?: number;
 }
 
 /** No assignee — assignment never moves via edit. Carries the version. */
@@ -112,6 +114,8 @@ export interface UpdateChoreRequest {
   photoPath?: string | null;
   /** Optional emoji/short-code icon; "" or omitted = none. */
   icon?: string;
+  /** Number of distinct contributors required to satisfy the chore (WP-05). Omit or 1 = normal. */
+  requiredCount?: number;
 }
 
 export interface SeedStarterResponse {
@@ -128,6 +132,8 @@ export interface CompleteRequest {
   note?: string | null;
   photoPath?: string | null;
   version: number;
+  /** Co-signers for multi-person chores (WP-05); omit for single-person completions. */
+  participantUserIds?: number[];
 }
 
 export interface PhotoUploadResponse {

--- a/frontend/chores/src/lib/components/ChoreCard.svelte
+++ b/frontend/chores/src/lib/components/ChoreCard.svelte
@@ -85,6 +85,16 @@
   let isClaimed = $derived(chore.assignmentKind === 'claimed' && !chore.isClaimStale);
   let isAssigned = $derived(chore.assignmentKind === 'assigned');
 
+  // ── Multi-person co-sign (WP-07) ─────────────────────────────────────────
+  // SERVER fields only (MN3 — no client count/membership math). `requiredCount
+  // > 1` marks a co-sign chore; `completedCount`/`contributorUserIds` are the
+  // authoritative current-occurrence progress from the board GET (the store
+  // reconciles after each mutation, so these are fresh). When the viewing user
+  // is already in `contributorUserIds` they've signed this occurrence and the
+  // Done button shows a waiting state (D6) instead of re-opening the dialog.
+  let isMultiPerson = $derived(chore.requiredCount > 1);
+  let iSigned = $derived(chore.contributorUserIds.includes(currentUserId));
+
   // ── Who can do what (drives the action buttons) ──────────────────────────
   // The viewing user "holds" the chore when they're the active (non-stale)
   // assignee. Drop is Claimed-only (a deliberate Assigned chore can't be
@@ -172,6 +182,20 @@
     {/if}
 
     <div class="ch-card-meta">
+      {#if isMultiPerson}
+        <span
+          class="ch-tag ch-tag-cosign"
+          title="{chore.completedCount} of {chore.requiredCount} people have marked this done"
+        >
+          <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true">
+            <path
+              d="M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5s-3 1.34-3 3 1.34 3 3 3zm-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z"
+              fill="currentColor"
+            />
+          </svg>
+          {chore.completedCount} of {chore.requiredCount} done
+        </span>
+      {/if}
       {#if room}
         <span class="ch-tag ch-tag-room" title="Room: {room.name}">
           {#if room.icon}
@@ -298,16 +322,42 @@
               Drop
             </button>
           {/if}
-          <button
-            type="button"
-            class="ch-btn ch-btn-primary"
-            data-action="complete"
-            onclick={() => onComplete?.(chore)}
-            disabled={pending}
-            title="Mark this chore done"
-          >
-            Done
-          </button>
+          {#if !isMultiPerson}
+            <!-- Single-person chore — today's exact one-tap Done (unchanged, P2). -->
+            <button
+              type="button"
+              class="ch-btn ch-btn-primary"
+              data-action="complete"
+              onclick={() => onComplete?.(chore)}
+              disabled={pending}
+              title="Mark this chore done"
+            >
+              Done
+            </button>
+          {:else if iSigned}
+            <!-- Co-sign chore the viewing user has already signed (D6). -->
+            <button
+              type="button"
+              class="ch-btn ch-btn-ghost"
+              data-action="complete"
+              disabled
+              title="You've marked this done — waiting on others"
+            >
+              You're in — waiting on others
+            </button>
+          {:else}
+            <!-- Co-sign chore the viewing user hasn't signed — opens the dialog. -->
+            <button
+              type="button"
+              class="ch-btn ch-btn-primary"
+              data-action="complete"
+              onclick={() => onComplete?.(chore)}
+              disabled={pending}
+              title="Mark this chore done"
+            >
+              Mark done
+            </button>
+          {/if}
         {/if}
         {#if onEdit}
           <button
@@ -504,6 +554,14 @@
   .ch-tag-room-icon {
     font-size: 0.875rem;
     line-height: 1;
+  }
+  /* Co-sign progress chip ("X of N done") — solid tint with white text so it
+     reads as a status cue distinct from the muted effort/recurrence tags. The
+     accent color carries the meaning; the same fill the room locator uses. */
+  .ch-tag-cosign {
+    color: #fff;
+    background: var(--color-info);
+    font-weight: 600;
   }
 
   .ch-card-foot {

--- a/frontend/chores/src/lib/components/CompleteDialog.svelte
+++ b/frontend/chores/src/lib/components/CompleteDialog.svelte
@@ -1,0 +1,307 @@
+<script lang="ts">
+  // ───────────────────────────────────────────────────────────────────────
+  // Complete dialog (WP-07, D7). Shown ONLY for multi-person (co-sign) chores
+  // — `requiredCount > 1`. Mirrors the HandOffPicker modal pattern: a styled
+  // <dialog> hosted in App.svelte, opened via the card's `onComplete` callback.
+  //
+  // It lets the present member record who marked the chore done — themselves
+  // (prefilled) plus, optionally, another household member who's also present
+  // (the escape hatch that satisfies the count in one action). Members already
+  // in `contributorUserIds` have signed THIS occurrence already; they're shown
+  // checked + disabled (D6 distinctness — the server dedupes regardless).
+  //
+  // v1 is participant selection ONLY — there is no completion note/photo UI in
+  // the app today, so adding one is out of scope (WP-07 boundary).
+  //
+  // SERVER fields only (MN3): `completedCount`/`requiredCount`/`contributorUserIds`
+  // come straight off the chore DTO; no client count/membership math.
+  // ───────────────────────────────────────────────────────────────────────
+  import type { ChoreDto, MemberDto } from '../types';
+  import { memberFor } from '../state.svelte';
+  import MemberAvatar from './MemberAvatar.svelte';
+
+  interface Props {
+    open: boolean;
+    /** The target co-sign chore (null while closed). Drives the heading + progress. */
+    chore: ChoreDto | null;
+    members: MemberDto[];
+    /** The viewing user's id — prefilled as a participant. */
+    currentUserId: number;
+    onClose: () => void;
+    /** The chosen NEW participant ids (current user + any newly selected; never the already-in). */
+    onSubmit: (participantUserIds: number[]) => void;
+  }
+
+  let { open, chore, members, currentUserId, onClose, onSubmit }: Props = $props();
+
+  let dialogEl: HTMLDialogElement | null = $state(null);
+
+  // The contributors who have already signed THIS occurrence (server field).
+  let alreadyIn = $derived<number[]>(chore?.contributorUserIds ?? []);
+
+  // The members the user can newly select (everyone NOT already in). The
+  // current user, if not already in, is prefilled (see `selected` seeding).
+  let selectable = $derived(members.filter((m) => !alreadyIn.includes(m.userId)));
+
+  // Newly-selected participant ids (excludes the already-in contributors). A
+  // Set swapped by reference so the `$state` reactivity fires.
+  let selected = $state(new Set<number>());
+
+  // (Re)seed the selection whenever the dialog opens for a chore: prefill the
+  // current user if they haven't already signed. Tracking `open`/`chore` makes
+  // this re-run on each open (and on a target change).
+  $effect(() => {
+    if (!dialogEl) return;
+    if (open && !dialogEl.open) {
+      const next = new Set<number>();
+      if (chore && !(chore.contributorUserIds ?? []).includes(currentUserId)) {
+        next.add(currentUserId);
+      }
+      selected = next;
+      dialogEl.showModal();
+    } else if (!open && dialogEl.open) {
+      dialogEl.close();
+    }
+  });
+
+  function toggle(userId: number): void {
+    const next = new Set(selected);
+    if (next.has(userId)) next.delete(userId);
+    else next.add(userId);
+    selected = next;
+  }
+
+  function nameOf(userId: number): string {
+    if (userId === currentUserId) return 'You';
+    return memberFor(userId)?.displayName ?? 'Someone';
+  }
+
+  // At least the current user (or one newly-selected member) is required to
+  // submit. If the user is already in, they must pick someone new.
+  let canSubmit = $derived(selected.size > 0);
+
+  function submit(): void {
+    if (!canSubmit) return;
+    // The server dedupes against existing contributors, but we send only the
+    // NEW ids ("who's signing now") — never re-send the already-in.
+    onSubmit([...selected]);
+  }
+</script>
+
+<dialog bind:this={dialogEl} onclose={onClose} class="ch-dialog">
+  {#if open && chore}
+    <div class="ch-dialog-body">
+      <h2>Mark done</h2>
+      <p class="ch-dialog-sub">
+        “{chore.name}” needs {chore.requiredCount} people — {chore.completedCount} of {chore.requiredCount}
+        done. Who's marking it done?
+      </p>
+
+      {#if alreadyIn.length > 0}
+        <div class="ch-cd-already">
+          <span class="ch-cd-already-label">Already in</span>
+          <div class="ch-cd-already-list">
+            {#each alreadyIn as uid (uid)}
+              {@const m = memberFor(uid)}
+              <span class="ch-cd-already-chip" title="{nameOf(uid)} has marked this done">
+                <MemberAvatar
+                  name={m?.displayName ?? null}
+                  initials={m?.initials ?? null}
+                  pictureUrl={m?.pictureUrl ?? null}
+                  size={22}
+                  relation="Marked done by"
+                />
+                {nameOf(uid)}
+              </span>
+            {/each}
+          </div>
+        </div>
+      {/if}
+
+      <div class="ch-cd-list" role="group" aria-label="Who's marking this done">
+        {#if selectable.length === 0}
+          <p class="ch-cd-empty">Everyone has already marked this done.</p>
+        {:else}
+          {#each selectable as member (member.userId)}
+            <label class="ch-cd-row" class:checked={selected.has(member.userId)}>
+              <input
+                type="checkbox"
+                checked={selected.has(member.userId)}
+                onchange={() => toggle(member.userId)}
+              />
+              <MemberAvatar
+                name={member.displayName}
+                initials={member.initials}
+                pictureUrl={member.pictureUrl}
+                size={28}
+                relation="Mark done for"
+              />
+              <span class="ch-cd-name">{nameOf(member.userId)}</span>
+            </label>
+          {/each}
+        {/if}
+      </div>
+
+      <div class="ch-dialog-actions">
+        <button type="button" class="ch-btn-ghost" onclick={onClose}>Cancel</button>
+        <button type="button" class="ch-btn-solid" onclick={submit} disabled={!canSubmit}>
+          Mark done
+        </button>
+      </div>
+    </div>
+  {/if}
+</dialog>
+
+<style>
+  /* Gate the layout to [open] so the CLOSED dialog never paints a full-viewport
+     overlay that eats clicks (project memory: dialog-display-css-click-trap). */
+  .ch-dialog[open] {
+    position: fixed;
+    inset: 0;
+    margin: auto;
+    border: none;
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text);
+    padding: 0;
+    width: min(420px, calc(100vw - 32px));
+    max-height: calc(100vh - 32px);
+    box-shadow: var(--shadow-4);
+  }
+  .ch-dialog::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+  }
+  .ch-dialog-body {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 24px;
+  }
+  .ch-dialog h2 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 500;
+  }
+  .ch-dialog-sub {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+
+  /* ── Already-signed contributors ──────────────────────────────────────── */
+  .ch-cd-already {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .ch-cd-already-label {
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-text-muted);
+  }
+  .ch-cd-already-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .ch-cd-already-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.8125rem;
+    color: var(--color-text);
+    background: var(--color-action-hover);
+    border-radius: var(--radius-sm);
+    padding: 4px 10px 4px 4px;
+  }
+
+  /* ── Selectable participants ──────────────────────────────────────────── */
+  .ch-cd-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: 4px;
+  }
+  .ch-cd-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    text-align: left;
+    font: inherit;
+    color: inherit;
+    background: transparent;
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-sm);
+    padding: 10px 12px;
+    min-height: 48px;
+    cursor: pointer;
+    transition:
+      background-color 0.15s,
+      border-color 0.15s;
+  }
+  .ch-cd-row:hover {
+    background: var(--color-action-hover);
+    border-color: var(--color-line-strong);
+  }
+  .ch-cd-row.checked {
+    border-color: var(--color-primary);
+    background: var(--color-action-hover);
+  }
+  .ch-cd-row input[type='checkbox'] {
+    width: 18px;
+    height: 18px;
+    accent-color: var(--color-primary);
+    cursor: pointer;
+  }
+  .ch-cd-name {
+    font-weight: 500;
+    flex: 1;
+    min-width: 0;
+  }
+  .ch-cd-empty {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+
+  .ch-dialog-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 8px;
+  }
+  .ch-btn-ghost {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    border: none;
+    cursor: pointer;
+    min-height: 40px;
+    font-weight: 500;
+    background: transparent;
+    color: var(--color-primary);
+  }
+  .ch-btn-ghost:hover {
+    background: var(--color-action-hover);
+  }
+  .ch-btn-solid {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    border: none;
+    cursor: pointer;
+    min-height: 40px;
+    font-weight: 500;
+    background: var(--color-primary);
+    color: #fff;
+  }
+  .ch-btn-solid:hover:not(:disabled) {
+    background: var(--color-primary-hover);
+  }
+  .ch-btn-solid:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+</style>

--- a/frontend/chores/src/lib/components/EditChoreSheet.svelte
+++ b/frontend/chores/src/lib/components/EditChoreSheet.svelte
@@ -52,6 +52,8 @@
   let effort = $state<EffortTier>('Standard');
   let roomId = $state<number | null>(null);
   let ownerUserId = $state<number | null>(null);
+  /** 1 = single person (default); ≥2 = multi-person requirement. */
+  let requiredCount = $state(1);
   let existingPhotoPath = $state<string | null>(null);
   let newPhotoFile = $state<File | null>(null);
   let localError = $state<string | null>(null);
@@ -180,6 +182,7 @@
     roomId = c.roomId ?? null;
     effort = c.effortTier;
     ownerUserId = c.ownerUserId ?? null;
+    requiredCount = c.requiredCount ?? 1;
     existingPhotoPath = c.photoPath;
     newPhotoFile = null;
     localError = null;
@@ -308,6 +311,7 @@
         effortTier: effort,
         icon: choreIcon,
         ownerUserId,
+        requiredCount,
         version: chore.version,
         photoPath: resolvedPhotoPath,
       };
@@ -444,6 +448,48 @@
           {/each}
         </div>
       </fieldset>
+
+      {#if members.length >= 2}
+        <fieldset class="ch-field">
+          <legend class="ch-field-label">How many people?</legend>
+          <div class="ch-chip-row" role="group" aria-label="How many people">
+            <button
+              type="button"
+              class="ch-chip"
+              class:active={requiredCount === 1}
+              aria-pressed={requiredCount === 1}
+              onclick={() => (requiredCount = 1)}
+            >
+              One person
+            </button>
+            <button
+              type="button"
+              class="ch-chip"
+              class:active={requiredCount > 1}
+              aria-pressed={requiredCount > 1}
+              onclick={() => { if (requiredCount < 2) requiredCount = 2; }}
+            >
+              Needs more than one
+            </button>
+          </div>
+          {#if requiredCount > 1}
+            <div class="ch-chip-row" role="group" aria-label="Number of people needed">
+              {#each { length: members.length - 1 } as _, i (i)}
+                {@const n = i + 2}
+                <button
+                  type="button"
+                  class="ch-chip"
+                  class:active={requiredCount === n}
+                  aria-pressed={requiredCount === n}
+                  onclick={() => (requiredCount = n)}
+                >
+                  Needs {n} people
+                </button>
+              {/each}
+            </div>
+          {/if}
+        </fieldset>
+      {/if}
 
       <fieldset class="ch-field">
         <legend class="ch-field-label">Room</legend>

--- a/frontend/chores/src/lib/components/QuickAddSheet.svelte
+++ b/frontend/chores/src/lib/components/QuickAddSheet.svelte
@@ -64,6 +64,8 @@
   let roomId = $state<number | null>(null);
   /** null ⇒ "Leave for anyone" (pile). */
   let assigneeUserId = $state<number | null>(null);
+  /** 1 = single person (default); ≥2 = multi-person requirement. */
+  let requiredCount = $state(1);
   let photo = $state<File | null>(null);
   let localError = $state<string | null>(null);
 
@@ -173,6 +175,7 @@
     effort = 'Standard';
     roomId = null;
     assigneeUserId = null;
+    requiredCount = 1;
     photo = null;
     localError = null;
     // Reset the inline new-room form UI (keep createdRooms — a later board reload dedups them).
@@ -262,6 +265,7 @@
       icon: choreIcon,
       ownerUserId: null,
       assigneeUserId,
+      requiredCount,
       // Photo is NEVER in the create JSON (council C2) — the parent uploads it
       // separately to /api/chores/{id}/photo after the create returns an id.
       photoPath: null,
@@ -373,6 +377,48 @@
           {/each}
         </div>
       </fieldset>
+
+      {#if members.length >= 2}
+        <fieldset class="ch-field">
+          <legend class="ch-field-label">How many people?</legend>
+          <div class="ch-chip-row" role="group" aria-label="How many people">
+            <button
+              type="button"
+              class="ch-chip"
+              class:active={requiredCount === 1}
+              aria-pressed={requiredCount === 1}
+              onclick={() => (requiredCount = 1)}
+            >
+              One person
+            </button>
+            <button
+              type="button"
+              class="ch-chip"
+              class:active={requiredCount > 1}
+              aria-pressed={requiredCount > 1}
+              onclick={() => { if (requiredCount < 2) requiredCount = 2; }}
+            >
+              Needs more than one
+            </button>
+          </div>
+          {#if requiredCount > 1}
+            <div class="ch-chip-row" role="group" aria-label="Number of people needed">
+              {#each { length: members.length - 1 } as _, i (i)}
+                {@const n = i + 2}
+                <button
+                  type="button"
+                  class="ch-chip"
+                  class:active={requiredCount === n}
+                  aria-pressed={requiredCount === n}
+                  onclick={() => (requiredCount = n)}
+                >
+                  Needs {n} people
+                </button>
+              {/each}
+            </div>
+          {/if}
+        </fieldset>
+      {/if}
 
       <fieldset class="ch-field">
         <legend class="ch-field-label">Room</legend>

--- a/frontend/chores/src/lib/state.svelte.ts
+++ b/frontend/chores/src/lib/state.svelte.ts
@@ -554,6 +554,63 @@ class BoardStore {
     if (this.refresh) await this.refresh();
   }
 
+  /** Is this chore a multi-person (co-sign) chore per the CURRENT board? */
+  private isMultiPerson(choreId: number): boolean {
+    return (this.choreById(choreId)?.requiredCount ?? 1) > 1;
+  }
+
+  /**
+   * Mutation runner for MULTI-PERSON (`requiredCount > 1`) chores. Unlike
+   * `runOptimistic`, it applies NO optimistic patch: a single co-sign
+   * (claim / drop / hand-off / partial complete) does NOT change the card to a
+   * "done" state, and — critically — the single-chore mutation RESPONSE carries
+   * `completedCount = 0` for the co-sign progress (the board GET is the only
+   * authoritative source, see WP-07). So we fire the call, then `reconcile()`
+   * (full board refetch) so the card reflects the true current-occurrence
+   * progress (or drops off / resets if the count was just satisfied). The 409 /
+   * other-4xx / network branches mirror `runOptimistic` exactly — refetch +
+   * surface, never an auto-retry.
+   *
+   * The returned DTO is still applied first so the version stays fresh even in
+   * the (rare) window before the reconcile lands; the reconcile then overwrites
+   * the whole board with authoritative progress.
+   */
+  private async runMultiPersonMutation(
+    choreId: number,
+    call: (chore: ChoreDto) => Promise<ChoreDto>,
+    conflictMessage: string,
+  ): Promise<void> {
+    if (this.pendingChoreIds.has(choreId)) return;
+    const chore = this.choreById(choreId);
+    if (!chore) return;
+
+    const snapshot: ChoreDto = { ...chore };
+    this.markPending(choreId, true);
+    try {
+      const updated = await call(snapshot);
+      this.applyChore(updated);
+      // Authoritative co-sign progress comes only from the board GET (the
+      // mutation response can't signal "X of N" — it returns completedCount=0).
+      await this.reconcile();
+    } catch (e) {
+      if (e instanceof ApiError && e.isConflict) {
+        await this.reconcile();
+        showToast({ message: conflictMessage, kind: 'info' });
+      } else if (e instanceof ApiError && e.isClientRejection) {
+        // Incl. the D6 distinctness rejection (a non-409 4xx). Resync + notice.
+        await this.reconcile();
+        showToast({
+          message: "That didn't go through — the board has been refreshed.",
+          kind: 'info',
+        });
+      } else {
+        showToast({ message: 'Something went wrong. Please try again.', kind: 'error' });
+      }
+    } finally {
+      this.markPending(choreId, false);
+    }
+  }
+
   /**
    * Core optimistic runner. Snapshots the chore, applies an optimistic patch,
    * fires the request, then commits the returned DTO or rolls back + reconciles
@@ -614,6 +671,15 @@ class BoardStore {
   /** Claim an unclaimed (or stale-claimed) pile chore for the current user. */
   async claim(choreId: number): Promise<void> {
     const me = this.currentUserId;
+    const call = (c: ChoreDto) => claimChore(c.id, c.version);
+    // Multi-person: reconcile after so the card never shows a stale
+    // `completedCount=0` from the single-chore response (WP-07). Assignment
+    // isn't co-sign progress, but the response carries no live progress at all,
+    // so we re-read the board for truth. Single-person path untouched.
+    if (this.isMultiPerson(choreId)) {
+      await this.runMultiPersonMutation(choreId, call, 'Someone got there first — board refreshed.');
+      return;
+    }
     await this.runOptimistic(
       choreId,
       {
@@ -622,41 +688,72 @@ class BoardStore {
         claimedAt: new Date().toISOString(),
         isClaimStale: false,
       },
-      (c) => claimChore(c.id, c.version),
+      call,
       'Someone got there first — board refreshed.',
     );
   }
 
   /** Drop a chore the current user holds (returns it to the pile). */
   async drop(choreId: number): Promise<void> {
+    const call = (c: ChoreDto) => dropChore(c.id, c.version);
+    if (this.isMultiPerson(choreId)) {
+      await this.runMultiPersonMutation(choreId, call, 'That chore changed — board refreshed.');
+      return;
+    }
     await this.runOptimistic(
       choreId,
       { assigneeUserId: null, assignmentKind: 'none', claimedAt: null, isClaimStale: false },
-      (c) => dropChore(c.id, c.version),
+      call,
       'That chore changed — board refreshed.',
     );
   }
 
-  /** Mark a chore done (optionally with a note / already-uploaded photo path). */
-  async complete(choreId: number, extra?: { note?: string | null; photoPath?: string | null }): Promise<void> {
-    await this.runOptimistic(
-      choreId,
-      // Optimistically reflect "just completed" by stamping lastCompletedAt.
-      // We do NOT recompute dueness/colorTier — the authoritative post-completion
-      // tier (e.g. recurring chore's next dueness) comes from the returned DTO.
-      { lastCompletedAt: new Date().toISOString() },
-      (c) =>
-        completeChore(c.id, {
-          note: extra?.note ?? null,
-          photoPath: extra?.photoPath ?? null,
-          version: c.version,
-        } satisfies CompleteRequest),
-      'That chore changed — board refreshed.',
-    );
+  /**
+   * Mark a chore done. `extra` may carry a note / already-uploaded photo path
+   * and — for multi-person (co-sign) chores — the `participantUserIds` recorded
+   * via the complete dialog (WP-07). The `api.ts` CompleteRequest already has
+   * the field; we pass it straight through.
+   *
+   * SINGLE-PERSON (`requiredCount == 1`): the EXISTING optimistic path —
+   * stamp `lastCompletedAt` then commit the returned DTO. Behaviorally identical
+   * to before this WP.
+   *
+   * MULTI-PERSON (`requiredCount > 1`): no optimistic `{ lastCompletedAt }`
+   * patch (a partial co-sign is NOT "done"); fire then reconcile so the card
+   * shows the authoritative "X of N" (or drops off when the count is satisfied).
+   * The mutation response can't signal progress (returns completedCount=0), so
+   * the board refetch is the only correct source — see WP-07.
+   */
+  async complete(
+    choreId: number,
+    extra?: { note?: string | null; photoPath?: string | null; participantUserIds?: number[] },
+  ): Promise<void> {
+    const call = (c: ChoreDto) =>
+      completeChore(c.id, {
+        note: extra?.note ?? null,
+        photoPath: extra?.photoPath ?? null,
+        participantUserIds: extra?.participantUserIds,
+        version: c.version,
+      } satisfies CompleteRequest);
+
+    if (this.isMultiPerson(choreId)) {
+      await this.runMultiPersonMutation(choreId, call, 'That chore changed — board refreshed.');
+    } else {
+      await this.runOptimistic(
+        choreId,
+        // Optimistically reflect "just completed" by stamping lastCompletedAt.
+        // We do NOT recompute dueness/colorTier — the authoritative post-completion
+        // tier (e.g. recurring chore's next dueness) comes from the returned DTO.
+        { lastCompletedAt: new Date().toISOString() },
+        call,
+        'That chore changed — board refreshed.',
+      );
+    }
     // A completion shifts the distribution — invalidate the cached equity so it
-    // reloads when next viewed (or now, if the equity lens is active). The happy
-    // path doesn't refetch the board, so this is the only equity hook for it; a
-    // 409/4xx already reconciled via setBoard (which also invalidates).
+    // reloads when next viewed (or now, if the equity lens is active). The
+    // single-person happy path doesn't refetch the board, so this is its only
+    // equity hook; the multi-person path already reconciled via setBoard (which
+    // also invalidates), and a 409/4xx reconciled the same way.
     this.invalidateEquity();
   }
 
@@ -665,6 +762,11 @@ class BoardStore {
    */
   async handOff(choreId: number, targetUserId: number | null): Promise<void> {
     const toPile = targetUserId == null;
+    const call = (c: ChoreDto) => handOffChore(c.id, { targetUserId, version: c.version });
+    if (this.isMultiPerson(choreId)) {
+      await this.runMultiPersonMutation(choreId, call, 'That chore changed — board refreshed.');
+      return;
+    }
     await this.runOptimistic(
       choreId,
       toPile
@@ -675,7 +777,7 @@ class BoardStore {
             claimedAt: new Date().toISOString(),
             isClaimStale: false,
           },
-      (c) => handOffChore(c.id, { targetUserId, version: c.version }),
+      call,
       'That chore changed — board refreshed.',
     );
   }

--- a/frontend/chores/src/lib/types.ts
+++ b/frontend/chores/src/lib/types.ts
@@ -62,6 +62,12 @@ export interface ChoreDto {
   photoPath: string | null;
   /** xmin optimistic-concurrency token. Echo back on mutations (WP-11). */
   version: number;
+  /** 1 = normal chore; >1 = multi-person (co-sign required). Always ≥ 1. */
+  requiredCount: number;
+  /** Distinct contributors toward the CURRENT open occurrence (0..requiredCount). Board GET only; ProjectChore path always returns 0. */
+  completedCount: number;
+  /** User IDs who have signed the current occurrence, ascending. Empty for single-person chores. */
+  contributorUserIds: number[];
 }
 
 export interface RoomRollupDto {

--- a/src/FamilyCoordinationApp/Data/Configurations/ChoreConfiguration.cs
+++ b/src/FamilyCoordinationApp/Data/Configurations/ChoreConfiguration.cs
@@ -46,6 +46,13 @@ public class ChoreConfiguration : IEntityTypeConfiguration<Chore>
             .IsRequired()
             .HasDefaultValue(1);
 
+        // Multi-person fields (WP-01).
+        builder.Property(c => c.RequiredCount)
+            .IsRequired()
+            .HasDefaultValue(1);
+
+        // LastContributionAt: nullable timestamptz — no special config needed (Npgsql convention).
+
         builder.Property(c => c.Status)
             .IsRequired()
             .HasConversion<string>()

--- a/src/FamilyCoordinationApp/Data/Entities/Chore.cs
+++ b/src/FamilyCoordinationApp/Data/Entities/Chore.cs
@@ -13,6 +13,12 @@ public class Chore
     // Optional emoji/short-code icon (parity with Room.Icon). Empty string = no icon.
     public string Icon { get; set; } = string.Empty;
 
+    // Multi-person: number of distinct members required to complete (1 = normal single-completion chore).
+    public int RequiredCount { get; set; } = 1;
+
+    // Multi-person: UTC timestamp set on every contribution — activity marker, not a progress count.
+    public DateTime? LastContributionAt { get; set; }
+
     // Optional room association (nullable FK -> Room).
     public int? RoomId { get; set; }
 

--- a/src/FamilyCoordinationApp/Endpoints/ChoresEndpoints.cs
+++ b/src/FamilyCoordinationApp/Endpoints/ChoresEndpoints.cs
@@ -631,7 +631,8 @@ public static class ChoresEndpoints
         int? OwnerUserId,
         int? AssigneeUserId,
         string? PhotoPath,
-        string? Icon = null)
+        string? Icon = null,
+        int RequiredCount = 1)
     {
         public CreateChoreCommand ToCommand() => new(
             Name,
@@ -646,7 +647,8 @@ public static class ChoresEndpoints
             OwnerUserId,
             AssigneeUserId,
             PhotoPath,
-            Icon ?? string.Empty);
+            Icon ?? string.Empty,
+            RequiredCount);
     }
 
     public sealed record UpdateChoreRequest(
@@ -662,7 +664,8 @@ public static class ChoresEndpoints
         int? OwnerUserId,
         string? PhotoPath,
         uint Version,
-        string? Icon = null)
+        string? Icon = null,
+        int RequiredCount = 1)
     {
         public UpdateChoreCommand ToCommand() => new(
             Name,
@@ -676,6 +679,7 @@ public static class ChoresEndpoints
             EffortTier,
             OwnerUserId,
             PhotoPath,
-            Icon ?? string.Empty);
+            Icon ?? string.Empty,
+            RequiredCount);
     }
 }

--- a/src/FamilyCoordinationApp/Endpoints/ChoresEndpoints.cs
+++ b/src/FamilyCoordinationApp/Endpoints/ChoresEndpoints.cs
@@ -237,7 +237,7 @@ public static class ChoresEndpoints
         try
         {
             var chore = await svc.CompleteAsync(
-                user.HouseholdId, choreId, user.UserId, req.Note, req.PhotoPath, req.Version, ct);
+                user.HouseholdId, choreId, user.UserId, req.Note, req.PhotoPath, req.ParticipantUserIds, req.Version, ct);
             return Results.Ok(Project(boardService, chore, timeProvider, timeZone));
         }
         catch (ChoreNotFoundException) { return Results.NotFound(); }
@@ -570,7 +570,7 @@ public static class ChoresEndpoints
 
     public sealed record HandOffRequest(int? TargetUserId, uint Version);
 
-    public sealed record CompleteRequest(string? Note, string? PhotoPath, uint Version);
+    public sealed record CompleteRequest(string? Note, string? PhotoPath, uint Version, IReadOnlyList<int>? ParticipantUserIds = null);
 
     public sealed record DefaultViewRequest(string? View);
 

--- a/src/FamilyCoordinationApp/Migrations/20260605010232_AddChoreRequiredCount.Designer.cs
+++ b/src/FamilyCoordinationApp/Migrations/20260605010232_AddChoreRequiredCount.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FamilyCoordinationApp.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FamilyCoordinationApp.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260605010232_AddChoreRequiredCount")]
+    partial class AddChoreRequiredCount
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/FamilyCoordinationApp/Migrations/20260605010232_AddChoreRequiredCount.cs
+++ b/src/FamilyCoordinationApp/Migrations/20260605010232_AddChoreRequiredCount.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FamilyCoordinationApp.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddChoreRequiredCount : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastContributionAt",
+                table: "Chores",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "RequiredCount",
+                table: "Chores",
+                type: "integer",
+                nullable: false,
+                defaultValue: 1);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LastContributionAt",
+                table: "Chores");
+
+            migrationBuilder.DropColumn(
+                name: "RequiredCount",
+                table: "Chores");
+        }
+    }
+}

--- a/src/FamilyCoordinationApp/Services/ChoreBoardService.cs
+++ b/src/FamilyCoordinationApp/Services/ChoreBoardService.cs
@@ -52,6 +52,26 @@ public class ChoreBoardService(
             .Select(u => u.ChoresDefaultView)
             .FirstOrDefaultAsync(cancellationToken);
 
+        // P5: Lazy progress query — only issued when the household has at least one multi-person chore.
+        // Load completions in ONE query, group by ChoreId; single-person chores get an empty set.
+        var multiPersonIds = chores
+            .Where(c => c.RequiredCount > 1)
+            .Select(c => c.ChoreId)
+            .ToList();
+
+        Dictionary<int, List<ChoreCompletion>> completionsByChore = [];
+        if (multiPersonIds.Count > 0)
+        {
+            // M7: single household-scoped query covering only the multi-person chore ids.
+            var allCompletions = await context.ChoreCompletions
+                .Where(c => c.HouseholdId == householdId && multiPersonIds.Contains(c.ChoreId))
+                .ToListAsync(cancellationToken);
+
+            completionsByChore = allCompletions
+                .GroupBy(c => c.ChoreId)
+                .ToDictionary(g => g.Key, g => g.ToList());
+        }
+
         // Project each chore once; reuse the computed dueness for both the per-chore DTO and the rollups so
         // a chore's dueness is computed in exactly one place (no divergence between the card and the room
         // bucket). The board buckets off COMPUTED dueness, never stored Status (decay would be ignored).
@@ -65,7 +85,16 @@ public class ChoreBoardService(
             .ToList();
 
         var choreDtos = projected
-            .Select(p => ToDto(p.Chore, p.Dueness, p.IsClaimStale))
+            .Select(p =>
+            {
+                // A RequiredCount==1 chore gets an empty set (CompletedCount=0, ContributorUserIds=[]).
+                IReadOnlySet<int> contributors = p.Chore.RequiredCount > 1
+                    ? ChoreCompletionProgress.DistinctContributorsSince(
+                        completionsByChore.GetValueOrDefault(p.Chore.ChoreId) ?? [],
+                        p.Chore.LastCompletedAt)
+                    : (IReadOnlySet<int>)new HashSet<int>();
+                return ToDto(p.Chore, p.Dueness, p.IsClaimStale, contributors);
+            })
             .ToList();
 
         var rollups = BuildRollups(projected.Select(p => (p.Chore, p.Dueness)), rooms);
@@ -91,12 +120,18 @@ public class ChoreBoardService(
     {
         var dueness = calculator.Compute(ChoreRecurrenceSnapshot.FromChore(chore), now, timeZone);
         var isClaimStale = calculator.IsClaimStale(chore.AssignmentKind, chore.ClaimedAt, now);
-        return ToDto(chore, dueness, isClaimStale);
+        // progress is computed only in GetBoardAsync; single-chore projections report requiredCount plus
+        // zeroed progress — the client refetches the board for authoritative co-sign progress.
+        return ToDto(chore, dueness, isClaimStale, contributors: new HashSet<int>());
     }
 
     // ------------------------------------------------------------------ projection
 
-    private static ChoreDto ToDto(Chore chore, ChoreDuenessResult dueness, bool isClaimStale) => new(
+    private static ChoreDto ToDto(
+        Chore chore,
+        ChoreDuenessResult dueness,
+        bool isClaimStale,
+        IReadOnlySet<int> contributors) => new(
         chore.ChoreId,
         chore.Name,
         chore.Icon,
@@ -118,7 +153,10 @@ public class ChoreBoardService(
         chore.ClaimedAt,
         chore.LastCompletedAt,
         chore.PhotoPath,
-        chore.Version);
+        chore.Version,
+        chore.RequiredCount,
+        contributors.Count,
+        contributors.OrderBy(x => x).ToList());
 
     // ------------------------------------------------------------------ rollups
 

--- a/src/FamilyCoordinationApp/Services/ChoreCommands.cs
+++ b/src/FamilyCoordinationApp/Services/ChoreCommands.cs
@@ -23,7 +23,8 @@ public record CreateChoreCommand(
     int? OwnerUserId,
     int? AssigneeUserId,
     string? PhotoPath,
-    string Icon = "");
+    string Icon = "",
+    int RequiredCount = 1);
 
 /// <summary>
 /// Command to update a chore's editable fields (council M11) — the same editable subset as
@@ -42,4 +43,5 @@ public record UpdateChoreCommand(
     EffortTier EffortTier,
     int? OwnerUserId,
     string? PhotoPath,
-    string Icon = "");
+    string Icon = "",
+    int RequiredCount = 1);

--- a/src/FamilyCoordinationApp/Services/ChoreCompletionProgress.cs
+++ b/src/FamilyCoordinationApp/Services/ChoreCompletionProgress.cs
@@ -1,0 +1,26 @@
+using FamilyCoordinationApp.Data.Entities;
+
+namespace FamilyCoordinationApp.Services;
+
+/// <summary>
+/// Pure progress-derivation for multi-person (co-sign) completion (D1=C, D3). The contributor count is
+/// NEVER stored (M5/MN6) — it is derived on read the same way dueness is derived
+/// (<see cref="ChoreStatusCalculator"/> philosophy): the distinct <c>CompletedByUserId</c> among
+/// <see cref="ChoreCompletion"/> rows toward the CURRENT open occurrence (rows whose <c>CompletedAt</c> is
+/// strictly after <c>LastCompletedAt</c>, or ALL rows when <c>LastCompletedAt is null</c>). Consumed by
+/// <see cref="ChoreService"/> (write-path gate) and the board projection (WP-04, read-path "X of N").
+/// </summary>
+public static class ChoreCompletionProgress
+{
+    // Distinct user IDs who have contributed toward the CURRENT open occurrence:
+    // completions with CompletedAt strictly after lastCompletedAt (or ALL when null).
+    public static IReadOnlySet<int> DistinctContributorsSince(
+        IEnumerable<ChoreCompletion> completions, DateTime? lastCompletedAt) =>
+        completions
+            .Where(c => lastCompletedAt is null || c.CompletedAt > lastCompletedAt.Value)
+            .Select(c => c.CompletedByUserId)
+            .ToHashSet();
+
+    public static bool IsSatisfied(int distinctCount, int requiredCount) =>
+        distinctCount >= Math.Max(1, requiredCount);
+}

--- a/src/FamilyCoordinationApp/Services/ChoreService.cs
+++ b/src/FamilyCoordinationApp/Services/ChoreService.cs
@@ -32,6 +32,7 @@ public class ChoreService(
     {
         ValidateName(cmd.Name);
         ValidateRecurrence(cmd.RecurrenceMode, cmd.IntervalDays, cmd.DaysOfWeek, cmd.DayOfMonth);
+        ValidateRequiredCount(cmd.RequiredCount);
 
         var now = UtcNow();
 
@@ -65,6 +66,7 @@ public class ChoreService(
                     DayOfMonth = cmd.DayOfMonth,
                     EffortTier = cmd.EffortTier,
                     EffortPoints = ChoreEffort.PointsFor(cmd.EffortTier),
+                    RequiredCount = cmd.RequiredCount,
                     Status = ChoreStatus.Active,
                     EnteredByUserId = actorUserId,
                     OwnerUserId = cmd.OwnerUserId,
@@ -99,6 +101,7 @@ public class ChoreService(
     {
         ValidateName(cmd.Name);
         ValidateRecurrence(cmd.RecurrenceMode, cmd.IntervalDays, cmd.DaysOfWeek, cmd.DayOfMonth);
+        ValidateRequiredCount(cmd.RequiredCount);
 
         await using var context = await dbFactory.CreateDbContextAsync(cancellationToken);
         var chore = await LoadChoreAsync(context, householdId, choreId, cancellationToken);
@@ -120,6 +123,7 @@ public class ChoreService(
         chore.DayOfMonth = cmd.DayOfMonth;
         chore.EffortTier = cmd.EffortTier;
         chore.EffortPoints = ChoreEffort.PointsFor(cmd.EffortTier);
+        chore.RequiredCount = cmd.RequiredCount;
         chore.OwnerUserId = cmd.OwnerUserId;
         chore.PhotoPath = cmd.PhotoPath;
         // NOTE: the assignment trio is intentionally NOT touched by an edit — assignment moves only via
@@ -227,7 +231,7 @@ public class ChoreService(
         return chore;
     }
 
-    public async Task<Chore> CompleteAsync(int householdId, int choreId, int actorUserId, string? note, string? photoPath, uint version, CancellationToken cancellationToken = default)
+    public async Task<Chore> CompleteAsync(int householdId, int choreId, int actorUserId, string? note, string? photoPath, IReadOnlyList<int>? participantUserIds, uint version, CancellationToken cancellationToken = default)
     {
         await using var context = await dbFactory.CreateDbContextAsync(cancellationToken);
         var chore = await LoadChoreAsync(context, householdId, choreId, cancellationToken);
@@ -238,39 +242,95 @@ public class ChoreService(
         // chore stays on the pile after completion — consistent with D7.)
         MaterializeAutoReleaseIfStale(context, chore, now);
 
-        // Snapshot the effort points at completion time (the v1.1 equity substrate, MN3/MN4).
-        var completion = new ChoreCompletion
+        // Resolve the contributor set for THIS call: the actor plus any named participants (D7 name-others).
+        // Each named member is validated for household membership (reusing EnsureHouseholdMemberAsync, M1);
+        // the set dedupes within the call.
+        var candidates = new HashSet<int> { actorUserId };
+        if (participantUserIds is not null)
         {
-            HouseholdId = householdId,
-            ChoreId = choreId,
-            CompletedByUserId = actorUserId,   // council M8 — the completer, even if a different user held it
-            CompletedAt = now,
-            EffortPointsSnapshot = chore.EffortPoints,
-            Note = string.IsNullOrWhiteSpace(note) ? null : note.Trim(),
-            PhotoPath = photoPath
-        };
-        context.ChoreCompletions.Add(completion);
-
-        chore.LastCompletedAt = now;
-
-        if (chore.RecurrenceMode == RecurrenceMode.OneOff)
-        {
-            // OneOff: lifecycle terminates. The board (WP-05) excludes Done chores.
-            chore.Status = ChoreStatus.Done;
+            foreach (var participantId in participantUserIds)
+            {
+                candidates.Add(participantId);
+            }
         }
-        // Flexible/Fixed: recurrence advance is DERIVED, not stored. Flexible decays off the new
-        // LastCompletedAt; Fixed derives the next slot from the unchanged AnchorDate/cadence — we mutate NO
-        // recurrence field here (do not rewrite AnchorDate). The calculator owns the next-due derivation.
 
-        // Post-completion assignment: a recurring chore held by a self-claim returns to the pile so it is
-        // up-for-grabs again; a deliberately-Assigned chore keeps its sticky assignee.
-        if (chore.RecurrenceMode != RecurrenceMode.OneOff && chore.AssignmentKind == AssignmentKind.Claimed)
+        foreach (var candidateId in candidates)
         {
-            ClearToPile(chore);
+            await EnsureHouseholdMemberAsync(context, householdId, candidateId, cancellationToken);
         }
+
+        // Prior distinct contributors toward the CURRENT open occurrence (rows after LastCompletedAt, M7 —
+        // filtered by HouseholdId AND ChoreId). The count is derived, never stored (M5/MN6).
+        var priorCompletions = await context.ChoreCompletions
+            .Where(cc => cc.HouseholdId == householdId && cc.ChoreId == choreId)
+            .ToListAsync(cancellationToken);
+        var priorSet = ChoreCompletionProgress.DistinctContributorsSince(priorCompletions, chore.LastCompletedAt);
+
+        // Only members not already counted toward the current occurrence add anything (D6 distinctness).
+        var newContributors = candidates.Where(id => !priorSet.Contains(id)).ToHashSet();
+
+        // Nothing this call would add => reject (D6). Critically, an actor already in priorSet who names a
+        // NEW participant has a non-empty newContributors set and does NOT throw (D7 escape hatch).
+        if (newContributors.Count == 0)
+        {
+            throw new ChoreValidationException("You've already marked your part — waiting on the others.");
+        }
+
+        // Write one ChoreCompletion per newly-contributing member — full effort points each (D5). The
+        // note/photo attach to the actor's OWN row iff the actor is newly contributing; otherwise discarded.
+        foreach (var contributorId in newContributors)
+        {
+            var attachActorPayload = contributorId == actorUserId;
+            context.ChoreCompletions.Add(new ChoreCompletion
+            {
+                HouseholdId = householdId,
+                ChoreId = choreId,
+                CompletedByUserId = contributorId,   // council M8 — the completer, even if a different user held it
+                CompletedAt = now,
+                EffortPointsSnapshot = chore.EffortPoints,
+                Note = attachActorPayload && !string.IsNullOrWhiteSpace(note) ? note.Trim() : null,
+                PhotoPath = attachActorPayload ? photoPath : null
+            });
+        }
+
+        var newDistinctCount = priorSet.Count + newContributors.Count;
+
+        // Every contribution (partial OR final) stamps LastContributionAt and FORCES the row UPDATE so the
+        // xmin concurrency check always fires (D3/M4). EF emits no UPDATE for a row with no changed scalar,
+        // and a same-tick / fixed-clock `now` could equal the existing value — so mark it modified
+        // explicitly. Without this, two racing partials can both skip the UPDATE, never serialize, and wedge
+        // the chore at "N of N, not advanced" (E2). LOAD-BEARING — do not remove.
+        chore.LastContributionAt = now;
+        context.Entry(chore).Property(c => c.LastContributionAt).IsModified = true;
+
+        if (ChoreCompletionProgress.IsSatisfied(newDistinctCount, chore.RequiredCount))
+        {
+            // SATISFYING completion — run the existing advance logic UNCHANGED.
+            chore.LastCompletedAt = now;
+
+            if (chore.RecurrenceMode == RecurrenceMode.OneOff)
+            {
+                // OneOff: lifecycle terminates. The board (WP-05) excludes Done chores.
+                chore.Status = ChoreStatus.Done;
+            }
+            // Flexible/Fixed: recurrence advance is DERIVED, not stored. Flexible decays off the new
+            // LastCompletedAt; Fixed derives the next slot from the unchanged AnchorDate/cadence — we mutate
+            // NO recurrence field here (do not rewrite AnchorDate). The calculator owns the next-due derivation.
+
+            // Post-completion assignment: a recurring chore held by a self-claim returns to the pile so it is
+            // up-for-grabs again; a deliberately-Assigned chore keeps its sticky assignee.
+            if (chore.RecurrenceMode != RecurrenceMode.OneOff && chore.AssignmentKind == AssignmentKind.Claimed)
+            {
+                ClearToPile(chore);
+            }
+        }
+        // Else (partial): leave LastCompletedAt, Status, and the assignment trio untouched (D4) — only the
+        // ChoreCompletion rows + LastContributionAt above were written.
 
         await SaveWithConcurrencyAsync(context, chore, version, cancellationToken);
-        logger.LogInformation("Chore {ChoreId} completed by user {UserId} (household {HouseholdId})", choreId, actorUserId, householdId);
+        logger.LogInformation(
+            "Chore {ChoreId} contribution by user {UserId} (+{New} contributor(s), {Distinct} of {Required}) (household {HouseholdId})",
+            choreId, actorUserId, newContributors.Count, newDistinctCount, chore.RequiredCount, householdId);
         return chore;
     }
 
@@ -394,6 +454,20 @@ public class ChoreService(
 
         throw new ChoreValidationException(
             $"A {mode} chore requires a positive IntervalDays or a DaysOfWeek selection.");
+    }
+
+    /// <summary>
+    /// The multi-person requirement (D2): <c>1</c> = a normal single-completion chore (the default);
+    /// <c>&gt;= 2</c> = co-sign. Reject <c>&lt; 1</c>. There is NO server-side upper bound (a member can leave;
+    /// the create/edit UI caps the picker at the household member count, WP-06; an unsatisfiable count is
+    /// recovered by editing it down, E1) — do not clamp.
+    /// </summary>
+    private static void ValidateRequiredCount(int requiredCount)
+    {
+        if (requiredCount < 1)
+        {
+            throw new ChoreValidationException("RequiredCount must be at least 1.");
+        }
     }
 
     /// <summary>

--- a/src/FamilyCoordinationApp/Services/Dtos/ChoreDtos.cs
+++ b/src/FamilyCoordinationApp/Services/Dtos/ChoreDtos.cs
@@ -28,6 +28,12 @@ public sealed record ChoreBoardDto(
 /// fixed-weekly / every-N / dated one-off chore lost the existing selection). <see cref="DaysOfWeek"/>
 /// serializes as a camelCase CSV (e.g. <c>"monday, thursday"</c>); <see cref="AnchorDate"/> as an ISO date
 /// (<c>"2026-06-10"</c>) — the same shapes the write request accepts.</para>
+/// <para>Multi-person co-sign progress (WP-04): <see cref="RequiredCount"/> is always ≥ 1 (1 = normal,
+/// &gt;1 = multi-person). <see cref="CompletedCount"/> is the count of distinct contributors toward the
+/// CURRENT open occurrence (0..<see cref="RequiredCount"/>); <see cref="ContributorUserIds"/> lists those
+/// users in ascending order. These are populated only in the board projection (<c>GetBoardAsync</c>);
+/// single-chore projections always report <c>completedCount=0, contributorUserIds=[]</c> — the client
+/// refetches the board for authoritative co-sign progress (WP-07).</para>
 /// </summary>
 public sealed record ChoreDto(
     int Id,
@@ -51,7 +57,11 @@ public sealed record ChoreDto(
     DateTime? ClaimedAt,
     DateTime? LastCompletedAt,
     string? PhotoPath,
-    uint Version);
+    uint Version,
+    int RequiredCount,                    // 1 = normal; >1 = multi-person
+    int CompletedCount,                   // distinct contributors toward the CURRENT occurrence (0..RequiredCount)
+    IReadOnlyList<int> ContributorUserIds // who has signed the current occurrence (drives per-user button state)
+    );
 
 /// <summary>
 /// Per-room dirtiness rollup. The <see cref="Status"/> bucket is derived from the count of chores in the

--- a/src/FamilyCoordinationApp/Services/Interfaces/IChoreService.cs
+++ b/src/FamilyCoordinationApp/Services/Interfaces/IChoreService.cs
@@ -78,15 +78,24 @@ public interface IChoreService
     Task<Chore> HandOffAsync(int householdId, int choreId, int actorUserId, int? targetUserId, uint version, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Completes a chore (council M8 — any household member may complete; an unclaimed pile chore may be
-    /// completed directly; <c>CompletedByUserId = actorUserId</c> even if a different user held the claim).
-    /// Writes a <see cref="ChoreCompletion"/> snapshotting <c>EffortPoints</c>, sets <c>LastCompletedAt = now</c>,
-    /// and advances the clock per recurrence: Flexible recomputes off the new completion, Fixed mutates no
-    /// field beyond <c>LastCompletedAt</c> (the calculator derives the next slot from the unchanged anchor),
-    /// OneOff sets <c>Status = Done</c>. A recurring chore held by Claimed returns to the pile; an Assigned
-    /// chore keeps its sticky assignee.
+    /// Records a completion contribution toward a chore (council M8 — any household member may complete; an
+    /// unclaimed pile chore may be completed directly; <c>CompletedByUserId = actorUserId</c> even if a
+    /// different user held the claim). Multi-person (co-sign, D1=C): the chore advances only when
+    /// <b>distinct</b> contributors toward the current occurrence reach <c>RequiredCount</c>.
+    /// <para>The contributor set for this call is <c>{actorUserId} ∪ participantUserIds</c> (the D7 name-others
+    /// escape hatch — each named member validated via household membership). One <see cref="ChoreCompletion"/>
+    /// is written per <b>newly-contributing</b> member (full <c>EffortPoints</c> each, D5); members who already
+    /// contributed to the current occurrence are silently skipped. If nothing new would be added (the actor
+    /// already contributed and named no new participant), a <see cref="ChoreValidationException"/> is thrown
+    /// (D6). <c>note</c>/<c>photoPath</c> attach to the actor's own row iff the actor is newly contributing.</para>
+    /// <para>Every contribution stamps <c>LastContributionAt = now</c> (forcing the xmin UPDATE so concurrent
+    /// contributions serialize, D3). A <b>partial</b> contribution leaves <c>LastCompletedAt</c>, <c>Status</c>,
+    /// and the assignment trio untouched (D4). The <b>satisfying</b> contribution runs the existing advance:
+    /// sets <c>LastCompletedAt = now</c>; OneOff → <c>Status = Done</c>; a recurring chore held by Claimed
+    /// returns to the pile; an Assigned chore keeps its sticky assignee.</para>
     /// </summary>
     /// <exception cref="ChoreNotFoundException">No such chore in the household.</exception>
+    /// <exception cref="ChoreValidationException">A named participant is outside the household, or nothing new would be recorded (the actor already contributed, D6).</exception>
     /// <exception cref="ChoreConflictException">The client <paramref name="version"/> is stale.</exception>
-    Task<Chore> CompleteAsync(int householdId, int choreId, int actorUserId, string? note, string? photoPath, uint version, CancellationToken cancellationToken = default);
+    Task<Chore> CompleteAsync(int householdId, int choreId, int actorUserId, string? note, string? photoPath, IReadOnlyList<int>? participantUserIds, uint version, CancellationToken cancellationToken = default);
 }

--- a/tests/FamilyCoordinationApp.Tests/Fixtures/ChoreBoard/board.json
+++ b/tests/FamilyCoordinationApp.Tests/Fixtures/ChoreBoard/board.json
@@ -22,7 +22,10 @@
       "claimedAt": "2026-05-25T05:00:00Z",
       "lastCompletedAt": "2026-05-20T05:00:00Z",
       "photoPath": "/uploads/1/abc.jpg",
-      "version": 7
+      "version": 7,
+      "requiredCount": 1,
+      "completedCount": 0,
+      "contributorUserIds": []
     },
     {
       "id": 2,
@@ -46,7 +49,10 @@
       "claimedAt": "2026-05-30T04:00:00Z",
       "lastCompletedAt": null,
       "photoPath": null,
-      "version": 3
+      "version": 3,
+      "requiredCount": 1,
+      "completedCount": 0,
+      "contributorUserIds": []
     },
     {
       "id": 3,
@@ -70,7 +76,10 @@
       "claimedAt": null,
       "lastCompletedAt": "2026-05-15T05:00:00Z",
       "photoPath": null,
-      "version": 1
+      "version": 1,
+      "requiredCount": 2,
+      "completedCount": 1,
+      "contributorUserIds": [100]
     },
     {
       "id": 4,
@@ -94,7 +103,10 @@
       "claimedAt": "2026-05-30T03:00:00Z",
       "lastCompletedAt": null,
       "photoPath": null,
-      "version": 2
+      "version": 2,
+      "requiredCount": 1,
+      "completedCount": 0,
+      "contributorUserIds": []
     }
   ],
   "rooms": [

--- a/tests/FamilyCoordinationApp.Tests/Integration/ChoreRoundTripTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Integration/ChoreRoundTripTests.cs
@@ -24,8 +24,10 @@ public sealed class ChoreRoundTripTests(PostgresContainerFixture postgres) : IAs
     public async Task DisposeAsync() => await _factory.DisposeAsync();
 
     private sealed record Chore(
-        int id, string name, uint version, string assignmentKind, int? assigneeUserId, DateTime? lastCompletedAt);
+        int id, string name, uint version, string assignmentKind, int? assigneeUserId, DateTime? lastCompletedAt,
+        int requiredCount = 1);
     private sealed record VersionBody(uint version);
+    private sealed record Board(List<Chore> chores);
 
     private HttpClient ClientA => _factory.CreateClientAs(ChoresWebAppFactory.UserAEmail);
 
@@ -109,5 +111,52 @@ public sealed class ChoreRoundTripTests(PostgresContainerFixture postgres) : IAs
 
         claimResp.StatusCode.Should().BeOneOf(HttpStatusCode.NotFound, HttpStatusCode.BadRequest);
         claimResp.StatusCode.Should().NotBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task RequiredCount_CreateAndUpdate_EchoesOnBoard()
+    {
+        var client = ClientA;
+
+        // CREATE with requiredCount:2 (201) — the DTO echoes the value back.
+        var createResp = await client.PostAsJsonAsync("/api/chores/", new
+        {
+            name = "Multi-person chore",
+            recurrenceMode = "flexible",
+            intervalDays = 7,
+            effortTier = "standard",
+            requiredCount = 2
+        }, Json);
+        createResp.StatusCode.Should().Be(HttpStatusCode.Created);
+        var created = await createResp.Content.ReadFromJsonAsync<Chore>(Json);
+        created.Should().NotBeNull();
+        created!.requiredCount.Should().Be(2, "create response must echo the supplied requiredCount");
+
+        // GET /board — the created chore must appear with requiredCount:2.
+        var board = await client.GetFromJsonAsync<Board>("/api/chores/board", Json);
+        var onBoard = board!.chores.SingleOrDefault(c => c.id == created.id);
+        onBoard.Should().NotBeNull("the newly created chore must be on the board");
+        onBoard!.requiredCount.Should().Be(2, "board projection must echo requiredCount from the entity");
+
+        // UPDATE requiredCount to 3 via PUT (200).
+        var updateResp = await client.PutAsJsonAsync($"/api/chores/{created.id}", new
+        {
+            name = "Multi-person chore",
+            recurrenceMode = "flexible",
+            intervalDays = 7,
+            effortTier = "standard",
+            requiredCount = 3,
+            version = created.version
+        }, Json);
+        updateResp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var updated = await updateResp.Content.ReadFromJsonAsync<Chore>(Json);
+        updated.Should().NotBeNull();
+        updated!.requiredCount.Should().Be(3, "update response must echo the new requiredCount");
+
+        // GET /board again — must reflect the updated value.
+        var boardAfterUpdate = await client.GetFromJsonAsync<Board>("/api/chores/board", Json);
+        var onBoardAfterUpdate = boardAfterUpdate!.chores.SingleOrDefault(c => c.id == created.id);
+        onBoardAfterUpdate.Should().NotBeNull();
+        onBoardAfterUpdate!.requiredCount.Should().Be(3, "board must echo requiredCount after a PUT update");
     }
 }

--- a/tests/FamilyCoordinationApp.Tests/Integration/MultiPersonChoreTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Integration/MultiPersonChoreTests.cs
@@ -1,0 +1,397 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FamilyCoordinationApp.Data;
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Services;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace FamilyCoordinationApp.Tests.Integration;
+
+/// <summary>
+/// The real-Postgres seam for the multi-person (co-sign) chore feature (WP-03). Proves the FOUR things the
+/// InMemory unit suite (WP-02) physically cannot, because InMemory has no <c>xmin</c> system column and
+/// silently ignores the rowversion:
+/// <list type="number">
+///   <item><description><b>V1 — end-to-end co-sign gate</b> through the real HTTP endpoint + real save path:
+///   a <c>requiredCount=2</c> OneOff chore advances to <c>Done</c> only when the SECOND distinct member
+///   contributes; after the first (partial) contribution the board still lists it with
+///   <c>completedCount=1</c>.</description></item>
+///   <item><description><b>D3 — xmin actually bumps on a partial</b>: a single partial contribution changes
+///   the chore <c>version</c> (the forced <c>LastContributionAt</c> write makes EF emit the UPDATE). Without
+///   this bump the two racers could not serialize.</description></item>
+///   <item><description><b>V3 — two-racer serialization (the load-bearing test)</b>: two <c>CompleteAsync</c>
+///   calls as DIFFERENT users on the SAME loaded <c>version</c>, forced to race via the same
+///   <see cref="SaveBarrier"/> / <see cref="GatedPostgresDbContextFactory"/> mechanism the claim-race uses
+///   (<see cref="ChoreServiceConcurrencyTests"/>). Postgres bumps xmin on the first commit, so the loser MUST
+///   get a <see cref="ChoreConflictException"/>; the loser then RE-SUBMITS against the refreshed version (the
+///   island does not auto-retry) and adds the 2nd distinct row → exactly TWO distinct contribution rows and
+///   exactly ONE advance. The FORBIDDEN states are asserted absent: never "2 rows, not advanced" and never
+///   "advanced twice".</description></item>
+///   <item><description><b>V6 — distinctness across the wire</b>: the same member completing twice is a
+///   non-retryable 400 (not a 409), and the board still shows <c>completedCount=1</c> (no second
+///   row).</description></item>
+/// </list>
+/// <para><b>Harness reuse (no parallel harness):</b> V1/D3/V6 run through <see cref="ChoresWebAppFactory"/>
+/// (the full-host HTTP harness, header auth via <c>X-Test-User</c>, two seeded household-A members A/A2). V3
+/// runs at the service layer over <see cref="PostgresDbContextFactory"/> /
+/// <see cref="GatedPostgresDbContextFactory"/> on its OWN <c>EnsureCreated</c> database — the ONLY way to
+/// force a DETERMINISTIC write-write race at the same <c>version</c> with a controllable
+/// <see cref="FixedTimeProvider"/> (the HTTP host's clock is frozen and not advanceable per-call). This
+/// mirrors <see cref="ChoreServiceConcurrencyTests"/> exactly.</para>
+/// </summary>
+[Collection(IntegrationCollection.Name)]
+[Trait("kind", "integration")]
+public sealed class MultiPersonChoreTests(PostgresContainerFixture postgres) : IAsyncLifetime
+{
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    // ── HTTP harness (V1/D3/V6) — the seeded full host with household A's two members A / A2. ──
+    private readonly ChoresWebAppFactory _factory = new(postgres);
+
+    public async Task InitializeAsync() => await _factory.EnsureSeededAsync();
+
+    public async Task DisposeAsync() => await _factory.DisposeAsync();
+
+    // The slice of the board ChoreDto this suite reads (camelCase, mirrors ChoreDtos.cs). Board excludes
+    // Status==Done, so a Done chore is simply ABSENT from `chores` — there is no `status` field to read.
+    private sealed record BoardChore(
+        int id,
+        uint version,
+        string assignmentKind,
+        int? assigneeUserId,
+        DateTime? lastCompletedAt,
+        int requiredCount,
+        int completedCount,
+        IReadOnlyList<int> contributorUserIds);
+
+    private sealed record Board(List<BoardChore> chores);
+
+    private async Task<Board> GetBoardAsync(HttpClient client)
+    {
+        var board = await client.GetFromJsonAsync<Board>("/api/chores/board", Json);
+        board.Should().NotBeNull();
+        return board!;
+    }
+
+    private static BoardChore? FindChore(Board board, int choreId) =>
+        board.chores.SingleOrDefault(c => c.id == choreId);
+
+    /// <summary>Create a requiredCount=2 OneOff chore through the real endpoint and return its DTO.</summary>
+    private static async Task<BoardChore> CreateCoSignOneOffAsync(HttpClient client, string name)
+    {
+        var resp = await client.PostAsJsonAsync("/api/chores/", new
+        {
+            name,
+            recurrenceMode = "oneOff",
+            effortTier = "standard",
+            requiredCount = 2
+        }, Json);
+        resp.StatusCode.Should().Be(HttpStatusCode.Created, "a valid co-sign OneOff create must succeed");
+        var created = await resp.Content.ReadFromJsonAsync<BoardChore>(Json);
+        created.Should().NotBeNull();
+        created!.requiredCount.Should().Be(2, "the create request carried requiredCount=2");
+        return created;
+    }
+
+    private static Task<HttpResponseMessage> CompleteAsync(HttpClient client, int choreId, uint version) =>
+        client.PostAsync($"/api/chores/{choreId}/complete",
+            JsonContent.Create(new { version }, options: Json));
+
+    // ──────────────────────────────────────────────────────────────────────────────────────────────
+    // V1 — end-to-end co-sign gate through the HTTP endpoint against REAL Postgres.
+    // ──────────────────────────────────────────────────────────────────────────────────────────────
+    [Fact]
+    public async Task CoSignOneOff_AdvancesToDoneOnly_WhenSecondDistinctMemberCompletes_OnRealPostgres()
+    {
+        var clientA = _factory.CreateClientAs(ChoresWebAppFactory.UserAEmail);
+        var clientA2 = _factory.CreateClientAs(ChoresWebAppFactory.UserA2Email);
+
+        // Create a requiredCount=2 OneOff chore in household A.
+        var created = await CreateCoSignOneOffAsync(clientA, "Co-sign OneOff (V1)");
+        var choreId = created.id;
+
+        // First (partial) contribution by member A. The chore must STILL be on the board, requiredCount=2,
+        // completedCount=1, A listed as the lone contributor, and NOT yet advanced (no LastCompletedAt).
+        var firstResp = await CompleteAsync(clientA, choreId, created.version);
+        firstResp.StatusCode.Should().Be(HttpStatusCode.OK, "the first contribution toward a co-sign chore succeeds");
+
+        var afterFirstBoard = await GetBoardAsync(clientA);
+        var afterFirst = FindChore(afterFirstBoard, choreId);
+        afterFirst.Should().NotBeNull("a partial co-sign OneOff must remain on the board (not yet Done)");
+        afterFirst!.requiredCount.Should().Be(2);
+        afterFirst.completedCount.Should().Be(1, "exactly one distinct member has contributed so far");
+        afterFirst.contributorUserIds.Should().BeEquivalentTo(new[] { ChoresWebAppFactory.UserAId });
+        afterFirst.lastCompletedAt.Should().BeNull("a partial contribution must NOT advance the chore (D4)");
+
+        // Second distinct member (A2) contributes against the chore's CURRENT version (fresh read off the board).
+        var secondResp = await CompleteAsync(clientA2, choreId, afterFirst.version);
+        secondResp.StatusCode.Should().Be(HttpStatusCode.OK, "the satisfying contribution succeeds");
+
+        // The board no longer lists the chore: a OneOff that reaches RequiredCount goes Status=Done, and the
+        // board excludes Done. (Absence from the board IS the Status=Done assertion — there is no Done card.)
+        var afterSecondBoard = await GetBoardAsync(clientA);
+        FindChore(afterSecondBoard, choreId).Should()
+            .BeNull("a satisfied co-sign OneOff advances to Status=Done, which the board excludes");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────────────────────
+    // D3 — the xmin token actually bumps on a PARTIAL contribution (the forced LastContributionAt write).
+    // ──────────────────────────────────────────────────────────────────────────────────────────────
+    [Fact]
+    public async Task PartialContribution_BumpsXminVersion_OnRealPostgres()
+    {
+        var clientA = _factory.CreateClientAs(ChoresWebAppFactory.UserAEmail);
+
+        // requiredCount=2 so a single contribution is a PARTIAL (does not advance / does not go Done).
+        var created = await CreateCoSignOneOffAsync(clientA, "Co-sign OneOff (D3)");
+        var choreId = created.id;
+        var versionBefore = created.version;
+
+        var resp = await CompleteAsync(clientA, choreId, versionBefore);
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var board = await GetBoardAsync(clientA);
+        var after = FindChore(board, choreId);
+        after.Should().NotBeNull("still partial → still on the board");
+        after!.lastCompletedAt.Should().BeNull("the contribution was partial (not yet satisfying)");
+
+        // THE assertion: even though only ChoreCompletion rows + LastContributionAt changed (no advance), the
+        // forced LastContributionAt write made EF emit the UPDATE, so Postgres bumped xmin. Without this bump
+        // the two-racer serialization in V3 is impossible.
+        after.version.Should().NotBe(versionBefore,
+            "a partial contribution must bump xmin via the forced LastContributionAt UPDATE (D3) — " +
+            "without it concurrent contributions cannot serialize (E2)");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────────────────────
+    // V3 — TWO-RACER SERIALIZATION (the load-bearing test), service-level on real Postgres.
+    //
+    // Reuses the EXACT mechanism from ChoreServiceConcurrencyTests: a SaveBarrier rendezvous +
+    // GatedPostgresDbContextFactory so both CompleteAsync calls reach SaveChanges after both loaded the chore
+    // at the SAME xmin version. Because each forces a Chore UPDATE (LastContributionAt), Postgres bumps xmin
+    // on the first commit → the second MUST throw ChoreConflictException. The loser re-submits against the
+    // refreshed version. End state: exactly 2 distinct contribution rows, exactly one advance (Status=Done).
+    // ──────────────────────────────────────────────────────────────────────────────────────────────
+    [Fact]
+    public async Task TwoConcurrentContributions_SameVersion_DifferentUsers_SerializeViaXmin_OnRealPostgres()
+    {
+        const int householdId = 1;
+        const int alice = 1;   // first distinct contributor
+        const int amy = 2;     // second distinct contributor
+        const int choreId = 1;
+        var t0 = new DateTime(2026, 6, 1, 12, 0, 0, DateTimeKind.Utc);
+
+        // Own EnsureCreated database on the shared container (cannot share the MigrateAsync HTTP DB) — exactly
+        // as ChoreServiceConcurrencyTests does.
+        var connectionString = await postgres.CreateDatabaseConnectionStringAsync();
+        var dbFactory = new PostgresDbContextFactory(connectionString);
+
+        await using (var ctx = dbFactory.CreateDbContext())
+        {
+            await ctx.Database.EnsureCreatedAsync();
+            ctx.Households.Add(new Household { Id = householdId, Name = "Race House", CreatedAt = t0 });
+            ctx.Users.AddRange(
+                new User { Id = alice, HouseholdId = householdId, Email = "alice@race.test", DisplayName = "Alice", Initials = "A", IsWhitelisted = true, CreatedAt = t0 },
+                new User { Id = amy, HouseholdId = householdId, Email = "amy@race.test", DisplayName = "Amy", Initials = "AM", IsWhitelisted = true, CreatedAt = t0 });
+            // requiredCount=2 OneOff: two DISTINCT contributors satisfy it; advance ⇒ Status=Done.
+            ctx.Chores.Add(new Chore
+            {
+                HouseholdId = householdId,
+                ChoreId = choreId,
+                Name = "Co-sign race target",
+                RecurrenceMode = RecurrenceMode.OneOff,
+                EffortTier = EffortTier.Standard,
+                EffortPoints = ChoreEffort.PointsFor(EffortTier.Standard),
+                RequiredCount = 2,
+                Status = ChoreStatus.Active,
+                EnteredByUserId = alice,
+                AssignmentKind = AssignmentKind.None,
+                CreatedAt = t0
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        // A controllable clock so we can advance time BETWEEN contributions for realism (correctness must NOT
+        // depend on the value differing — WP-02 forces the row modified regardless).
+        var clock = new FamilyCoordinationApp.Tests.Services.FixedTimeProvider(t0);
+
+        var version = await ReadVersionAsync(dbFactory, householdId, choreId);
+        version.Should().NotBe(0u, "real Postgres assigns a non-zero xmin to a committed row");
+
+        // The gated racing service: both contributions block at SaveChanges until both have arrived (after
+        // both loaded the chore at `version`), then commit — a genuine write-write race at the same version.
+        var barrier = new SaveBarrier(participants: 2);
+        var gatedFactory = new GatedPostgresDbContextFactory(connectionString, barrier);
+        var racingService = NewService(gatedFactory, clock);
+
+        clock.SetUtcNow(t0.AddSeconds(1)); // advance the clock for the racing contributions (realism only)
+        var attemptAlice = AttemptContributeAsync(racingService, householdId, choreId, alice, version);
+        var attemptAmy = AttemptContributeAsync(racingService, householdId, choreId, amy, version);
+        var results = await Task.WhenAll(attemptAlice, attemptAmy);
+
+        var winners = results.Count(r => r.Won);
+        var conflicts = results.Count(r => r.Conflicted);
+        winners.Should().Be(1,
+            "exactly one racer commits at the shared version — two wins would mean xmin did NOT serialize the " +
+            "partials (the 'both commit from the same version' state the spec forbids)");
+        conflicts.Should().Be(1,
+            "the loser MUST get a ChoreConflictException once the winner bumped xmin (D3/V3)");
+        results.Should().NotContain(r => r.OtherError,
+            "the loser must lose on the xmin token, not the 'nothing new' (D6) validation guard");
+
+        // After exactly ONE racer committed: exactly one contribution row, chore NOT advanced (1 of 2),
+        // still Active. This is the intermediate state the loser will resolve by re-submitting.
+        var winner = results.Single(r => r.Won);
+        await AssertStateAsync(dbFactory, householdId, choreId,
+            expectedRows: 1, expectedDistinct: 1, expectAdvancedDone: false);
+
+        // ── The loser RE-SUBMITS against the refreshed version (the island does not auto-retry). This is the
+        // SATISFYING contribution: it re-reads the contributor set under the now-serialized write, sees Alice
+        // already counted, adds the 2nd distinct row (the loser's own user), and advances exactly once. ──
+        var loser = results.Single(r => r.Conflicted);
+        var refreshed = await ReadVersionAsync(dbFactory, householdId, choreId);
+        clock.SetUtcNow(t0.AddSeconds(2)); // advance again before the re-submit (realism only)
+        var nonRacingService = NewService(dbFactory, clock);
+        var resubmit = await AttemptContributeAsync(nonRacingService, householdId, choreId, loser.UserId, refreshed);
+        resubmit.Won.Should().BeTrue("the loser's re-submit against the refreshed version must succeed");
+
+        // ── End state: EXACTLY 2 distinct contribution rows and EXACTLY ONE advance (Status=Done). ──
+        await AssertStateAsync(dbFactory, householdId, choreId,
+            expectedRows: 2, expectedDistinct: 2, expectAdvancedDone: true);
+
+        // Belt-and-braces over the FORBIDDEN states (asserting them ABSENT, not merely that "a completion
+        // happened"):
+        await using var verify = dbFactory.CreateDbContext();
+        var finalChore = await verify.Chores.AsNoTracking()
+            .SingleAsync(c => c.HouseholdId == householdId && c.ChoreId == choreId);
+        var finalRows = await verify.ChoreCompletions.AsNoTracking()
+            .Where(c => c.HouseholdId == householdId && c.ChoreId == choreId)
+            .ToListAsync();
+        var distinctContributors = finalRows.Select(c => c.CompletedByUserId).Distinct().ToList();
+
+        // FORBIDDEN: "2 distinct contributors recorded but NOT advanced" (the E2 wedge).
+        (distinctContributors.Count == 2 && (finalChore.Status != ChoreStatus.Done || finalChore.LastCompletedAt is null))
+            .Should().BeFalse("FORBIDDEN: 2 distinct contributors recorded but the chore did not advance (E2 wedge)");
+
+        // FORBIDDEN: "advanced twice" — surfaced as MORE than RequiredCount distinct rows toward one
+        // occurrence, or extra completion rows beyond the two distinct contributors.
+        finalRows.Should().HaveCount(2, "FORBIDDEN: more than one row per distinct contributor ⇒ a double-advance / double-count");
+        distinctContributors.Should().BeEquivalentTo(new[] { alice, amy },
+            "the two distinct contributors are exactly Alice and Amy — one win + one re-submit");
+        finalChore.Status.Should().Be(ChoreStatus.Done, "the satisfied co-sign OneOff advanced exactly once");
+        finalChore.LastCompletedAt.Should().NotBeNull("the satisfying contribution set LastCompletedAt exactly once");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────────────────────
+    // V6 — distinctness across the wire: the SAME member completing twice is a non-retryable 400.
+    // ──────────────────────────────────────────────────────────────────────────────────────────────
+    [Fact]
+    public async Task SameMemberCompletesTwice_SecondIs400NotRetryable_BoardStillCompletedCountOne_OnRealPostgres()
+    {
+        var clientA = _factory.CreateClientAs(ChoresWebAppFactory.UserAEmail);
+
+        var created = await CreateCoSignOneOffAsync(clientA, "Co-sign OneOff (V6)");
+        var choreId = created.id;
+
+        // First contribution by A succeeds (partial — completedCount=1).
+        var first = await CompleteAsync(clientA, choreId, created.version);
+        first.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var afterFirstBoard = await GetBoardAsync(clientA);
+        var afterFirst = FindChore(afterFirstBoard, choreId);
+        afterFirst.Should().NotBeNull();
+        afterFirst!.completedCount.Should().Be(1);
+
+        // SAME member completes again against the CURRENT (non-stale) version → the "nothing new" guard (D6)
+        // rejects it as a 400, NOT a 409. This is the key distinction: a non-retryable client rejection, not
+        // a concurrency conflict the island should retry.
+        var second = await CompleteAsync(clientA, choreId, afterFirst.version);
+        second.StatusCode.Should().Be(HttpStatusCode.BadRequest,
+            "the same member re-completing is a non-retryable distinctness rejection (400), never a 409 conflict");
+
+        // No second row was written: the board still shows completedCount=1 with A as the lone contributor.
+        var afterSecondBoard = await GetBoardAsync(clientA);
+        var afterSecond = FindChore(afterSecondBoard, choreId);
+        afterSecond.Should().NotBeNull("rejected re-completion must NOT have advanced/removed the chore");
+        afterSecond!.completedCount.Should().Be(1, "the rejected duplicate added no second contribution row");
+        afterSecond.contributorUserIds.Should().BeEquivalentTo(new[] { ChoresWebAppFactory.UserAId });
+    }
+
+    // ── service-level helpers (mirror ChoreServiceConcurrencyTests) ──────────────────────────────────
+
+    private static ChoreService NewService(
+        Microsoft.EntityFrameworkCore.IDbContextFactory<ApplicationDbContext> factory,
+        FamilyCoordinationApp.Tests.Services.FixedTimeProvider clock) =>
+        new(
+            factory,
+            new ChoreStatusCalculator(),
+            Mock.Of<IImageService>(),
+            clock,
+            NullLogger<ChoreService>.Instance);
+
+    private static async Task<uint> ReadVersionAsync(
+        PostgresDbContextFactory dbFactory, int householdId, int choreId)
+    {
+        await using var ctx = dbFactory.CreateDbContext();
+        var chore = await ctx.Chores.AsNoTracking()
+            .SingleAsync(c => c.HouseholdId == householdId && c.ChoreId == choreId);
+        return chore.Version;
+    }
+
+    /// <summary>
+    /// One co-sign contribution attempt, classifying the outcome the same way
+    /// <see cref="ChoreServiceConcurrencyTests"/> classifies a claim: a clean win, an xmin
+    /// <see cref="ChoreConflictException"/> (the loser), or the "nothing new" <see cref="ChoreValidationException"/>
+    /// guard (which here would mean the race did NOT serialize on xmin — surfaced so the assertion fails loudly).
+    /// </summary>
+    private static async Task<ContributeResult> AttemptContributeAsync(
+        ChoreService service, int householdId, int choreId, int actorUserId, uint version)
+    {
+        try
+        {
+            await service.CompleteAsync(householdId, choreId, actorUserId,
+                note: null, photoPath: null, participantUserIds: null, version);
+            return new ContributeResult(actorUserId, Won: true, Conflicted: false, OtherError: false);
+        }
+        catch (ChoreConflictException)
+        {
+            return new ContributeResult(actorUserId, Won: false, Conflicted: true, OtherError: false);
+        }
+        catch (ChoreValidationException)
+        {
+            return new ContributeResult(actorUserId, Won: false, Conflicted: false, OtherError: true);
+        }
+    }
+
+    private static async Task AssertStateAsync(
+        PostgresDbContextFactory dbFactory, int householdId, int choreId,
+        int expectedRows, int expectedDistinct, bool expectAdvancedDone)
+    {
+        await using var ctx = dbFactory.CreateDbContext();
+        var chore = await ctx.Chores.AsNoTracking()
+            .SingleAsync(c => c.HouseholdId == householdId && c.ChoreId == choreId);
+        var rows = await ctx.ChoreCompletions.AsNoTracking()
+            .Where(c => c.HouseholdId == householdId && c.ChoreId == choreId)
+            .ToListAsync();
+
+        rows.Should().HaveCount(expectedRows, "exactly one ChoreCompletion row is written per newly-contributing member");
+        rows.Select(c => c.CompletedByUserId).Distinct().Should().HaveCount(expectedDistinct);
+
+        if (expectAdvancedDone)
+        {
+            chore.Status.Should().Be(ChoreStatus.Done, "a satisfied co-sign OneOff advances to Done");
+            chore.LastCompletedAt.Should().NotBeNull("the satisfying contribution sets LastCompletedAt");
+        }
+        else
+        {
+            chore.Status.Should().Be(ChoreStatus.Active, "a partial contribution leaves Status untouched (D4)");
+            chore.LastCompletedAt.Should().BeNull("a partial contribution leaves LastCompletedAt untouched (D4)");
+        }
+    }
+
+    private sealed record ContributeResult(int UserId, bool Won, bool Conflicted, bool OtherError);
+}

--- a/tests/FamilyCoordinationApp.Tests/Services/ChoreBoardDtoContractTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/ChoreBoardDtoContractTests.cs
@@ -65,7 +65,10 @@ public class ChoreBoardDtoContractTests
                 ClaimedAt: new DateTime(2026, 5, 25, 5, 0, 0, DateTimeKind.Utc),
                 LastCompletedAt: new DateTime(2026, 5, 20, 5, 0, 0, DateTimeKind.Utc),
                 PhotoPath: "/uploads/1/abc.jpg",
-                Version: 7),
+                Version: 7,
+                RequiredCount: 1,
+                CompletedCount: 0,
+                ContributorUserIds: []),
 
             // Due today, assigned (sticky), in the Kitchen room.
             new(
@@ -90,9 +93,12 @@ public class ChoreBoardDtoContractTests
                 ClaimedAt: new DateTime(2026, 5, 30, 4, 0, 0, DateTimeKind.Utc),
                 LastCompletedAt: null,
                 PhotoPath: null,
-                Version: 3),
+                Version: 3,
+                RequiredCount: 1,
+                CompletedCount: 0,
+                ContributorUserIds: []),
 
-            // Scheduled, unclaimed pile (up-for-grabs), roomless (General group).
+            // Scheduled, unclaimed pile (up-for-grabs), roomless (General group). Multi-person: 2 required, 1 signed.
             new(
                 Id: 3,
                 Name: "Water the plants",
@@ -115,7 +121,10 @@ public class ChoreBoardDtoContractTests
                 ClaimedAt: null,
                 LastCompletedAt: new DateTime(2026, 5, 15, 5, 0, 0, DateTimeKind.Utc),
                 PhotoPath: null,
-                Version: 1),
+                Version: 1,
+                RequiredCount: 2,
+                CompletedCount: 1,
+                ContributorUserIds: [100]),
 
             // Not due, fresh, roomless one-off in the General group (claimed, not stale).
             new(
@@ -140,7 +149,10 @@ public class ChoreBoardDtoContractTests
                 ClaimedAt: new DateTime(2026, 5, 30, 3, 0, 0, DateTimeKind.Utc),
                 LastCompletedAt: null,
                 PhotoPath: null,
-                Version: 2),
+                Version: 2,
+                RequiredCount: 1,
+                CompletedCount: 0,
+                ContributorUserIds: []),
         };
 
         var rooms = new List<RoomRollupDto>
@@ -230,7 +242,8 @@ public class ChoreBoardDtoContractTests
             "id", "name", "icon", "description", "roomId", "recurrenceMode", "intervalDays", "daysOfWeek", "anchorDate",
             "dueState", "colorTier", "nextDueAt",
             "isClaimStale", "effortTier", "effortPoints", "ownerUserId", "assigneeUserId", "assignmentKind",
-            "claimedAt", "lastCompletedAt", "photoPath", "version");
+            "claimedAt", "lastCompletedAt", "photoPath", "version",
+            "requiredCount", "completedCount", "contributorUserIds");
 
         // Enums serialize as camelCase strings (M11), NOT integers and NOT PascalCase.
         firstChore["dueState"]!.GetValue<string>().Should().Be("overdue");

--- a/tests/FamilyCoordinationApp.Tests/Services/ChoreBoardServiceTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/ChoreBoardServiceTests.cs
@@ -349,4 +349,69 @@ public class ChoreBoardServiceTests
         dto.RecurrenceMode.Should().Be("OneOff");
         dto.Version.Should().Be(5u);
     }
+
+    // ------------------------------------------------------------------ multi-person co-sign progress (WP-04)
+
+    [Fact]
+    public async Task MultiPersonChore_WithOneCompletion_ProjectsCorrectProgress()
+    {
+        // Arrange: one RequiredCount=2 chore with one completion; one RequiredCount=1 chore with no completions.
+        var multiChore = OneOff(1, H1, roomId: null, new DateOnly(2026, 6, 10));
+        multiChore.RequiredCount = 2;
+
+        var singleChore = OneOff(2, H1, roomId: null, new DateOnly(2026, 6, 10));
+        // RequiredCount defaults to 1 (entity default)
+
+        Seed(multiChore, singleChore);
+
+        // Alice has signed chore 1 in the current occurrence window (no LastCompletedAt → all rows count).
+        using (var ctx = new ApplicationDbContext(_options))
+        {
+            ctx.ChoreCompletions.Add(new ChoreCompletion
+            {
+                HouseholdId = H1,
+                ChoreId = 1,
+                CompletionId = 1,
+                CompletedByUserId = Alice,
+                CompletedAt = Now.AddHours(-2),
+                EffortPointsSnapshot = 2,
+            });
+            ctx.SaveChanges();
+        }
+
+        // Act
+        var board = await CreateService().GetBoardAsync(H1, Alice, Now);
+
+        // Assert: multi-person chore has progress from Alice's completion.
+        var multiDto = board.Chores.Single(c => c.Id == 1);
+        multiDto.RequiredCount.Should().Be(2);
+        multiDto.CompletedCount.Should().Be(1);
+        multiDto.ContributorUserIds.Should().Equal(Alice);  // [100]
+
+        // Assert: single-person chore reports zeroed progress.
+        var singleDto = board.Chores.Single(c => c.Id == 2);
+        singleDto.RequiredCount.Should().Be(1);
+        singleDto.CompletedCount.Should().Be(0);
+        singleDto.ContributorUserIds.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task MultiPersonChore_ProgressQuerySkipped_WhenNoMultiPersonChores()
+    {
+        // Arrange: all chores have RequiredCount=1 (default). The lazy P5 query should not run.
+        Seed(
+            OneOff(1, H1, null, new DateOnly(2026, 6, 10)),
+            OneOff(2, H1, null, new DateOnly(2026, 6, 10)));
+
+        // Act
+        var board = await CreateService().GetBoardAsync(H1, Alice, Now);
+
+        // All single-person chores get zeroed progress.
+        foreach (var dto in board.Chores)
+        {
+            dto.RequiredCount.Should().Be(1);
+            dto.CompletedCount.Should().Be(0);
+            dto.ContributorUserIds.Should().BeEmpty();
+        }
+    }
 }

--- a/tests/FamilyCoordinationApp.Tests/Services/ChoreEquityCalculatorTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/ChoreEquityCalculatorTests.cs
@@ -82,6 +82,35 @@ public class ChoreEquityCalculatorTests
         bob.SharePct.Should().Be(37.5);
     }
 
+    // ---- Multi-person credit (D5 — full points to EACH contributor) --------------------------------
+
+    [Fact]
+    public void Compute_MultiPersonChore_FullPointsToEachContributor()
+    {
+        // D5: a multi-person (co-sign) chore writes one ChoreCompletion per contributor, each snapshotting the
+        // chore's FULL EffortPoints (no split). Two distinct contributors of a BigJob (3 pts) each get +3, so
+        // the household total is +6. The calculator is unchanged — it just sums the two rows.
+        var now = Utc0(2026, 6, 15, 12); // Monday
+        var completions = new[]
+        {
+            Completion(userId: 1, Utc0(2026, 6, 15, 10), effortPoints: 3),
+            Completion(userId: 2, Utc0(2026, 6, 15, 11), effortPoints: 3),
+        };
+        var members = new[] { Member(1, "Alice"), Member(2, "Bob") };
+
+        var result = _calc.Compute(completions, members, EquityWindow.Week, now, Utc);
+
+        result.TotalPoints.Should().Be(6, "full points to each of the two contributors (3 + 3)");
+        result.TotalCompletions.Should().Be(2);
+
+        var alice = result.Members.Single(m => m.UserId == 1);
+        var bob = result.Members.Single(m => m.UserId == 2);
+        alice.Points.Should().Be(3);
+        bob.Points.Should().Be(3);
+        alice.SharePct.Should().Be(50.0);
+        bob.SharePct.Should().Be(50.0);
+    }
+
     // ---- Monday week boundary (council MAJOR) -------------------------------------------------------
 
     [Fact]

--- a/tests/FamilyCoordinationApp.Tests/Services/ChoreServiceTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/ChoreServiceTests.cs
@@ -293,7 +293,7 @@ public class ChoreServiceTests : IDisposable
         var created = await _service.CreateChoreAsync(HouseholdId, Alice, FlexibleCmd());
         var current = await ReloadAsync(created.ChoreId);
 
-        var result = await _service.CompleteAsync(HouseholdId, created.ChoreId, Bob, note: " good ", photoPath: null, current.Version);
+        var result = await _service.CompleteAsync(HouseholdId, created.ChoreId, Bob, note: " good ", photoPath: null, participantUserIds: null, current.Version);
 
         result.LastCompletedAt.Should().Be(NowBase);
 
@@ -313,7 +313,7 @@ public class ChoreServiceTests : IDisposable
         await _service.ClaimAsync(HouseholdId, created.ChoreId, Bob, (await ReloadAsync(created.ChoreId)).Version);
 
         var current = await ReloadAsync(created.ChoreId);
-        await _service.CompleteAsync(HouseholdId, created.ChoreId, Alice, note: null, photoPath: null, current.Version);
+        await _service.CompleteAsync(HouseholdId, created.ChoreId, Alice, note: null, photoPath: null, participantUserIds: null, current.Version);
 
         await using var ctx = new ApplicationDbContext(_options);
         var completion = await ctx.ChoreCompletions.SingleAsync(cc => cc.ChoreId == created.ChoreId);
@@ -327,7 +327,7 @@ public class ChoreServiceTests : IDisposable
         await _service.ClaimAsync(HouseholdId, created.ChoreId, Bob, (await ReloadAsync(created.ChoreId)).Version);
 
         var current = await ReloadAsync(created.ChoreId);
-        var result = await _service.CompleteAsync(HouseholdId, created.ChoreId, Bob, null, null, current.Version);
+        var result = await _service.CompleteAsync(HouseholdId, created.ChoreId, Bob, null, null, participantUserIds: null, current.Version);
 
         // Recurring + Claimed => back to pile after completion (all three cleared, council M1).
         result.AssigneeUserId.Should().BeNull();
@@ -342,7 +342,7 @@ public class ChoreServiceTests : IDisposable
         var created = await _service.CreateChoreAsync(HouseholdId, Alice, FlexibleCmd(assignee: Bob));
         var current = await ReloadAsync(created.ChoreId);
 
-        var result = await _service.CompleteAsync(HouseholdId, created.ChoreId, Bob, null, null, current.Version);
+        var result = await _service.CompleteAsync(HouseholdId, created.ChoreId, Bob, null, null, participantUserIds: null, current.Version);
 
         // Recurring + Assigned => keeps the sticky assignee.
         result.AssigneeUserId.Should().Be(Bob);
@@ -362,7 +362,7 @@ public class ChoreServiceTests : IDisposable
         var created = await _service.CreateChoreAsync(HouseholdId, Alice, cmd);
         var current = await ReloadAsync(created.ChoreId);
 
-        var result = await _service.CompleteAsync(HouseholdId, created.ChoreId, Alice, null, null, current.Version);
+        var result = await _service.CompleteAsync(HouseholdId, created.ChoreId, Alice, null, null, participantUserIds: null, current.Version);
 
         result.Status.Should().Be(ChoreStatus.Done);
         result.LastCompletedAt.Should().Be(NowBase);
@@ -382,7 +382,7 @@ public class ChoreServiceTests : IDisposable
         var created = await _service.CreateChoreAsync(HouseholdId, Alice, cmd);
         var current = await ReloadAsync(created.ChoreId);
 
-        var result = await _service.CompleteAsync(HouseholdId, created.ChoreId, Alice, null, null, current.Version);
+        var result = await _service.CompleteAsync(HouseholdId, created.ChoreId, Alice, null, null, participantUserIds: null, current.Version);
 
         // Fixed completion mutates NO recurrence field beyond LastCompletedAt — the anchor is untouched.
         result.AnchorDate.Should().Be(anchor);
@@ -393,8 +393,270 @@ public class ChoreServiceTests : IDisposable
     [Fact]
     public async Task Complete_MissingChore_ThrowsNotFound()
     {
-        var act = async () => await _service.CompleteAsync(HouseholdId, choreId: 99, Alice, null, null, version: 0);
+        var act = async () => await _service.CompleteAsync(HouseholdId, choreId: 99, Alice, null, null, participantUserIds: null, version: 0);
         await act.Should().ThrowAsync<ChoreNotFoundException>();
+    }
+
+    // ---- MULTI-PERSON COMPLETE (co-sign gate, D1=C / D4 / D5 / D6 / D7) ------
+
+    /// <summary>Council M1 trio invariant: AssigneeUserId==null ⟺ AssignmentKind==None ⟺ ClaimedAt==null.</summary>
+    private static void AssertTrioInvariant(Chore chore)
+    {
+        var noAssignee = chore.AssigneeUserId is null;
+        var kindNone = chore.AssignmentKind == AssignmentKind.None;
+        var noClaimedAt = chore.ClaimedAt is null;
+        (noAssignee == kindNone).Should().BeTrue("AssigneeUserId==null ⟺ AssignmentKind==None");
+        (kindNone == noClaimedAt).Should().BeTrue("AssignmentKind==None ⟺ ClaimedAt==null");
+    }
+
+    private async Task<int> CompletionRowCountAsync(int choreId)
+    {
+        await using var ctx = new ApplicationDbContext(_options);
+        return await ctx.ChoreCompletions.CountAsync(cc => cc.HouseholdId == HouseholdId && cc.ChoreId == choreId);
+    }
+
+    private static CreateChoreCommand OneOffCmd(int requiredCount) => FlexibleCmd() with
+    {
+        RecurrenceMode = RecurrenceMode.OneOff,
+        IntervalDays = null,
+        DaysOfWeek = null,
+        AnchorDate = new DateOnly(2026, 6, 1),
+        RequiredCount = requiredCount
+    };
+
+    [Fact]
+    public async Task Complete_OneOff_RequiredTwo_FirstCompleter_IsPartial_NoAdvance()
+    {
+        var created = await _service.CreateChoreAsync(HouseholdId, Alice, OneOffCmd(requiredCount: 2));
+        var current = await ReloadAsync(created.ChoreId);
+
+        var result = await _service.CompleteAsync(
+            HouseholdId, created.ChoreId, Alice, null, null, participantUserIds: null, current.Version);
+
+        // Partial: not satisfied — no advance, no Done, but LastContributionAt stamped + 1 row.
+        result.Status.Should().Be(ChoreStatus.Active);
+        result.LastCompletedAt.Should().BeNull();
+        result.LastContributionAt.Should().Be(NowBase);
+        (await CompletionRowCountAsync(created.ChoreId)).Should().Be(1);
+        AssertTrioInvariant(result);
+    }
+
+    [Fact]
+    public async Task Complete_OneOff_RequiredTwo_SecondDistinctUser_Satisfies_SetsDone()
+    {
+        var created = await _service.CreateChoreAsync(HouseholdId, Alice, OneOffCmd(requiredCount: 2));
+
+        await _service.CompleteAsync(
+            HouseholdId, created.ChoreId, Alice, null, null, participantUserIds: null, (await ReloadAsync(created.ChoreId)).Version);
+
+        var afterFirst = await ReloadAsync(created.ChoreId);
+        var result = await _service.CompleteAsync(
+            HouseholdId, created.ChoreId, Bob, null, null, participantUserIds: null, afterFirst.Version);
+
+        // The 2nd distinct contributor satisfies RequiredCount=2 → advance.
+        result.Status.Should().Be(ChoreStatus.Done);
+        result.LastCompletedAt.Should().Be(NowBase);
+        (await CompletionRowCountAsync(created.ChoreId)).Should().Be(2);
+        AssertTrioInvariant(result);
+    }
+
+    [Fact]
+    public async Task Complete_Flexible_RequiredTwo_ClaimedByA_PartialByA_LeavesTrioAndClockUntouched()
+    {
+        var created = await _service.CreateChoreAsync(HouseholdId, Alice, FlexibleCmd() with { RequiredCount = 2 });
+        await _service.ClaimAsync(HouseholdId, created.ChoreId, Alice, (await ReloadAsync(created.ChoreId)).Version);
+
+        var current = await ReloadAsync(created.ChoreId);
+        var result = await _service.CompleteAsync(
+            HouseholdId, created.ChoreId, Alice, null, null, participantUserIds: null, current.Version);
+
+        // Partial completion by the holder must NOT advance or change assignment (D4): trio still (A, Claimed).
+        result.AssigneeUserId.Should().Be(Alice);
+        result.AssignmentKind.Should().Be(AssignmentKind.Claimed);
+        result.LastCompletedAt.Should().BeNull();
+        result.LastContributionAt.Should().Be(NowBase);
+        (await CompletionRowCountAsync(created.ChoreId)).Should().Be(1);
+        AssertTrioInvariant(result);
+    }
+
+    [Fact]
+    public async Task Complete_Flexible_RequiredTwo_ClaimedByA_SecondByB_ReturnsToPile()
+    {
+        var created = await _service.CreateChoreAsync(HouseholdId, Alice, FlexibleCmd() with { RequiredCount = 2 });
+        await _service.ClaimAsync(HouseholdId, created.ChoreId, Alice, (await ReloadAsync(created.ChoreId)).Version);
+
+        await _service.CompleteAsync(
+            HouseholdId, created.ChoreId, Alice, null, null, participantUserIds: null, (await ReloadAsync(created.ChoreId)).Version);
+
+        var afterFirst = await ReloadAsync(created.ChoreId);
+        var result = await _service.CompleteAsync(
+            HouseholdId, created.ChoreId, Bob, null, null, participantUserIds: null, afterFirst.Version);
+
+        // The satisfying completion of a recurring + Claimed chore returns it to the pile (existing branch).
+        result.AssigneeUserId.Should().BeNull();
+        result.AssignmentKind.Should().Be(AssignmentKind.None);
+        result.ClaimedAt.Should().BeNull();
+        result.Status.Should().Be(ChoreStatus.Active);
+        result.LastCompletedAt.Should().Be(NowBase);
+        (await CompletionRowCountAsync(created.ChoreId)).Should().Be(2);
+        AssertTrioInvariant(result);
+    }
+
+    [Fact]
+    public async Task Complete_RequiredTwo_SameUserTwice_SecondThrows_StillOneRow()
+    {
+        var created = await _service.CreateChoreAsync(HouseholdId, Alice, FlexibleCmd() with { RequiredCount = 2 });
+
+        await _service.CompleteAsync(
+            HouseholdId, created.ChoreId, Alice, null, null, participantUserIds: null, (await ReloadAsync(created.ChoreId)).Version);
+
+        var afterFirst = await ReloadAsync(created.ChoreId);
+        var act = async () => await _service.CompleteAsync(
+            HouseholdId, created.ChoreId, Alice, null, null, participantUserIds: null, afterFirst.Version);
+
+        // The same user contributing twice toward the same occurrence is rejected (D6) — still 1 row.
+        await act.Should().ThrowAsync<ChoreValidationException>();
+        (await CompletionRowCountAsync(created.ChoreId)).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Complete_NameOthers_ActorPlusParticipant_SatisfiesInOneCall_TwoRows()
+    {
+        var created = await _service.CreateChoreAsync(HouseholdId, Alice, FlexibleCmd() with { RequiredCount = 2 });
+        var current = await ReloadAsync(created.ChoreId);
+
+        // Actor Alice names Bob as a co-participant (D7) — [A,B] on a RequiredCount=2 chore satisfies at once.
+        var result = await _service.CompleteAsync(
+            HouseholdId, created.ChoreId, Alice, null, null, participantUserIds: new[] { Alice, Bob }, current.Version);
+
+        result.LastCompletedAt.Should().Be(NowBase);
+        (await CompletionRowCountAsync(created.ChoreId)).Should().Be(2);
+
+        await using var ctx = new ApplicationDbContext(_options);
+        var contributors = await ctx.ChoreCompletions
+            .Where(cc => cc.ChoreId == created.ChoreId)
+            .Select(cc => cc.CompletedByUserId)
+            .ToListAsync();
+        contributors.Should().BeEquivalentTo(new[] { Alice, Bob });
+        AssertTrioInvariant(result);
+    }
+
+    [Fact]
+    public async Task Complete_NameOthers_DuplicateInList_DedupesToOneRow()
+    {
+        var created = await _service.CreateChoreAsync(HouseholdId, Alice, FlexibleCmd() with { RequiredCount = 2 });
+        var current = await ReloadAsync(created.ChoreId);
+
+        // [A,A] dedupes within the call → a single contributor → 1 row (and a partial, RequiredCount=2 unmet).
+        var result = await _service.CompleteAsync(
+            HouseholdId, created.ChoreId, Alice, null, null, participantUserIds: new[] { Alice }, current.Version);
+
+        (await CompletionRowCountAsync(created.ChoreId)).Should().Be(1);
+        result.LastCompletedAt.Should().BeNull();
+        result.LastContributionAt.Should().Be(NowBase);
+        AssertTrioInvariant(result);
+    }
+
+    [Fact]
+    public async Task Complete_NameOthers_NonMember_IsRejected()
+    {
+        var created = await _service.CreateChoreAsync(HouseholdId, Alice, FlexibleCmd() with { RequiredCount = 2 });
+        var current = await ReloadAsync(created.ChoreId);
+
+        // Carol belongs to another household — naming her must be rejected (D7 member validation, M1).
+        var act = async () => await _service.CompleteAsync(
+            HouseholdId, created.ChoreId, Alice, null, null, participantUserIds: new[] { Carol }, current.Version);
+
+        await act.Should().ThrowAsync<ChoreValidationException>();
+        (await CompletionRowCountAsync(created.ChoreId)).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Complete_NameOthers_RepeatActorNamesNewParticipant_DoesNotThrow_AdvancesViaParticipant()
+    {
+        // D7 escape hatch: a present member (already in priorSet) can record a NEW participant. Even though the
+        // actor already contributed, newContributors is non-empty → no D6 throw, and the new participant
+        // satisfies the count.
+        var created = await _service.CreateChoreAsync(HouseholdId, Alice, FlexibleCmd() with { RequiredCount = 2 });
+
+        await _service.CompleteAsync(
+            HouseholdId, created.ChoreId, Alice, null, null, participantUserIds: null, (await ReloadAsync(created.ChoreId)).Version);
+
+        var afterFirst = await ReloadAsync(created.ChoreId);
+        var result = await _service.CompleteAsync(
+            HouseholdId, created.ChoreId, Alice, null, null, participantUserIds: new[] { Bob }, afterFirst.Version);
+
+        // Alice (already counted) is silently skipped; Bob is the only new row → 2 distinct → satisfied.
+        result.LastCompletedAt.Should().Be(NowBase);
+        (await CompletionRowCountAsync(created.ChoreId)).Should().Be(2);
+        AssertTrioInvariant(result);
+    }
+
+    [Fact]
+    public async Task Complete_RequiredOne_Regression_AdvancesOnFirstCompletion()
+    {
+        // The RequiredCount=1 default path is unchanged: one completion satisfies and advances.
+        var created = await _service.CreateChoreAsync(HouseholdId, Alice, FlexibleCmd());
+        var current = await ReloadAsync(created.ChoreId);
+
+        var result = await _service.CompleteAsync(
+            HouseholdId, created.ChoreId, Alice, null, null, participantUserIds: null, current.Version);
+
+        result.LastCompletedAt.Should().Be(NowBase);
+        result.LastContributionAt.Should().Be(NowBase);
+        (await CompletionRowCountAsync(created.ChoreId)).Should().Be(1);
+        AssertTrioInvariant(result);
+    }
+
+    // ---- REQUIRED-COUNT VALIDATION (D2 / ValidateRequiredCount) -------------
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task Create_RequiredCountBelowOne_IsRejected(int requiredCount)
+    {
+        var cmd = FlexibleCmd() with { RequiredCount = requiredCount };
+        var act = async () => await _service.CreateChoreAsync(HouseholdId, Alice, cmd);
+        await act.Should().ThrowAsync<ChoreValidationException>();
+    }
+
+    [Fact]
+    public async Task Create_RequiredCountTwo_IsPersisted()
+    {
+        var chore = await _service.CreateChoreAsync(HouseholdId, Alice, FlexibleCmd() with { RequiredCount = 2 });
+        chore.RequiredCount.Should().Be(2);
+        (await ReloadAsync(chore.ChoreId)).RequiredCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Update_RequiredCountBelowOne_IsRejected()
+    {
+        var created = await _service.CreateChoreAsync(HouseholdId, Alice, FlexibleCmd() with { RequiredCount = 2 });
+        var current = await ReloadAsync(created.ChoreId);
+        var cmd = new UpdateChoreCommand(
+            Name: "Dishes", Description: null, RoomId: null,
+            RecurrenceMode: RecurrenceMode.Flexible, IntervalDays: 7, AnchorDate: null,
+            DaysOfWeek: null, DayOfMonth: null, EffortTier: EffortTier.Standard,
+            OwnerUserId: null, PhotoPath: null, Icon: "", RequiredCount: 0);
+
+        var act = async () => await _service.UpdateChoreAsync(HouseholdId, created.ChoreId, cmd, current.Version);
+        await act.Should().ThrowAsync<ChoreValidationException>();
+    }
+
+    [Fact]
+    public async Task Update_RequiredCount_IsPersisted()
+    {
+        var created = await _service.CreateChoreAsync(HouseholdId, Alice, FlexibleCmd());
+        var current = await ReloadAsync(created.ChoreId);
+        var cmd = new UpdateChoreCommand(
+            Name: "Dishes", Description: null, RoomId: null,
+            RecurrenceMode: RecurrenceMode.Flexible, IntervalDays: 7, AnchorDate: null,
+            DaysOfWeek: null, DayOfMonth: null, EffortTier: EffortTier.Standard,
+            OwnerUserId: null, PhotoPath: null, Icon: "", RequiredCount: 3);
+
+        var updated = await _service.UpdateChoreAsync(HouseholdId, created.ChoreId, cmd, current.Version);
+        updated.RequiredCount.Should().Be(3);
+        (await ReloadAsync(created.ChoreId)).RequiredCount.Should().Be(3);
     }
 
     // ---- CONCURRENCY MAPPING (not the xmin detection — that's WP-08) -------


### PR DESCRIPTION
## What

Adds an option for a chore to **require N distinct people to complete** (default 1 = today's behavior). A multi-person chore stays on the board showing **"X of N done"** until N distinct household members have each registered; only the Nth completion advances it. A completer can **name other participants** in one action (the escape hatch), so one present member can satisfy the count.

Implements the workshop spec `chore-multi-person-requirement` (D1 = co-sign gate; E1 = "edit the count down" recovery for v1).

## How (7 work packages, 5 waves)

1. **Schema** — `Chore.RequiredCount` (int, default 1) + `LastContributionAt` (serialization marker); additive migration `AddChoreRequiredCount`.
2. **Service gate** — `CompleteAsync` is contribution-aware: writes one `ChoreCompletion` per distinct *new* contributor, forces an xmin-guarded `Chore` write on every contribution (so concurrent contributions serialize), and advances **only** when distinct contributors reach `RequiredCount`. All existing completion behavior preserved (effort snapshot, auto-release-stale, OneOff→Done, recurring pile/keep). Duplicate contribution by the same user → rejected (400). Adds the `ChoreCompletionProgress` helper.
4. **Board projection** — `ChoreDto` gains `requiredCount` / `completedCount` / `contributorUserIds`, computed lazily in `GetBoardAsync` (only when multi-person chores exist). Contract lockstep updated (`board.json` + `types.ts` + `api.ts`).
5. **Endpoints** — create/update accept `requiredCount`.
6. **Sheets** — "How many people?" control in the create/edit sheets, capped at the household member count.
7. **Card + flow** — "X of N done" chip, per-user Done-button state ("Mark done" / disabled "You're in — waiting on others"), a new `CompleteDialog` participant picker, and a store reconcile that refetches the board after multi-person mutations (single-chore responses can't signal progress).
3. **Concurrency tests** — real-Postgres `MultiPersonChoreTests`: e2e gate, xmin-bumps-on-partial, the load-bearing two-racer serialization proof (asserts the "N-of-N-not-advanced" wedge and double-advance never occur), and distinctness-across-the-wire.

## Design notes

- **Equity**: each contributor credited *full* points (a 2-person Standard chore = 2 pts each), not split.
- **Concurrency**: every contribution forces `LastContributionAt = now` (property marked modified) so EF emits an UPDATE and the xmin check fires — this is what serializes racing contributions. Proven on real Postgres.
- **Progress is derived, never stored** (distinct `CompletedByUserId` with `CompletedAt > LastCompletedAt`).
- Single-person (`requiredCount == 1`) path is byte-for-byte behaviorally unchanged.

## Verification

- **464 unit tests** green (zero regression), incl. new co-sign / distinctness / name-others / equity / M2-trio cases.
- **Integration (real Postgres, run individually)**: `ChoreRoundTripTests` 4/4, `MultiPersonChoreTests` 4/4 (incl. the two-racer xmin proof — no E2 escalation).
- **svelte-check** 0/0, island build OK.
- **Manual browser verification** on a feature-branch Docker build with real auth: create-with-"needs 2 people" (cap at member count) → "0 of 2" chip → claim keeps "0 of 2" → partial completion reconciles to **"1 of 2" + "waiting on others"** (not optimistically removed) → name-others satisfies 2 of 2 in one action → OneOff advances off the board → equity credits both contributors full points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)