### PR TITLE
fix(chores): keep multi-person chores up-for-grabs until full complement

### DIFF
--- a/frontend/chores/src/lib/components/ChoreCard.svelte
+++ b/frontend/chores/src/lib/components/ChoreCard.svelte
@@ -286,7 +286,39 @@
         (`pending`) to prevent double-submit.
       -->
       <div class="ch-actions">
-        {#if isUnclaimed}
+        {#if isMultiPerson}
+          <!--
+            Multi-person (co-sign) chores are NOT claimable — they stay in the
+            pile until the full complement signs, so every member who hasn't yet
+            signed can pick up their part from up-for-grabs. No Claim / Drop /
+            Hand-off here (the grouping in state.svelte.ts routes a co-sign chore
+            to up-for-grabs for non-signers, Mine for signers).
+          -->
+          {#if iSigned}
+            <!-- Already signed this occurrence (D6) — waiting on the others. -->
+            <button
+              type="button"
+              class="ch-btn ch-btn-ghost"
+              data-action="complete"
+              disabled
+              title="You've marked this done — waiting on others"
+            >
+              You're in — waiting on others
+            </button>
+          {:else}
+            <!-- Hasn't signed — opens the participant dialog (App.svelte). -->
+            <button
+              type="button"
+              class="ch-btn ch-btn-primary"
+              data-action="complete"
+              onclick={() => onComplete?.(chore)}
+              disabled={pending}
+              title="Mark this chore done"
+            >
+              Mark done
+            </button>
+          {/if}
+        {:else if isUnclaimed}
           <button
             type="button"
             class="ch-btn ch-btn-primary"
@@ -322,42 +354,17 @@
               Drop
             </button>
           {/if}
-          {#if !isMultiPerson}
-            <!-- Single-person chore — today's exact one-tap Done (unchanged, P2). -->
-            <button
-              type="button"
-              class="ch-btn ch-btn-primary"
-              data-action="complete"
-              onclick={() => onComplete?.(chore)}
-              disabled={pending}
-              title="Mark this chore done"
-            >
-              Done
-            </button>
-          {:else if iSigned}
-            <!-- Co-sign chore the viewing user has already signed (D6). -->
-            <button
-              type="button"
-              class="ch-btn ch-btn-ghost"
-              data-action="complete"
-              disabled
-              title="You've marked this done — waiting on others"
-            >
-              You're in — waiting on others
-            </button>
-          {:else}
-            <!-- Co-sign chore the viewing user hasn't signed — opens the dialog. -->
-            <button
-              type="button"
-              class="ch-btn ch-btn-primary"
-              data-action="complete"
-              onclick={() => onComplete?.(chore)}
-              disabled={pending}
-              title="Mark this chore done"
-            >
-              Mark done
-            </button>
-          {/if}
+          <!-- Single-person chore — today's exact one-tap Done (unchanged, P2). -->
+          <button
+            type="button"
+            class="ch-btn ch-btn-primary"
+            data-action="complete"
+            onclick={() => onComplete?.(chore)}
+            disabled={pending}
+            title="Mark this chore done"
+          >
+            Done
+          </button>
         {/if}
         {#if onEdit}
           <button

--- a/frontend/chores/src/lib/state.svelte.ts
+++ b/frontend/chores/src/lib/state.svelte.ts
@@ -276,12 +276,22 @@ class BoardStore {
   // Unclaimed pile chores PLUS stale claims (isClaimStale — pile-eligible per
   // WP-04/05 stale-claim UX). Dirtiest-first. WP-12 builds the lane UI.
 
-  upForGrabsChores = $derived.by<ChoreDto[]>(() =>
-    this.chores
-      .filter((c) => c.assignmentKind === 'none' || c.isClaimStale)
+  upForGrabsChores = $derived.by<ChoreDto[]>(() => {
+    const uid = this.currentUserId;
+    return this.chores
+      .filter((c) => {
+        // Multi-person (co-sign) chores stay in the pile until the full
+        // complement signs — claiming no longer hides them (a still-incomplete
+        // co-sign chore is "up for grabs" to every member who hasn't signed yet,
+        // so they can pick up their part). Signers see it in Mine instead.
+        if (c.requiredCount > 1 && c.completedCount < c.requiredCount) {
+          return !c.contributorUserIds.includes(uid);
+        }
+        return c.assignmentKind === 'none' || c.isClaimStale;
+      })
       .slice()
-      .sort(sortDirtiestFirst),
-  );
+      .sort(sortDirtiestFirst);
+  });
 
   // ── Mine lens (grouping seam — full UI is WP-12) ─────────────────────────
   //
@@ -292,6 +302,13 @@ class BoardStore {
     const uid = this.currentUserId;
     return this.chores
       .filter((c) => {
+        // A co-sign chore the viewer has already signed sits on their plate
+        // (waiting on the others) until it's satisfied; if they haven't signed,
+        // it's an up-for-grabs pile chore, not theirs. Co-sign chores aren't
+        // claimable, so the claim/owner rules below don't apply to them.
+        if (c.requiredCount > 1 && c.completedCount < c.requiredCount) {
+          return c.contributorUserIds.includes(uid);
+        }
         const heldByMe =
           c.assigneeUserId === uid && c.assignmentKind !== 'none' && !c.isClaimStale;
         const ownedByMe = c.ownerUserId === uid;
@@ -332,16 +349,21 @@ class BoardStore {
   // ── Helpers ──────────────────────────────────────────────────────────────
 
   private passesAttentionFilter(c: ChoreDto): boolean {
+    // Co-sign chores partition by whether the viewer has signed (mirrors
+    // upForGrabsChores / mineChores): not-yet-signed → up-for-grabs, signed →
+    // mine. They are never claimable, so the claim/owner rules don't apply.
+    const coSignInProgress = c.requiredCount > 1 && c.completedCount < c.requiredCount;
+    const uid = this.currentUserId;
     switch (this.attentionFilter) {
       case 'up-for-grabs':
-        return c.assignmentKind === 'none' || c.isClaimStale;
+        return coSignInProgress
+          ? !c.contributorUserIds.includes(uid)
+          : c.assignmentKind === 'none' || c.isClaimStale;
       case 'mine':
-        return (
-          (c.assigneeUserId === this.currentUserId &&
-            c.assignmentKind !== 'none' &&
-            !c.isClaimStale) ||
-          c.ownerUserId === this.currentUserId
-        );
+        return coSignInProgress
+          ? c.contributorUserIds.includes(uid)
+          : (c.assigneeUserId === uid && c.assignmentKind !== 'none' && !c.isClaimStale) ||
+              c.ownerUserId === uid;
       case 'everything':
       default:
         return true;


### PR DESCRIPTION
## Problem

A multi-person (co-sign) chore that someone **claimed** dropped out of the up-for-grabs pile and landed only in the claimer's "Mine" — so the *other* members who still need to contribute couldn't see it anywhere. A two-person chore would get stuck because the second person had no way to find it and mark their part.

The original lane grouping was purely claim-based and never consulted completion progress.

## Fix (frontend-only)

A co-sign chore stays in the pile until it has its **full complement** of signers. The lanes now partition **per viewer by whether they've signed**, ignoring claim/assignment:

- **`upForGrabsChores` / `mineChores` / `passesAttentionFilter`** (`state.svelte.ts`): for `requiredCount > 1 && completedCount < requiredCount` — *haven't signed → up-for-grabs*, *signed → Mine (waiting on others)*. Otherwise the existing claim-based rules apply (single-person chores unchanged).
- **`ChoreCard.svelte`**: multi-person chores are **no longer claimable** — they show only **"Mark done"** / disabled **"You're in — waiting on others"**, with no Claim / Drop / Hand-off. Single-person card actions are byte-for-byte unchanged.

So: a "needs 2" chore sits in up-for-grabs with a **Mark done** button; the first person marks their part → it moves to *their* Mine but **stays visible to everyone else** in up-for-grabs until the 2nd signs, then advances off the board. Per the design decision: drop "claim" for multi-person chores; keep up-for-grabs visibility until full complement.

All data is server-supplied (`requiredCount` / `completedCount` / `contributorUserIds`) — no client-side count/membership math (MN3), no backend change.

## Verification

- svelte-check **0 errors / 0 warnings**, island build OK.
- No island grouping test harness exists (documented gap); manual browser eyeball recommended on deploy.

Fast follow-up to #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)