### PR TITLE
feat(chores): multi-person named soft roster (rework of co-sign)

### DIFF
--- a/frontend/chores/src/App.svelte
+++ b/frontend/chores/src/App.svelte
@@ -81,6 +81,12 @@
   function handleDrop(chore: ChoreDto) {
     store.drop(chore.id);
   }
+  function handleCommit(chore: ChoreDto) {
+    store.commit(chore.id);
+  }
+  function handleLeave(chore: ChoreDto) {
+    store.leave(chore.id);
+  }
   function handleComplete(chore: ChoreDto) {
     // Multi-person (co-sign) chore → open the participant dialog so the present
     // member can record who's marking it done (D7). Single-person chore → keep
@@ -243,6 +249,8 @@
         onDrop={handleDrop}
         onComplete={handleComplete}
         onHandOff={handleHandOff}
+        onCommit={handleCommit}
+        onLeave={handleLeave}
         onEdit={handleEdit}
       />
     {:else if store.lens === 'rooms'}
@@ -254,6 +262,8 @@
         onDrop={handleDrop}
         onComplete={handleComplete}
         onHandOff={handleHandOff}
+        onCommit={handleCommit}
+        onLeave={handleLeave}
         onEdit={handleEdit}
       />
     {:else if store.lens === 'up-for-grabs'}
@@ -265,6 +275,8 @@
         onDrop={handleDrop}
         onComplete={handleComplete}
         onHandOff={handleHandOff}
+        onCommit={handleCommit}
+        onLeave={handleLeave}
         onEdit={handleEdit}
       />
     {:else if store.lens === 'mine'}
@@ -277,6 +289,8 @@
         onDrop={handleDrop}
         onComplete={handleComplete}
         onHandOff={handleHandOff}
+        onCommit={handleCommit}
+        onLeave={handleLeave}
         onEdit={handleEdit}
       />
     {:else if store.lens === 'equity'}

--- a/frontend/chores/src/lib/api.ts
+++ b/frontend/chores/src/lib/api.ts
@@ -93,8 +93,10 @@ export interface CreateChoreRequest {
   photoPath?: string | null;
   /** Optional emoji/short-code icon; "" or omitted = none. */
   icon?: string;
-  /** Number of distinct contributors required to satisfy the chore (WP-05). Omit or 1 = normal. */
+  /** Number of people required to satisfy the chore. Omit or 1 = normal single-person chore. */
   requiredCount?: number;
+  /** Initial named roster for a multi-person chore (X>1) — each seeded as Assigned. Ignored for X=1. */
+  assignedUserIds?: number[];
 }
 
 /** No assignee — assignment never moves via edit. Carries the version. */
@@ -134,6 +136,18 @@ export interface CompleteRequest {
   version: number;
   /** Co-signers for multi-person chores (WP-05); omit for single-person completions. */
   participantUserIds?: number[];
+}
+
+/** Add a named member to a multi-person chore's roster (Assigned). */
+export interface AssignRosterRequest {
+  subjectUserId: number;
+  version: number;
+}
+
+/** Leave/remove from a roster. subjectUserId omitted/null ⇒ the caller leaves. */
+export interface LeaveRosterRequest {
+  subjectUserId?: number | null;
+  version: number;
 }
 
 export interface PhotoUploadResponse {
@@ -221,6 +235,42 @@ export async function completeChore(
   return request<ChoreDto>(`${CHORES_BASE}/${choreId}/complete`, {
     method: 'POST',
     ...jsonBody(body),
+  });
+}
+
+// ─── Roster mutations (multi-person named soft roster, rework) ──────────────
+// Each returns the projected ChoreDto; the store reconciles via the board GET
+// for the authoritative roster (the single-chore response carries an empty one).
+
+/** Assign a named member to a multi-person chore's roster (Assigned — a declinable pre-opt-in). */
+export async function assignRoster(
+  choreId: number,
+  subjectUserId: number,
+  version: number,
+): Promise<ChoreDto> {
+  return request<ChoreDto>(`${CHORES_BASE}/${choreId}/roster/assign`, {
+    method: 'POST',
+    ...jsonBody({ subjectUserId, version } satisfies AssignRosterRequest),
+  });
+}
+
+/** Commit the caller to a multi-person chore's roster ("I'm in" — self-opt-in or confirm). */
+export async function commitRoster(choreId: number, version: number): Promise<ChoreDto> {
+  return request<ChoreDto>(`${CHORES_BASE}/${choreId}/roster/commit`, {
+    method: 'POST',
+    ...jsonBody({ version } satisfies VersionRequest),
+  });
+}
+
+/** Leave/remove from a roster. `subjectUserId` null ⇒ the caller leaves. */
+export async function leaveRoster(
+  choreId: number,
+  subjectUserId: number | null,
+  version: number,
+): Promise<ChoreDto> {
+  return request<ChoreDto>(`${CHORES_BASE}/${choreId}/roster/leave`, {
+    method: 'POST',
+    ...jsonBody({ subjectUserId, version } satisfies LeaveRosterRequest),
   });
 }
 

--- a/frontend/chores/src/lib/components/ChoreCard.svelte
+++ b/frontend/chores/src/lib/components/ChoreCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { ChoreDto, ColorTier, DueState, EffortTier, RecurrenceMode } from '../types';
+  import type { ChoreDto, ColorTier, DueState, EffortTier, RecurrenceMode, RosterState } from '../types';
   import { memberFor, roomFor } from '../state.svelte';
   import { showPhoto } from '../lightbox.svelte';
   import MemberAvatar from './MemberAvatar.svelte';
@@ -36,6 +36,10 @@
     onDrop?: (chore: ChoreDto) => void;
     onComplete?: (chore: ChoreDto) => void;
     onHandOff?: (chore: ChoreDto) => void;
+    /** Commit ("I'm in") on a multi-person chore's roster. */
+    onCommit?: (chore: ChoreDto) => void;
+    /** Leave ("Not me") a multi-person chore's roster. */
+    onLeave?: (chore: ChoreDto) => void;
     /** Open the edit sheet for this chore. */
     onEdit?: (chore: ChoreDto) => void;
   }
@@ -49,6 +53,8 @@
     onDrop,
     onComplete,
     onHandOff,
+    onCommit,
+    onLeave,
     onEdit,
   }: Props = $props();
 
@@ -85,15 +91,31 @@
   let isClaimed = $derived(chore.assignmentKind === 'claimed' && !chore.isClaimStale);
   let isAssigned = $derived(chore.assignmentKind === 'assigned');
 
-  // ── Multi-person co-sign (WP-07) ─────────────────────────────────────────
-  // SERVER fields only (MN3 — no client count/membership math). `requiredCount
-  // > 1` marks a co-sign chore; `completedCount`/`contributorUserIds` are the
-  // authoritative current-occurrence progress from the board GET (the store
-  // reconciles after each mutation, so these are fresh). When the viewing user
-  // is already in `contributorUserIds` they've signed this occurrence and the
-  // Done button shows a waiting state (D6) instead of re-opening the dialog.
+  // ── Multi-person named roster (rework) ───────────────────────────────────
+  // SERVER fields only (MN3 — no client count/membership math). `roster` carries
+  // each member's derived state (assigned/in/done); `completedCount`/`requiredCount`
+  // are the authoritative "k of X" gate (fresh — the store reconciles via the board
+  // GET after each mutation). The viewer's OWN roster state drives which actions show.
   let isMultiPerson = $derived(chore.requiredCount > 1);
-  let iSigned = $derived(chore.contributorUserIds.includes(currentUserId));
+  let myRosterState = $derived<RosterState | null>(
+    chore.roster.find((m) => m.userId === currentUserId)?.state ?? null,
+  );
+  let iAmDone = $derived(myRosterState === 'done');
+  let onRoster = $derived(myRosterState !== null);
+  let rosterMembers = $derived(
+    chore.roster.map((m) => ({ userId: m.userId, state: m.state, member: memberFor(m.userId) })),
+  );
+
+  const ROSTER_LABEL: Record<RosterState, string> = {
+    assigned: 'Assigned',
+    in: "I'm in",
+    done: 'Done',
+  };
+  const ROSTER_GLYPH: Record<RosterState, string> = {
+    assigned: '○',
+    in: '●',
+    done: '✓',
+  };
 
   // ── Who can do what (drives the action buttons) ──────────────────────────
   // The viewing user "holds" the chore when they're the active (non-stale)
@@ -253,7 +275,30 @@
           </span>
         {/if}
 
-        {#if isClaimed && assignee}
+        {#if isMultiPerson}
+          <div class="ch-roster" aria-label="Roster: {chore.completedCount} of {chore.requiredCount} done">
+            {#each rosterMembers as r (r.userId)}
+              {#if r.member}
+                <span
+                  class="ch-roster-member ch-roster-{r.state}"
+                  title="{nameOf(r.userId, r.member.displayName)} — {ROSTER_LABEL[r.state]}"
+                >
+                  <MemberAvatar
+                    name={r.member.displayName}
+                    initials={r.member.initials}
+                    pictureUrl={r.member.pictureUrl}
+                    size={26}
+                    relation={ROSTER_LABEL[r.state]}
+                  />
+                  <span class="ch-roster-badge" aria-hidden="true">{ROSTER_GLYPH[r.state]}</span>
+                </span>
+              {/if}
+            {/each}
+            {#if rosterMembers.length === 0}
+              <span class="ch-claim ch-claim-open">Needs {chore.requiredCount} — no one yet</span>
+            {/if}
+          </div>
+        {:else if isClaimed && assignee}
           <span class="ch-claim ch-claim-claimed">
             <MemberAvatar
               name={assignee.displayName}
@@ -288,35 +333,57 @@
       <div class="ch-actions">
         {#if isMultiPerson}
           <!--
-            Multi-person (co-sign) chores are NOT claimable — they stay in the
-            pile until the full complement signs, so every member who hasn't yet
-            signed can pick up their part from up-for-grabs. No Claim / Drop /
-            Hand-off here (the grouping in state.svelte.ts routes a co-sign chore
-            to up-for-grabs for non-signers, Mine for signers).
+            Multi-person chores are NOT claimable. Actions depend on the viewer's
+            roster state: done → waiting; on-roster → mark-done / not-me; assigned
+            or not-on-roster → I'm-in/I'll-help to join, plus mark-done (anyone may
+            complete toward the count). The store routes the chore to Mine (on
+            roster) or Up-for-grabs (not) — see state.svelte.ts.
           -->
-          {#if iSigned}
-            <!-- Already signed this occurrence (D6) — waiting on the others. -->
+          {#if iAmDone}
             <button
               type="button"
               class="ch-btn ch-btn-ghost"
               data-action="complete"
               disabled
-              title="You've marked this done — waiting on others"
+              title="You've done your part — waiting on the others"
             >
-              You're in — waiting on others
+              You're done ✓
             </button>
           {:else}
-            <!-- Hasn't signed — opens the participant dialog (App.svelte). -->
+            {#if !onRoster || myRosterState === 'assigned'}
+              <button
+                type="button"
+                class="ch-btn ch-btn-ghost"
+                data-action="commit"
+                onclick={() => onCommit?.(chore)}
+                disabled={pending}
+                title={onRoster ? "Confirm you're in" : "Join in — I'll help"}
+              >
+                {onRoster ? "I'm in" : "I'll help"}
+              </button>
+            {/if}
             <button
               type="button"
               class="ch-btn ch-btn-primary"
               data-action="complete"
               onclick={() => onComplete?.(chore)}
               disabled={pending}
-              title="Mark this chore done"
+              title="Mark your part done"
             >
-              Mark done
+              Mark my part done
             </button>
+            {#if onRoster}
+              <button
+                type="button"
+                class="ch-btn ch-btn-ghost"
+                data-action="leave"
+                onclick={() => onLeave?.(chore)}
+                disabled={pending}
+                title="I can't do this one — take me off"
+              >
+                Not me
+              </button>
+            {/if}
           {/if}
         {:else if isUnclaimed}
           <button
@@ -608,6 +675,43 @@
   }
   .ch-claim-open {
     font-style: italic;
+  }
+
+  /* ── Multi-person roster strip (avatars badged assigned ○ / in ● / done ✓) ── */
+  .ch-roster {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .ch-roster-member {
+    position: relative;
+    display: inline-flex;
+  }
+  /* An assigned (not-yet-confirmed) member reads quieter than a committed one. */
+  .ch-roster-assigned {
+    opacity: 0.65;
+  }
+  .ch-roster-badge {
+    position: absolute;
+    right: -3px;
+    bottom: -3px;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    font-size: 9px;
+    line-height: 1;
+    color: #fff;
+    background: var(--color-text-muted);
+    box-shadow: 0 0 0 2px var(--color-surface);
+  }
+  .ch-roster-in .ch-roster-badge {
+    background: var(--color-info);
+  }
+  .ch-roster-done .ch-roster-badge {
+    background: var(--color-success);
   }
 
   .ch-actions {

--- a/frontend/chores/src/lib/components/CompleteDialog.svelte
+++ b/frontend/chores/src/lib/components/CompleteDialog.svelte
@@ -36,8 +36,10 @@
 
   let dialogEl: HTMLDialogElement | null = $state(null);
 
-  // The contributors who have already signed THIS occurrence (server field).
-  let alreadyIn = $derived<number[]>(chore?.contributorUserIds ?? []);
+  // The members who have already completed THIS occurrence — the roster's done members (server field).
+  let alreadyIn = $derived<number[]>(
+    (chore?.roster ?? []).filter((m) => m.state === 'done').map((m) => m.userId),
+  );
 
   // The members the user can newly select (everyone NOT already in). The
   // current user, if not already in, is prefilled (see `selected` seeding).
@@ -54,7 +56,8 @@
     if (!dialogEl) return;
     if (open && !dialogEl.open) {
       const next = new Set<number>();
-      if (chore && !(chore.contributorUserIds ?? []).includes(currentUserId)) {
+      const doneIds = (chore?.roster ?? []).filter((m) => m.state === 'done').map((m) => m.userId);
+      if (chore && !doneIds.includes(currentUserId)) {
         next.add(currentUserId);
       }
       selected = next;

--- a/frontend/chores/src/lib/components/MineView.svelte
+++ b/frontend/chores/src/lib/components/MineView.svelte
@@ -26,11 +26,24 @@
     onDrop: (chore: ChoreDto) => void;
     onComplete: (chore: ChoreDto) => void;
     onHandOff: (chore: ChoreDto) => void;
+    onCommit: (chore: ChoreDto) => void;
+    onLeave: (chore: ChoreDto) => void;
     onEdit: (chore: ChoreDto) => void;
   }
 
-  let { chores, loads, currentUserId, isPending, onClaim, onDrop, onComplete, onHandOff, onEdit }: Props =
-    $props();
+  let {
+    chores,
+    loads,
+    currentUserId,
+    isPending,
+    onClaim,
+    onDrop,
+    onComplete,
+    onHandOff,
+    onCommit,
+    onLeave,
+    onEdit,
+  }: Props = $props();
 
   // Deterministic per-user avatar accent (hash userId → palette). Purely
   // cosmetic, no schema change — gives each member a stable color in the strip.
@@ -102,6 +115,8 @@
             {onDrop}
             {onComplete}
             {onHandOff}
+            {onCommit}
+            {onLeave}
             {onEdit}
           />
         {/each}

--- a/frontend/chores/src/lib/components/NeedsAttentionBoard.svelte
+++ b/frontend/chores/src/lib/components/NeedsAttentionBoard.svelte
@@ -26,6 +26,8 @@
     onDrop: (chore: ChoreDto) => void;
     onComplete: (chore: ChoreDto) => void;
     onHandOff: (chore: ChoreDto) => void;
+    onCommit: (chore: ChoreDto) => void;
+    onLeave: (chore: ChoreDto) => void;
     onEdit: (chore: ChoreDto) => void;
   }
 
@@ -40,6 +42,8 @@
     onDrop,
     onComplete,
     onHandOff,
+    onCommit,
+    onLeave,
     onEdit,
   }: Props = $props();
 
@@ -84,6 +88,8 @@
               {onDrop}
               {onComplete}
               {onHandOff}
+              {onCommit}
+              {onLeave}
               {onEdit}
             />
           {/each}

--- a/frontend/chores/src/lib/components/QuickAddSheet.svelte
+++ b/frontend/chores/src/lib/components/QuickAddSheet.svelte
@@ -66,6 +66,8 @@
   let assigneeUserId = $state<number | null>(null);
   /** 1 = single person (default); ≥2 = multi-person requirement. */
   let requiredCount = $state(1);
+  /** Named roster for a multi-person chore (assigned at create as a soft pre-opt-in). Ignored when 1. */
+  let assignedUserIds = $state<number[]>([]);
   let photo = $state<File | null>(null);
   let localError = $state<string | null>(null);
 
@@ -176,6 +178,7 @@
     roomId = null;
     assigneeUserId = null;
     requiredCount = 1;
+    assignedUserIds = [];
     photo = null;
     localError = null;
     // Reset the inline new-room form UI (keep createdRooms — a later board reload dedups them).
@@ -202,6 +205,13 @@
     if (next.has(flag)) next.delete(flag);
     else next.add(flag);
     selectedDays = next;
+  }
+
+  /** Toggle a member in the multi-person create-time roster (assigned). */
+  function toggleAssignee(userId: number) {
+    assignedUserIds = assignedUserIds.includes(userId)
+      ? assignedUserIds.filter((id) => id !== userId)
+      : [...assignedUserIds, userId];
   }
 
   function onPhotoChange(e: Event) {
@@ -264,8 +274,10 @@
       effortTier: effort,
       icon: choreIcon,
       ownerUserId: null,
-      assigneeUserId,
+      // X=1 uses the single-holder trio; X>1 ignores it and seeds the named roster instead.
+      assigneeUserId: requiredCount > 1 ? null : assigneeUserId,
       requiredCount,
+      assignedUserIds: requiredCount > 1 ? assignedUserIds : undefined,
       // Photo is NEVER in the create JSON (council C2) — the parent uploads it
       // separately to /api/chores/{id}/photo after the create returns an id.
       photoPath: null,
@@ -520,31 +532,53 @@
       </fieldset>
 
       <fieldset class="ch-field">
-        <legend class="ch-field-label">Who's on it?</legend>
-        <div class="ch-chip-row" role="group" aria-label="Assignee">
-          <button
-            type="button"
-            class="ch-chip"
-            class:active={assigneeUserId === null}
-            aria-pressed={assigneeUserId === null}
-            onclick={() => (assigneeUserId = null)}
-          >
-            Leave for anyone
-          </button>
-          {#each members as member (member.userId)}
+        <legend class="ch-field-label">
+          {requiredCount > 1 ? 'Assign people (optional)' : "Who's on it?"}
+        </legend>
+        {#if requiredCount > 1}
+          <div class="ch-chip-row" role="group" aria-label="Assign people">
+            {#each members as member (member.userId)}
+              <button
+                type="button"
+                class="ch-chip"
+                class:active={assignedUserIds.includes(member.userId)}
+                aria-pressed={assignedUserIds.includes(member.userId)}
+                onclick={() => toggleAssignee(member.userId)}
+              >
+                {member.displayName}
+              </button>
+            {/each}
+          </div>
+          <p class="ch-hint">
+            Name up to {requiredCount} — or leave it open and let people pitch in. Assigning is just a
+            suggestion: anyone can join (“I'm in”) or step off.
+          </p>
+        {:else}
+          <div class="ch-chip-row" role="group" aria-label="Assignee">
             <button
               type="button"
               class="ch-chip"
-              class:active={assigneeUserId === member.userId}
-              aria-pressed={assigneeUserId === member.userId}
-              onclick={() => (assigneeUserId = member.userId)}
+              class:active={assigneeUserId === null}
+              aria-pressed={assigneeUserId === null}
+              onclick={() => (assigneeUserId = null)}
             >
-              {member.displayName}
+              Leave for anyone
             </button>
-          {/each}
-        </div>
-        {#if assigneeUserId === null}
-          <p class="ch-hint">Anyone can pick it up — no one gets nagged.</p>
+            {#each members as member (member.userId)}
+              <button
+                type="button"
+                class="ch-chip"
+                class:active={assigneeUserId === member.userId}
+                aria-pressed={assigneeUserId === member.userId}
+                onclick={() => (assigneeUserId = member.userId)}
+              >
+                {member.displayName}
+              </button>
+            {/each}
+          </div>
+          {#if assigneeUserId === null}
+            <p class="ch-hint">Anyone can pick it up — no one gets nagged.</p>
+          {/if}
         {/if}
       </fieldset>
 

--- a/frontend/chores/src/lib/components/RoomsDashboard.svelte
+++ b/frontend/chores/src/lib/components/RoomsDashboard.svelte
@@ -25,11 +25,23 @@
     onDrop: (chore: ChoreDto) => void;
     onComplete: (chore: ChoreDto) => void;
     onHandOff: (chore: ChoreDto) => void;
+    onCommit: (chore: ChoreDto) => void;
+    onLeave: (chore: ChoreDto) => void;
     onEdit: (chore: ChoreDto) => void;
   }
 
-  let { groups, currentUserId, isPending, onClaim, onDrop, onComplete, onHandOff, onEdit }: Props =
-    $props();
+  let {
+    groups,
+    currentUserId,
+    isPending,
+    onClaim,
+    onDrop,
+    onComplete,
+    onHandOff,
+    onCommit,
+    onLeave,
+    onEdit,
+  }: Props = $props();
 
   // The drilled-into room (by roomId; null = the General group; undefined = the
   // dashboard grid). Number-or-null can't disambiguate "General" from "grid", so
@@ -172,6 +184,8 @@
             {onDrop}
             {onComplete}
             {onHandOff}
+            {onCommit}
+            {onLeave}
             {onEdit}
           />
         {/each}

--- a/frontend/chores/src/lib/components/UpForGrabsLane.svelte
+++ b/frontend/chores/src/lib/components/UpForGrabsLane.svelte
@@ -21,11 +21,23 @@
     onDrop: (chore: ChoreDto) => void;
     onComplete: (chore: ChoreDto) => void;
     onHandOff: (chore: ChoreDto) => void;
+    onCommit: (chore: ChoreDto) => void;
+    onLeave: (chore: ChoreDto) => void;
     onEdit: (chore: ChoreDto) => void;
   }
 
-  let { chores, currentUserId, isPending, onClaim, onDrop, onComplete, onHandOff, onEdit }: Props =
-    $props();
+  let {
+    chores,
+    currentUserId,
+    isPending,
+    onClaim,
+    onDrop,
+    onComplete,
+    onHandOff,
+    onCommit,
+    onLeave,
+    onEdit,
+  }: Props = $props();
 </script>
 
 <div class="ch-grabs">
@@ -45,6 +57,8 @@
           {onDrop}
           {onComplete}
           {onHandOff}
+          {onCommit}
+          {onLeave}
           {onEdit}
         />
       {/each}

--- a/frontend/chores/src/lib/state.svelte.ts
+++ b/frontend/chores/src/lib/state.svelte.ts
@@ -32,6 +32,9 @@ import {
   dropChore,
   completeChore,
   handOffChore,
+  assignRoster,
+  commitRoster,
+  leaveRoster,
   createChore,
   deleteChore,
   updateChore,
@@ -280,12 +283,11 @@ class BoardStore {
     const uid = this.currentUserId;
     return this.chores
       .filter((c) => {
-        // Multi-person (co-sign) chores stay in the pile until the full
-        // complement signs — claiming no longer hides them (a still-incomplete
-        // co-sign chore is "up for grabs" to every member who hasn't signed yet,
-        // so they can pick up their part). Signers see it in Mine instead.
+        // Multi-person chores are up-for-grabs to anyone NOT yet on the roster —
+        // they can join ("I'm in") or just do their part. Members already on the
+        // roster (assigned / in / done) see it in Mine instead.
         if (c.requiredCount > 1 && c.completedCount < c.requiredCount) {
-          return !c.contributorUserIds.includes(uid);
+          return !c.roster.some((m) => m.userId === uid);
         }
         return c.assignmentKind === 'none' || c.isClaimStale;
       })
@@ -302,12 +304,13 @@ class BoardStore {
     const uid = this.currentUserId;
     return this.chores
       .filter((c) => {
-        // A co-sign chore the viewer has already signed sits on their plate
-        // (waiting on the others) until it's satisfied; if they haven't signed,
-        // it's an up-for-grabs pile chore, not theirs. Co-sign chores aren't
-        // claimable, so the claim/owner rules below don't apply to them.
+        // A multi-person chore is "mine" if I'm on its roster in any state
+        // (assigned/in/done) — awaiting my confirm, my part, or done-and-waiting
+        // on the others. If I'm not on the roster it's an up-for-grabs chore, not
+        // mine. Multi-person chores aren't claimable, so the claim/owner rules
+        // below don't apply to them.
         if (c.requiredCount > 1 && c.completedCount < c.requiredCount) {
-          return c.contributorUserIds.includes(uid);
+          return c.roster.some((m) => m.userId === uid);
         }
         const heldByMe =
           c.assigneeUserId === uid && c.assignmentKind !== 'none' && !c.isClaimStale;
@@ -354,14 +357,15 @@ class BoardStore {
     // mine. They are never claimable, so the claim/owner rules don't apply.
     const coSignInProgress = c.requiredCount > 1 && c.completedCount < c.requiredCount;
     const uid = this.currentUserId;
+    const onRoster = c.roster.some((m) => m.userId === uid);
     switch (this.attentionFilter) {
       case 'up-for-grabs':
         return coSignInProgress
-          ? !c.contributorUserIds.includes(uid)
+          ? !onRoster
           : c.assignmentKind === 'none' || c.isClaimStale;
       case 'mine':
         return coSignInProgress
-          ? c.contributorUserIds.includes(uid)
+          ? onRoster
           : (c.assigneeUserId === uid && c.assignmentKind !== 'none' && !c.isClaimStale) ||
               c.ownerUserId === uid;
       case 'everything':
@@ -777,6 +781,40 @@ class BoardStore {
     // equity hook; the multi-person path already reconciled via setBoard (which
     // also invalidates), and a 409/4xx reconciled the same way.
     this.invalidateEquity();
+  }
+
+  // ── Roster (multi-person named soft roster, rework) ───────────────────────
+  // All three are multi-person-only and use the runMultiPersonMutation path
+  // (fire → reconcile via the board GET; never auto-retry on 409/4xx — MN4).
+
+  /**
+   * Commit the current user to a multi-person chore's roster ("I'm in" — self-opt-in or confirming an
+   * assignment). The single-chore response carries an empty roster, so we reconcile via the board GET.
+   */
+  async commit(choreId: number): Promise<void> {
+    await this.runMultiPersonMutation(
+      choreId,
+      (c) => commitRoster(c.id, c.version),
+      'That chore changed — board refreshed.',
+    );
+  }
+
+  /** Leave a multi-person chore's roster (decline / "not me"). */
+  async leave(choreId: number): Promise<void> {
+    await this.runMultiPersonMutation(
+      choreId,
+      (c) => leaveRoster(c.id, null, c.version),
+      'That chore changed — board refreshed.',
+    );
+  }
+
+  /** Assign a named member to a multi-person chore's roster (Assigned — from the edit sheet). */
+  async assign(choreId: number, subjectUserId: number): Promise<void> {
+    await this.runMultiPersonMutation(
+      choreId,
+      (c) => assignRoster(c.id, subjectUserId, c.version),
+      'That chore changed — board refreshed.',
+    );
   }
 
   /**

--- a/frontend/chores/src/lib/types.ts
+++ b/frontend/chores/src/lib/types.ts
@@ -28,6 +28,19 @@ export type ColorTier = 'fresh' | 'mid' | 'due' | 'overdue';
 /** camelCase — enum via JsonStringEnumConverter(CamelCase). */
 export type AssignmentKind = 'none' | 'assigned' | 'claimed';
 
+/**
+ * camelCase — enum via JsonStringEnumConverter(CamelCase). A member's DERIVED state on a multi-person
+ * chore's named roster (rework): `assigned` = suggested (a pre-opt-in, no reply); `in` = committed
+ * ("I'm in"); `done` = completed their part this occurrence.
+ */
+export type RosterState = 'assigned' | 'in' | 'done';
+
+/** One member of a multi-person chore's derived roster. */
+export interface RosterMemberDto {
+  userId: number;
+  state: RosterState;
+}
+
 /** camelCase — enum via JsonStringEnumConverter(CamelCase). Room rollup dirtiness. */
 export type RoomRollupStatus = 'clean' | 'attention' | 'needsWork';
 
@@ -62,12 +75,12 @@ export interface ChoreDto {
   photoPath: string | null;
   /** xmin optimistic-concurrency token. Echo back on mutations (WP-11). */
   version: number;
-  /** 1 = normal chore; >1 = multi-person (co-sign required). Always ≥ 1. */
+  /** 1 = normal chore; >1 = multi-person (named roster). Always ≥ 1. */
   requiredCount: number;
-  /** Distinct contributors toward the CURRENT open occurrence (0..requiredCount). Board GET only; ProjectChore path always returns 0. */
+  /** Distinct members DONE toward the CURRENT open occurrence (0..requiredCount) — the gate. Board GET only. */
   completedCount: number;
-  /** User IDs who have signed the current occurrence, ascending. Empty for single-person chores. */
-  contributorUserIds: number[];
+  /** Named roster + per-member state (assigned/in/done), ascending by userId. [] = open / single-person. */
+  roster: RosterMemberDto[];
 }
 
 export interface RoomRollupDto {

--- a/src/FamilyCoordinationApp/Data/ApplicationDbContext.cs
+++ b/src/FamilyCoordinationApp/Data/ApplicationDbContext.cs
@@ -26,6 +26,7 @@ public class ApplicationDbContext : DbContext
     public DbSet<Chore> Chores => Set<Chore>();
     public DbSet<ChoreCompletion> ChoreCompletions => Set<ChoreCompletion>();
     public DbSet<ChoreEvent> ChoreEvents => Set<ChoreEvent>();
+    public DbSet<ChoreParticipationEvent> ChoreParticipationEvents => Set<ChoreParticipationEvent>();
     public DbSet<HouseholdChoreDigestSettings> ChoreDigestSettings => Set<HouseholdChoreDigestSettings>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/src/FamilyCoordinationApp/Data/Configurations/ChoreParticipationEventConfiguration.cs
+++ b/src/FamilyCoordinationApp/Data/Configurations/ChoreParticipationEventConfiguration.cs
@@ -1,0 +1,45 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using FamilyCoordinationApp.Data.Entities;
+
+namespace FamilyCoordinationApp.Data.Configurations;
+
+public class ChoreParticipationEventConfiguration : IEntityTypeConfiguration<ChoreParticipationEvent>
+{
+    public void Configure(EntityTypeBuilder<ChoreParticipationEvent> builder)
+    {
+        builder.ToTable("ChoreParticipationEvents");
+
+        // Composite PK: HouseholdId + ChoreId + ParticipationEventId (DB-generated, mirroring ChoreEvent).
+        builder.HasKey(pe => new { pe.HouseholdId, pe.ChoreId, pe.ParticipationEventId });
+        builder.Property(pe => pe.ParticipationEventId).ValueGeneratedOnAdd();
+
+        builder.Property(pe => pe.Type)
+            .IsRequired()
+            .HasConversion<string>()
+            .HasMaxLength(20);
+
+        builder.Property(pe => pe.At)
+            .IsRequired();
+
+        // FK to Chore (composite). Cascade on Chore delete (household-scoped teardown).
+        builder.HasOne(pe => pe.Chore)
+            .WithMany(c => c.ParticipationEvents)
+            .HasForeignKey(pe => new { pe.HouseholdId, pe.ChoreId })
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // User FKs => Restrict: a user delete must not wipe roster history (mirror ChoreEvent, council M4).
+        builder.HasOne(pe => pe.Subject)
+            .WithMany()
+            .HasForeignKey(pe => pe.SubjectUserId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne(pe => pe.Actor)
+            .WithMany()
+            .HasForeignKey(pe => pe.ActorUserId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        // Read-path fold scans events per chore in chronological order.
+        builder.HasIndex(pe => new { pe.HouseholdId, pe.ChoreId, pe.At });
+    }
+}

--- a/src/FamilyCoordinationApp/Data/Entities/Chore.cs
+++ b/src/FamilyCoordinationApp/Data/Entities/Chore.cs
@@ -65,4 +65,5 @@ public class Chore
     public User? Assignee { get; set; }
     public ICollection<ChoreCompletion> Completions { get; set; } = new List<ChoreCompletion>();
     public ICollection<ChoreEvent> Events { get; set; } = new List<ChoreEvent>();
+    public ICollection<ChoreParticipationEvent> ParticipationEvents { get; set; } = new List<ChoreParticipationEvent>();
 }

--- a/src/FamilyCoordinationApp/Data/Entities/ChoreEnums.cs
+++ b/src/FamilyCoordinationApp/Data/Entities/ChoreEnums.cs
@@ -60,6 +60,23 @@ public enum ChoreEventType
 }
 
 /// <summary>
+/// Append-only participation event type for a multi-person chore's named soft roster (rework). The roster
+/// and each member's display state are DERIVED by folding these (see <c>ChoreRosterCalculator</c>); "done"
+/// is NOT here — it stays in <see cref="ChoreCompletion"/>.
+/// <list type="bullet">
+///   <item><see cref="Assigned"/> — someone added the subject (a pre-opt-in; declinable, never binding).</item>
+///   <item><see cref="Committed"/> — the subject is in (self-opt-in, or confirming an assignment).</item>
+///   <item><see cref="Left"/> — the subject was removed from the roster (decline / leave / admin-remove).</item>
+/// </list>
+/// </summary>
+public enum ChoreParticipationType
+{
+    Assigned,
+    Committed,
+    Left
+}
+
+/// <summary>
 /// Custom project flags enum for the days a fixed-weekly chore recurs on. This is a deliberate
 /// project type — do NOT wrap <see cref="System.DayOfWeek"/> (which is not a flags enum).
 /// </summary>

--- a/src/FamilyCoordinationApp/Data/Entities/ChoreParticipationEvent.cs
+++ b/src/FamilyCoordinationApp/Data/Entities/ChoreParticipationEvent.cs
@@ -1,0 +1,34 @@
+namespace FamilyCoordinationApp.Data.Entities;
+
+/// <summary>
+/// Append-only participation event for a multi-person (<c>RequiredCount &gt; 1</c>) chore's named soft
+/// roster. The current roster and each member's display state (assigned/in/done) are DERIVED on read by
+/// folding these events — windowed to the current occurrence — plus the <see cref="ChoreCompletion"/>
+/// ledger (see <c>ChoreRosterCalculator</c>). "Done" is NOT an event: it stays in
+/// <see cref="ChoreCompletion"/> (the equity substrate) and is overlaid in the fold.
+/// <para>Mirrors <see cref="ChoreEvent"/>: composite PK with a DB-generated
+/// <see cref="ParticipationEventId"/>, Chore FK cascades, the two user FKs restrict (history survives a
+/// user delete). The roster is single-frontier-serialized on the <c>Chore</c> row's xmin — this table
+/// carries no concurrency token of its own (appends never conflict; the fold normalizes order).</para>
+/// </summary>
+public class ChoreParticipationEvent
+{
+    public int HouseholdId { get; set; }
+    public int ChoreId { get; set; }
+    public int ParticipationEventId { get; set; }
+
+    public ChoreParticipationType Type { get; set; }
+
+    /// <summary>The member this event is about (the person assigned, committing, or leaving).</summary>
+    public int SubjectUserId { get; set; }
+
+    /// <summary>Who performed the action — may differ from the subject (e.g. a creator assigning someone).</summary>
+    public int ActorUserId { get; set; }
+
+    public DateTime At { get; set; }  // UTC
+
+    // Navigation
+    public Chore Chore { get; set; } = default!;
+    public User Subject { get; set; } = default!;
+    public User Actor { get; set; } = default!;
+}

--- a/src/FamilyCoordinationApp/Endpoints/ChoresEndpoints.cs
+++ b/src/FamilyCoordinationApp/Endpoints/ChoresEndpoints.cs
@@ -41,6 +41,9 @@ public static class ChoresEndpoints
         group.MapPost("/{choreId:int}/drop", DropChore);
         group.MapPost("/{choreId:int}/handoff", HandOffChore);
         group.MapPost("/{choreId:int}/complete", CompleteChore);
+        group.MapPost("/{choreId:int}/roster/assign", AssignRoster);
+        group.MapPost("/{choreId:int}/roster/commit", CommitRoster);
+        group.MapPost("/{choreId:int}/roster/leave", LeaveRoster);
         group.MapPost("/{choreId:int}/photo", UploadChorePhoto);
 
         group.MapPatch("/me/default-view", SetDefaultView);
@@ -238,6 +241,80 @@ public static class ChoresEndpoints
         {
             var chore = await svc.CompleteAsync(
                 user.HouseholdId, choreId, user.UserId, req.Note, req.PhotoPath, req.ParticipantUserIds, req.Version, ct);
+            return Results.Ok(Project(boardService, chore, timeProvider, timeZone));
+        }
+        catch (ChoreNotFoundException) { return Results.NotFound(); }
+        catch (ChoreValidationException ex) { return Results.BadRequest(new { message = ex.Message }); }
+        catch (ChoreConflictException ex) { return Results.Conflict(new { message = ex.Message }); }
+    }
+
+    // ─── Roster (multi-person named soft roster, rework) ────────────────────────────
+
+    private static async Task<IResult> AssignRoster(
+        int choreId,
+        AssignRosterRequest req,
+        ClaimsPrincipal principal,
+        IChoreService svc,
+        IChoreBoardService boardService,
+        TimeProvider timeProvider,
+        TimeZoneInfo timeZone,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        try
+        {
+            var chore = await svc.AssignToRosterAsync(user.HouseholdId, choreId, user.UserId, req.SubjectUserId, req.Version, ct);
+            return Results.Ok(Project(boardService, chore, timeProvider, timeZone));
+        }
+        catch (ChoreNotFoundException) { return Results.NotFound(); }
+        catch (ChoreValidationException ex) { return Results.BadRequest(new { message = ex.Message }); }
+        catch (ChoreConflictException ex) { return Results.Conflict(new { message = ex.Message }); }
+    }
+
+    private static async Task<IResult> CommitRoster(
+        int choreId,
+        VersionRequest req,
+        ClaimsPrincipal principal,
+        IChoreService svc,
+        IChoreBoardService boardService,
+        TimeProvider timeProvider,
+        TimeZoneInfo timeZone,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        try
+        {
+            var chore = await svc.CommitToRosterAsync(user.HouseholdId, choreId, user.UserId, req.Version, ct);
+            return Results.Ok(Project(boardService, chore, timeProvider, timeZone));
+        }
+        catch (ChoreNotFoundException) { return Results.NotFound(); }
+        catch (ChoreValidationException ex) { return Results.BadRequest(new { message = ex.Message }); }
+        catch (ChoreConflictException ex) { return Results.Conflict(new { message = ex.Message }); }
+    }
+
+    private static async Task<IResult> LeaveRoster(
+        int choreId,
+        LeaveRosterRequest req,
+        ClaimsPrincipal principal,
+        IChoreService svc,
+        IChoreBoardService boardService,
+        TimeProvider timeProvider,
+        TimeZoneInfo timeZone,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        try
+        {
+            var chore = await svc.LeaveRosterAsync(user.HouseholdId, choreId, user.UserId, req.SubjectUserId, req.Version, ct);
             return Results.Ok(Project(boardService, chore, timeProvider, timeZone));
         }
         catch (ChoreNotFoundException) { return Results.NotFound(); }
@@ -572,6 +649,13 @@ public static class ChoresEndpoints
 
     public sealed record CompleteRequest(string? Note, string? PhotoPath, uint Version, IReadOnlyList<int>? ParticipantUserIds = null);
 
+    /// <summary>Add a named member to a multi-person chore's roster (Assigned). Subject = the member to add.</summary>
+    public sealed record AssignRosterRequest(int SubjectUserId, uint Version);
+
+    /// <summary>Leave/remove from a roster. Null SubjectUserId ⇒ the caller leaves; a non-null subject
+    /// (removing someone else) requires the caller be the chore creator/owner.</summary>
+    public sealed record LeaveRosterRequest(int? SubjectUserId, uint Version);
+
     public sealed record DefaultViewRequest(string? View);
 
     /// <summary>
@@ -632,7 +716,8 @@ public static class ChoresEndpoints
         int? AssigneeUserId,
         string? PhotoPath,
         string? Icon = null,
-        int RequiredCount = 1)
+        int RequiredCount = 1,
+        IReadOnlyList<int>? AssignedUserIds = null)
     {
         public CreateChoreCommand ToCommand() => new(
             Name,
@@ -648,7 +733,8 @@ public static class ChoresEndpoints
             AssigneeUserId,
             PhotoPath,
             Icon ?? string.Empty,
-            RequiredCount);
+            RequiredCount,
+            AssignedUserIds);
     }
 
     public sealed record UpdateChoreRequest(

--- a/src/FamilyCoordinationApp/Migrations/20260605050159_AddChoreParticipationEvents.Designer.cs
+++ b/src/FamilyCoordinationApp/Migrations/20260605050159_AddChoreParticipationEvents.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FamilyCoordinationApp.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FamilyCoordinationApp.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260605050159_AddChoreParticipationEvents")]
+    partial class AddChoreParticipationEvents
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/FamilyCoordinationApp/Migrations/20260605050159_AddChoreParticipationEvents.cs
+++ b/src/FamilyCoordinationApp/Migrations/20260605050159_AddChoreParticipationEvents.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace FamilyCoordinationApp.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddChoreParticipationEvents : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ChoreParticipationEvents",
+                columns: table => new
+                {
+                    HouseholdId = table.Column<int>(type: "integer", nullable: false),
+                    ChoreId = table.Column<int>(type: "integer", nullable: false),
+                    ParticipationEventId = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Type = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    SubjectUserId = table.Column<int>(type: "integer", nullable: false),
+                    ActorUserId = table.Column<int>(type: "integer", nullable: false),
+                    At = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ChoreParticipationEvents", x => new { x.HouseholdId, x.ChoreId, x.ParticipationEventId });
+                    table.ForeignKey(
+                        name: "FK_ChoreParticipationEvents_Chores_HouseholdId_ChoreId",
+                        columns: x => new { x.HouseholdId, x.ChoreId },
+                        principalTable: "Chores",
+                        principalColumns: new[] { "HouseholdId", "ChoreId" },
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ChoreParticipationEvents_Users_ActorUserId",
+                        column: x => x.ActorUserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_ChoreParticipationEvents_Users_SubjectUserId",
+                        column: x => x.SubjectUserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChoreParticipationEvents_ActorUserId",
+                table: "ChoreParticipationEvents",
+                column: "ActorUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChoreParticipationEvents_HouseholdId_ChoreId_At",
+                table: "ChoreParticipationEvents",
+                columns: new[] { "HouseholdId", "ChoreId", "At" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChoreParticipationEvents_SubjectUserId",
+                table: "ChoreParticipationEvents",
+                column: "SubjectUserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ChoreParticipationEvents");
+        }
+    }
+}

--- a/src/FamilyCoordinationApp/Services/ChoreBoardService.cs
+++ b/src/FamilyCoordinationApp/Services/ChoreBoardService.cs
@@ -72,6 +72,20 @@ public class ChoreBoardService(
                 .ToDictionary(g => g.Key, g => g.ToList());
         }
 
+        // P5 (rework): lazily load participation events for the same multi-person chore set — the fold
+        // (ChoreRosterCalculator) derives the named roster on read. Single-person chores never query this.
+        Dictionary<int, List<ChoreParticipationEvent>> participationByChore = [];
+        if (multiPersonIds.Count > 0)
+        {
+            var allEvents = await context.ChoreParticipationEvents
+                .Where(e => e.HouseholdId == householdId && multiPersonIds.Contains(e.ChoreId))
+                .ToListAsync(cancellationToken);
+
+            participationByChore = allEvents
+                .GroupBy(e => e.ChoreId)
+                .ToDictionary(g => g.Key, g => g.ToList());
+        }
+
         // Project each chore once; reuse the computed dueness for both the per-chore DTO and the rollups so
         // a chore's dueness is computed in exactly one place (no divergence between the card and the room
         // bucket). The board buckets off COMPUTED dueness, never stored Status (decay would be ignored).
@@ -87,13 +101,27 @@ public class ChoreBoardService(
         var choreDtos = projected
             .Select(p =>
             {
-                // A RequiredCount==1 chore gets an empty set (CompletedCount=0, ContributorUserIds=[]).
-                IReadOnlySet<int> contributors = p.Chore.RequiredCount > 1
-                    ? ChoreCompletionProgress.DistinctContributorsSince(
+                // X>1: fold the named roster (events + completion ledger) for the current occurrence.
+                // X=1: synthesize a 0/1-member roster from the assignment trio (CompletedCount stays 0).
+                IReadOnlyList<RosterMemberDto> roster;
+                int completedCount;
+                if (p.Chore.RequiredCount > 1)
+                {
+                    var derived = ChoreRosterCalculator.Fold(
+                        participationByChore.GetValueOrDefault(p.Chore.ChoreId) ?? [],
                         completionsByChore.GetValueOrDefault(p.Chore.ChoreId) ?? [],
-                        p.Chore.LastCompletedAt)
-                    : (IReadOnlySet<int>)new HashSet<int>();
-                return ToDto(p.Chore, p.Dueness, p.IsClaimStale, contributors);
+                        p.Chore.LastCompletedAt,
+                        p.Chore.RequiredCount,
+                        recurring: p.Chore.RecurrenceMode != RecurrenceMode.OneOff);
+                    roster = derived.Members;
+                    completedCount = derived.CompletedCount;
+                }
+                else
+                {
+                    roster = SynthesizeTrioRoster(p.Chore);
+                    completedCount = 0;
+                }
+                return ToDto(p.Chore, p.Dueness, p.IsClaimStale, roster, completedCount);
             })
             .ToList();
 
@@ -120,9 +148,11 @@ public class ChoreBoardService(
     {
         var dueness = calculator.Compute(ChoreRecurrenceSnapshot.FromChore(chore), now, timeZone);
         var isClaimStale = calculator.IsClaimStale(chore.AssignmentKind, chore.ClaimedAt, now);
-        // progress is computed only in GetBoardAsync; single-chore projections report requiredCount plus
-        // zeroed progress — the client refetches the board for authoritative co-sign progress.
-        return ToDto(chore, dueness, isClaimStale, contributors: new HashSet<int>());
+        // The roster is folded only in GetBoardAsync (it needs the participation events + completion ledger).
+        // The single-chore mutation response synthesizes the X=1 trio roster and returns an EMPTY roster for
+        // X>1 with completedCount=0 — the island reconciles via the board GET for authoritative progress (WP-07).
+        var roster = chore.RequiredCount > 1 ? Array.Empty<RosterMemberDto>() : SynthesizeTrioRoster(chore);
+        return ToDto(chore, dueness, isClaimStale, roster, completedCount: 0);
     }
 
     // ------------------------------------------------------------------ projection
@@ -131,7 +161,8 @@ public class ChoreBoardService(
         Chore chore,
         ChoreDuenessResult dueness,
         bool isClaimStale,
-        IReadOnlySet<int> contributors) => new(
+        IReadOnlyList<RosterMemberDto> roster,
+        int completedCount) => new(
         chore.ChoreId,
         chore.Name,
         chore.Icon,
@@ -155,8 +186,26 @@ public class ChoreBoardService(
         chore.PhotoPath,
         chore.Version,
         chore.RequiredCount,
-        contributors.Count,
-        contributors.OrderBy(x => x).ToList());
+        completedCount,
+        roster);
+
+    /// <summary>
+    /// Synthesize the uniform <c>roster[]</c> for a single-person (X=1) chore from the assignment trio (D3),
+    /// so the card can render it identically to a multi-person chore. The trio holder becomes one member:
+    /// <see cref="RosterState.In"/> when self-<see cref="AssignmentKind.Claimed"/>,
+    /// <see cref="RosterState.Assigned"/> when deliberately <see cref="AssignmentKind.Assigned"/>. Unassigned
+    /// ⇒ empty. (X=1 advances on a single completion, so a "done" state is transient and not surfaced here.)
+    /// </summary>
+    private static IReadOnlyList<RosterMemberDto> SynthesizeTrioRoster(Chore chore)
+    {
+        if (chore.AssigneeUserId is int assignee && chore.AssignmentKind != AssignmentKind.None)
+        {
+            var state = chore.AssignmentKind == AssignmentKind.Claimed ? RosterState.In : RosterState.Assigned;
+            return [new RosterMemberDto(assignee, state)];
+        }
+
+        return [];
+    }
 
     // ------------------------------------------------------------------ rollups
 

--- a/src/FamilyCoordinationApp/Services/ChoreCommands.cs
+++ b/src/FamilyCoordinationApp/Services/ChoreCommands.cs
@@ -10,6 +10,9 @@ namespace FamilyCoordinationApp.Services;
 /// <param name="Name">Required, non-empty after trim.</param>
 /// <param name="EffortTier">Named effort tier (P3) — drives the default <c>EffortPoints</c> snapshot.</param>
 /// <param name="Icon">Optional emoji/short-code icon (parity with Room.Icon); empty string = none.</param>
+/// <param name="AssignedUserIds">Initial named roster for a multi-person (<c>RequiredCount &gt; 1</c>) chore
+/// (rework, D8) — one <c>Assigned</c> participation event is written per member at creation. Ignored for
+/// X=1 chores (which use the single-holder trio via <see cref="AssigneeUserId"/>). null ⇒ no roster seed.</param>
 public record CreateChoreCommand(
     string Name,
     string? Description,
@@ -24,7 +27,8 @@ public record CreateChoreCommand(
     int? AssigneeUserId,
     string? PhotoPath,
     string Icon = "",
-    int RequiredCount = 1);
+    int RequiredCount = 1,
+    IReadOnlyList<int>? AssignedUserIds = null);
 
 /// <summary>
 /// Command to update a chore's editable fields (council M11) — the same editable subset as

--- a/src/FamilyCoordinationApp/Services/ChoreRosterCalculator.cs
+++ b/src/FamilyCoordinationApp/Services/ChoreRosterCalculator.cs
@@ -1,0 +1,140 @@
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Services.Dtos;
+
+namespace FamilyCoordinationApp.Services;
+
+/// <summary>
+/// Pure derive-on-read fold for a multi-person (<c>RequiredCount &gt; 1</c>) chore's named soft roster
+/// (rework). The current roster + each member's state are NEVER stored — they are folded on read from the
+/// append-only <see cref="ChoreParticipationEvent"/> log plus the <see cref="ChoreCompletion"/> ledger,
+/// exactly as <see cref="ChoreStatusCalculator"/> derives dueness and <see cref="ChoreCompletionProgress"/>
+/// derives the contributor count. DB-free and side-effect-free (unit-testable without EF).
+///
+/// <para>The satisfaction gate is unchanged and lives elsewhere (<see cref="ChoreCompletionProgress"/>):
+/// this calculator is the VISIBILITY + recurrence-carry-over layer, not the gate.</para>
+///
+/// <para>Fold rule (decisions D5/D7):
+/// <list type="number">
+///   <item><b>Window</b> participation events to the current occurrence (<c>At &gt; lastCompletedAt</c>, or
+///   all when null), ordered by <c>At</c> then <c>ParticipationEventId</c>.</item>
+///   <item><b>Base roster</b> (last-N-done carry-over): for a recurring chore with a prior completion, seed
+///   the most-recent <c>requiredCount</c> distinct completers (<c>CompletedAt &lt;= lastCompletedAt</c>) as
+///   soft <see cref="RosterState.Assigned"/> defaults. (First occurrence / one-off: no base — the create-time
+///   Assigned events are themselves in-window.)</item>
+///   <item><b>Apply window events</b>: <c>Left</c> removes the member; <c>Assigned</c> sets Assigned only if
+///   absent (never downgrades an In member — monotonic); <c>Committed</c> sets In.</item>
+///   <item><b>Overlay Done</b>: every current-occurrence completer becomes <see cref="RosterState.Done"/>
+///   (added if absent — anyone may complete toward X; Done wins over a same-occurrence Left).</item>
+/// </list></para>
+/// </summary>
+public static class ChoreRosterCalculator
+{
+    /// <summary>
+    /// Fold the participation events + completion ledger into the current-occurrence roster.
+    /// </summary>
+    /// <param name="events">All participation events for the chore (windowed internally).</param>
+    /// <param name="completions">All completion rows for the chore (used for the done-overlay AND the
+    /// last-N-done base).</param>
+    /// <param name="lastCompletedAt">The chore's <c>LastCompletedAt</c> (the current-occurrence boundary).</param>
+    /// <param name="requiredCount">The chore's <c>RequiredCount</c> (X).</param>
+    /// <param name="recurring">True for Fixed/Flexible chores (enables last-N-done carry-over).</param>
+    public static DerivedRoster Fold(
+        IEnumerable<ChoreParticipationEvent> events,
+        IEnumerable<ChoreCompletion> completions,
+        DateTime? lastCompletedAt,
+        int requiredCount,
+        bool recurring)
+    {
+        var completionList = completions as IReadOnlyList<ChoreCompletion> ?? completions.ToList();
+
+        // Distinct completers toward the CURRENT occurrence — the satisfaction-relevant "done" set (M1: the
+        // same windowing the gate uses).
+        var doneUserIds = ChoreCompletionProgress.DistinctContributorsSince(completionList, lastCompletedAt);
+
+        var state = new Dictionary<int, RosterState>();
+
+        // 1. Last-N-done base (recurrence carry-over, D5) — soft Assigned defaults.
+        if (recurring && lastCompletedAt is not null)
+        {
+            foreach (var userId in LastNDoneDefaults(completionList, lastCompletedAt.Value, requiredCount))
+            {
+                state[userId] = RosterState.Assigned;
+            }
+        }
+
+        // 2. Apply current-occurrence events in chronological order (monotonic — D7/MN9).
+        var windowEvents = events
+            .Where(e => lastCompletedAt is null || e.At > lastCompletedAt.Value)
+            .OrderBy(e => e.At)
+            .ThenBy(e => e.ParticipationEventId);
+
+        foreach (var e in windowEvents)
+        {
+            switch (e.Type)
+            {
+                case ChoreParticipationType.Left:
+                    state.Remove(e.SubjectUserId);
+                    break;
+                case ChoreParticipationType.Assigned:
+                    // Set Assigned only if absent — never downgrade an In/committed member.
+                    if (!state.ContainsKey(e.SubjectUserId))
+                    {
+                        state[e.SubjectUserId] = RosterState.Assigned;
+                    }
+                    break;
+                case ChoreParticipationType.Committed:
+                    state[e.SubjectUserId] = RosterState.In;
+                    break;
+            }
+        }
+
+        // 3. Overlay Done — completion wins over any participation state (and adds non-rostered completers).
+        foreach (var userId in doneUserIds)
+        {
+            state[userId] = RosterState.Done;
+        }
+
+        var members = state
+            .Select(kv => new RosterMemberDto(kv.Key, kv.Value))
+            .OrderBy(m => m.UserId)
+            .ToList();
+
+        return new DerivedRoster(members, doneUserIds.Count);
+    }
+
+    /// <summary>
+    /// "Last N done": the most-recent <paramref name="requiredCount"/> distinct <c>CompletedByUserId</c>
+    /// among completions with <c>CompletedAt &lt;= lastCompletedAt</c> (the previous occurrence's doers),
+    /// most-recent first. Stable tie-break by <c>CompletionId</c> descending.
+    /// </summary>
+    public static IReadOnlyList<int> LastNDoneDefaults(
+        IReadOnlyList<ChoreCompletion> completions, DateTime lastCompletedAt, int requiredCount)
+    {
+        var target = Math.Max(1, requiredCount);
+        var result = new List<int>();
+        var seen = new HashSet<int>();
+
+        foreach (var c in completions
+            .Where(c => c.CompletedAt <= lastCompletedAt)
+            .OrderByDescending(c => c.CompletedAt)
+            .ThenByDescending(c => c.CompletionId))
+        {
+            if (seen.Add(c.CompletedByUserId))
+            {
+                result.Add(c.CompletedByUserId);
+                if (result.Count >= target)
+                {
+                    break;
+                }
+            }
+        }
+
+        return result;
+    }
+}
+
+/// <summary>
+/// The derived roster for one chore's current occurrence: the ordered member list (by userId) and the
+/// distinct-done count (0..RequiredCount). Returned by <see cref="ChoreRosterCalculator.Fold"/>.
+/// </summary>
+public sealed record DerivedRoster(IReadOnlyList<RosterMemberDto> Members, int CompletedCount);

--- a/src/FamilyCoordinationApp/Services/ChoreService.cs
+++ b/src/FamilyCoordinationApp/Services/ChoreService.cs
@@ -41,8 +41,9 @@ public class ChoreService(
             {
                 await using var context = await dbFactory.CreateDbContextAsync(cancellationToken);
 
-                // A non-null assignee at creation must be a member of this household (M1 isolation).
-                if (cmd.AssigneeUserId is { } assigneeId)
+                // A non-null assignee at creation must be a member (M1). X=1 only — a multi-person chore
+                // (RequiredCount>1) ignores AssigneeUserId and seeds its named roster from AssignedUserIds.
+                if (cmd.RequiredCount == 1 && cmd.AssigneeUserId is { } assigneeId)
                 {
                     await EnsureHouseholdMemberAsync(context, householdId, assigneeId, cancellationToken);
                 }
@@ -75,8 +76,9 @@ public class ChoreService(
                     LastCompletedAt = null
                 };
 
-                // Assignment trio (council M1) — assign-at-creation if an assignee was supplied, else pile.
-                if (cmd.AssigneeUserId is { } assignee)
+                // Assignment: X=1 uses the single-holder trio (today's behavior); X>1 leaves the trio on the
+                // pile and seeds its named roster from AssignedUserIds via participation events (D3/D8).
+                if (chore.RequiredCount == 1 && cmd.AssigneeUserId is { } assignee)
                 {
                     SetAssigned(chore, assignee, now);
                 }
@@ -87,6 +89,17 @@ public class ChoreService(
 
                 context.Chores.Add(chore);
                 AppendEvent(context, chore, ChoreEventType.Created, actorUserId, targetUserId: null, now);
+
+                // Multi-person named roster seed (D8): one Assigned event per member (validated, deduped). The
+                // events save in the SAME transaction as the chore, so the (HouseholdId, ChoreId) FK resolves.
+                if (chore.RequiredCount > 1 && cmd.AssignedUserIds is { Count: > 0 } assignedUserIds)
+                {
+                    foreach (var memberId in assignedUserIds.Distinct())
+                    {
+                        await EnsureHouseholdMemberAsync(context, householdId, memberId, cancellationToken);
+                        AppendParticipation(context, chore, ChoreParticipationType.Assigned, memberId, actorUserId, now);
+                    }
+                }
 
                 await context.SaveChangesAsync(cancellationToken);
 
@@ -105,6 +118,7 @@ public class ChoreService(
 
         await using var context = await dbFactory.CreateDbContextAsync(cancellationToken);
         var chore = await LoadChoreAsync(context, householdId, choreId, cancellationToken);
+        var previousRequiredCount = chore.RequiredCount;
 
         // Delete-on-replace for the photo (M8) — drop the old file when the path changes.
         if (!string.Equals(chore.PhotoPath, cmd.PhotoPath, StringComparison.Ordinal) && !string.IsNullOrWhiteSpace(chore.PhotoPath))
@@ -126,8 +140,23 @@ public class ChoreService(
         chore.RequiredCount = cmd.RequiredCount;
         chore.OwnerUserId = cmd.OwnerUserId;
         chore.PhotoPath = cmd.PhotoPath;
-        // NOTE: the assignment trio is intentionally NOT touched by an edit — assignment moves only via
-        // claim/drop/hand-off/complete.
+        // Assignment is otherwise NOT touched by an edit (it moves via claim/drop/hand-off/complete) — EXCEPT
+        // when RequiredCount crosses the single↔multi boundary (D9), which migrates the representation.
+        if (previousRequiredCount == 1 && cmd.RequiredCount > 1)
+        {
+            // 1 → N: preserve a lone trio assignee as an Assigned roster member, then free the trio to the pile.
+            if (chore.AssigneeUserId is { } heldBy && chore.AssignmentKind != AssignmentKind.None)
+            {
+                AppendParticipation(context, chore, ChoreParticipationType.Assigned, heldBy, heldBy, UtcNow());
+            }
+            ClearToPile(chore);
+        }
+        else if (previousRequiredCount > 1 && cmd.RequiredCount == 1)
+        {
+            // N → 1: back to single-person; clear the (already-None) trio to the pile. Dormant participation
+            // events are simply ignored by the X=1 read path (D3).
+            ClearToPile(chore);
+        }
 
         await SaveWithConcurrencyAsync(context, chore, version, cancellationToken);
         logger.LogInformation("Updated Chore {ChoreId} for household {HouseholdId}", choreId, householdId);
@@ -334,6 +363,73 @@ public class ChoreService(
         return chore;
     }
 
+    // -------------------------------------------------------- roster (multi-person named soft roster, rework)
+
+    public async Task<Chore> AssignToRosterAsync(int householdId, int choreId, int actorUserId, int subjectUserId, uint version, CancellationToken cancellationToken = default)
+    {
+        await using var context = await dbFactory.CreateDbContextAsync(cancellationToken);
+        var chore = await LoadChoreAsync(context, householdId, choreId, cancellationToken);
+        EnsureMultiPerson(chore);
+        await EnsureHouseholdMemberAsync(context, householdId, subjectUserId, cancellationToken);
+
+        var now = UtcNow();
+        AppendParticipation(context, chore, ChoreParticipationType.Assigned, subjectUserId, actorUserId, now);
+        MarkChoreTouched(context, chore, now);
+
+        await SaveWithConcurrencyAsync(context, chore, version, cancellationToken);
+        logger.LogInformation("Chore {ChoreId} roster: user {Subject} assigned by {Actor} (household {HouseholdId})",
+            choreId, subjectUserId, actorUserId, householdId);
+        return chore;
+    }
+
+    public async Task<Chore> CommitToRosterAsync(int householdId, int choreId, int actorUserId, uint version, CancellationToken cancellationToken = default)
+    {
+        await using var context = await dbFactory.CreateDbContextAsync(cancellationToken);
+        var chore = await LoadChoreAsync(context, householdId, choreId, cancellationToken);
+        EnsureMultiPerson(chore);
+        // The caller is a resolved household member; assert defensively (M1).
+        await EnsureHouseholdMemberAsync(context, householdId, actorUserId, cancellationToken);
+
+        var now = UtcNow();
+        AppendParticipation(context, chore, ChoreParticipationType.Committed, actorUserId, actorUserId, now);
+        MarkChoreTouched(context, chore, now);
+
+        await SaveWithConcurrencyAsync(context, chore, version, cancellationToken);
+        logger.LogInformation("Chore {ChoreId} roster: user {UserId} committed (household {HouseholdId})",
+            choreId, actorUserId, householdId);
+        return chore;
+    }
+
+    public async Task<Chore> LeaveRosterAsync(int householdId, int choreId, int actorUserId, int? subjectUserId, uint version, CancellationToken cancellationToken = default)
+    {
+        await using var context = await dbFactory.CreateDbContextAsync(cancellationToken);
+        var chore = await LoadChoreAsync(context, householdId, choreId, cancellationToken);
+        EnsureMultiPerson(chore);
+
+        var subject = subjectUserId ?? actorUserId;
+        if (subject != actorUserId)
+        {
+            // Removing SOMEONE ELSE requires the actor be the chore creator or owner (non-punitive default:
+            // anyone may remove themselves; only the owner/creator may remove others).
+            if (actorUserId != chore.EnteredByUserId && actorUserId != chore.OwnerUserId)
+            {
+                throw new ChoreValidationException(
+                    $"User {actorUserId} cannot remove user {subject} from chore {choreId}'s roster " +
+                    "(only the creator or owner may remove others).");
+            }
+            await EnsureHouseholdMemberAsync(context, householdId, subject, cancellationToken);
+        }
+
+        var now = UtcNow();
+        AppendParticipation(context, chore, ChoreParticipationType.Left, subject, actorUserId, now);
+        MarkChoreTouched(context, chore, now);
+
+        await SaveWithConcurrencyAsync(context, chore, version, cancellationToken);
+        logger.LogInformation("Chore {ChoreId} roster: user {Subject} left (by {Actor}, household {HouseholdId})",
+            choreId, subject, actorUserId, householdId);
+        return chore;
+    }
+
     // ------------------------------------------------------------ helpers
 
     /// <summary>
@@ -396,6 +492,42 @@ public class ChoreService(
             TargetUserId = targetUserId,
             At = now
         });
+    }
+
+    /// <summary>Append a roster participation event (rework). <c>ParticipationEventId</c> is DB-generated.</summary>
+    private static void AppendParticipation(ApplicationDbContext context, Chore chore, ChoreParticipationType type, int subjectUserId, int actorUserId, DateTime now)
+    {
+        context.ChoreParticipationEvents.Add(new ChoreParticipationEvent
+        {
+            HouseholdId = chore.HouseholdId,
+            ChoreId = chore.ChoreId,
+            Type = type,
+            SubjectUserId = subjectUserId,
+            ActorUserId = actorUserId,
+            At = now
+        });
+    }
+
+    /// <summary>
+    /// Force the xmin UPDATE on every roster write (M3/D6) so concurrent roster mutations serialize on the
+    /// single Chore-row frontier — the same discipline as <c>CompleteAsync</c>. EF emits no UPDATE for a row
+    /// with no changed scalar (and a same-tick <c>now</c> could equal the stored value), so mark it modified.
+    /// </summary>
+    private static void MarkChoreTouched(ApplicationDbContext context, Chore chore, DateTime now)
+    {
+        chore.LastContributionAt = now;
+        context.Entry(chore).Property(c => c.LastContributionAt).IsModified = true;
+    }
+
+    /// <summary>Reject a roster action on a single-person chore — the roster exists only for X &gt; 1 (D3).</summary>
+    private static void EnsureMultiPerson(Chore chore)
+    {
+        if (chore.RequiredCount <= 1)
+        {
+            throw new ChoreValidationException(
+                $"Chore {chore.ChoreId} is a single-person chore (RequiredCount={chore.RequiredCount}); " +
+                "roster actions apply only to multi-person chores.");
+        }
     }
 
     private static async Task<Chore> LoadChoreAsync(ApplicationDbContext context, int householdId, int choreId, CancellationToken cancellationToken)

--- a/src/FamilyCoordinationApp/Services/Dtos/ChoreDtos.cs
+++ b/src/FamilyCoordinationApp/Services/Dtos/ChoreDtos.cs
@@ -64,6 +64,29 @@ public sealed record ChoreDto(
     );
 
 /// <summary>
+/// A member's DERIVED state on a multi-person chore's named roster, for the current occurrence (rework).
+/// Serialized camelCase via <c>JsonStringEnumConverter(CamelCase)</c>: <c>"assigned" | "in" | "done"</c>.
+/// <list type="bullet">
+///   <item><see cref="Assigned"/> — suggested (a pre-opt-in by someone else; no reply yet, declinable).</item>
+///   <item><see cref="In"/> — committed ("I'm in": self-opt-in, or confirming an assignment).</item>
+///   <item><see cref="Done"/> — completed their part this occurrence (overlaid from <c>ChoreCompletion</c>).</item>
+/// </list>
+/// </summary>
+public enum RosterState
+{
+    Assigned,
+    In,
+    Done
+}
+
+/// <summary>
+/// One member of a multi-person chore's derived roster (D10). Wire shape: <c>{ userId, state }</c>.
+/// Empty roster list ⇒ no one on the chore (open / single-person). Derived on read by
+/// <c>ChoreRosterCalculator</c>; never stored.
+/// </summary>
+public sealed record RosterMemberDto(int UserId, RosterState State);
+
+/// <summary>
 /// Per-room dirtiness rollup. The <see cref="Status"/> bucket is derived from the count of chores in the
 /// room whose computed dueness is due-or-overdue (NOT from stored <c>ChoreStatus</c>), bucketed by the
 /// named thresholds in <see cref="ChoreRollup"/> (P4): 0 ⇒ clean, 1–2 ⇒ attention, 3+ ⇒ needs-work.

--- a/src/FamilyCoordinationApp/Services/Dtos/ChoreDtos.cs
+++ b/src/FamilyCoordinationApp/Services/Dtos/ChoreDtos.cs
@@ -28,12 +28,14 @@ public sealed record ChoreBoardDto(
 /// fixed-weekly / every-N / dated one-off chore lost the existing selection). <see cref="DaysOfWeek"/>
 /// serializes as a camelCase CSV (e.g. <c>"monday, thursday"</c>); <see cref="AnchorDate"/> as an ISO date
 /// (<c>"2026-06-10"</c>) — the same shapes the write request accepts.</para>
-/// <para>Multi-person co-sign progress (WP-04): <see cref="RequiredCount"/> is always ≥ 1 (1 = normal,
-/// &gt;1 = multi-person). <see cref="CompletedCount"/> is the count of distinct contributors toward the
-/// CURRENT open occurrence (0..<see cref="RequiredCount"/>); <see cref="ContributorUserIds"/> lists those
-/// users in ascending order. These are populated only in the board projection (<c>GetBoardAsync</c>);
-/// single-chore projections always report <c>completedCount=0, contributorUserIds=[]</c> — the client
-/// refetches the board for authoritative co-sign progress (WP-07).</para>
+/// <para>Multi-person named roster (rework): <see cref="RequiredCount"/> is always ≥ 1 (1 = normal,
+/// &gt;1 = multi-person). <see cref="CompletedCount"/> is the count of distinct members DONE toward the
+/// CURRENT open occurrence (0..<see cref="RequiredCount"/> — the satisfaction gate). <see cref="Roster"/>
+/// is the derived named roster: each member with state assigned/in/done (ascending by userId). For X&gt;1
+/// chores it is folded by <c>ChoreRosterCalculator</c>; for X=1 it is synthesized from the assignment trio
+/// (0 or 1 member); these are populated only in the board projection (<c>GetBoardAsync</c>). Single-chore
+/// projections report <c>completedCount=0</c> and an X&gt;1 chore's roster empty — the client refetches the
+/// board for authoritative roster progress (WP-07).</para>
 /// </summary>
 public sealed record ChoreDto(
     int Id,
@@ -59,8 +61,8 @@ public sealed record ChoreDto(
     string? PhotoPath,
     uint Version,
     int RequiredCount,                    // 1 = normal; >1 = multi-person
-    int CompletedCount,                   // distinct contributors toward the CURRENT occurrence (0..RequiredCount)
-    IReadOnlyList<int> ContributorUserIds // who has signed the current occurrence (drives per-user button state)
+    int CompletedCount,                   // distinct DONE toward the CURRENT occurrence (0..RequiredCount) — the gate
+    IReadOnlyList<RosterMemberDto> Roster // named roster + per-member state; [] = open / single-person unassigned
     );
 
 /// <summary>

--- a/src/FamilyCoordinationApp/Services/Interfaces/IChoreService.cs
+++ b/src/FamilyCoordinationApp/Services/Interfaces/IChoreService.cs
@@ -98,4 +98,35 @@ public interface IChoreService
     /// <exception cref="ChoreValidationException">A named participant is outside the household, or nothing new would be recorded (the actor already contributed, D6).</exception>
     /// <exception cref="ChoreConflictException">The client <paramref name="version"/> is stale.</exception>
     Task<Chore> CompleteAsync(int householdId, int choreId, int actorUserId, string? note, string? photoPath, IReadOnlyList<int>? participantUserIds, uint version, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Adds a named member to a multi-person chore's roster as <b>Assigned</b> (a pre-opt-in by
+    /// <paramref name="actorUserId"/>; declinable, never binding — rework D8). Appends a
+    /// <c>ChoreParticipationEvent{Assigned}</c> and forces the xmin touch (M3). X=1 ⇒ rejected.
+    /// </summary>
+    /// <exception cref="ChoreNotFoundException">No such chore.</exception>
+    /// <exception cref="ChoreValidationException">Single-person chore, or subject outside the household.</exception>
+    /// <exception cref="ChoreConflictException">Stale <paramref name="version"/>.</exception>
+    Task<Chore> AssignToRosterAsync(int householdId, int choreId, int actorUserId, int subjectUserId, uint version, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Marks <paramref name="actorUserId"/> as <b>In</b> ("I'm in") on a multi-person chore's roster —
+    /// self-opt-in or confirming an assignment (rework D4). Appends a <c>ChoreParticipationEvent{Committed}</c>
+    /// and forces the xmin touch (M3). X=1 ⇒ rejected.
+    /// </summary>
+    /// <exception cref="ChoreNotFoundException">No such chore.</exception>
+    /// <exception cref="ChoreValidationException">Single-person chore.</exception>
+    /// <exception cref="ChoreConflictException">Stale <paramref name="version"/>.</exception>
+    Task<Chore> CommitToRosterAsync(int householdId, int choreId, int actorUserId, uint version, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes a member from a multi-person chore's roster (decline / leave). <paramref name="subjectUserId"/>
+    /// null ⇒ the caller leaves; a non-null subject (removing someone else) requires the caller be the chore
+    /// creator or owner. Appends a <c>ChoreParticipationEvent{Left}</c> and forces the xmin touch (M3). A
+    /// completion already recorded this occurrence still counts (Done overlay wins, D7). X=1 ⇒ rejected.
+    /// </summary>
+    /// <exception cref="ChoreNotFoundException">No such chore.</exception>
+    /// <exception cref="ChoreValidationException">Single-person chore, or removing another without authority.</exception>
+    /// <exception cref="ChoreConflictException">Stale <paramref name="version"/>.</exception>
+    Task<Chore> LeaveRosterAsync(int householdId, int choreId, int actorUserId, int? subjectUserId, uint version, CancellationToken cancellationToken = default);
 }

--- a/tests/FamilyCoordinationApp.Tests/Fixtures/ChoreBoard/board.json
+++ b/tests/FamilyCoordinationApp.Tests/Fixtures/ChoreBoard/board.json
@@ -25,7 +25,12 @@
       "version": 7,
       "requiredCount": 1,
       "completedCount": 0,
-      "contributorUserIds": []
+      "roster": [
+        {
+          "userId": 101,
+          "state": "in"
+        }
+      ]
     },
     {
       "id": 2,
@@ -52,7 +57,12 @@
       "version": 3,
       "requiredCount": 1,
       "completedCount": 0,
-      "contributorUserIds": []
+      "roster": [
+        {
+          "userId": 100,
+          "state": "assigned"
+        }
+      ]
     },
     {
       "id": 3,
@@ -79,7 +89,16 @@
       "version": 1,
       "requiredCount": 2,
       "completedCount": 1,
-      "contributorUserIds": [100]
+      "roster": [
+        {
+          "userId": 100,
+          "state": "done"
+        },
+        {
+          "userId": 101,
+          "state": "in"
+        }
+      ]
     },
     {
       "id": 4,
@@ -106,7 +125,12 @@
       "version": 2,
       "requiredCount": 1,
       "completedCount": 0,
-      "contributorUserIds": []
+      "roster": [
+        {
+          "userId": 101,
+          "state": "in"
+        }
+      ]
     }
   ],
   "rooms": [

--- a/tests/FamilyCoordinationApp.Tests/Integration/MultiPersonChoreTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Integration/MultiPersonChoreTests.cs
@@ -66,7 +66,9 @@ public sealed class MultiPersonChoreTests(PostgresContainerFixture postgres) : I
         DateTime? lastCompletedAt,
         int requiredCount,
         int completedCount,
-        IReadOnlyList<int> contributorUserIds);
+        IReadOnlyList<RosterMember> roster);
+
+    private sealed record RosterMember(int userId, string state);
 
     private sealed record Board(List<BoardChore> chores);
 
@@ -124,7 +126,8 @@ public sealed class MultiPersonChoreTests(PostgresContainerFixture postgres) : I
         afterFirst.Should().NotBeNull("a partial co-sign OneOff must remain on the board (not yet Done)");
         afterFirst!.requiredCount.Should().Be(2);
         afterFirst.completedCount.Should().Be(1, "exactly one distinct member has contributed so far");
-        afterFirst.contributorUserIds.Should().BeEquivalentTo(new[] { ChoresWebAppFactory.UserAId });
+        afterFirst.roster.Should().ContainSingle(m => m.userId == ChoresWebAppFactory.UserAId && m.state == "done",
+            "the lone contributor shows as done on the derived roster");
         afterFirst.lastCompletedAt.Should().BeNull("a partial contribution must NOT advance the chore (D4)");
 
         // Second distinct member (A2) contributes against the chore's CURRENT version (fresh read off the board).
@@ -318,7 +321,7 @@ public sealed class MultiPersonChoreTests(PostgresContainerFixture postgres) : I
         var afterSecond = FindChore(afterSecondBoard, choreId);
         afterSecond.Should().NotBeNull("rejected re-completion must NOT have advanced/removed the chore");
         afterSecond!.completedCount.Should().Be(1, "the rejected duplicate added no second contribution row");
-        afterSecond.contributorUserIds.Should().BeEquivalentTo(new[] { ChoresWebAppFactory.UserAId });
+        afterSecond.roster.Should().ContainSingle(m => m.userId == ChoresWebAppFactory.UserAId && m.state == "done");
     }
 
     // ── service-level helpers (mirror ChoreServiceConcurrencyTests) ──────────────────────────────────

--- a/tests/FamilyCoordinationApp.Tests/Integration/MultiPersonRosterTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Integration/MultiPersonRosterTests.cs
@@ -1,0 +1,186 @@
+using FamilyCoordinationApp.Data;
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Services;
+using FamilyCoordinationApp.Services.Dtos;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using FixedTimeProvider = FamilyCoordinationApp.Tests.Services.FixedTimeProvider;
+
+namespace FamilyCoordinationApp.Tests.Integration;
+
+/// <summary>
+/// Real-Postgres seam for the multi-person NAMED ROSTER (rework). Proves the three things the InMemory unit
+/// suites cannot: (R1) the assign → commit → complete write paths persist participation events that the board
+/// FOLD derives into the right per-member states; (R2) the last-N-done recurrence carry-over (the previous
+/// occurrence's doers reappear as Assigned defaults) over real persistence; (R3) two concurrent roster writes
+/// at the SAME xmin version serialize on the single Chore-row frontier (one wins, the loser gets a 409) —
+/// the load-bearing concurrency guarantee (E1), reusing the exact <see cref="SaveBarrier"/> /
+/// <see cref="GatedPostgresDbContextFactory"/> mechanism as the co-sign race.
+/// </summary>
+[Collection(IntegrationCollection.Name)]
+[Trait("kind", "integration")]
+public sealed class MultiPersonRosterTests(PostgresContainerFixture postgres)
+{
+    private static readonly DateTime T0 = new(2026, 6, 1, 12, 0, 0, DateTimeKind.Utc);
+
+    // ── R1: assign / commit / complete round-trip → board roster ────────────────────────────────────
+    [Fact]
+    public async Task AssignCommitComplete_ReflectedAsRosterStatesOnBoard_OnRealPostgres()
+    {
+        const int hh = 1, alice = 1, bob = 2, carol = 3, choreId = 1;
+        var dbFactory = new PostgresDbContextFactory(await postgres.CreateDatabaseConnectionStringAsync());
+        await SeedAsync(dbFactory, hh, choreId, RecurrenceMode.Flexible, requiredCount: 2, alice, bob, carol);
+
+        var clock = new FixedTimeProvider(T0);
+        var svc = NewService(dbFactory, clock);
+
+        // Alice assigns Bob; Carol opts in (commits herself); Bob completes his part (partial — 1 of 2).
+        var v0 = await ReadVersionAsync(dbFactory, hh, choreId);
+        var afterAssign = await svc.AssignToRosterAsync(hh, choreId, actorUserId: alice, subjectUserId: bob, v0);
+        clock.SetUtcNow(T0.AddMinutes(1));
+        var afterCommit = await svc.CommitToRosterAsync(hh, choreId, actorUserId: carol, afterAssign.Version);
+        clock.SetUtcNow(T0.AddMinutes(2));
+        await svc.CompleteAsync(hh, choreId, actorUserId: bob, note: null, photoPath: null, participantUserIds: null, afterCommit.Version);
+
+        var board = await NewBoardService(dbFactory, clock).GetBoardAsync(hh, alice, T0.AddMinutes(3));
+        var dto = board.Chores.Single(c => c.Id == choreId);
+
+        dto.RequiredCount.Should().Be(2);
+        dto.CompletedCount.Should().Be(1, "only Bob has completed (1 of 2) — still Active");
+        dto.Roster.Should().ContainSingle(m => m.UserId == bob && m.State == RosterState.Done);
+        dto.Roster.Should().ContainSingle(m => m.UserId == carol && m.State == RosterState.In);
+    }
+
+    // ── R2: last-N-done recurrence carry-over ───────────────────────────────────────────────────────
+    [Fact]
+    public async Task PreviousOccurrenceDoers_SeedNextOccurrenceAsAssignedDefaults_OnRealPostgres()
+    {
+        const int hh = 1, alice = 1, amy = 2, kai = 3, choreId = 1;
+        var dbFactory = new PostgresDbContextFactory(await postgres.CreateDatabaseConnectionStringAsync());
+        await SeedAsync(dbFactory, hh, choreId, RecurrenceMode.Flexible, requiredCount: 2, alice, amy, kai);
+
+        var clock = new FixedTimeProvider(T0);
+        var svc = NewService(dbFactory, clock);
+
+        // Occurrence 1: Alice (partial) then Amy (satisfying) → advances (Flexible stays Active).
+        var v0 = await ReadVersionAsync(dbFactory, hh, choreId);
+        var c1 = await svc.CompleteAsync(hh, choreId, alice, null, null, null, v0);
+        clock.SetUtcNow(T0.AddMinutes(1));
+        await svc.CompleteAsync(hh, choreId, amy, null, null, null, c1.Version);
+
+        var board = await NewBoardService(dbFactory, clock).GetBoardAsync(hh, alice, T0.AddMinutes(2));
+        var dto = board.Chores.Single(c => c.Id == choreId);
+
+        dto.CompletedCount.Should().Be(0, "no one has completed the NEW occurrence yet");
+        dto.Roster.Should().HaveCount(2);
+        dto.Roster.Should().OnlyContain(m => m.State == RosterState.Assigned,
+            "the previous occurrence's doers carry over as soft Assigned defaults (last-N-done)");
+        dto.Roster.Select(m => m.UserId).Should().BeEquivalentTo(new[] { alice, amy });
+    }
+
+    // ── R3: two concurrent roster writes serialize on the Chore-row xmin (E1) ───────────────────────
+    [Fact]
+    public async Task TwoConcurrentCommits_SameVersion_SerializeViaXmin_OnRealPostgres()
+    {
+        const int hh = 1, alice = 1, amy = 2, choreId = 1;
+        var connectionString = await postgres.CreateDatabaseConnectionStringAsync();
+        var dbFactory = new PostgresDbContextFactory(connectionString);
+        await SeedAsync(dbFactory, hh, choreId, RecurrenceMode.OneOff, requiredCount: 2, alice, amy);
+
+        var version = await ReadVersionAsync(dbFactory, hh, choreId);
+        version.Should().NotBe(0u, "real Postgres assigns a non-zero xmin to a committed row");
+
+        // Both commits load the chore at `version`, block at SaveChanges, then race to commit.
+        var barrier = new SaveBarrier(participants: 2);
+        var gated = new GatedPostgresDbContextFactory(connectionString, barrier);
+        var svc = NewService(gated, new FixedTimeProvider(T0.AddSeconds(1)));
+
+        var a = AttemptCommitAsync(svc, hh, choreId, alice, version);
+        var b = AttemptCommitAsync(svc, hh, choreId, amy, version);
+        var results = await Task.WhenAll(a, b);
+
+        results.Count(r => r.Won).Should().Be(1,
+            "exactly one commit succeeds at the shared version — two wins would mean xmin did NOT serialize the roster writes");
+        results.Count(r => r.Conflicted).Should().Be(1,
+            "the loser MUST get a ChoreConflictException once the winner bumped xmin (M3/E1)");
+
+        // Exactly one participation event landed (the winner's); the loser would re-submit against the refreshed version.
+        await using var ctx = dbFactory.CreateDbContext();
+        var events = await ctx.ChoreParticipationEvents.AsNoTracking()
+            .Where(e => e.HouseholdId == hh && e.ChoreId == choreId).ToListAsync();
+        events.Should().ContainSingle("only the winning commit persisted its participation event");
+        events[0].Type.Should().Be(ChoreParticipationType.Committed);
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────────────────────────
+
+    private static ChoreService NewService(
+        IDbContextFactory<ApplicationDbContext> factory, FixedTimeProvider clock) =>
+        new(factory, new ChoreStatusCalculator(), Mock.Of<IImageService>(), clock, NullLogger<ChoreService>.Instance);
+
+    private static ChoreBoardService NewBoardService(
+        IDbContextFactory<ApplicationDbContext> factory, FixedTimeProvider clock) =>
+        new(factory, new ChoreStatusCalculator(), TimeZoneInfo.Utc, clock);
+
+    private static async Task SeedAsync(
+        PostgresDbContextFactory dbFactory, int hh, int choreId, RecurrenceMode mode, int requiredCount, params int[] userIds)
+    {
+        await using var ctx = dbFactory.CreateDbContext();
+        await ctx.Database.EnsureCreatedAsync();
+        ctx.Households.Add(new Household { Id = hh, Name = "Roster House", CreatedAt = T0 });
+        foreach (var uid in userIds)
+        {
+            ctx.Users.Add(new User
+            {
+                Id = uid,
+                HouseholdId = hh,
+                Email = $"u{uid}@roster.test",
+                DisplayName = $"User{uid}",
+                Initials = "U",
+                IsWhitelisted = true,
+                CreatedAt = T0
+            });
+        }
+        ctx.Chores.Add(new Chore
+        {
+            HouseholdId = hh,
+            ChoreId = choreId,
+            Name = "Roster target",
+            RecurrenceMode = mode,
+            IntervalDays = mode == RecurrenceMode.OneOff ? null : 7,
+            AnchorDate = mode == RecurrenceMode.OneOff ? new DateOnly(2026, 6, 10) : null,
+            EffortTier = EffortTier.Standard,
+            EffortPoints = ChoreEffort.PointsFor(EffortTier.Standard),
+            RequiredCount = requiredCount,
+            Status = ChoreStatus.Active,
+            EnteredByUserId = userIds[0],
+            AssignmentKind = AssignmentKind.None,
+            CreatedAt = T0
+        });
+        await ctx.SaveChangesAsync();
+    }
+
+    private static async Task<uint> ReadVersionAsync(PostgresDbContextFactory dbFactory, int hh, int choreId)
+    {
+        await using var ctx = dbFactory.CreateDbContext();
+        var chore = await ctx.Chores.AsNoTracking().SingleAsync(c => c.HouseholdId == hh && c.ChoreId == choreId);
+        return chore.Version;
+    }
+
+    private static async Task<RosterAttempt> AttemptCommitAsync(ChoreService svc, int hh, int choreId, int actor, uint version)
+    {
+        try
+        {
+            await svc.CommitToRosterAsync(hh, choreId, actor, version);
+            return new RosterAttempt(Won: true, Conflicted: false);
+        }
+        catch (ChoreConflictException)
+        {
+            return new RosterAttempt(Won: false, Conflicted: true);
+        }
+    }
+
+    private sealed record RosterAttempt(bool Won, bool Conflicted);
+}

--- a/tests/FamilyCoordinationApp.Tests/Services/ChoreBoardDtoContractTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/ChoreBoardDtoContractTests.cs
@@ -68,7 +68,7 @@ public class ChoreBoardDtoContractTests
                 Version: 7,
                 RequiredCount: 1,
                 CompletedCount: 0,
-                ContributorUserIds: []),
+                Roster: [new RosterMemberDto(101, RosterState.In)]),
 
             // Due today, assigned (sticky), in the Kitchen room.
             new(
@@ -96,7 +96,7 @@ public class ChoreBoardDtoContractTests
                 Version: 3,
                 RequiredCount: 1,
                 CompletedCount: 0,
-                ContributorUserIds: []),
+                Roster: [new RosterMemberDto(100, RosterState.Assigned)]),
 
             // Scheduled, unclaimed pile (up-for-grabs), roomless (General group). Multi-person: 2 required, 1 signed.
             new(
@@ -124,7 +124,7 @@ public class ChoreBoardDtoContractTests
                 Version: 1,
                 RequiredCount: 2,
                 CompletedCount: 1,
-                ContributorUserIds: [100]),
+                Roster: [new RosterMemberDto(100, RosterState.Done), new RosterMemberDto(101, RosterState.In)]),
 
             // Not due, fresh, roomless one-off in the General group (claimed, not stale).
             new(
@@ -152,7 +152,7 @@ public class ChoreBoardDtoContractTests
                 Version: 2,
                 RequiredCount: 1,
                 CompletedCount: 0,
-                ContributorUserIds: []),
+                Roster: [new RosterMemberDto(101, RosterState.In)]),
         };
 
         var rooms = new List<RoomRollupDto>
@@ -243,12 +243,14 @@ public class ChoreBoardDtoContractTests
             "dueState", "colorTier", "nextDueAt",
             "isClaimStale", "effortTier", "effortPoints", "ownerUserId", "assigneeUserId", "assignmentKind",
             "claimedAt", "lastCompletedAt", "photoPath", "version",
-            "requiredCount", "completedCount", "contributorUserIds");
+            "requiredCount", "completedCount", "roster");
 
         // Enums serialize as camelCase strings (M11), NOT integers and NOT PascalCase.
         firstChore["dueState"]!.GetValue<string>().Should().Be("overdue");
         firstChore["colorTier"]!.GetValue<string>().Should().Be("overdue");
         firstChore["assignmentKind"]!.GetValue<string>().Should().Be("claimed");
+        // Roster member state serializes as a camelCase enum string ("assigned" | "in" | "done").
+        firstChore["roster"]!.AsArray()[0]!.AsObject()["state"]!.GetValue<string>().Should().Be("in");
 
         var assignedChore = root["chores"]!.AsArray()[1]!.AsObject();
         assignedChore["dueState"]!.GetValue<string>().Should().Be("dueToday");
@@ -259,6 +261,9 @@ public class ChoreBoardDtoContractTests
         pileChore["dueState"]!.GetValue<string>().Should().Be("scheduled");
         pileChore["colorTier"]!.GetValue<string>().Should().Be("fresh");
         pileChore["assignmentKind"]!.GetValue<string>().Should().Be("none");
+        // Multi-person roster: a done member + an in member (ascending by userId).
+        pileChore["roster"]!.AsArray()[0]!.AsObject()["state"]!.GetValue<string>().Should().Be("done");
+        pileChore["roster"]!.AsArray()[1]!.AsObject()["state"]!.GetValue<string>().Should().Be("in");
 
         var firstRollup = root["rooms"]!.AsArray()[0]!.AsObject();
         firstRollup.Select(kvp => kvp.Key).Should().BeEquivalentTo(

--- a/tests/FamilyCoordinationApp.Tests/Services/ChoreBoardServiceTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/ChoreBoardServiceTests.cs
@@ -386,13 +386,13 @@ public class ChoreBoardServiceTests
         var multiDto = board.Chores.Single(c => c.Id == 1);
         multiDto.RequiredCount.Should().Be(2);
         multiDto.CompletedCount.Should().Be(1);
-        multiDto.ContributorUserIds.Should().Equal(Alice);  // [100]
+        multiDto.Roster.Should().ContainSingle(m => m.UserId == Alice && m.State == RosterState.Done);
 
         // Assert: single-person chore reports zeroed progress.
         var singleDto = board.Chores.Single(c => c.Id == 2);
         singleDto.RequiredCount.Should().Be(1);
         singleDto.CompletedCount.Should().Be(0);
-        singleDto.ContributorUserIds.Should().BeEmpty();
+        singleDto.Roster.Should().BeEmpty();
     }
 
     [Fact]
@@ -411,7 +411,7 @@ public class ChoreBoardServiceTests
         {
             dto.RequiredCount.Should().Be(1);
             dto.CompletedCount.Should().Be(0);
-            dto.ContributorUserIds.Should().BeEmpty();
+            dto.Roster.Should().BeEmpty();
         }
     }
 }

--- a/tests/FamilyCoordinationApp.Tests/Services/ChoreRosterCalculatorTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/ChoreRosterCalculatorTests.cs
@@ -1,0 +1,261 @@
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Services;
+using FamilyCoordinationApp.Services.Dtos;
+using FluentAssertions;
+
+namespace FamilyCoordinationApp.Tests.Services;
+
+/// <summary>
+/// Unit tests for the pure <see cref="ChoreRosterCalculator"/> fold (V1). No DB, no I/O — events and
+/// completions are constructed in memory and folded directly. Covers the window, the last-N-done
+/// carry-over base, the monotonic event application (Assigned never downgrades In; Left removes), and the
+/// Done overlay (anyone may complete; Done wins over a same-occurrence Left).
+/// </summary>
+public class ChoreRosterCalculatorTests
+{
+    private static DateTime Utc(int day, int hour = 12) => new(2026, 6, day, hour, 0, 0, DateTimeKind.Utc);
+
+    private static ChoreParticipationEvent Ev(ChoreParticipationType type, int subject, DateTime at, int id, int? actor = null) =>
+        new()
+        {
+            HouseholdId = 1,
+            ChoreId = 1,
+            ParticipationEventId = id,
+            Type = type,
+            SubjectUserId = subject,
+            ActorUserId = actor ?? subject,
+            At = at
+        };
+
+    private static ChoreCompletion Done(int user, DateTime at, int id) =>
+        new()
+        {
+            HouseholdId = 1,
+            ChoreId = 1,
+            CompletionId = id,
+            CompletedByUserId = user,
+            CompletedAt = at,
+            EffortPointsSnapshot = 1
+        };
+
+    private static DerivedRoster Fold(
+        IEnumerable<ChoreParticipationEvent> events,
+        IEnumerable<ChoreCompletion> completions,
+        DateTime? lastCompletedAt = null,
+        int requiredCount = 2,
+        bool recurring = false) =>
+        ChoreRosterCalculator.Fold(events, completions, lastCompletedAt, requiredCount, recurring);
+
+    // ---- Empty / base cases --------------------------------------------------------------------------
+
+    [Fact]
+    public void NoEventsNoCompletions_EmptyRoster()
+    {
+        var result = Fold([], []);
+        result.Members.Should().BeEmpty();
+        result.CompletedCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void SingleAssigned_ShowsAssigned()
+    {
+        var result = Fold([Ev(ChoreParticipationType.Assigned, 100, Utc(1), 1, actor: 999)], []);
+        result.Members.Should().BeEquivalentTo(new[] { new RosterMemberDto(100, RosterState.Assigned) });
+    }
+
+    [Fact]
+    public void SelfCommitted_ShowsIn()
+    {
+        var result = Fold([Ev(ChoreParticipationType.Committed, 100, Utc(1), 1)], []);
+        result.Members.Should().BeEquivalentTo(new[] { new RosterMemberDto(100, RosterState.In) });
+    }
+
+    // ---- Monotonic event application -----------------------------------------------------------------
+
+    [Fact]
+    public void AssignedThenCommitted_UpgradesToIn()
+    {
+        var result = Fold(
+            [Ev(ChoreParticipationType.Assigned, 100, Utc(1), 1, actor: 999),
+             Ev(ChoreParticipationType.Committed, 100, Utc(2), 2)],
+            []);
+        result.Members.Should().BeEquivalentTo(new[] { new RosterMemberDto(100, RosterState.In) });
+    }
+
+    [Fact]
+    public void CommittedThenAssigned_DoesNotDowngrade()
+    {
+        // A stray later Assigned (e.g. a re-assign) must NOT knock an in member back to assigned.
+        var result = Fold(
+            [Ev(ChoreParticipationType.Committed, 100, Utc(1), 1),
+             Ev(ChoreParticipationType.Assigned, 100, Utc(2), 2, actor: 999)],
+            []);
+        result.Members.Should().BeEquivalentTo(new[] { new RosterMemberDto(100, RosterState.In) });
+    }
+
+    [Fact]
+    public void AssignedThenLeft_RemovesMember()
+    {
+        var result = Fold(
+            [Ev(ChoreParticipationType.Assigned, 100, Utc(1), 1, actor: 999),
+             Ev(ChoreParticipationType.Left, 100, Utc(2), 2)],
+            []);
+        result.Members.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void LeftThenReAssigned_ReAddsAsAssigned()
+    {
+        var result = Fold(
+            [Ev(ChoreParticipationType.Committed, 100, Utc(1), 1),
+             Ev(ChoreParticipationType.Left, 100, Utc(2), 2),
+             Ev(ChoreParticipationType.Assigned, 100, Utc(3), 3, actor: 999)],
+            []);
+        result.Members.Should().BeEquivalentTo(new[] { new RosterMemberDto(100, RosterState.Assigned) });
+    }
+
+    [Fact]
+    public void EventsOrderedByAtThenId_NotInsertionOrder()
+    {
+        // Provide events out of chronological order; the fold must order by At then id.
+        var result = Fold(
+            [Ev(ChoreParticipationType.Left, 100, Utc(3), 3),
+             Ev(ChoreParticipationType.Assigned, 100, Utc(1), 1, actor: 999),
+             Ev(ChoreParticipationType.Committed, 100, Utc(2), 2)],
+            []);
+        result.Members.Should().BeEmpty(); // assigned -> committed -> left
+    }
+
+    // ---- Done overlay --------------------------------------------------------------------------------
+
+    [Fact]
+    public void Completion_OverlaysDone_AndCounts()
+    {
+        var result = Fold(
+            [Ev(ChoreParticipationType.Assigned, 100, Utc(1), 1, actor: 999),
+             Ev(ChoreParticipationType.Committed, 101, Utc(1), 2)],
+            [Done(100, Utc(2), 1)]);
+        result.Members.Should().BeEquivalentTo(new[]
+        {
+            new RosterMemberDto(100, RosterState.Done),
+            new RosterMemberDto(101, RosterState.In)
+        });
+        result.CompletedCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void CompleterNotOnRoster_AddedAsDone()
+    {
+        // Anyone may complete toward X even if never assigned/committed.
+        var result = Fold([], [Done(200, Utc(2), 1)]);
+        result.Members.Should().BeEquivalentTo(new[] { new RosterMemberDto(200, RosterState.Done) });
+        result.CompletedCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void DoneWinsOverSameOccurrenceLeft()
+    {
+        // Completed then left: the work counts — Done overlay wins (operator-accepted).
+        var result = Fold(
+            [Ev(ChoreParticipationType.Left, 100, Utc(3), 1)],
+            [Done(100, Utc(2), 1)]);
+        result.Members.Should().BeEquivalentTo(new[] { new RosterMemberDto(100, RosterState.Done) });
+        result.CompletedCount.Should().Be(1);
+    }
+
+    // ---- Window exclusion ----------------------------------------------------------------------------
+
+    [Fact]
+    public void EventsBeforeLastCompletedAt_Excluded()
+    {
+        // A previous-occurrence Assigned (At <= lastCompletedAt) must NOT leak into the new occurrence.
+        var lastCompleted = Utc(10);
+        var result = Fold(
+            [Ev(ChoreParticipationType.Assigned, 100, Utc(5), 1, actor: 999),   // previous occurrence
+             Ev(ChoreParticipationType.Committed, 101, Utc(12), 2)],            // current occurrence
+            [],
+            lastCompletedAt: lastCompleted);
+        result.Members.Should().BeEquivalentTo(new[] { new RosterMemberDto(101, RosterState.In) });
+    }
+
+    [Fact]
+    public void CompletionsBeforeLastCompletedAt_NotCountedDone()
+    {
+        var lastCompleted = Utc(10);
+        var result = Fold([], [Done(100, Utc(5), 1)], lastCompletedAt: lastCompleted, recurring: false);
+        result.CompletedCount.Should().Be(0);
+        result.Members.Should().BeEmpty();
+    }
+
+    // ---- Last-N-done carry-over (recurrence) ---------------------------------------------------------
+
+    [Fact]
+    public void RecurringWithPriorCompleters_SeedsLastNDoneAsAssigned()
+    {
+        var lastCompleted = Utc(10);
+        var result = Fold(
+            [],
+            [Done(100, Utc(9), 1), Done(101, Utc(10), 2)],   // previous occurrence's two doers
+            lastCompletedAt: lastCompleted,
+            requiredCount: 2,
+            recurring: true);
+        result.Members.Should().BeEquivalentTo(new[]
+        {
+            new RosterMemberDto(100, RosterState.Assigned),
+            new RosterMemberDto(101, RosterState.Assigned)
+        });
+        result.CompletedCount.Should().Be(0); // none done in the NEW occurrence yet
+    }
+
+    [Fact]
+    public void NonRecurring_DoesNotSeedDefaults()
+    {
+        var lastCompleted = Utc(10);
+        var result = Fold(
+            [],
+            [Done(100, Utc(9), 1), Done(101, Utc(10), 2)],
+            lastCompletedAt: lastCompleted,
+            requiredCount: 2,
+            recurring: false);
+        result.Members.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void LastNDone_TakesMostRecentDistinct_UpToRequiredCount()
+    {
+        var lastCompleted = Utc(20);
+        // Older occurrence done by {1,2}; most recent done by {3,4}. requiredCount=2 -> {3,4}.
+        var completions = new[]
+        {
+            Done(1, Utc(5), 1), Done(2, Utc(6), 2),
+            Done(3, Utc(18), 3), Done(4, Utc(19), 4)
+        };
+        var defaults = ChoreRosterCalculator.LastNDoneDefaults(completions, lastCompleted, requiredCount: 2);
+        defaults.Should().BeEquivalentTo(new[] { 4, 3 }, o => o.WithStrictOrdering()); // most-recent first
+    }
+
+    [Fact]
+    public void LeftRemovesACarriedDefault()
+    {
+        // A carried-over default who declines the new occurrence is removed.
+        var lastCompleted = Utc(10);
+        var result = Fold(
+            [Ev(ChoreParticipationType.Left, 101, Utc(11), 5)],
+            [Done(100, Utc(9), 1), Done(101, Utc(10), 2)],
+            lastCompletedAt: lastCompleted,
+            requiredCount: 2,
+            recurring: true);
+        result.Members.Should().BeEquivalentTo(new[] { new RosterMemberDto(100, RosterState.Assigned) });
+    }
+
+    [Fact]
+    public void MembersOrderedByUserId()
+    {
+        var result = Fold(
+            [Ev(ChoreParticipationType.Committed, 300, Utc(1), 1),
+             Ev(ChoreParticipationType.Committed, 100, Utc(1), 2),
+             Ev(ChoreParticipationType.Committed, 200, Utc(1), 3)],
+            []);
+        result.Members.Select(m => m.UserId).Should().ContainInOrder(100, 200, 300);
+    }
+}

--- a/tests/FamilyCoordinationApp.Tests/Services/ChoreRosterServiceTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/ChoreRosterServiceTests.cs
@@ -1,0 +1,257 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using FamilyCoordinationApp.Data;
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Services;
+
+namespace FamilyCoordinationApp.Tests.Services;
+
+/// <summary>
+/// Unit tests (InMemory) for the multi-person roster write-path LOGIC (WP-04, rework): assign/commit/leave
+/// event-writing + rejections, the create-time roster seed, and the X=1↔X&gt;1 transition. The real two-writer
+/// xmin serialization (V3) is verified against Postgres in WP-05 — the InMemory provider never raises
+/// <see cref="DbUpdateConcurrencyException"/>, so concurrency is NOT faked here.
+/// </summary>
+public class ChoreRosterServiceTests : IDisposable
+{
+    private const int HouseholdId = 1;
+    private const int OtherHouseholdId = 2;
+    private const int Alice = 1;
+    private const int Bob = 2;
+    private const int Carol = 3;   // other household
+
+    private static readonly DateTime NowBase = new(2026, 6, 1, 12, 0, 0, DateTimeKind.Utc);
+
+    private readonly DbContextOptions<ApplicationDbContext> _options;
+    private readonly ApplicationDbContext _seedContext;
+    private readonly FixedTimeProvider _clock = new(NowBase);
+    private readonly ChoreService _service;
+
+    public ChoreRosterServiceTests()
+    {
+        _options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        _seedContext = new ApplicationDbContext(_options);
+
+        var dbFactoryMock = new Mock<IDbContextFactory<ApplicationDbContext>>();
+        dbFactoryMock.Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new ApplicationDbContext(_options));
+
+        _service = new ChoreService(
+            dbFactoryMock.Object,
+            new ChoreStatusCalculator(),
+            Mock.Of<IImageService>(),
+            _clock,
+            new Mock<ILogger<ChoreService>>().Object);
+
+        _seedContext.Households.AddRange(
+            new Household { Id = HouseholdId, Name = "Smith" },
+            new Household { Id = OtherHouseholdId, Name = "Jones" });
+        _seedContext.Users.AddRange(
+            new User { Id = Alice, HouseholdId = HouseholdId, Email = "a@x.com", DisplayName = "Alice" },
+            new User { Id = Bob, HouseholdId = HouseholdId, Email = "b@x.com", DisplayName = "Bob" },
+            new User { Id = Carol, HouseholdId = OtherHouseholdId, Email = "c@x.com", DisplayName = "Carol" });
+        _seedContext.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        _seedContext.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private void SeedChore(int choreId, int requiredCount, int? assigneeUserId = null,
+        AssignmentKind kind = AssignmentKind.None, int enteredBy = Alice, int? ownerUserId = null)
+    {
+        _seedContext.Chores.Add(new Chore
+        {
+            HouseholdId = HouseholdId,
+            ChoreId = choreId,
+            Name = "Test chore",
+            RecurrenceMode = RecurrenceMode.OneOff,
+            EffortTier = EffortTier.Standard,
+            EffortPoints = 2,
+            RequiredCount = requiredCount,
+            Status = ChoreStatus.Active,
+            EnteredByUserId = enteredBy,
+            OwnerUserId = ownerUserId,
+            AssigneeUserId = assigneeUserId,
+            AssignmentKind = kind,
+            ClaimedAt = assigneeUserId is null ? null : NowBase,
+            CreatedAt = NowBase
+        });
+        _seedContext.SaveChanges();
+    }
+
+    private async Task<List<ChoreParticipationEvent>> EventsAsync(int choreId)
+    {
+        await using var ctx = new ApplicationDbContext(_options);
+        return await ctx.ChoreParticipationEvents.Where(e => e.ChoreId == choreId).ToListAsync();
+    }
+
+    private async Task<Chore> ReloadAsync(int choreId)
+    {
+        await using var ctx = new ApplicationDbContext(_options);
+        return await ctx.Chores.SingleAsync(c => c.ChoreId == choreId);
+    }
+
+    // ---- assign / commit / leave -----------------------------------------------------
+
+    [Fact]
+    public async Task AssignToRoster_SinglePerson_Throws()
+    {
+        SeedChore(1, requiredCount: 1);
+        var act = () => _service.AssignToRosterAsync(HouseholdId, 1, Alice, Bob, version: 0);
+        await act.Should().ThrowAsync<ChoreValidationException>().WithMessage("*single-person*");
+    }
+
+    [Fact]
+    public async Task AssignToRoster_MultiPerson_WritesAssignedEvent()
+    {
+        SeedChore(1, requiredCount: 2);
+        await _service.AssignToRosterAsync(HouseholdId, 1, actorUserId: Alice, subjectUserId: Bob, version: 0);
+
+        var events = await EventsAsync(1);
+        events.Should().ContainSingle();
+        events[0].Type.Should().Be(ChoreParticipationType.Assigned);
+        events[0].SubjectUserId.Should().Be(Bob);
+        events[0].ActorUserId.Should().Be(Alice);
+    }
+
+    [Fact]
+    public async Task AssignToRoster_NonMemberSubject_Throws()
+    {
+        SeedChore(1, requiredCount: 2);
+        var act = () => _service.AssignToRosterAsync(HouseholdId, 1, Alice, Carol, version: 0);
+        await act.Should().ThrowAsync<ChoreValidationException>();
+    }
+
+    [Fact]
+    public async Task CommitToRoster_WritesCommittedEvent()
+    {
+        SeedChore(1, requiredCount: 2);
+        await _service.CommitToRosterAsync(HouseholdId, 1, actorUserId: Bob, version: 0);
+
+        var events = await EventsAsync(1);
+        events.Should().ContainSingle();
+        events[0].Type.Should().Be(ChoreParticipationType.Committed);
+        events[0].SubjectUserId.Should().Be(Bob);
+    }
+
+    [Fact]
+    public async Task LeaveRoster_Self_WritesLeftEvent()
+    {
+        SeedChore(1, requiredCount: 2);
+        await _service.LeaveRosterAsync(HouseholdId, 1, actorUserId: Bob, subjectUserId: null, version: 0);
+
+        var events = await EventsAsync(1);
+        events.Should().ContainSingle();
+        events[0].Type.Should().Be(ChoreParticipationType.Left);
+        events[0].SubjectUserId.Should().Be(Bob);
+    }
+
+    [Fact]
+    public async Task LeaveRoster_RemoveOther_WithoutAuthority_Throws()
+    {
+        SeedChore(1, requiredCount: 2, enteredBy: Alice, ownerUserId: null);
+        // Bob is neither creator nor owner — cannot remove Alice.
+        var act = () => _service.LeaveRosterAsync(HouseholdId, 1, actorUserId: Bob, subjectUserId: Alice, version: 0);
+        await act.Should().ThrowAsync<ChoreValidationException>().WithMessage("*creator or owner*");
+    }
+
+    [Fact]
+    public async Task LeaveRoster_RemoveOther_AsCreator_Writes()
+    {
+        SeedChore(1, requiredCount: 2, enteredBy: Alice);
+        await _service.LeaveRosterAsync(HouseholdId, 1, actorUserId: Alice, subjectUserId: Bob, version: 0);
+
+        var events = await EventsAsync(1);
+        events.Should().ContainSingle();
+        events[0].SubjectUserId.Should().Be(Bob);
+        events[0].Type.Should().Be(ChoreParticipationType.Left);
+    }
+
+    // ---- create-time roster seed -----------------------------------------------------
+
+    [Fact]
+    public async Task CreateChore_MultiPerson_SeedsRoster_AndLeavesTrioOnPile()
+    {
+        var cmd = new CreateChoreCommand(
+            Name: "Flip the mattress", Description: null, RoomId: null,
+            RecurrenceMode: RecurrenceMode.OneOff, IntervalDays: null, AnchorDate: new DateOnly(2026, 6, 10),
+            DaysOfWeek: null, DayOfMonth: null, EffortTier: EffortTier.BigJob,
+            OwnerUserId: null, AssigneeUserId: null, PhotoPath: null,
+            RequiredCount: 2, AssignedUserIds: new[] { Alice, Bob });
+
+        var chore = await _service.CreateChoreAsync(HouseholdId, Alice, cmd);
+
+        chore.AssignmentKind.Should().Be(AssignmentKind.None);
+        chore.AssigneeUserId.Should().BeNull();
+
+        var events = await EventsAsync(chore.ChoreId);
+        events.Should().HaveCount(2);
+        events.Should().OnlyContain(e => e.Type == ChoreParticipationType.Assigned);
+        events.Select(e => e.SubjectUserId).Should().BeEquivalentTo(new[] { Alice, Bob });
+    }
+
+    [Fact]
+    public async Task CreateChore_SinglePerson_IgnoresAssignedUserIds()
+    {
+        var cmd = new CreateChoreCommand(
+            Name: "Dishes", Description: null, RoomId: null,
+            RecurrenceMode: RecurrenceMode.OneOff, IntervalDays: null, AnchorDate: new DateOnly(2026, 6, 10),
+            DaysOfWeek: null, DayOfMonth: null, EffortTier: EffortTier.Quick,
+            OwnerUserId: null, AssigneeUserId: Bob, PhotoPath: null,
+            RequiredCount: 1, AssignedUserIds: new[] { Alice });
+
+        var chore = await _service.CreateChoreAsync(HouseholdId, Alice, cmd);
+
+        chore.AssignmentKind.Should().Be(AssignmentKind.Assigned);
+        chore.AssigneeUserId.Should().Be(Bob);
+        (await EventsAsync(chore.ChoreId)).Should().BeEmpty();
+    }
+
+    // ---- X=1 ↔ X>1 transition (D9) ---------------------------------------------------
+
+    [Fact]
+    public async Task UpdateChore_OneToMany_ConvertsAssigneeToRoster_AndClearsTrio()
+    {
+        SeedChore(1, requiredCount: 1, assigneeUserId: Bob, kind: AssignmentKind.Assigned);
+        var cmd = new UpdateChoreCommand(
+            Name: "Test chore", Description: null, RoomId: null,
+            RecurrenceMode: RecurrenceMode.OneOff, IntervalDays: null, AnchorDate: new DateOnly(2026, 6, 10),
+            DaysOfWeek: null, DayOfMonth: null, EffortTier: EffortTier.Standard,
+            OwnerUserId: null, PhotoPath: null, RequiredCount: 2);
+
+        var chore = await _service.UpdateChoreAsync(HouseholdId, 1, cmd, version: 0);
+
+        chore.AssignmentKind.Should().Be(AssignmentKind.None);
+        chore.AssigneeUserId.Should().BeNull();
+
+        var events = await EventsAsync(1);
+        events.Should().ContainSingle();
+        events[0].Type.Should().Be(ChoreParticipationType.Assigned);
+        events[0].SubjectUserId.Should().Be(Bob);
+    }
+
+    [Fact]
+    public async Task UpdateChore_ManyToOne_ClearsToPile()
+    {
+        SeedChore(1, requiredCount: 2);
+        var cmd = new UpdateChoreCommand(
+            Name: "Test chore", Description: null, RoomId: null,
+            RecurrenceMode: RecurrenceMode.OneOff, IntervalDays: null, AnchorDate: new DateOnly(2026, 6, 10),
+            DaysOfWeek: null, DayOfMonth: null, EffortTier: EffortTier.Standard,
+            OwnerUserId: null, PhotoPath: null, RequiredCount: 1);
+
+        var chore = await _service.UpdateChoreAsync(HouseholdId, 1, cmd, version: 0);
+
+        chore.RequiredCount.Should().Be(1);
+        chore.AssignmentKind.Should().Be(AssignmentKind.None);
+        chore.AssigneeUserId.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## What & why

Replaces the just-shipped **anonymous co-sign** multi-person model (PRs #32/#33, merged & live), which the operator browser-verified and rejected: *"no idea who is collaborating, who's agreed to contribute."* The count was never the problem — its **facelessness** was. This keeps the count and gives it **faces**: a chore needs X people, and you can name them, see who's assigned vs. agreed vs. done, with assignment that is a soft, declinable suggestion rather than a binding lock.

Direction was chosen via a 3-branch [parallel-explore](../tree/feat/chores-named-roster) + synthesis + operator review, then a deep workshop spec (`data/outputs/workshops/chore-named-roster/`).

## The model

- **Needs-X gate kept.** `Chore.RequiredCount = X` stays the satisfaction gate (X distinct completions) — *unchanged* from co-sign.
- **Soft named roster.** Optional, partial-OK: assign 0..X named people at create. **Assignment = a pre-opt-in done by someone else; fully declinable, never binding.** Per-member state: **assigned → in ("I'm in") → done**. Self-opt-in enters at "in"; completing enters at "done". Anyone may complete toward X.
- **Recurrence = last-N-done.** The previous occurrence's X completers auto-seed the next occurrence as soft *assigned* defaults — derived on read, no carry-over bookkeeping.
- **Mechanism (parallel-explore Branch 3).** An append-only `ChoreParticipationEvent` log (assign / commit / leave); the roster + each member's state is **derived on read by a fold** (`ChoreRosterCalculator`), like `ChoreStatusCalculator` derives dueness. "Done" stays in the existing `ChoreCompletion` ledger. Reuses the proven `LastContributionAt` xmin discipline — **one serialization frontier**. The single-holder **trio is untouched for X=1**; the board emits a **uniform `roster[]`** either way.

## What changed

**Backend:** `ChoreParticipationEvent` entity + `ChoreParticipationType {Assigned,Committed,Left}` + additive migration (no backfill); `ChoreRosterCalculator` fold + `RosterState`/`RosterMemberDto`; `ChoreDto` gains `roster[]`, drops `contributorUserIds`; board projection folds X>1 / synthesizes X=1; `AssignToRosterAsync`/`CommitToRosterAsync`/`LeaveRosterAsync` + create-time roster seed + the X=1↔X>1 edit transition; `POST /api/chores/{id}/roster/{assign,commit,leave}`.

**Island:** `roster[]` types; `assignRoster`/`commitRoster`/`leaveRoster` api; store lenses re-pointed to roster membership + commit/leave/assign actions; `ChoreCard` renders badged avatars (assigned ○ / in ● / done ✓) with per-viewer buttons ("I'm in" / "Mark my part done" / "Not me" / "I'll help"); single-person card unchanged; `QuickAddSheet` "assign people" multi-picker for X>1.

## Verification

- **Unit/contract:** 18 fold + 11 roster-service + 53 existing-untouched + the `board.json` contract fixture (lockstep with `types.ts`). svelte-check clean (126 files).
- **Real-Postgres integration:** roster round-trip, last-N-done carry-over, and the **two-writer xmin race** (the load-bearing concurrency guarantee). Existing co-sign tests still green.
- **Live on :8080:** image rebuilt, app recreated, migration applied, and the **full lifecycle browser-verified** — create partial roster → card avatars (assigned/in/done) + "k of X done" → "I'm in" (commit) → "Mark my part done" (dialog → done, "You're done ✓").

## Migration / relationship to #32/#33

Builds **forward** on the co-sign substrate: keeps `RequiredCount`/`LastContributionAt`/`ChoreCompletion`, purely additive table. No backfill; existing co-sign chores keep working via the unchanged gate. This supersedes the co-sign UX on merge with **no revert**.

## Deferred (v1 gap)

The **edit sheet has no named-roster picker** — the count control + the 1↔N transition work, but adding/removing *named* people after creation happens via the card (commit/leave) or recreate. A clean fast-follow if wanted.