### PR TITLE
fix(islands): self-heal Svelte islands across Blazor circuit resume

### DIFF
--- a/frontend/chores/src/main.ts
+++ b/frontend/chores/src/main.ts
@@ -5,6 +5,13 @@ import type { ShellContext } from './lib/types';
 
 type MountedApp = ReturnType<typeof svelteMount>;
 
+interface Instance {
+  app: MountedApp;
+  /** The exact node we mounted into — lets us detect a Blazor resume that
+   *  replaced or emptied the root out from under us. */
+  el: HTMLElement;
+}
+
 // Blazor Server inserts component output via DOM diff, and inline <script>
 // tags in that output are NOT executed by the browser. The Razor shell
 // (Chores.razor) uses IJSRuntime.InvokeAsync("import", ...) to load this
@@ -21,7 +28,12 @@ declare global {
 
 const ROOT_ID = 'chores-root';
 
-const instances = new Map<string, MountedApp>();
+const instances = new Map<string, Instance>();
+
+// Roots the Razor shell has asked us to mount. We re-assert these when the page
+// is restored so a Blazor circuit resume / enhanced-nav merge that wiped our
+// content can't leave the island permanently blank (see reassertMounts below).
+const desiredRoots = new Set<string>();
 
 function readContext(el: HTMLElement): ShellContext {
   const householdId = Number(el.dataset.householdId ?? '0');
@@ -69,22 +81,58 @@ function installDarkObserver(rootId: string, el: HTMLElement) {
   });
 }
 
+/**
+ * A mount is healthy only if the CURRENT root element is the exact node we
+ * mounted into, it's still in the document, and it still holds our rendered
+ * children. Blazor's .NET 10 circuit resume (the path that fires on a mobile
+ * background→return) REPLACES the root node and re-runs the host component's
+ * lifecycle — a fresh firstRender re-calls mount(). The old mount-once guard
+ * (`instances.has`) refused to re-mount into that new node, leaving the board
+ * blank until a full reload. Comparing the live node to the one we mounted into
+ * lets the re-invoked mount() rebuild instead of no-op.
+ */
+function isHealthy(rootId: string): boolean {
+  const inst = instances.get(rootId);
+  if (!inst) return false;
+  const el = document.getElementById(rootId);
+  return el != null && el === inst.el && el.isConnected && el.childElementCount > 0;
+}
+
 function mountRoot(rootId: string) {
+  desiredRoots.add(rootId);
+  // Already mounted AND still intact — nothing to do.
+  if (isHealthy(rootId)) return;
+  // A stale prior mount (root emptied / replaced / detached): tear it down first
+  // so we don't leak the Svelte instance or its observers before remounting.
+  if (instances.has(rootId)) destroyRoot(rootId, /* internal */ true);
   const el = document.getElementById(rootId) as HTMLElement | null;
   if (!el) {
     console.warn('[chores-island] root element not found:', rootId);
     return;
   }
-  if (instances.has(rootId)) return;
   installDarkObserver(rootId, el);
   const app = svelteMount(App, { target: el, props: { ctx: readContext(el) } });
-  instances.set(rootId, app);
+  instances.set(rootId, { app, el });
+  ensureHealObserver();
 }
 
-function destroyRoot(rootId: string) {
-  const app = instances.get(rootId);
-  if (!app) return;
-  unmount(app);
+function destroyRoot(rootId: string, internal = false) {
+  const inst = instances.get(rootId);
+  if (!inst) {
+    if (!internal) desiredRoots.delete(rootId);
+    return;
+  }
+  // Blazor's circuit resume disposes the OLD page component AFTER it has already
+  // re-initialised the new one — whose firstRender re-calls mount(), which we use
+  // to rebuild into the freshly-replaced root. That trailing destroy() targets a
+  // SUPERSEDED component and would otherwise tear our live island back down.
+  // Ignore an external destroy while the current mount is healthy; a genuine
+  // navigation-away leaves no healthy root (the page is gone), so real teardown
+  // still runs then. `internal` is our own self-heal replacing a stale mount — it
+  // must always proceed.
+  if (!internal && isHealthy(rootId)) return;
+  if (!internal) desiredRoots.delete(rootId);
+  unmount(inst.app);
   instances.delete(rootId);
   const disposer = darkObservers.get(rootId);
   if (disposer) {
@@ -94,6 +142,53 @@ function destroyRoot(rootId: string) {
 }
 
 window.ChoresIsland = { mount: mountRoot, destroy: destroyRoot };
+
+// ── Resilience: self-heal after a Blazor circuit resume ────────────────────
+// Mobile browsers background the tab on an app/tab switch; Blazor Server's .NET
+// 10 circuit pause/resume then reconciles the DOM on return and can REPLACE the
+// island root — sometimes re-invoking our mount() (handled in mountRoot), and
+// sometimes NOT (observed: nondeterministic). Either way the swap is a DOM
+// mutation, so we watch a STABLE anchor (document.body — Blazor replaces a chunk
+// of the island's ancestors, so observing the root or its parent misses it) and
+// rebuild any desired root that has gone unhealthy.
+//
+// The heal runs SYNCHRONOUSLY in the observer microtask — NOT via
+// requestAnimationFrame, which is paused while the tab is hidden (the wipe can
+// land a beat after the tab is technically still settling). `healing` guards
+// re-entrancy (mountRoot mutates the DOM, which re-queues this callback); once
+// the root is healthy again the next pass no-ops, so it can't loop. The cost on
+// every unrelated DOM change is one getElementById + isHealthy per desired root
+// (normally one), which is negligible.
+let healObserver: MutationObserver | null = null;
+let healing = false;
+function runHeal() {
+  if (healing) return;
+  healing = true;
+  try {
+    for (const rootId of desiredRoots) {
+      // Only rebuild when the root EXISTS but is stale/empty. A missing root is
+      // a navigation-away (or mid-reconcile) — not ours to remount; the next
+      // mutation re-checks once the fresh root lands.
+      if (document.getElementById(rootId) && !isHealthy(rootId)) mountRoot(rootId);
+    }
+  } finally {
+    healing = false;
+  }
+}
+function ensureHealObserver() {
+  if (healObserver || !document.body) return;
+  healObserver = new MutationObserver(runHeal);
+  healObserver.observe(document.body, { childList: true, subtree: true });
+}
+
+// bfcache restore re-attaches the frozen DOM without any mutation, so the body
+// observer won't fire — re-assert directly on pageshow as a cheap belt.
+window.addEventListener('pageshow', () => {
+  ensureHealObserver();
+  for (const rootId of desiredRoots) {
+    if (document.getElementById(rootId) && !isHealthy(rootId)) mountRoot(rootId);
+  }
+});
 
 // Standalone dev auto-mount: if the root is already on the page when the
 // module loads (Vite's index.html), mount immediately. In production the

--- a/frontend/shopping-list/src/main.ts
+++ b/frontend/shopping-list/src/main.ts
@@ -5,6 +5,13 @@ import type { ShellContext } from './lib/types';
 
 type MountedApp = ReturnType<typeof svelteMount>;
 
+interface Instance {
+  app: MountedApp;
+  /** The exact node we mounted into — lets us detect a Blazor resume that
+   *  replaced or emptied the root out from under us. */
+  el: HTMLElement;
+}
+
 // Blazor Server inserts component output via DOM diff, and inline <script>
 // tags in that output are NOT executed by the browser. The Razor shell uses
 // IJSRuntime.InvokeAsync("import", ...) to load this module, then calls the
@@ -19,7 +26,12 @@ declare global {
   }
 }
 
-const instances = new Map<string, MountedApp>();
+const instances = new Map<string, Instance>();
+
+// Roots the Razor shell has asked us to mount. We re-assert these when the page
+// is restored so a Blazor circuit resume / enhanced-nav merge that wiped our
+// content can't leave the island permanently blank (see reassertMounts below).
+const desiredRoots = new Set<string>();
 
 function readContext(el: HTMLElement): ShellContext {
   const householdId = Number(el.dataset.householdId ?? '0');
@@ -69,22 +81,58 @@ function installDarkObserver(rootId: string, el: HTMLElement) {
   });
 }
 
+/**
+ * A mount is healthy only if the CURRENT root element is the exact node we
+ * mounted into, it's still in the document, and it still holds our rendered
+ * children. Blazor's .NET 10 circuit resume (the path that fires on a mobile
+ * background→return) REPLACES the root node and re-runs the host component's
+ * lifecycle — a fresh firstRender re-calls mount(). The old mount-once guard
+ * (`instances.has`) refused to re-mount into that new node, leaving the list
+ * blank until a full reload. Comparing the live node to the one we mounted into
+ * lets the re-invoked mount() rebuild instead of no-op.
+ */
+function isHealthy(rootId: string): boolean {
+  const inst = instances.get(rootId);
+  if (!inst) return false;
+  const el = document.getElementById(rootId);
+  return el != null && el === inst.el && el.isConnected && el.childElementCount > 0;
+}
+
 function mountRoot(rootId: string) {
+  desiredRoots.add(rootId);
+  // Already mounted AND still intact — nothing to do.
+  if (isHealthy(rootId)) return;
+  // A stale prior mount (root emptied / replaced / detached): tear it down first
+  // so we don't leak the Svelte instance or its observers before remounting.
+  if (instances.has(rootId)) destroyRoot(rootId, /* internal */ true);
   const el = document.getElementById(rootId) as HTMLElement | null;
   if (!el) {
     console.warn('[shopping-list-island] root element not found:', rootId);
     return;
   }
-  if (instances.has(rootId)) return;
   installDarkObserver(rootId, el);
   const app = svelteMount(App, { target: el, props: { ctx: readContext(el) } });
-  instances.set(rootId, app);
+  instances.set(rootId, { app, el });
+  ensureHealObserver();
 }
 
-function destroyRoot(rootId: string) {
-  const app = instances.get(rootId);
-  if (!app) return;
-  unmount(app);
+function destroyRoot(rootId: string, internal = false) {
+  const inst = instances.get(rootId);
+  if (!inst) {
+    if (!internal) desiredRoots.delete(rootId);
+    return;
+  }
+  // Blazor's circuit resume disposes the OLD page component AFTER it has already
+  // re-initialised the new one — whose firstRender re-calls mount(), which we use
+  // to rebuild into the freshly-replaced root. That trailing destroy() targets a
+  // SUPERSEDED component and would otherwise tear our live island back down.
+  // Ignore an external destroy while the current mount is healthy; a genuine
+  // navigation-away leaves no healthy root (the page is gone), so real teardown
+  // still runs then. `internal` is our own self-heal replacing a stale mount — it
+  // must always proceed.
+  if (!internal && isHealthy(rootId)) return;
+  if (!internal) desiredRoots.delete(rootId);
+  unmount(inst.app);
   instances.delete(rootId);
   const disposer = darkObservers.get(rootId);
   if (disposer) {
@@ -94,6 +142,53 @@ function destroyRoot(rootId: string) {
 }
 
 window.ShoppingListIsland = { mount: mountRoot, destroy: destroyRoot };
+
+// ── Resilience: self-heal after a Blazor circuit resume ────────────────────
+// Mobile browsers background the tab on an app/tab switch; Blazor Server's .NET
+// 10 circuit pause/resume then reconciles the DOM on return and can REPLACE the
+// island root — sometimes re-invoking our mount() (handled in mountRoot), and
+// sometimes NOT (observed: nondeterministic). Either way the swap is a DOM
+// mutation, so we watch a STABLE anchor (document.body — Blazor replaces a chunk
+// of the island's ancestors, so observing the root or its parent misses it) and
+// rebuild any desired root that has gone unhealthy.
+//
+// The heal runs SYNCHRONOUSLY in the observer microtask — NOT via
+// requestAnimationFrame, which is paused while the tab is hidden (the wipe can
+// land a beat after the tab is technically still settling). `healing` guards
+// re-entrancy (mountRoot mutates the DOM, which re-queues this callback); once
+// the root is healthy again the next pass no-ops, so it can't loop. The cost on
+// every unrelated DOM change is one getElementById + isHealthy per desired root
+// (normally one), which is negligible.
+let healObserver: MutationObserver | null = null;
+let healing = false;
+function runHeal() {
+  if (healing) return;
+  healing = true;
+  try {
+    for (const rootId of desiredRoots) {
+      // Only rebuild when the root EXISTS but is stale/empty. A missing root is
+      // a navigation-away (or mid-reconcile) — not ours to remount; the next
+      // mutation re-checks once the fresh root lands.
+      if (document.getElementById(rootId) && !isHealthy(rootId)) mountRoot(rootId);
+    }
+  } finally {
+    healing = false;
+  }
+}
+function ensureHealObserver() {
+  if (healObserver || !document.body) return;
+  healObserver = new MutationObserver(runHeal);
+  healObserver.observe(document.body, { childList: true, subtree: true });
+}
+
+// bfcache restore re-attaches the frozen DOM without any mutation, so the body
+// observer won't fire — re-assert directly on pageshow as a cheap belt.
+window.addEventListener('pageshow', () => {
+  ensureHealObserver();
+  for (const rootId of desiredRoots) {
+    if (document.getElementById(rootId) && !isHealthy(rootId)) mountRoot(rootId);
+  }
+});
 
 // Standalone dev auto-mount: if the root is already on the page when the
 // module loads (Vite's index.html), mount immediately. In production the


### PR DESCRIPTION
## Symptom

On mobile, backgrounding the tab on a **chores** (or **shopping-list**) page and returning shows a **blank board with no cards until a manual refresh**. Hard to reproduce by hand — far more prevalent on phones.

## Root cause (reproduced authentically)

Reproduced in-browser by driving `Blazor.pauseCircuit()` + `resumeCircuit()` — the literal **.NET 10 circuit pause/resume** path that fires on a mobile background→return (the `<ReconnectModal>` "session paused / Resume" feature, on by default with `blazor.web.js` + global `InteractiveServer`).

On resume, Blazor reconciles the DOM and **replaces the island root node** (`#chores-root` / `#shopping-list-root`), detaching the node that held the Svelte content. Because the Razor shell only mounts on `firstRender` and tracks the mount in a module-singleton `instances` map, the old `if (instances.has(rootId)) return` guard refused to re-mount into the new node → blank until a full reload rebuilds the JS realm. Affects both islands; the liveness poll can't help (it refreshes data, not the DOM).

Two facts from the repro shaped the fix:
- Whether resume re-invokes our `mount()`/`destroy()` is **nondeterministic** — some resumes re-run the host lifecycle, some replace the DOM silently. The fix cannot rely on `mount()` being called.
- A `data-permanent` attempt was **dropped** — verified live that resume replaces the node and re-runs lifecycle regardless, so it had no effect (it only governs the enhanced-nav merge path).

## Fix (in each island `main.ts`)

1. **Self-healing `mountRoot`** — rebuild when the live root != the tracked node (covers the resume that *does* re-call `mount`).
2. **Spurious-destroy guard** — the old component's trailing `destroy()` lands after the new one re-mounted; ignore an external `destroy()` while the mount is healthy so it can't tear the live island down. A real navigation-away leaves no healthy root, so genuine teardown still runs.
3. **`document.body` subtree `MutationObserver`** with a **synchronous** heal (NOT `requestAnimationFrame`, which is paused while the tab is hidden) — the reliable backstop for resumes that wipe *without* re-calling `mount`. Anchored at `<body>` because resume replaces a chunk of the island ancestors, so observing the root or its parent misses it. Plus a `pageshow` re-assert for bfcache restores.

## Verification

Built the bundles, hot-patched them into the running container, and re-ran the authentic pause/resume cycle (islands are served by `UseStaticFiles` from live wwwroot, so a `docker cp` is honored):

| | unfixed bundle | fixed bundle |
|---|---|---|
| chores pause/resume | blank (cc 0) every cycle | **survives, cc 9** (×3 cycles) |
| shopping-list pause/resume | — | **survives, cc 10** |

All with the tab **hidden** — the hardest case (rAF unavailable). `svelte-check` + `vite build` clean for both islands; `dotnet build` clean.

## Notes

- **Source-only** — island `dist/` is regenerated by the Docker build; no Razor/server changes.
- Repro technique + mechanism captured for future debugging.
