### PR TITLE
feat: dog/cat chore icons + home shopping summary across all active lists

### DIFF
--- a/frontend/chores/src/lib/components/IconPicker.svelte
+++ b/frontend/chores/src/lib/components/IconPicker.svelte
@@ -35,7 +35,7 @@
     // Garage, home & outdoors
     '🚗', '🏡', '🌳', '🪴', '🌿',
     // Pets
-    '🐾',
+    '🐾', '🐕', '🐈',
     // Cleaning & chores
     '🧹', '🧺', '🧽', '🗑️', '🪟',
     // Other spaces

--- a/src/FamilyCoordinationApp/Components/Pages/Home.razor
+++ b/src/FamilyCoordinationApp/Components/Pages/Home.razor
@@ -356,16 +356,16 @@
 
     private async Task LoadShoppingListStats()
     {
+        // Summarize across ALL active (non-archived) lists, not just the most recent one —
+        // the household may have several lists going at once and the home card should reflect
+        // everything still to buy.
         var lists = await ShoppingListService.GetActiveShoppingListsAsync(_householdId);
-        var currentList = lists.OrderByDescending(l => l.CreatedAt).FirstOrDefault();
-        
-        if (currentList != null)
-        {
-            _shoppingListCount = currentList.Items.Count(i => !i.IsChecked);
-            _shoppingListChecked = currentList.Items.Count(i => i.IsChecked);
-            var total = _shoppingListCount + _shoppingListChecked;
-            _shoppingListProgress = total > 0 ? (_shoppingListChecked * 100.0 / total) : 0;
-        }
+        var allItems = lists.SelectMany(l => l.Items).ToList();
+
+        _shoppingListCount = allItems.Count(i => !i.IsChecked);
+        _shoppingListChecked = allItems.Count(i => i.IsChecked);
+        var total = _shoppingListCount + _shoppingListChecked;
+        _shoppingListProgress = total > 0 ? (_shoppingListChecked * 100.0 / total) : 0;
     }
 
     private async Task LoadChoreStats(int userId)


### PR DESCRIPTION
## Feedback addressed

Two pieces of in-app feedback from the household:

### 1. Dog icon for chores (Natalie)
The chore/room icon palette (`IconPicker.svelte`) only offered a generic paw `🐾` under Pets. Added a dog `🐕` and a cat `🐈` so chores (and rooms) can be tagged with an actual pet icon. The picker is shared by the chore add/edit sheets and the room icon picker, so both surfaces get the new options.

### 2. Home shopping-list summary counts all active lists
`Home.razor`'s `LoadShoppingListStats` loaded every active list but then discarded all but the most-recently-created one (`OrderByDescending(CreatedAt).FirstOrDefault()`), counting only that single list. It now flattens items across **all** non-archived lists:

```csharp
var lists = await ShoppingListService.GetActiveShoppingListsAsync(_householdId);
var allItems = lists.SelectMany(l => l.Items).ToList();
```

The header count, progress bar, and "X of Y checked" caption now reflect the household's full outstanding shopping rather than just the selected list.

## Verification
- `dotnet build` (Release): 0 errors (warnings all pre-existing).
- `svelte-check` on the chores island: 0 errors, 0 warnings.
- No existing tests pinned the old single-list home behavior.

## Deploy note
The icon change is island source — it takes effect once the Docker image rebuilds `wwwroot/islands` (hard-refresh busts the cached island). The Home.razor change ships with the normal server build.