### PR TITLE
fix(chores): use dog/cat face emoji in icon picker

### DIFF
--- a/frontend/chores/src/lib/components/IconPicker.svelte
+++ b/frontend/chores/src/lib/components/IconPicker.svelte
@@ -35,7 +35,7 @@
     // Garage, home & outdoors
     '🚗', '🏡', '🌳', '🪴', '🌿',
     // Pets
-    '🐾', '🐕', '🐈',
+    '🐾', '🐶', '🐱',
     // Cleaning & chores
     '🧹', '🧺', '🧽', '🗑️', '🪟',
     // Other spaces


### PR DESCRIPTION
Follow-up to #36 (which already merged).

The full-body `🐕`/`🐈` added in #36 are near-indistinguishable at the 40px icon-picker size — both read as a generic side-profile animal. Natalie flagged that "they both look like cats."

This swaps them for the **face** variants `🐶`/`🐱`, which are clearly distinct at small sizes. Pets row is now `🐾 🐶 🐱`.

## Verification
- `svelte-check` on the chores island: 0 errors, 0 warnings.

## Deploy note
Island source change — takes effect once the Docker image rebuilds `wwwroot/islands`; hard-refresh busts the cached island.