### PR TITLE
feat(chores): take a chore held by someone else (claim-steal) + reassign

### DIFF
--- a/frontend/chores/src/App.svelte
+++ b/frontend/chores/src/App.svelte
@@ -114,6 +114,13 @@
     handOffChore = null;
     if (chore) store.handOff(chore.id, targetUserId);
   }
+  function handleTake(chore: ChoreDto) {
+    // Take a chore currently held by someone else — grab it as a self-claim in
+    // one tap (covering for someone out/sick). No coordination with the holder
+    // needed; lands a Claimed (not a sticky assignment), so a recurring chore
+    // returns to the pile after this user completes it.
+    store.take(chore.id);
+  }
 
   /** Open the edit sheet for a chore. */
   function handleEdit(chore: ChoreDto) {
@@ -249,6 +256,7 @@
         onDrop={handleDrop}
         onComplete={handleComplete}
         onHandOff={handleHandOff}
+        onTake={handleTake}
         onCommit={handleCommit}
         onLeave={handleLeave}
         onEdit={handleEdit}
@@ -262,6 +270,7 @@
         onDrop={handleDrop}
         onComplete={handleComplete}
         onHandOff={handleHandOff}
+        onTake={handleTake}
         onCommit={handleCommit}
         onLeave={handleLeave}
         onEdit={handleEdit}
@@ -275,6 +284,7 @@
         onDrop={handleDrop}
         onComplete={handleComplete}
         onHandOff={handleHandOff}
+        onTake={handleTake}
         onCommit={handleCommit}
         onLeave={handleLeave}
         onEdit={handleEdit}
@@ -289,6 +299,7 @@
         onDrop={handleDrop}
         onComplete={handleComplete}
         onHandOff={handleHandOff}
+        onTake={handleTake}
         onCommit={handleCommit}
         onLeave={handleLeave}
         onEdit={handleEdit}

--- a/frontend/chores/src/lib/api.ts
+++ b/frontend/chores/src/lib/api.ts
@@ -211,6 +211,14 @@ export async function claimChore(choreId: number, version: number): Promise<Chor
   });
 }
 
+/** Take a chore held by someone else — assign it to the caller as a self-claim (displaces the holder). */
+export async function takeChore(choreId: number, version: number): Promise<ChoreDto> {
+  return request<ChoreDto>(`${CHORES_BASE}/${choreId}/take`, {
+    method: 'POST',
+    ...jsonBody({ version } satisfies VersionRequest),
+  });
+}
+
 export async function dropChore(choreId: number, version: number): Promise<ChoreDto> {
   return request<ChoreDto>(`${CHORES_BASE}/${choreId}/drop`, {
     method: 'POST',

--- a/frontend/chores/src/lib/components/ChoreCard.svelte
+++ b/frontend/chores/src/lib/components/ChoreCard.svelte
@@ -36,6 +36,8 @@
     onDrop?: (chore: ChoreDto) => void;
     onComplete?: (chore: ChoreDto) => void;
     onHandOff?: (chore: ChoreDto) => void;
+    /** Take a chore held by someone else — assign it to the current user (one tap). */
+    onTake?: (chore: ChoreDto) => void;
     /** Commit ("I'm in") on a multi-person chore's roster. */
     onCommit?: (chore: ChoreDto) => void;
     /** Leave ("Not me") a multi-person chore's roster. */
@@ -53,6 +55,7 @@
     onDrop,
     onComplete,
     onHandOff,
+    onTake,
     onCommit,
     onLeave,
     onEdit,
@@ -120,14 +123,18 @@
   // ── Who can do what (drives the action buttons) ──────────────────────────
   // The viewing user "holds" the chore when they're the active (non-stale)
   // assignee. Drop is Claimed-only (a deliberate Assigned chore can't be
-  // dropped — WP-04). Hand-off is available to the active holder. Done is
+  // dropped — WP-04). The holder can hand off; ANYONE can take a chore held by
+  // someone else or reassign it — the service has no holder guard on hand-off
+  // ("anyone can reassign, no roles", ChoreService.HandOffAsync). Done is
   // available on any non-pile chore (any member may complete — WP-04 M8).
   let heldByMe = $derived(
     chore.assigneeUserId === currentUserId &&
       (isClaimed || isAssigned),
   );
+  // Held (fresh, non-stale) by another member — surfaces Take it / Reassign so
+  // you can grab or pass a chore without coordinating with the current holder.
+  let heldByOther = $derived(!isUnclaimed && !heldByMe);
   let canDrop = $derived(heldByMe && isClaimed);
-  let canHandOff = $derived(heldByMe);
 
   // ── Recurrence hint (human, derived from the plain-string union) ─────────
   const RECURRENCE_HINT: Record<RecurrenceMode, string> = {
@@ -397,7 +404,7 @@
             Claim
           </button>
         {:else}
-          {#if canHandOff}
+          {#if heldByMe}
             <button
               type="button"
               class="ch-btn ch-btn-ghost"
@@ -408,17 +415,47 @@
             >
               Hand off
             </button>
-          {/if}
-          {#if canDrop}
+            {#if canDrop}
+              <button
+                type="button"
+                class="ch-btn ch-btn-ghost"
+                data-action="drop"
+                onclick={() => onDrop?.(chore)}
+                disabled={pending}
+                title="Put this chore back in the pile"
+              >
+                Drop
+              </button>
+            {/if}
+          {:else if heldByOther}
+            <!--
+              Held by someone else. Take it (claim it for yourself in one tap —
+              covering for someone who's out/sick, no need to coordinate) or
+              Reassign it to another member / release it via the shared hand-off
+              picker. Take lands a self-CLAIM (not a sticky assignment), so a
+              recurring chore returns to the pile after you finish it; completion
+              already credits the completer, so Take-then-Done attributes the
+              work to you.
+            -->
             <button
               type="button"
               class="ch-btn ch-btn-ghost"
-              data-action="drop"
-              onclick={() => onDrop?.(chore)}
+              data-action="take"
+              onclick={() => onTake?.(chore)}
               disabled={pending}
-              title="Put this chore back in the pile"
+              title="Take this chore — claim it for yourself"
             >
-              Drop
+              Take it
+            </button>
+            <button
+              type="button"
+              class="ch-btn ch-btn-ghost"
+              data-action="handoff"
+              onclick={() => onHandOff?.(chore)}
+              disabled={pending}
+              title="Reassign this chore to someone else or release it"
+            >
+              Reassign
             </button>
           {/if}
           <!-- Single-person chore — today's exact one-tap Done (unchanged, P2). -->

--- a/frontend/chores/src/lib/components/MineView.svelte
+++ b/frontend/chores/src/lib/components/MineView.svelte
@@ -26,6 +26,7 @@
     onDrop: (chore: ChoreDto) => void;
     onComplete: (chore: ChoreDto) => void;
     onHandOff: (chore: ChoreDto) => void;
+    onTake: (chore: ChoreDto) => void;
     onCommit: (chore: ChoreDto) => void;
     onLeave: (chore: ChoreDto) => void;
     onEdit: (chore: ChoreDto) => void;
@@ -40,6 +41,7 @@
     onDrop,
     onComplete,
     onHandOff,
+    onTake,
     onCommit,
     onLeave,
     onEdit,
@@ -115,6 +117,7 @@
             {onDrop}
             {onComplete}
             {onHandOff}
+            {onTake}
             {onCommit}
             {onLeave}
             {onEdit}

--- a/frontend/chores/src/lib/components/NeedsAttentionBoard.svelte
+++ b/frontend/chores/src/lib/components/NeedsAttentionBoard.svelte
@@ -26,6 +26,7 @@
     onDrop: (chore: ChoreDto) => void;
     onComplete: (chore: ChoreDto) => void;
     onHandOff: (chore: ChoreDto) => void;
+    onTake: (chore: ChoreDto) => void;
     onCommit: (chore: ChoreDto) => void;
     onLeave: (chore: ChoreDto) => void;
     onEdit: (chore: ChoreDto) => void;
@@ -42,6 +43,7 @@
     onDrop,
     onComplete,
     onHandOff,
+    onTake,
     onCommit,
     onLeave,
     onEdit,
@@ -88,6 +90,7 @@
               {onDrop}
               {onComplete}
               {onHandOff}
+              {onTake}
               {onCommit}
               {onLeave}
               {onEdit}

--- a/frontend/chores/src/lib/components/RoomsDashboard.svelte
+++ b/frontend/chores/src/lib/components/RoomsDashboard.svelte
@@ -25,6 +25,7 @@
     onDrop: (chore: ChoreDto) => void;
     onComplete: (chore: ChoreDto) => void;
     onHandOff: (chore: ChoreDto) => void;
+    onTake: (chore: ChoreDto) => void;
     onCommit: (chore: ChoreDto) => void;
     onLeave: (chore: ChoreDto) => void;
     onEdit: (chore: ChoreDto) => void;
@@ -38,6 +39,7 @@
     onDrop,
     onComplete,
     onHandOff,
+    onTake,
     onCommit,
     onLeave,
     onEdit,
@@ -184,6 +186,7 @@
             {onDrop}
             {onComplete}
             {onHandOff}
+            {onTake}
             {onCommit}
             {onLeave}
             {onEdit}

--- a/frontend/chores/src/lib/components/UpForGrabsLane.svelte
+++ b/frontend/chores/src/lib/components/UpForGrabsLane.svelte
@@ -21,6 +21,7 @@
     onDrop: (chore: ChoreDto) => void;
     onComplete: (chore: ChoreDto) => void;
     onHandOff: (chore: ChoreDto) => void;
+    onTake: (chore: ChoreDto) => void;
     onCommit: (chore: ChoreDto) => void;
     onLeave: (chore: ChoreDto) => void;
     onEdit: (chore: ChoreDto) => void;
@@ -34,6 +35,7 @@
     onDrop,
     onComplete,
     onHandOff,
+    onTake,
     onCommit,
     onLeave,
     onEdit,
@@ -57,6 +59,7 @@
           {onDrop}
           {onComplete}
           {onHandOff}
+          {onTake}
           {onCommit}
           {onLeave}
           {onEdit}

--- a/frontend/chores/src/lib/state.svelte.ts
+++ b/frontend/chores/src/lib/state.svelte.ts
@@ -29,6 +29,7 @@ import { CHORE_LENSES } from './types';
 import {
   ApiError,
   claimChore,
+  takeChore,
   dropChore,
   completeChore,
   handOffChore,
@@ -719,6 +720,32 @@ class BoardStore {
     );
   }
 
+  /**
+   * Take a chore currently held by another member — grab it as a self-claim
+   * ("covering" for someone out/sick). The server displaces the holder and
+   * lands a Claimed (NOT a sticky Assigned), so a recurring chore returns to the
+   * pile after the taker completes it. Optimistic end-state is the same as claim.
+   */
+  async take(choreId: number): Promise<void> {
+    const me = this.currentUserId;
+    const call = (c: ChoreDto) => takeChore(c.id, c.version);
+    if (this.isMultiPerson(choreId)) {
+      await this.runMultiPersonMutation(choreId, call, 'That chore changed — board refreshed.');
+      return;
+    }
+    await this.runOptimistic(
+      choreId,
+      {
+        assigneeUserId: me,
+        assignmentKind: 'claimed',
+        claimedAt: new Date().toISOString(),
+        isClaimStale: false,
+      },
+      call,
+      'That chore changed — board refreshed.',
+    );
+  }
+
   /** Drop a chore the current user holds (returns it to the pile). */
   async drop(choreId: number): Promise<void> {
     const call = (c: ChoreDto) => dropChore(c.id, c.version);
@@ -832,8 +859,11 @@ class BoardStore {
       toPile
         ? { assigneeUserId: null, assignmentKind: 'none', claimedAt: null, isClaimStale: false }
         : {
+            // Hand-off to a member is a deliberate Assigned server-side
+            // (SetAssigned) — reflect that optimistically so the taker doesn't
+            // see a "Drop" flash (Drop is Claimed-only) before the board GET.
             assigneeUserId: targetUserId,
-            assignmentKind: 'claimed',
+            assignmentKind: 'assigned',
             claimedAt: new Date().toISOString(),
             isClaimStale: false,
           },

--- a/src/FamilyCoordinationApp/Endpoints/ChoresEndpoints.cs
+++ b/src/FamilyCoordinationApp/Endpoints/ChoresEndpoints.cs
@@ -38,6 +38,7 @@ public static class ChoresEndpoints
         group.MapDelete("/{choreId:int}", DeleteChore);
 
         group.MapPost("/{choreId:int}/claim", ClaimChore);
+        group.MapPost("/{choreId:int}/take", TakeChore);
         group.MapPost("/{choreId:int}/drop", DropChore);
         group.MapPost("/{choreId:int}/handoff", HandOffChore);
         group.MapPost("/{choreId:int}/complete", CompleteChore);
@@ -168,6 +169,30 @@ public static class ChoresEndpoints
         try
         {
             var chore = await svc.ClaimAsync(user.HouseholdId, choreId, user.UserId, req.Version, ct);
+            return Results.Ok(Project(boardService, chore, timeProvider, timeZone));
+        }
+        catch (ChoreNotFoundException) { return Results.NotFound(); }
+        catch (ChoreValidationException ex) { return Results.BadRequest(new { message = ex.Message }); }
+        catch (ChoreConflictException ex) { return Results.Conflict(new { message = ex.Message }); }
+    }
+
+    private static async Task<IResult> TakeChore(
+        int choreId,
+        VersionRequest req,
+        ClaimsPrincipal principal,
+        IChoreService svc,
+        IChoreBoardService boardService,
+        TimeProvider timeProvider,
+        TimeZoneInfo timeZone,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        try
+        {
+            var chore = await svc.TakeAsync(user.HouseholdId, choreId, user.UserId, req.Version, ct);
             return Results.Ok(Project(boardService, chore, timeProvider, timeZone));
         }
         catch (ChoreNotFoundException) { return Results.NotFound(); }

--- a/src/FamilyCoordinationApp/Services/ChoreService.cs
+++ b/src/FamilyCoordinationApp/Services/ChoreService.cs
@@ -207,6 +207,28 @@ public class ChoreService(
         return chore;
     }
 
+    public async Task<Chore> TakeAsync(int householdId, int choreId, int actorUserId, uint version, CancellationToken cancellationToken = default)
+    {
+        await using var context = await dbFactory.CreateDbContextAsync(cancellationToken);
+        var chore = await LoadChoreAsync(context, householdId, choreId, cancellationToken);
+        var now = UtcNow();
+
+        // "Take it" (covering for someone out/sick): grab the chore as a self-CLAIM regardless of who holds
+        // it, silently displacing any current holder (no coordination — mirrors hand-off's no-roles model).
+        // Unlike ClaimAsync (pile-only, MN8) Take is allowed to displace; unlike hand-off-to-self it lands a
+        // Claimed (not a sticky Assigned), so a recurring chore returns to the pile after the taker completes
+        // it. A stale prior claim still materializes its auto-release event first (records the lapsed claimer,
+        // M16) before the new self-claim overwrites the trio.
+        MaterializeAutoReleaseIfStale(context, chore, now);
+
+        SetClaimed(chore, actorUserId, now);
+        AppendEvent(context, chore, ChoreEventType.Claimed, actorUserId, targetUserId: null, now);
+
+        await SaveWithConcurrencyAsync(context, chore, version, cancellationToken);
+        logger.LogInformation("Chore {ChoreId} taken (self-claim) by user {UserId} (household {HouseholdId})", choreId, actorUserId, householdId);
+        return chore;
+    }
+
     public async Task<Chore> DropAsync(int householdId, int choreId, int actorUserId, uint version, CancellationToken cancellationToken = default)
     {
         await using var context = await dbFactory.CreateDbContextAsync(cancellationToken);

--- a/src/FamilyCoordinationApp/Services/Interfaces/IChoreService.cs
+++ b/src/FamilyCoordinationApp/Services/Interfaces/IChoreService.cs
@@ -56,6 +56,19 @@ public interface IChoreService
     Task<Chore> ClaimAsync(int householdId, int choreId, int actorUserId, uint version, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Takes a chore for <paramref name="actorUserId"/> as a self-<see cref="AssignmentKind.Claimed"/>,
+    /// <b>displacing any current holder</b> (the "covering for someone out/sick" case — no coordination, no
+    /// roles). Unlike <see cref="ClaimAsync"/> (pile-only, rejects a held chore, MN8) this is allowed to take
+    /// a chore another member holds; unlike hand-off-to-self it lands a Claimed (not a sticky Assigned), so a
+    /// recurring chore returns to the pile after the taker completes it. A stale prior claim materializes its
+    /// auto-release event first (records the lapsed claimer, M16). Sets the trio to <c>(actor, Claimed, now)</c>
+    /// and appends a <c>ChoreEvent{Claimed}</c>.
+    /// </summary>
+    /// <exception cref="ChoreNotFoundException">No such chore in the household.</exception>
+    /// <exception cref="ChoreConflictException">The client <paramref name="version"/> is stale.</exception>
+    Task<Chore> TakeAsync(int householdId, int choreId, int actorUserId, uint version, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Drops a self-claim back to the pile. Precondition: <paramref name="actorUserId"/> holds it AND the
     /// hold is <see cref="AssignmentKind.Claimed"/> (drop is Claimed-only; a deliberately-Assigned chore is
     /// freed via hand-off, council M9). Clears the trio to <c>(null, None, null)</c> and appends a

--- a/tests/FamilyCoordinationApp.Tests/Services/ChoreClaimStateMachineTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/ChoreClaimStateMachineTests.cs
@@ -194,6 +194,68 @@ public class ChoreClaimStateMachineTests : IDisposable
     }
 
     [Fact]
+    public async Task Take_AChoreFreshlyClaimedByAnother_BecomesSelfClaim_NoCoordinationNeeded()
+    {
+        // "Take it": Bob holds a FRESH (non-stale) self-claim; Alice takes it (covering). The chore becomes a
+        // self-CLAIM by Alice — NOT a sticky Assigned — displacing Bob with no coordination. A Claimed event
+        // records Alice. (Completion separately credits whoever marks it done — council M8.)
+        SeedChoreWithHold(Bob, AssignmentKind.Claimed, NowBase.AddHours(-1));
+        var chore = await ReloadAsync();
+
+        var result = await _service.TakeAsync(HouseholdId, ChoreId, Alice, chore.Version);
+
+        result.AssigneeUserId.Should().Be(Alice);
+        result.AssignmentKind.Should().Be(AssignmentKind.Claimed);   // claim (returns to pile on complete), not a sticky assignment
+        result.ClaimedAt.Should().Be(NowBase);
+
+        var reloaded = await ReloadAsync();
+        reloaded.AssigneeUserId.Should().Be(Alice);
+        reloaded.AssignmentKind.Should().Be(AssignmentKind.Claimed);
+
+        var events = await EventsAsync();
+        events.Should().ContainSingle(e => e.Type == ChoreEventType.Claimed)
+            .Which.ActorUserId.Should().Be(Alice);
+    }
+
+    [Fact]
+    public async Task Take_AnAssignedChore_DisplacesTheAssignee_AsSelfClaim()
+    {
+        // Bob is deliberately ASSIGNED (it's "his" chore) but is out sick. Alice takes it: the chore is
+        // displaced to a self-CLAIM by Alice — so after she completes a recurring instance it returns to the
+        // pile rather than staying assigned. Take is allowed to displace an Assigned hold (unlike Claim/Drop).
+        SeedChoreWithHold(Bob, AssignmentKind.Assigned, NowBase.AddHours(-1));
+        var chore = await ReloadAsync();
+
+        var result = await _service.TakeAsync(HouseholdId, ChoreId, Alice, chore.Version);
+
+        result.AssigneeUserId.Should().Be(Alice);
+        result.AssignmentKind.Should().Be(AssignmentKind.Claimed);
+
+        var events = await EventsAsync();
+        events.Should().ContainSingle(e => e.Type == ChoreEventType.Claimed)
+            .Which.ActorUserId.Should().Be(Alice);
+    }
+
+    [Fact]
+    public async Task Take_AStaleClaimByAnother_AutoReleasesThenSelfClaims()
+    {
+        // Bob's claim is stale (49h). Alice takes it: the stale claim auto-releases first (actor = the lapsed
+        // claimer Bob, M16), then Alice's self-claim lands — events in that order.
+        SeedChoreWithHold(Bob, AssignmentKind.Claimed, NowBase.AddHours(-49));
+        var chore = await ReloadAsync();
+
+        var result = await _service.TakeAsync(HouseholdId, ChoreId, Alice, chore.Version);
+
+        result.AssigneeUserId.Should().Be(Alice);
+        result.AssignmentKind.Should().Be(AssignmentKind.Claimed);
+
+        var events = await EventsAsync();
+        events.Select(e => e.Type).Should().ContainInOrder(ChoreEventType.AutoReleased, ChoreEventType.Claimed);
+        events.Single(e => e.Type == ChoreEventType.AutoReleased).ActorUserId.Should().Be(Bob);
+        events.Single(e => e.Type == ChoreEventType.Claimed).ActorUserId.Should().Be(Alice);
+    }
+
+    [Fact]
     public async Task HandOff_ToNull_ReturnsAssignedChoreToPile_TheStuckAssignedEscapeHatch()
     {
         // A deliberately-Assigned chore (cannot be dropped) — hand-off-to-null is its escape hatch (council M9).


### PR DESCRIPTION
## Feedback addressed

When a chore was already picked up by another member, the only available action was **Done** — there was no way to take it or reassign it without coordinating with the current holder. Real case: *"I saw an overdue task, did it, but I could only mark it done, not assign it to myself."* And the broader one: covering a chore for someone who's out/sick.

## What this adds

A chore held by **someone else** now shows two actions on the card (in addition to Done):

- **Take it** — grab it in one tap as a self-**claim**. It displaces whoever currently holds it (claimed *or* assigned), no coordination needed, and lands a `Claimed` — **not** a sticky `Assigned` — so a recurring chore returns to the pile after you complete it (you covered it once; it isn't permanently yours).
- **Reassign** — opens the existing hand-off picker to pass it to another member or release it to the pile.

### Action semantics (now cleanly separated)

| Action | Precondition | Result | Recurring chore after completion |
|---|---|---|---|
| Claim | must be unheld (pile) | Claimed by you | returns to pile |
| **Take it** | *any* holder — displaces them | **Claimed by you** | **returns to pile** |
| Reassign / Hand off | any | Assigned to target (or pile) | stays with the assignee |

## Implementation

- **Backend**: `IChoreService.TakeAsync` + `ChoreService.TakeAsync`; route `POST /api/chores/{id}/take` (mirrors the claim endpoint). `TakeAsync` is allowed to displace a holder (unlike `ClaimAsync`, which stays pile-only — council MN8 intact) and lands a self-claim (unlike hand-off, which assigns). A stale prior claim still auto-releases first, recording the lapsed claimer (M16). Completion already credits the completer (council M8), so Take-then-Done attributes the work to the taker.
- **Island**: `takeChore()` api + `store.take()` (optimistic) wired through all four lenses; the card's "Take it" / "Reassign" affordances are gated on `heldByOther`. Also corrected the hand-off optimistic patch to `assigned` so a reassign no longer flashes a "Drop" button before the board reconciles.

## Verification

- 3 new claim-state-machine unit tests (take a claimed / assigned / stale chore held by another).
- **451** Services unit tests + **26** wiring tests green.
- Backend build: 0 errors. Island `svelte-check`: 0 errors; `vite build`: OK. Changed C# files format-clean.

## Deploy note

The island changes are source-level — they take effect once the Docker image rebuilds `wwwroot/islands`; hard-refresh busts the cached island. The backend (new endpoint + `TakeAsync`) ships with the normal build.