### PR TITLE
feat(chores): separate minder from doer + assign a person

### DIFF
--- a/frontend/chores/src/App.svelte
+++ b/frontend/chores/src/App.svelte
@@ -49,6 +49,10 @@
   let quickAddSubmitting = $state(false);
   let handOffOpen = $state(false);
   let handOffChore = $state<ChoreDto | null>(null);
+  // The shared member picker serves both "hand off / reassign" (held chores) and
+  // "assign" (up-for-grabs chores). The mode only changes copy + whether the
+  // "Leave for anyone" pile row shows — both call store.handOff on select.
+  let pickerMode = $state<'handoff' | 'assign'>('handoff');
   let completeOpen = $state(false);
   let completeChore = $state<ChoreDto | null>(null);
   let editOpen = $state(false);
@@ -105,6 +109,18 @@
     if (chore) store.complete(chore.id, { participantUserIds });
   }
   function handleHandOff(chore: ChoreDto) {
+    pickerMode = 'handoff';
+    handOffChore = chore;
+    handOffOpen = true;
+  }
+  /**
+   * Assign an up-for-grabs chore to a chosen member. Opens the SAME member picker
+   * in "assign" mode; selecting a member runs store.handOff (a member target lands
+   * a deliberate Assigned server-side — see ChoreService.HandOffAsync). No new
+   * endpoint: assigning from the pile is just a hand-off with no current holder.
+   */
+  function handleAssign(chore: ChoreDto) {
+    pickerMode = 'assign';
     handOffChore = chore;
     handOffOpen = true;
   }
@@ -257,6 +273,7 @@
         onComplete={handleComplete}
         onHandOff={handleHandOff}
         onTake={handleTake}
+        onAssign={handleAssign}
         onCommit={handleCommit}
         onLeave={handleLeave}
         onEdit={handleEdit}
@@ -271,6 +288,7 @@
         onComplete={handleComplete}
         onHandOff={handleHandOff}
         onTake={handleTake}
+        onAssign={handleAssign}
         onCommit={handleCommit}
         onLeave={handleLeave}
         onEdit={handleEdit}
@@ -285,6 +303,7 @@
         onComplete={handleComplete}
         onHandOff={handleHandOff}
         onTake={handleTake}
+        onAssign={handleAssign}
         onCommit={handleCommit}
         onLeave={handleLeave}
         onEdit={handleEdit}
@@ -300,6 +319,7 @@
         onComplete={handleComplete}
         onHandOff={handleHandOff}
         onTake={handleTake}
+        onAssign={handleAssign}
         onCommit={handleCommit}
         onLeave={handleLeave}
         onEdit={handleEdit}
@@ -363,7 +383,8 @@
   open={handOffOpen}
   choreName={handOffChore?.name ?? ''}
   members={store.board?.members ?? []}
-  excludeUserId={handOffChore?.assigneeUserId ?? null}
+  mode={pickerMode}
+  excludeUserId={pickerMode === 'assign' ? null : (handOffChore?.assigneeUserId ?? null)}
   onClose={() => {
     handOffOpen = false;
     handOffChore = null;

--- a/frontend/chores/src/lib/components/ChoreCard.svelte
+++ b/frontend/chores/src/lib/components/ChoreCard.svelte
@@ -38,6 +38,8 @@
     onHandOff?: (chore: ChoreDto) => void;
     /** Take a chore held by someone else — assign it to the current user (one tap). */
     onTake?: (chore: ChoreDto) => void;
+    /** Assign an up-for-grabs chore to a chosen member (opens the member picker). */
+    onAssign?: (chore: ChoreDto) => void;
     /** Commit ("I'm in") on a multi-person chore's roster. */
     onCommit?: (chore: ChoreDto) => void;
     /** Leave ("Not me") a multi-person chore's roster. */
@@ -56,6 +58,7 @@
     onComplete,
     onHandOff,
     onTake,
+    onAssign,
     onCommit,
     onLeave,
     onEdit,
@@ -264,24 +267,39 @@
           Done {lastDoneLabel}
         </span>
       {/if}
+
+      <!--
+        Minder chip (the chore's ultimate owner — "makes sure it gets done").
+        Deliberately lives UP HERE among the chore's attribute chips, NOT down in
+        the footer next to the doer — the minder is a property of the chore, the
+        doer is the live work state. Rendering it as an eye-icon chip (no avatar)
+        keeps it visually distinct from the footer's avatar-led doer, so the two
+        roles never read as the same thing.
+      -->
+      {#if owner}
+        <span
+          class="ch-tag ch-tag-minder"
+          title="Minder — makes sure this gets done: {nameOf(chore.ownerUserId, owner.displayName)}"
+        >
+          <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true">
+            <path
+              d="M12 5c-5 0-9.27 3.11-11 7 1.73 3.89 6 7 11 7s9.27-3.11 11-7c-1.73-3.89-6-7-11-7zm0 12a5 5 0 1 1 0-10 5 5 0 0 1 0 10zm0-8a3 3 0 1 0 0 6 3 3 0 0 0 0-6z"
+              fill="currentColor"
+            />
+          </svg>
+          <span class="ch-tag-minder-role">Minder</span>
+          {nameOf(chore.ownerUserId, owner.displayName)}
+        </span>
+      {/if}
     </div>
 
     <div class="ch-card-foot">
+      <!--
+        The footer people row is the DOER only — who's actively on it (roster /
+        claimed / assigned) or "Up for grabs". The minder moved up to the chip row
+        above so the two roles are visually separated (operator feedback).
+      -->
       <div class="ch-people">
-        {#if owner}
-          <span class="ch-minder" title="Minder: {nameOf(chore.ownerUserId, owner.displayName)}">
-            <MemberAvatar
-              name={owner.displayName}
-              initials={owner.initials}
-              pictureUrl={owner.pictureUrl}
-              size={28}
-              relation="Minded by"
-            />
-            <span class="ch-minder-label">Minder</span>
-            <span class="ch-minder-name">{nameOf(chore.ownerUserId, owner.displayName)}</span>
-          </span>
-        {/if}
-
         {#if isMultiPerson}
           <div class="ch-roster" aria-label="Roster: {chore.completedCount} of {chore.requiredCount} done">
             {#each rosterMembers as r (r.userId)}
@@ -403,6 +421,24 @@
           >
             Claim
           </button>
+          {#if onAssign}
+            <!--
+              Assign an up-for-grabs chore to a specific person (opens the member
+              picker). Lands a deliberate Assigned via the hand-off endpoint — the
+              same mechanism "Reassign" uses on held chores, just surfaced from the
+              pile. Distinct from Claim (self) and Take (grab someone else's).
+            -->
+            <button
+              type="button"
+              class="ch-btn ch-btn-ghost"
+              data-action="assign"
+              onclick={() => onAssign?.(chore)}
+              disabled={pending}
+              title="Assign this chore to someone"
+            >
+              Assign
+            </button>
+          {/if}
         {:else}
           {#if heldByMe}
             <button
@@ -674,6 +710,25 @@
     background: var(--color-info);
     font-weight: 600;
   }
+  /* Minder chip — the chore's ultimate owner. A quiet, bordered "accountability"
+     cue (eye icon + uppercase role + name) that reads distinctly from both the
+     muted attribute chips and the footer's avatar-led doer. */
+  .ch-tag-minder {
+    color: var(--color-text);
+    background: transparent;
+    border: 1px solid var(--color-line-strong);
+    font-weight: 500;
+  }
+  .ch-tag-minder svg {
+    color: var(--color-primary);
+  }
+  .ch-tag-minder-role {
+    text-transform: uppercase;
+    font-size: 0.625rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    color: var(--color-text-muted);
+  }
 
   .ch-card-foot {
     display: flex;
@@ -689,22 +744,12 @@
     min-width: 0;
     flex-wrap: wrap;
   }
-  .ch-minder,
   .ch-claim {
     display: inline-flex;
     align-items: center;
     gap: 6px;
     font-size: 0.8125rem;
     color: var(--color-text-muted);
-  }
-  .ch-minder-label {
-    font-size: 0.6875rem;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-  }
-  .ch-minder-name {
-    font-weight: 500;
-    color: var(--color-text);
   }
   .ch-claim-label {
     font-weight: 500;

--- a/frontend/chores/src/lib/components/EditChoreSheet.svelte
+++ b/frontend/chores/src/lib/components/EditChoreSheet.svelte
@@ -52,6 +52,12 @@
   let effort = $state<EffortTier>('Standard');
   let roomId = $state<number | null>(null);
   let ownerUserId = $state<number | null>(null);
+  /**
+   * Single-person assignee (null = up for grabs). Assignment is NOT part of the
+   * PUT contract — it's applied via the dedicated hand-off endpoint after the
+   * metadata save (see handleSubmit). Only meaningful when requiredCount === 1.
+   */
+  let assignTo = $state<number | null>(null);
   /** 1 = single person (default); ≥2 = multi-person requirement. */
   let requiredCount = $state(1);
   let existingPhotoPath = $state<string | null>(null);
@@ -182,6 +188,9 @@
     roomId = c.roomId ?? null;
     effort = c.effortTier;
     ownerUserId = c.ownerUserId ?? null;
+    // Single-person assignment, pre-filled from the chore's CURRENT holder
+    // (assigned or claimed); a None/pile chore reads as "Up for grabs" (null).
+    assignTo = c.assignmentKind !== 'none' ? (c.assigneeUserId ?? null) : null;
     requiredCount = c.requiredCount ?? 1;
     existingPhotoPath = c.photoPath;
     newPhotoFile = null;
@@ -317,6 +326,25 @@
       };
 
       await boardStore.edit(chore.id, body);
+
+      // Assignment isn't part of the PUT contract (it moves via the dedicated
+      // claim/hand-off endpoints). For a single-person chore, apply any change to
+      // "Assign to" via hand-off AFTER the metadata save: boardStore.edit just
+      // refreshed this chore's version in the board, so the follow-on read carries
+      // a fresh xmin (no self-409). A member target lands a deliberate Assigned;
+      // clearing back to "Up for grabs" returns a held chore to the pile.
+      if (requiredCount === 1) {
+        const currentAssignee =
+          chore.assignmentKind !== 'none' ? (chore.assigneeUserId ?? null) : null;
+        if (assignTo !== currentAssignee) {
+          if (assignTo === null) {
+            if (currentAssignee !== null) await boardStore.handOff(chore.id, null);
+          } else {
+            await boardStore.handOff(chore.id, assignTo);
+          }
+        }
+      }
+
       onClose();
     } finally {
       submitting = false;
@@ -616,7 +644,41 @@
         </div>
       </fieldset>
 
-      <!-- Assignment is NOT editable (v1.0 D6 — use Claim / Hand off on the card). -->
+      <!--
+        Assign to (single-person only). Multi-person chores use the named roster
+        (commit/leave on the card), so this is hidden when requiredCount > 1. The
+        change is applied via the hand-off endpoint on save (handleSubmit), NOT
+        through the PUT body — assignment moves through its own endpoint to keep
+        the assignment trio invariant intact.
+      -->
+      {#if requiredCount === 1}
+        <fieldset class="ch-field">
+          <legend class="ch-field-label">Assign to (optional)</legend>
+          <div class="ch-chip-row" role="group" aria-label="Assign to">
+            <button
+              type="button"
+              class="ch-chip"
+              class:active={assignTo === null}
+              aria-pressed={assignTo === null}
+              onclick={() => (assignTo = null)}
+            >
+              Up for grabs
+            </button>
+            {#each members as member (member.userId)}
+              <button
+                type="button"
+                class="ch-chip"
+                class:active={assignTo === member.userId}
+                aria-pressed={assignTo === member.userId}
+                onclick={() => (assignTo = member.userId)}
+              >
+                {member.displayName}
+              </button>
+            {/each}
+          </div>
+          <p class="ch-hint">Pin this on one person, or leave it up for grabs for anyone to claim.</p>
+        </fieldset>
+      {/if}
 
       <label class="ch-field">
         <span class="ch-field-label">Photo (optional)</span>

--- a/frontend/chores/src/lib/components/HandOffPicker.svelte
+++ b/frontend/chores/src/lib/components/HandOffPicker.svelte
@@ -15,14 +15,30 @@
     members: MemberDto[];
     /** Hide the current holder from the list (no point handing to yourself). */
     excludeUserId?: number | null;
+    /**
+     * 'handoff' (default) — passing a HELD chore on, with a "Leave for anyone"
+     * pile option. 'assign' — pushing an UP-FOR-GRABS chore onto someone; the
+     * pile option is hidden (it's already in the pile) and the copy says "Assign".
+     * Both call the SAME hand-off mechanism server-side (a member target ⇒ Assigned).
+     */
+    mode?: 'handoff' | 'assign';
     onClose: () => void;
     /** targetUserId null ⇒ return to the pile ("Leave for anyone"). */
     onSelect: (targetUserId: number | null) => void;
   }
 
-  let { open, choreName, members, excludeUserId = null, onClose, onSelect }: Props = $props();
+  let { open, choreName, members, excludeUserId = null, mode = 'handoff', onClose, onSelect }: Props =
+    $props();
 
   let dialogEl: HTMLDialogElement | null = $state(null);
+
+  let isAssign = $derived(mode === 'assign');
+  let heading = $derived(isAssign ? 'Assign chore' : 'Hand off');
+  let subtitle = $derived(
+    isAssign
+      ? `Pick who should take “${choreName}”.`
+      : `Pass “${choreName}” to someone — or leave it for anyone.`,
+  );
 
   let pickable = $derived(members.filter((m) => m.userId !== excludeUserId));
 
@@ -42,15 +58,17 @@
 
 <dialog bind:this={dialogEl} onclose={onClose} class="ch-dialog">
   <div class="ch-dialog-body">
-    <h2>Hand off</h2>
-    <p class="ch-dialog-sub">Pass “{choreName}” to someone — or leave it for anyone.</p>
+    <h2>{heading}</h2>
+    <p class="ch-dialog-sub">{subtitle}</p>
 
     <div class="ch-handoff-list">
-      <button type="button" class="ch-handoff-row ch-handoff-pile" onclick={() => choose(null)}>
-        <span class="ch-handoff-pile-icon" aria-hidden="true">↩</span>
-        <span class="ch-handoff-name">Leave for anyone</span>
-        <span class="ch-handoff-hint">No one gets nagged</span>
-      </button>
+      {#if !isAssign}
+        <button type="button" class="ch-handoff-row ch-handoff-pile" onclick={() => choose(null)}>
+          <span class="ch-handoff-pile-icon" aria-hidden="true">↩</span>
+          <span class="ch-handoff-name">Leave for anyone</span>
+          <span class="ch-handoff-hint">No one gets nagged</span>
+        </button>
+      {/if}
 
       {#each pickable as member (member.userId)}
         <button type="button" class="ch-handoff-row" onclick={() => choose(member.userId)}>
@@ -59,7 +77,7 @@
             initials={member.initials}
             pictureUrl={member.pictureUrl}
             size={28}
-            relation="Hand off to"
+            relation={isAssign ? 'Assign to' : 'Hand off to'}
           />
           <span class="ch-handoff-name">{member.displayName}</span>
         </button>

--- a/frontend/chores/src/lib/components/MineView.svelte
+++ b/frontend/chores/src/lib/components/MineView.svelte
@@ -27,6 +27,7 @@
     onComplete: (chore: ChoreDto) => void;
     onHandOff: (chore: ChoreDto) => void;
     onTake: (chore: ChoreDto) => void;
+    onAssign: (chore: ChoreDto) => void;
     onCommit: (chore: ChoreDto) => void;
     onLeave: (chore: ChoreDto) => void;
     onEdit: (chore: ChoreDto) => void;
@@ -42,6 +43,7 @@
     onComplete,
     onHandOff,
     onTake,
+    onAssign,
     onCommit,
     onLeave,
     onEdit,
@@ -118,6 +120,7 @@
             {onComplete}
             {onHandOff}
             {onTake}
+            {onAssign}
             {onCommit}
             {onLeave}
             {onEdit}

--- a/frontend/chores/src/lib/components/NeedsAttentionBoard.svelte
+++ b/frontend/chores/src/lib/components/NeedsAttentionBoard.svelte
@@ -27,6 +27,7 @@
     onComplete: (chore: ChoreDto) => void;
     onHandOff: (chore: ChoreDto) => void;
     onTake: (chore: ChoreDto) => void;
+    onAssign: (chore: ChoreDto) => void;
     onCommit: (chore: ChoreDto) => void;
     onLeave: (chore: ChoreDto) => void;
     onEdit: (chore: ChoreDto) => void;
@@ -44,6 +45,7 @@
     onComplete,
     onHandOff,
     onTake,
+    onAssign,
     onCommit,
     onLeave,
     onEdit,
@@ -91,6 +93,7 @@
               {onComplete}
               {onHandOff}
               {onTake}
+              {onAssign}
               {onCommit}
               {onLeave}
               {onEdit}

--- a/frontend/chores/src/lib/components/RoomsDashboard.svelte
+++ b/frontend/chores/src/lib/components/RoomsDashboard.svelte
@@ -26,6 +26,7 @@
     onComplete: (chore: ChoreDto) => void;
     onHandOff: (chore: ChoreDto) => void;
     onTake: (chore: ChoreDto) => void;
+    onAssign: (chore: ChoreDto) => void;
     onCommit: (chore: ChoreDto) => void;
     onLeave: (chore: ChoreDto) => void;
     onEdit: (chore: ChoreDto) => void;
@@ -40,6 +41,7 @@
     onComplete,
     onHandOff,
     onTake,
+    onAssign,
     onCommit,
     onLeave,
     onEdit,
@@ -187,6 +189,7 @@
             {onComplete}
             {onHandOff}
             {onTake}
+            {onAssign}
             {onCommit}
             {onLeave}
             {onEdit}

--- a/frontend/chores/src/lib/components/UpForGrabsLane.svelte
+++ b/frontend/chores/src/lib/components/UpForGrabsLane.svelte
@@ -22,6 +22,7 @@
     onComplete: (chore: ChoreDto) => void;
     onHandOff: (chore: ChoreDto) => void;
     onTake: (chore: ChoreDto) => void;
+    onAssign: (chore: ChoreDto) => void;
     onCommit: (chore: ChoreDto) => void;
     onLeave: (chore: ChoreDto) => void;
     onEdit: (chore: ChoreDto) => void;
@@ -36,6 +37,7 @@
     onComplete,
     onHandOff,
     onTake,
+    onAssign,
     onCommit,
     onLeave,
     onEdit,
@@ -60,6 +62,7 @@
           {onComplete}
           {onHandOff}
           {onTake}
+          {onAssign}
           {onCommit}
           {onLeave}
           {onEdit}


### PR DESCRIPTION
## What & why

Two operator asks, both **frontend-only** (no backend change, no migration):

### 1. Minder no longer reads like the doer
The **minder** (ultimate owner — "makes sure it gets done") used to sit shoulder-to-shoulder with the **doer** in the card footer as a near-identical avatar+label+name block. Too easy to confuse "who's accountable" with "who's actually on it."

- Minder moves up into a distinct **eye-icon chip** in the card's tag row (with the room/effort/recurrence chips).
- The footer people row is now the **doer only** (roster / claimed / assigned / "Up for grabs").
- Deliberate asymmetry — abstract icon chip vs. avatar-led face — so the two roles never read the same.

### 2. Assign a chore to a specific person
- **Up-for-grabs cards** gain an **"Assign"** button next to "Claim" → opens the member picker, reused in a new `assign` mode ("Assign chore" heading, no "Leave for anyone" pile row).
- **Edit sheet** gains an **"Assign to"** field (single-person chores only; multi-person uses the named roster). Applied via the hand-off endpoint **after** the metadata save, so it rides a fresh `xmin` (no self-409).
- **Add-chore sheet** already assigned via the existing "Who's on it?" picker — left unchanged.

Assigning reuses `ChoreService.HandOffAsync`, which has **no precondition on the chore's current state**: a member target lands a deliberate `Assigned` whether the chore is held or sitting in the pile. So assigning from the pile is just a hand-off with no current holder.

## Files
`ChoreCard.svelte`, `HandOffPicker.svelte`, `App.svelte`, `EditChoreSheet.svelte`, and the four lenses (`NeedsAttentionBoard`, `RoomsDashboard`, `UpForGrabsLane`, `MineView`) — `onAssign` is plumbed through each.

## Verification
- `npm run check` (svelte-check): 0 errors / 0 warnings.
- `vite build`: clean.
- Live behavior to confirm in the deployed app: Assign button on up-for-grabs cards, minder chip placement, Edit-sheet "Assign to".

## Note
Edit-sheet assignment is a follow-on hand-off call after the metadata PUT. If a concurrent edit rejected the metadata save (rare in a household), the assignment change would still apply — low risk, flagged for awareness.