### PR TITLE
fix(chores): subtask checklist follow-ups (quick-add, live edit, left-align)

### DIFF
--- a/frontend/chores/src/App.svelte
+++ b/frontend/chores/src/App.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { ChoreDto, ShellContext } from './lib/types';
-  import { getBoard, uploadChorePhoto, ApiError } from './lib/api';
+  import { getBoard, uploadChorePhoto, createSubtask, ApiError } from './lib/api';
   import { boardStore } from './lib/state.svelte';
   import { startLiveness, type LivenessHandle } from './lib/liveness';
   import { showToast } from './lib/toasts.svelte';
@@ -154,16 +154,28 @@
     try {
       // 1. POST the create JSON (no file in the body).
       const created = await store.create(value.request);
-      // 2. If a photo was chosen, upload it to the dedicated /photo route, then
-      //    refetch so the board reflects the stored photoPath.
+      // 2. Checklist items: a new chore has no id until now, so create each item
+      //    against the returned id (versionless). One bad item shouldn't block.
+      for (const title of value.subtasks) {
+        try {
+          await createSubtask(created.id, { title });
+        } catch {
+          // Skip a failed item; the chore + the rest still land.
+        }
+      }
+      // 3. If a photo was chosen, upload it to the dedicated /photo route.
       if (value.photo) {
         try {
           await uploadChorePhoto(created.id, value.photo);
-          await loadBoard();
         } catch {
           // The chore exists; only the photo failed. Don't block the create.
           showToast({ message: "Chore added, but the photo didn't upload.", kind: 'info' });
         }
+      }
+      // Refetch once so the new checklist + photo render (store.create reconciled
+      // BEFORE these follow-on writes, so the board doesn't carry them yet).
+      if (value.subtasks.length > 0 || value.photo) {
+        await loadBoard();
       }
       quickAddOpen = false;
       showToast({ message: `Added “${created.name}”.`, kind: 'success' });

--- a/frontend/chores/src/lib/components/ChoreCard.svelte
+++ b/frontend/chores/src/lib/components/ChoreCard.svelte
@@ -943,6 +943,9 @@
     min-width: 0;
     display: flex;
     align-items: center;
+    /* A flex <button> centers its content under the UA stylesheet — text-align is
+       ignored for flex children — so pin the checkbox + title hard-left. */
+    justify-content: flex-start;
     gap: 10px;
     font: inherit;
     font-size: 0.875rem;

--- a/frontend/chores/src/lib/components/EditChoreSheet.svelte
+++ b/frontend/chores/src/lib/components/EditChoreSheet.svelte
@@ -271,6 +271,16 @@
   // items is from the card; the sheet manages the list. Never gates completion.
   let newSubtaskTitle = $state('');
 
+  // Render the checklist from the LIVE board chore (looked up by id), NOT the
+  // `chore` prop. App captures that prop reference when the sheet opens, so a
+  // liveness refetch (~20s) swaps the board proxy underneath and the prop goes
+  // stale — an added item lands on the live proxy but the sheet kept rendering
+  // the old one (it only showed after save/close/reopen). The id-based lookup
+  // always tracks the current proxy, so add/remove/rename reflect immediately.
+  let liveSubtasks = $derived(
+    (chore ? boardStore.choresById.get(chore.id)?.subtasks : null) ?? chore?.subtasks ?? [],
+  );
+
   function addSubtaskItem(): void {
     if (!chore) return;
     const title = newSubtaskTitle.trim();
@@ -753,9 +763,9 @@
       {#if chore}
         <fieldset class="ch-field">
           <legend class="ch-field-label">Checklist (optional)</legend>
-          {#if chore.subtasks.length > 0}
+          {#if liveSubtasks.length > 0}
             <ul class="ch-subtasks">
-              {#each chore.subtasks as s (s.id)}
+              {#each liveSubtasks as s (s.id)}
                 <li class="ch-subtask-row">
                   <input
                     type="text"

--- a/frontend/chores/src/lib/components/QuickAddSheet.svelte
+++ b/frontend/chores/src/lib/components/QuickAddSheet.svelte
@@ -33,6 +33,8 @@
   export interface QuickAddValue {
     request: CreateChoreRequest;
     photo: File | null;
+    /** Checklist item titles — created by the parent AFTER the chore POST returns an id. */
+    subtasks: string[];
   }
 
   interface Props {
@@ -70,6 +72,22 @@
   let assignedUserIds = $state<number[]>([]);
   let photo = $state<File | null>(null);
   let localError = $state<string | null>(null);
+
+  // ── Checklist (optional) — collected locally; a new chore has no id yet, so
+  //    subtasks can't attach until it exists. The parent (App.handleQuickAdd)
+  //    creates each item after the chore POST returns an id.
+  let subtaskTitles = $state<string[]>([]);
+  let newSubtaskTitle = $state('');
+
+  function addSubtaskDraft(): void {
+    const t = newSubtaskTitle.trim();
+    if (!t) return;
+    subtaskTitles = [...subtaskTitles, t];
+    newSubtaskTitle = '';
+  }
+  function removeSubtaskDraft(index: number): void {
+    subtaskTitles = subtaskTitles.filter((_, i) => i !== index);
+  }
 
   // ── Inline "new room" (v1.2 quick win) ─────────────────────────────────────
   // Create a room without leaving the sheet (the full room manager is deferred —
@@ -180,6 +198,8 @@
     requiredCount = 1;
     assignedUserIds = [];
     photo = null;
+    subtaskTitles = [];
+    newSubtaskTitle = '';
     localError = null;
     // Reset the inline new-room form UI (keep createdRooms — a later board reload dedups them).
     showNewRoom = false;
@@ -283,7 +303,7 @@
       photoPath: null,
     };
 
-    await onSubmit({ request, photo });
+    await onSubmit({ request, photo, subtasks: subtaskTitles });
   }
 </script>
 
@@ -582,6 +602,55 @@
         {/if}
       </fieldset>
 
+      <fieldset class="ch-field">
+        <legend class="ch-field-label">Checklist (optional)</legend>
+        {#if subtaskTitles.length > 0}
+          <ul class="ch-subtasks">
+            {#each subtaskTitles as t, i (i)}
+              <li class="ch-subtask-row">
+                <span class="ch-subtask-text">{t}</span>
+                <button
+                  type="button"
+                  class="ch-subtask-del"
+                  onclick={() => removeSubtaskDraft(i)}
+                  title="Remove this item"
+                  aria-label="Remove {t}"
+                >
+                  ×
+                </button>
+              </li>
+            {/each}
+          </ul>
+        {/if}
+        <div class="ch-subtask-add">
+          <input
+            type="text"
+            class="ch-subtask-input"
+            bind:value={newSubtaskTitle}
+            autocomplete="off"
+            placeholder="Add an item…"
+            aria-label="Add a checklist item"
+            onkeydown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                addSubtaskDraft();
+              }
+            }}
+          />
+          <button
+            type="button"
+            class="ch-btn-primary ch-subtask-add-btn"
+            onclick={addSubtaskDraft}
+            disabled={!newSubtaskTitle.trim()}
+          >
+            Add
+          </button>
+        </div>
+        <p class="ch-hint">
+          A quick checklist anyone can tick off from the card — optional, and never needed to finish the chore.
+        </p>
+      </fieldset>
+
       <label class="ch-field">
         <span class="ch-field-label">Photo (optional)</span>
         <input type="file" accept="image/*" onchange={onPhotoChange} />
@@ -850,6 +919,66 @@
     margin: 0;
     font-size: 0.875rem;
     color: var(--color-error);
+  }
+
+  /* ── Checklist (optional) — draft items collected before the chore exists ── */
+  .ch-subtasks {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .ch-subtask-row,
+  .ch-subtask-add {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .ch-subtask-text {
+    flex: 1;
+    min-width: 0;
+    overflow-wrap: anywhere;
+    font-size: 0.875rem;
+  }
+  .ch-subtask-input {
+    flex: 1;
+    min-width: 0;
+    font: inherit;
+    color: inherit;
+    padding: 10px 12px;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    min-height: 44px;
+  }
+  .ch-subtask-input:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -1px;
+    border-color: var(--color-primary);
+  }
+  .ch-subtask-del {
+    flex-shrink: 0;
+    width: 44px;
+    height: 44px;
+    display: grid;
+    place-items: center;
+    font-size: 1.25rem;
+    line-height: 1;
+    color: var(--color-text-muted);
+    background: transparent;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+  }
+  .ch-subtask-del:hover {
+    background: var(--color-action-hover);
+    color: var(--color-error);
+  }
+  .ch-subtask-add-btn {
+    flex-shrink: 0;
+    min-height: 44px;
   }
 
   .ch-sheet-actions {


### PR DESCRIPTION
Three fixes from live use of the v1.4 subtask checklist (PR #41).

## 1. Add checklist items when creating a chore
QuickAddSheet had no checklist field — and a new chore has no id yet for the subtask FK. Collect the item titles locally in the sheet, then create them against the returned id in `App.handleQuickAdd` after the chore POST (versionless, one bad item doesn't block the create), then refetch once.

## 2. Edit-sheet adds didn't appear until save/close/reopen
The sheet rendered `chore.subtasks` off the `chore` prop captured at open time; a ~20s liveness refetch swaps the board proxy underneath, so an added item landed on the live proxy while the sheet kept rendering the stale one. Render the checklist from the **live** board chore (`boardStore.choresById.get(chore.id).subtasks`) — the same reactive lookup the card uses — so adds/removes/renames reflect immediately.

## 3. Checklist rows rendered centered, not left
`.ch-check-toggle` is a `<button>` made `display:flex`; the UA stylesheet centers a button's flex content and `text-align` is ignored for flex children. Pinned `justify-content: flex-start` — the checkbox now sits flush-left (verified by geometry: checkbox x 1070 → 708).

## Verification
- `svelte-check` 0 errors, vite build clean.
- Rebuilt the local `:8080` image; **#3 confirmed live via DOM geometry** (`justify-content: flex-start`, checkbox flush-left).
- **#1 and #2: code-level + render-confirmed, but the add-item *interaction* could not be cleanly driven through browser automation** — this app's modal-dialog Svelte-bound inputs don't accept synthetic events and the harness's typing didn't land reliably in focused modal fields. The fixes are small and follow the same patterns as already-working surfaces (the card's live store path; the inline new-room create-then-attach). Best confirmed by a real tap-test on `:8080`.