### PR TITLE
feat(chores): Phase 15 v1.5 — equity rework, measurement slice (rungs 1–3)

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -25,8 +25,8 @@ Decimal phases appear between their surrounding integers in numeric order.
 - [x] **Phase 11: Chores v1.1 — Equity View & Weekly Discord Digest** - Household effort-distribution lens + cron-triggered weekly digest, edit-chore dialog, starter backfill
 - [x] **Phase 12: Chores v1.2 — Finish the Surface** - COMPLETE (2026-05-31): icons, home card, photo display/capture, room manager
 - [ ] **Phase 13: Chores v1.3 — Multi-room chores** - PLANNED (from prod feedback #6): one chore belonging to multiple rooms (M:N) — needs a spec
-- [ ] **Phase 14: Chores v1.4 — Board simplification + subtask checklist** - IN PROGRESS (from prod feedback 2026-06-14): collapse the lens/sub-chip duplication into a single filter axis (Up for grabs / Mine / All) with always-on attention sectioning + on-demand organizers (Rooms kept, Equity demoted); plus a per-chore subtask checklist (last-write-wins, never gates completion, resets on recurrence completion). Spec: `workshops/chores-v1.4-views-subtasks`
-- [ ] **Phase 15: Chores v1.5 — Equity rework (invisible labor)** - CAPTURED (from prod feedback 2026-06-14): the Equity lens only counts physical board completions and undercounts invisible planning/coordination labor; rework to add new contribution dimensions + mechanisms that drive *toward* equity. Spec-first when prioritized.
+- [x] **Phase 14: Chores v1.4 — Board simplification + subtask checklist** - COMPLETE (2026-06-14, PRs #41–42): collapse the lens/sub-chip duplication into a single filter axis (Up for grabs / Mine / All) with always-on attention sectioning + on-demand organizers (Rooms kept, Equity demoted); plus a per-chore subtask checklist (last-write-wins, never gates completion, resets on recurrence completion). Spec: `workshops/chores-v1.4-views-subtasks`
+- [ ] **Phase 15: Chores v1.5 — Equity rework (invisible labor)** - GRILLED → BUILD (2026-06-14). Reframe: be plain about what numbers mean + credit planning/coordination labor the DB ALREADY attributes (no new user logging). A read-only prod probe proved the case: Natalie set up 49% of the board + most shopping curation, yet the physical-points lens ranks her ~3%. Plan = un-blended labeled tallies (no exchange rate), capacity-aware physical share, on-demand prominence. Slice stack: (1) rename→"Physical board-load (this week)"+demote, (2) capacity-aware physical share, (3) planning footprint lanes [spec target]; (4) capacity-aware suggestion mechanism [follow-up]. Probe deferred the MealPlanEntry creator migration (no meal-plan signal). KB: `chores-equity-rework-phase-15-grill-resolved-prod-probe-verdict-build`.
 
 ## Phase Details
 
@@ -214,8 +214,9 @@ Phases 8 and 9 were deprecated 2026-02-08. The identified gaps (attribution trac
   - the room-manager **delete→General** reassignment (a chore loses one room but may keep others).
 **Recommendation**: `/spec` before building — it's a data-model + board-contract change with broad blast radius, not a surface tweak. Brushes the room model shipped in v1.2.
 
-### Phase 14: Chores v1.4 — Board simplification + subtask checklist (IN PROGRESS)
+### Phase 14: Chores v1.4 — Board simplification + subtask checklist (COMPLETE)
 **Goal**: Cut the navigation duplication and add a lightweight per-chore checklist. From prod feedback 2026-06-14.
+**Status**: Delivered — merged 2026-06-14. PR #41 (`feat/chores-v1.4-board-simplify-subtasks`, merge `d9e4fda`) + follow-up PR #42 (`fix/chores-subtask-quickadd-and-followups`, merge `2a567d8`, subtask quick-add + prod-feedback fixes). Deploys via master→deploy.
 **Source**: in-app feedback (2026-06-14). Spec: `D:\Development\data\outputs\workshops\chores-v1.4-views-subtasks\`.
 **Two capabilities**:
   - **Board IA simplification (Model A)** — the 5 lenses (Needs attention / Rooms / Up for grabs / Mine / Equity) plus the 3 Needs-attention sub-chips (Everything / Up for grabs / Mine) conflate a *filter* (whose/what-state) with an *organizer* (how it's arranged) and duplicate "Up for grabs"/"Mine". Collapse to **one filter axis — Up for grabs · Mine · All** (default Up for grabs) — with the board **always** sectioning by attention (Falling behind / Due now / Coming up), and the organizers surfaced **on demand**: **Rooms kept accessible**, **Equity demoted** to a back-seat surface (it earns prominence back only via Phase 15). The per-user 📌 default machinery (already shipped) is reused, now pinning a filter state.
@@ -247,9 +248,9 @@ Phases execute in numeric order: 1 → 2 → 3 → 4 → 5 → 6 → 7 (8 & 9 de
 | 11. Chores v1.1 (Equity & Digest) | 11 WPs | Complete | 2026-05-31 |
 | 12. Chores v1.2 (Finish the Surface) | 6/6 items | Complete | PRs #13–15, #18–21 (2026-05-31) |
 | 13. Chores v1.3 (Multi-room chores) | - | Planned | from prod feedback #6 — needs a spec |
-| 14. Chores v1.4 (Board simplification + subtasks) | - | In progress | from prod feedback 2026-06-14 — Model A IA + subtask checklist |
+| 14. Chores v1.4 (Board simplification + subtasks) | - | Complete | PRs #41–42 (2026-06-14) — Model A IA + subtask checklist |
 | 15. Chores v1.5 (Equity rework / invisible labor) | - | Captured | from prod feedback 2026-06-14 — spec-first when prioritized |
 
 ---
 *Created: 2026-01-22*
-*Last updated: 2026-06-14 (added Phase 14 — Model A board simplification + subtask checklist, in progress; added Phase 15 — equity rework / invisible labor, captured — both from prod feedback 2026-06-14)*
+*Last updated: 2026-06-14 (Phase 14 — Model A board simplification + subtask checklist — COMPLETE, merged via PRs #41–42; Phase 15 — equity rework / invisible labor — captured, spec-first when prioritized)*

--- a/frontend/chores/src/App.svelte
+++ b/frontend/chores/src/App.svelte
@@ -319,6 +319,8 @@
         error={store.equityError}
         onWindow={(w) => store.setEquityWindow(w)}
         onRetry={() => store.loadEquity()}
+        onCapacity={(t) => store.saveCapacity(t)}
+        savingCapacity={store.savingCapacity}
       />
     {/if}
   {:else if !store.loading}

--- a/frontend/chores/src/lib/api.ts
+++ b/frontend/chores/src/lib/api.ts
@@ -4,6 +4,7 @@ import type {
   ChoreSubtaskDto,
   ChoreEquityDto,
   EquityWindow,
+  CapacityTier,
   RoomDto,
   EffortTier,
   RecurrenceMode,
@@ -352,6 +353,19 @@ export async function setDefaultView(view: string | null): Promise<DefaultViewRe
   return request<DefaultViewResponse>(`${CHORES_BASE}/me/default-view`, {
     method: 'PATCH',
     ...jsonBody({ view }),
+  });
+}
+
+/**
+ * Persist the caller's OWN physical-capacity tier (Phase 15 WP-05/WP-06; self-set only — MN5). Mirrors
+ * `setDefaultView`. The input is NON-nullable (the UI always sends one of {Full, Reduced, Minimal} — there
+ * is no clear-to-null path); the endpoint echoes the persisted `{ tier }` on 200. The fresh tier also rides
+ * the next equity payload as `callerCapacityTier`, so the store invalidates equity after a successful PATCH.
+ */
+export async function setCapacity(tier: CapacityTier): Promise<{ tier: CapacityTier | null }> {
+  return request<{ tier: CapacityTier | null }>(`${CHORES_BASE}/me/capacity`, {
+    method: 'PATCH',
+    ...jsonBody({ tier }),
   });
 }
 

--- a/frontend/chores/src/lib/components/EquityBoard.svelte
+++ b/frontend/chores/src/lib/components/EquityBoard.svelte
@@ -56,7 +56,7 @@
 <div class="ch-equity">
   <header class="ch-equity-head">
     <div class="ch-equity-titles">
-      <h2 class="ch-equity-title">Household load</h2>
+      <h2 class="ch-equity-title">Physical board-load — this week</h2>
       <p class="ch-equity-sub">How the chore load has been shared — not a scoreboard.</p>
     </div>
     <div class="ch-equity-windows" role="group" aria-label="Equity window">

--- a/frontend/chores/src/lib/components/EquityBoard.svelte
+++ b/frontend/chores/src/lib/components/EquityBoard.svelte
@@ -51,6 +51,28 @@
   let hasDistribution = $derived(
     equity != null && equity.members.length > 0 && equity.totalCompletions > 0,
   );
+
+  // ── Planning footprint (Phase 15) ────────────────────────────────────────
+  // The four planning lanes (chores set up / recipes / list items / hand-offs)
+  // are ALL-TIME, un-blended labeled tallies riding `equity.planning` (no new
+  // fetch — M7). They show INDEPENDENTLY of the physical distribution gate above:
+  // a low-physical, high-planning member (the founding case) must still surface,
+  // so this section renders whenever there is ANY planning signal even if
+  // `totalCompletions` is 0. NEVER sum the lanes, NEVER blend with points (MN4);
+  // neutral framing only — no winner/loser, no ranking (M6). Order by display
+  // name (stable, neutral — mirrors the physical rows).
+  let planning = $derived(equity?.planning ?? []);
+
+  let hasPlanningSignal = $derived(
+    planning.some(
+      (m) =>
+        m.choresSetUp + m.recipesAdded + m.listItemsCurated + m.handOffs > 0,
+    ),
+  );
+
+  let planningRows = $derived(
+    [...planning].sort((a, b) => a.displayName.localeCompare(b.displayName)),
+  );
 </script>
 
 <div class="ch-equity">
@@ -149,6 +171,53 @@
       <p class="ch-equity-empty-head">Nothing logged yet.</p>
       <p>No completions in this window — the load picture fills in as chores get done.</p>
     </div>
+  {/if}
+
+  <!-- ── Planning footprint (Phase 15) ─────────────────────────────────────
+       All-time system-building & coordination labor, as neutral labeled
+       tallies per member. Gated on its OWN `hasPlanningSignal` — independent of
+       the physical distribution above — so a low-physical, high-planning member
+       still shows even when this window has zero completions. NO summed total,
+       NO blended score (MN4); descriptive only, ordered by name (M6). Rides
+       `equity.planning` — no new fetch (M7). -->
+  {#if equity != null && hasPlanningSignal}
+    <section class="ch-plan" aria-label="System-building and coordination, all time">
+      <header class="ch-plan-head">
+        <h3 class="ch-plan-title">System-building &amp; coordination — all time</h3>
+        <p class="ch-plan-sub">
+          Setup and coordination work, counted across all time — separate from the
+          physical load above, never blended into a single score.
+        </p>
+      </header>
+      <ul class="ch-plan-rows">
+        {#each planningRows as member (member.userId)}
+          <li class="ch-plan-row">
+            <span class="ch-plan-name">{member.displayName}</span>
+            <span class="ch-plan-tallies">
+              <span class="ch-plan-tally">
+                {member.choresSetUp}
+                {member.choresSetUp === 1 ? 'chore set up' : 'chores set up'}
+              </span>
+              <span class="ch-plan-dot" aria-hidden="true">·</span>
+              <span class="ch-plan-tally">
+                {member.recipesAdded}
+                {member.recipesAdded === 1 ? 'recipe' : 'recipes'}
+              </span>
+              <span class="ch-plan-dot" aria-hidden="true">·</span>
+              <span class="ch-plan-tally">
+                {member.listItemsCurated}
+                {member.listItemsCurated === 1 ? 'list item' : 'list items'}
+              </span>
+              <span class="ch-plan-dot" aria-hidden="true">·</span>
+              <span class="ch-plan-tally">
+                {member.handOffs}
+                {member.handOffs === 1 ? 'hand-off' : 'hand-offs'}
+              </span>
+            </span>
+          </li>
+        {/each}
+      </ul>
+    </section>
   {/if}
 </div>
 
@@ -349,6 +418,67 @@
   .ch-equity-stat-label {
     font-size: 0.8125rem;
     color: var(--color-text-muted);
+  }
+
+  /* ── Planning footprint (Phase 15) ────────────────────────────────────── */
+  /* Neutral labeled tallies — plain source nouns, no bars, no ranking, no
+     summed total. Visually a quiet block beneath the physical distribution. */
+  .ch-plan {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 16px;
+    background: var(--color-action-hover);
+    border-radius: var(--radius-md);
+  }
+  .ch-plan-head {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .ch-plan-title {
+    margin: 0;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    color: var(--color-text);
+  }
+  .ch-plan-sub {
+    margin: 0;
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .ch-plan-rows {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .ch-plan-row {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .ch-plan-name {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--color-text);
+  }
+  .ch-plan-tallies {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 6px;
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+  }
+  .ch-plan-tally {
+    font-variant-numeric: tabular-nums;
+  }
+  .ch-plan-dot {
+    color: var(--color-text-muted);
+    opacity: 0.6;
   }
 
   /* ── Loading / empty / error states ───────────────────────────────────── */

--- a/frontend/chores/src/lib/components/EquityBoard.svelte
+++ b/frontend/chores/src/lib/components/EquityBoard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { ChoreEquityDto, EquityWindow } from '../types';
+  import type { ChoreEquityDto, EquityWindow, CapacityTier } from '../types';
   import MemberAvatar from './MemberAvatar.svelte';
 
   // ───────────────────────────────────────────────────────────────────────
@@ -31,14 +31,34 @@
     onWindow: (window: EquityWindow) => void;
     /** Retry after an error (re-runs loadEquity for the current window). */
     onRetry: () => void;
+    /** Set the CURRENT user's own physical-capacity tier (self-only — MN5). */
+    onCapacity: (tier: CapacityTier) => void;
+    /** True while a capacity PATCH is in flight (disables the selector). */
+    savingCapacity: boolean;
   }
 
-  let { equity, window, loading, error, onWindow, onRetry }: Props = $props();
+  let { equity, window, loading, error, onWindow, onRetry, onCapacity, savingCapacity }: Props =
+    $props();
 
   const WINDOWS: { id: EquityWindow; label: string }[] = [
     { id: 'week', label: 'This week' },
     { id: 'all', label: 'All time' },
   ];
+
+  // ── Self-only capacity selector (Phase 15 WP-06, MN5/M6) ──────────────────
+  // The current user sets ONLY their own physical-capacity tier. Descriptive,
+  // never evaluative (M6): "Full" / "Reduced" / "Minimal" describe how much
+  // physical work a member can take on right now — NOT a performance rating.
+  // The selected tier reshapes each member's EXPECTED reference line (below);
+  // it is NOT a target/quota or a blame label.
+  const CAPACITY_TIERS: { id: CapacityTier; label: string }[] = [
+    { id: 'Full', label: 'Full' },
+    { id: 'Reduced', label: 'Reduced' },
+    { id: 'Minimal', label: 'Minimal' },
+  ];
+
+  // The caller's current tier rides the equity payload (null ⇒ Full). No separate fetch (M7/P4).
+  let callerTier = $derived<CapacityTier>(equity?.callerCapacityTier ?? 'Full');
 
   // Render a percent without trailing-zero noise (e.g. 25 → "25", 41.7 → "41.7").
   // Pure number formatting — NOT date math. Values already arrive as 0..100.
@@ -96,6 +116,30 @@
     </div>
   </header>
 
+  <!-- Self-only physical-capacity selector (Phase 15 WP-06). The current user sets ONLY their own tier
+       (MN5). Descriptive, not evaluative (M6): it reshapes that member's EXPECTED reference line below —
+       it is never a score, target, or blame label. -->
+  <div class="ch-cap">
+    <span class="ch-cap-label" id="ch-cap-label">My physical capacity</span>
+    <div class="ch-cap-options" role="group" aria-labelledby="ch-cap-label">
+      {#each CAPACITY_TIERS as tier (tier.id)}
+        <button
+          type="button"
+          class="ch-cap-option"
+          class:active={callerTier === tier.id}
+          aria-pressed={callerTier === tier.id}
+          disabled={savingCapacity}
+          onclick={() => onCapacity(tier.id)}
+        >
+          {tier.label}
+        </button>
+      {/each}
+    </div>
+    <p class="ch-cap-hint">
+      Sets your own expected share of physical chores — descriptive, not a target.
+    </p>
+  </div>
+
   {#if error}
     <div class="ch-equity-error" role="alert">
       <span>{error}</span>
@@ -105,9 +149,12 @@
     <div class="ch-equity-state">Loading the household load…</div>
   {:else if equity != null && hasDistribution}
     <section class="ch-equity-dist" aria-label="Per-member share of the load">
-      <!-- Each row is a proportional bar at the member's share. A neutral
-           equal-share reference marker sits at `equalSharePct` so the even
-           split reads at a glance — no ranking, no highlight of high/low. -->
+      <!-- Each row is a proportional bar at the member's actual share (`sharePct`).
+           A neutral reference marker sits at THAT member's capacity-weighted EXPECTED
+           share (`expectedSharePct`, Phase 15 WP-06) — so a Reduced/Minimal member's
+           reference shifts to reflect their stated capacity, not a single flat line.
+           Descriptive only — no ranking, no highlight of high/low (M6). Server values
+           verbatim — NO client math (M7/MN9). -->
       <ul class="ch-equity-rows">
         {#each equity.members as member (member.userId)}
           <li class="ch-equity-row">
@@ -128,7 +175,7 @@
               ></span>
               <span
                 class="ch-equity-ref"
-                style="left: {equity.equalSharePct}%;"
+                style="left: {member.expectedSharePct}%;"
                 aria-hidden="true"
               ></span>
             </span>
@@ -145,7 +192,7 @@
 
       <p class="ch-equity-legend">
         <span class="ch-equity-legend-ref" aria-hidden="true"></span>
-        Even split: {pct(equity.equalSharePct)}% each
+        The marker shows each person's expected share, adjusted for their stated capacity.
       </p>
 
       <!-- Outstanding work — discrete entries, distinct from the completed-effort
@@ -289,6 +336,65 @@
   .ch-equity-window:focus-visible {
     outline: 2px solid var(--color-primary);
     outline-offset: -2px;
+  }
+
+  /* ── Self-only capacity selector ──────────────────────────────────────── */
+  .ch-cap {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .ch-cap-label {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: var(--color-text);
+  }
+  .ch-cap-options {
+    display: inline-flex;
+    gap: 2px;
+    padding: 3px;
+    background: var(--color-action-hover);
+    border-radius: var(--radius-md);
+    align-self: flex-start;
+  }
+  .ch-cap-option {
+    font: inherit;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
+    padding: 6px 14px;
+    min-height: 34px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    white-space: nowrap;
+    transition:
+      background-color 0.15s,
+      color 0.15s;
+    -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation;
+  }
+  .ch-cap-option:hover:not(.active):not(:disabled) {
+    color: var(--color-text);
+  }
+  .ch-cap-option.active {
+    background: var(--color-surface);
+    color: var(--color-text);
+    box-shadow: var(--shadow-1);
+  }
+  .ch-cap-option:disabled {
+    cursor: default;
+    opacity: 0.7;
+  }
+  .ch-cap-option:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -2px;
+  }
+  .ch-cap-hint {
+    margin: 0;
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
   }
 
   /* ── Distribution rows ────────────────────────────────────────────────── */

--- a/frontend/chores/src/lib/components/ViewSwitcher.svelte
+++ b/frontend/chores/src/lib/components/ViewSwitcher.svelte
@@ -45,7 +45,7 @@
     mine: 'Mine',
     'needs-attention': 'All',
     rooms: 'Rooms',
-    equity: 'Equity',
+    equity: 'Board load',
   };
 
   // The primary segmented filters (board filters) vs the secondary organizers.

--- a/frontend/chores/src/lib/state.svelte.ts
+++ b/frontend/chores/src/lib/state.svelte.ts
@@ -22,6 +22,7 @@ import type {
   ChoreSubtaskDto,
   ChoreEquityDto,
   EquityWindow,
+  CapacityTier,
   RoomRollupDto,
   MemberDto,
   ChoreLensId,
@@ -47,6 +48,7 @@ import {
   deleteSubtask,
   seedStarter as apiSeedStarter,
   setDefaultView,
+  setCapacity,
   getEquity,
   type CreateChoreRequest,
   type UpdateChoreRequest,
@@ -120,6 +122,12 @@ class BoardStore {
   savingDefaultView = $state(false);
   /** Guards `initLensFromDefault` so the landing lens is set only on first load. */
   private defaultViewInitialized = false;
+
+  /**
+   * True while a `setCapacity` PATCH is in flight (disables the self-only capacity selector). The caller's
+   * CURRENT tier is read off `equity?.callerCapacityTier` (no separate state) — Phase 15 WP-06, P4.
+   */
+  savingCapacity = $state(false);
 
   /**
    * Chore ids with an in-flight mutation. Drives per-card disabled state +
@@ -438,6 +446,40 @@ class BoardStore {
       showToast({ message: msg, kind: 'info' });
     } finally {
       this.savingDefaultView = false;
+    }
+  }
+
+  // ── Self-only physical-capacity tier (Phase 15 WP-06, MN5/P4) ─────────────
+  //
+  // The capacity tier is PER-USER and SERVER-PERSISTED (User.PhysicalCapacityTier), so it roams across
+  // devices like the default view — NOT localStorage. It arrives on every equity payload as
+  // `callerCapacityTier` (null ⇒ Full); no separate GET (M7). The PATCH writes ONLY the caller's own row
+  // (MN5 — no way to set another member's tier). On success we invalidate the equity cache so the
+  // per-member EXPECTED references recompute with the new weighting (the fresh tier rides the reload).
+
+  /**
+   * Set the current user's OWN physical-capacity tier (PATCH /api/chores/me/capacity). Self-set only —
+   * never another member's (MN5). On success: invalidate the cached equity so the expected references
+   * recompute (and reload now if the equity lens is open). On an ApiError we surface a non-blocking toast;
+   * the previously rendered tier stays until the next equity reload reconciles.
+   */
+  async saveCapacity(tier: CapacityTier): Promise<void> {
+    if (this.savingCapacity) return;
+    // No-op if it's already the caller's current tier (null ⇒ Full).
+    if ((this.equity?.callerCapacityTier ?? 'Full') === tier) return;
+    this.savingCapacity = true;
+    try {
+      await setCapacity(tier);
+      // The new tier rides the next equity payload as `callerCapacityTier`; recompute expected refs.
+      this.invalidateEquity();
+    } catch (e) {
+      const msg =
+        e instanceof ApiError
+          ? "Couldn't update your capacity right now — please try again."
+          : "Couldn't update your capacity right now.";
+      showToast({ message: msg, kind: 'info' });
+    } finally {
+      this.savingCapacity = false;
     }
   }
 

--- a/frontend/chores/src/lib/types.ts
+++ b/frontend/chores/src/lib/types.ts
@@ -188,6 +188,21 @@ export interface MemberShareDto {
   sharePct: number;
 }
 
+/**
+ * Per-member planning/coordination footprint (Phase 15). ALL-TIME, un-blended labeled tallies — the
+ * server computes them all-time regardless of `window` (D5). Plain integer COUNTS (no percent, no weight);
+ * NEVER summed into a blended score (MN4). Mirrors the C# `MemberPlanningDto` and the `planning` array in
+ * equity.json EXACTLY (M5 lockstep).
+ */
+export interface MemberPlanningDto {
+  userId: number;
+  displayName: string;
+  choresSetUp: number;
+  recipesAdded: number;
+  listItemsCurated: number;
+  handOffs: number;
+}
+
 export interface ChoreEquityDto {
   window: EquityWindow;
   totalPoints: number;
@@ -197,6 +212,11 @@ export interface ChoreEquityDto {
   fallingBehindCount: number;
   upForGrabsCount: number;
   members: MemberShareDto[];
+  /**
+   * All-time planning footprint per member (Phase 15). Always present (defaults to [] server-side) —
+   * INDEPENDENT of `window`. Render as neutral labeled tallies; never sum/blend with physical points (MN4).
+   */
+  planning: MemberPlanningDto[];
 }
 
 // ─── Digest settings (WP-11 — mirrors WP-06 frozen contract EXACTLY) ─────────

--- a/frontend/chores/src/lib/types.ts
+++ b/frontend/chores/src/lib/types.ts
@@ -176,6 +176,12 @@ export const CHORE_LENSES: readonly ChoreLensId[] = [
 /** The equity reporting window. Plain string on the DTO. */
 export type EquityWindow = 'week' | 'all';
 
+/**
+ * A member's physical-capacity tier (Phase 15). Mirrors the C# `CapacityTier.All` casing EXACTLY
+ * (PascalCase strings — NOT enum-converted). `null` on the DTO ⇒ Full (the pre-migration default).
+ */
+export type CapacityTier = 'Full' | 'Reduced' | 'Minimal';
+
 /** Per-member share of the household's completion load over the window. */
 export interface MemberShareDto {
   userId: number;
@@ -186,6 +192,12 @@ export interface MemberShareDto {
   completions: number;
   /** PERCENT 0..100 (e.g. 41.7). Render directly — no client `* 100`. */
   sharePct: number;
+  /**
+   * The member's capacity-WEIGHTED expected share (PERCENT 0..100, UNROUNDED — format for display; Phase 15
+   * WP-05). The island draws THIS as each member's per-member reference line instead of the single flat
+   * equal-share marker. `sharePct` stays the RAW actual bar. Render directly — no client `* 100`.
+   */
+  expectedSharePct: number;
 }
 
 /**
@@ -217,6 +229,12 @@ export interface ChoreEquityDto {
    * INDEPENDENT of `window`. Render as neutral labeled tallies; never sum/blend with physical points (MN4).
    */
   planning: MemberPlanningDto[];
+  /**
+   * The REQUESTING user's own physical-capacity tier (Phase 15 WP-05, P4); `null` ⇒ Full (the pre-migration
+   * default). Rides the equity payload so the self-only capacity selector reflects state without a separate
+   * GET (M7). The selector writes via PATCH /me/capacity (caller-scoped only — MN5).
+   */
+  callerCapacityTier: CapacityTier | null;
 }
 
 // ─── Digest settings (WP-11 — mirrors WP-06 frozen contract EXACTLY) ─────────

--- a/src/FamilyCoordinationApp/Data/Entities/ChoreEnums.cs
+++ b/src/FamilyCoordinationApp/Data/Entities/ChoreEnums.cs
@@ -132,3 +132,24 @@ public static class ChoreLens
         Equity
     };
 }
+
+/// <summary>
+/// Canonical physical-capacity tier constants (D2) — the single source of truth for the
+/// <c>PATCH /api/chores/me/capacity</c> allowlist (mirrors <see cref="ChoreLens"/>). No ad-hoc casings
+/// anywhere else. <c>null</c> and <see cref="Full"/> both mean Full (the pre-migration default); there is
+/// no clear-to-null client path.
+/// </summary>
+public static class CapacityTier
+{
+    public const string Full = "Full";
+    public const string Reduced = "Reduced";
+    public const string Minimal = "Minimal";
+
+    /// <summary>All valid capacity tiers, for allowlist validation.</summary>
+    public static readonly IReadOnlyList<string> All = new[]
+    {
+        Full,
+        Reduced,
+        Minimal
+    };
+}

--- a/src/FamilyCoordinationApp/Data/Entities/User.cs
+++ b/src/FamilyCoordinationApp/Data/Entities/User.cs
@@ -18,6 +18,10 @@ public class User
     // Chores: the user's preferred default board lens id (null => Needs-attention). D18 / approved E2 exception.
     public string? ChoresDefaultView { get; set; }
 
+    // Chores: the user's self-set physical-capacity tier (Full|Reduced|Minimal). Nullable scalar; null => Full
+    // (the pre-migration default — no backfill, M9). Self-set only via PATCH /api/chores/me/capacity (D2/MN5).
+    public string? PhysicalCapacityTier { get; set; }
+
     // Navigation
     public Household Household { get; set; } = default!;
 }

--- a/src/FamilyCoordinationApp/Endpoints/ChoresEndpoints.cs
+++ b/src/FamilyCoordinationApp/Endpoints/ChoresEndpoints.cs
@@ -504,6 +504,7 @@ public static class ChoresEndpoints
         [FromQuery] string? window,
         ClaimsPrincipal principal,
         ChoreEquityCalculator equityCalculator,
+        ChorePlanningCalculator planningCalculator,
         ChoreStatusCalculator statusCalculator,
         TimeProvider timeProvider,
         TimeZoneInfo timeZone,
@@ -537,7 +538,27 @@ public static class ChoresEndpoints
             .Where(c => c.HouseholdId == user.HouseholdId && c.Status == ChoreStatus.Active)
             .ToListAsync(ct);
 
+        // Planning footprint (Phase 15): ALL-TIME, household-scoped authorship across four lanes — these are
+        // independent of the equity `window` (which governs only the physical lane). All HouseholdId-scoped (M1).
+        var allChores = await context.Chores
+            .Where(c => c.HouseholdId == user.HouseholdId)
+            .ToListAsync(ct);
+
+        var recipes = await context.Recipes
+            .Where(r => r.HouseholdId == user.HouseholdId && !r.IsDeleted && r.CreatedByUserId != null)
+            .ToListAsync(ct);
+
+        var manualListItems = await context.ShoppingListItems
+            .Where(s => s.HouseholdId == user.HouseholdId && s.IsManuallyAdded && s.AddedByUserId != null)
+            .ToListAsync(ct);
+
+        var choreEvents = await context.ChoreEvents
+            .Where(e => e.HouseholdId == user.HouseholdId)
+            .ToListAsync(ct);
+
         var equity = equityCalculator.Compute(completions, members, equityWindow, now, timeZone);
+
+        var planning = planningCalculator.Compute(members, allChores, recipes, manualListItems, choreEvents);
 
         var fallingBehindCount = 0;
         var upForGrabsCount = 0;
@@ -566,7 +587,11 @@ public static class ChoresEndpoints
             Members: equity.Members
                 .Select(m => new MemberShareDto(
                     m.UserId, m.DisplayName, m.Initials, m.PictureUrl, m.Points, m.Completions, m.SharePct))
-                .ToList());
+                .ToList())
+        {
+            // Planning is ALL-TIME — independent of the window param (D5).
+            Planning = planning,
+        };
 
         return Results.Ok(dto);
     }

--- a/src/FamilyCoordinationApp/Endpoints/ChoresEndpoints.cs
+++ b/src/FamilyCoordinationApp/Endpoints/ChoresEndpoints.cs
@@ -608,7 +608,16 @@ public static class ChoresEndpoints
             .Where(e => e.HouseholdId == user.HouseholdId)
             .ToListAsync(ct);
 
-        var equity = equityCalculator.Compute(completions, members, equityWindow, now, timeZone);
+        // Per-member physical-capacity tiers (Phase 15 WP-05, D3). A lightweight household-scoped projection
+        // separate from the MemberDto projection (so the board DTO / ChoreDtos.cs stay untouched — MN1) and
+        // filtered to the caller's household (no cross-tenant leakage — M1). null tier ⇒ Full.
+        var tiersByUserId = (await context.Users
+                .Where(u => u.HouseholdId == user.HouseholdId)
+                .Select(u => new { u.Id, u.PhysicalCapacityTier })
+                .ToListAsync(ct))
+            .ToDictionary(u => u.Id, u => u.PhysicalCapacityTier);
+
+        var equity = equityCalculator.Compute(completions, members, equityWindow, now, timeZone, tiersByUserId);
 
         var planning = planningCalculator.Compute(members, allChores, recipes, manualListItems, choreEvents);
 
@@ -638,11 +647,17 @@ public static class ChoresEndpoints
             UpForGrabsCount: upForGrabsCount,
             Members: equity.Members
                 .Select(m => new MemberShareDto(
-                    m.UserId, m.DisplayName, m.Initials, m.PictureUrl, m.Points, m.Completions, m.SharePct))
+                    m.UserId, m.DisplayName, m.Initials, m.PictureUrl, m.Points, m.Completions, m.SharePct)
+                {
+                    // ExpectedSharePct is an init property, not a ctor param (Phase 15 WP-05).
+                    ExpectedSharePct = m.ExpectedSharePct,
+                })
                 .ToList())
         {
             // Planning is ALL-TIME — independent of the window param (D5).
             Planning = planning,
+            // The caller's own capacity tier rides the payload (P4); null ⇒ Full.
+            CallerCapacityTier = tiersByUserId.GetValueOrDefault(user.UserId),
         };
 
         return Results.Ok(dto);

--- a/src/FamilyCoordinationApp/Endpoints/ChoresEndpoints.cs
+++ b/src/FamilyCoordinationApp/Endpoints/ChoresEndpoints.cs
@@ -53,6 +53,7 @@ public static class ChoresEndpoints
         group.MapDelete("/{choreId:int}/subtasks/{subtaskId:int}", DeleteSubtask);
 
         group.MapPatch("/me/default-view", SetDefaultView);
+        group.MapPatch("/me/capacity", SetCapacity);
 
         // v1.1 (WP-06): equity distribution lens + digest settings + dev backfill — all cookie-authed,
         // household-scoped via UserContextResolver (M1).
@@ -490,6 +491,57 @@ public static class ChoresEndpoints
         return (DefaultViewOutcome.Ok, view);
     }
 
+    // ─── Per-user physical-capacity tier (Phase 15 WP-04, D2/MN5) ────────────────────
+
+    private static async Task<IResult> SetCapacity(
+        CapacityRequest req,
+        ClaimsPrincipal principal,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        var (outcome, normalized) = await ApplyCapacityAsync(dbFactory, user.UserId, req.Tier, ct);
+        return outcome switch
+        {
+            CapacityOutcome.Ok => Results.Ok(new { tier = normalized }),
+            CapacityOutcome.InvalidTier => Results.BadRequest(new { message = "Invalid capacity tier." }),
+            _ => Results.Unauthorized()
+        };
+    }
+
+    internal enum CapacityOutcome { Ok, InvalidTier, UserMissing }
+
+    /// <summary>
+    /// Core of <see cref="SetCapacity"/>, extracted so it is unit-testable without a WebApplicationFactory
+    /// (mirrors <see cref="ApplyDefaultViewAsync"/>). A non-null tier MUST be a canonical
+    /// <see cref="CapacityTier"/> value — anything else is rejected, never coerced (D2). <c>null</c> is the
+    /// pre-migration default (treated as Full) and there is no client clear-to-null path. The write is scoped
+    /// to <paramref name="userId"/> only (the resolved caller, MN5).
+    /// </summary>
+    internal static async Task<(CapacityOutcome Outcome, string? Normalized)> ApplyCapacityAsync(
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        int userId,
+        string? requestedTier,
+        CancellationToken ct)
+    {
+        string? tier = string.IsNullOrWhiteSpace(requestedTier) ? null : requestedTier.Trim();
+        if (tier is not null && !CapacityTier.All.Contains(tier))
+        {
+            return (CapacityOutcome.InvalidTier, null);
+        }
+
+        await using var context = await dbFactory.CreateDbContextAsync(ct);
+        var entity = await context.Users.FirstOrDefaultAsync(u => u.Id == userId, ct);
+        if (entity is null) return (CapacityOutcome.UserMissing, null);
+
+        entity.PhysicalCapacityTier = tier;
+        await context.SaveChangesAsync(ct);
+
+        return (CapacityOutcome.Ok, tier);
+    }
+
     // ─── Equity distribution lens (v1.1 WP-06) ──────────────────────────────────────
 
     /// <summary>
@@ -780,6 +832,13 @@ public static class ChoresEndpoints
     public sealed record LeaveRosterRequest(int? SubjectUserId, uint Version);
 
     public sealed record DefaultViewRequest(string? View);
+
+    /// <summary>
+    /// PATCH /me/capacity request body (Phase 15 WP-04, D2). The UI always sends one of
+    /// <c>{Full, Reduced, Minimal}</c>; a non-null tier outside <see cref="CapacityTier.All"/> is rejected
+    /// (400, never coerced). There is no clear-to-null client path.
+    /// </summary>
+    public sealed record CapacityRequest(string? Tier);
 
     /// <summary>
     /// PUT /digest-settings request body (v1.1 WP-06). Enums bind/serialize camelCase via the global

--- a/src/FamilyCoordinationApp/Migrations/20260615055614_AddPhysicalCapacityTier.Designer.cs
+++ b/src/FamilyCoordinationApp/Migrations/20260615055614_AddPhysicalCapacityTier.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FamilyCoordinationApp.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FamilyCoordinationApp.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260615055614_AddPhysicalCapacityTier")]
+    partial class AddPhysicalCapacityTier
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/FamilyCoordinationApp/Migrations/20260615055614_AddPhysicalCapacityTier.cs
+++ b/src/FamilyCoordinationApp/Migrations/20260615055614_AddPhysicalCapacityTier.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FamilyCoordinationApp.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPhysicalCapacityTier : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "PhysicalCapacityTier",
+                table: "Users",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PhysicalCapacityTier",
+                table: "Users");
+        }
+    }
+}

--- a/src/FamilyCoordinationApp/Program.cs
+++ b/src/FamilyCoordinationApp/Program.cs
@@ -108,6 +108,7 @@ builder.Services.AddSingleton(ResolveChoresTimeZone(builder.Configuration));
 // builder are pure/stateless singletons (mirroring ChoreStatusCalculator); the settings service (webhook
 // encryption) + run orchestration + sender are scoped. TimeProvider.System is already registered above.
 builder.Services.AddSingleton<ChoreEquityCalculator>();
+builder.Services.AddSingleton<ChorePlanningCalculator>();
 builder.Services.AddSingleton<DigestBuilder>();
 builder.Services.AddScoped<IDigestSettingsService, DigestSettingsService>();
 builder.Services.AddScoped<IDigestService, DigestService>();

--- a/src/FamilyCoordinationApp/Services/ChoreEquityCalculator.cs
+++ b/src/FamilyCoordinationApp/Services/ChoreEquityCalculator.cs
@@ -23,7 +23,18 @@ public record MemberEquityShare(
     string? PictureUrl,
     int Points,
     int Completions,
-    double SharePct);
+    double SharePct)
+{
+    /// <summary>
+    /// The member's capacity-WEIGHTED fair share of the physical load (PERCENT 0–100, UNROUNDED —
+    /// the UI formats). Phase 15 (D1/D3): a NON-positional <c>init</c>-only property in the record BODY,
+    /// so every existing positional <c>new MemberEquityShare(7 args)</c> site (the calculator tests, the
+    /// digest fixtures) compiles UNCHANGED. <c>SharePct</c> / <c>EqualSharePct</c> stay RAW physical facts
+    /// (digest-safe); this is the per-member EXPECTED reference the island draws instead of the single flat
+    /// equal-share line. Defaults to 0.0; the calculator sets the real computed value via object initializer.
+    /// </summary>
+    public double ExpectedSharePct { get; init; }
+}
 
 /// <summary>
 /// Pure, stateless, parameterless-ctor calculator that aggregates the completion log into a
@@ -46,6 +57,26 @@ public record MemberEquityShare(
 /// </summary>
 public class ChoreEquityCalculator
 {
+    /// <summary>Shared empty tier map for the no-capacity-data (all-<c>Full</c>) path.</summary>
+    private static readonly IReadOnlyDictionary<int, string?> EmptyTiers =
+        new Dictionary<int, string?>();
+
+    /// <summary>
+    /// Physical-capacity tier → expected-share weight (Phase 15 D3). <c>Full</c>=1.0, <c>Reduced</c>=0.5,
+    /// <c>Minimal</c>=0.15 (NOT zero — keeps a Minimal member's reference humane and Σweight&gt;0). A
+    /// null/absent/unrecognized tier is treated as <c>Full</c>. Tier strings mirror <c>CapacityTier.All</c>.
+    /// </summary>
+    private static double WeightFor(IReadOnlyDictionary<int, string?> tiers, int userId)
+    {
+        tiers.TryGetValue(userId, out var tier);
+        return tier switch
+        {
+            "Reduced" => 0.5,
+            "Minimal" => 0.15,
+            _ => 1.0, // Full, null, or any unrecognized value
+        };
+    }
+
     /// <summary>
     /// Compute the equity distribution for <paramref name="members"/> over the given
     /// <paramref name="window"/> using the effort-weighted <paramref name="completions"/> log.
@@ -59,14 +90,25 @@ public class ChoreEquityCalculator
     /// <param name="now">The current UTC instant (injected — never <see cref="DateTime.UtcNow"/>
     /// inside this method).</param>
     /// <param name="tz">The household timezone for local-day boundary math (M5).</param>
+    /// <param name="tiersByUserId">Optional per-member physical-capacity tier map (<c>Full</c> /
+    /// <c>Reduced</c> / <c>Minimal</c>, Phase 15 D3). A TRAILING OPTIONAL param (default <c>null</c>, the only
+    /// compile-time-constant default C# allows) — an absent/empty map OR a null/unrecognized tier means that
+    /// member is treated as <c>Full</c> (weight 1.0), so <c>ExpectedSharePct</c> falls back to the flat
+    /// distribution. The digest call site omits this arg (all-<c>Full</c>) so its output stays byte-identical
+    /// (MN2/D1). This does NOT touch <c>SharePct</c> / <c>EqualSharePct</c> — those stay RAW.</param>
     public ChoreEquityResult Compute(
         IEnumerable<ChoreCompletion> completions,
         IReadOnlyList<MemberDto> members,
         EquityWindow window,
         DateTime now,
-        TimeZoneInfo tz)
+        TimeZoneInfo tz,
+        IReadOnlyDictionary<int, string?>? tiersByUserId = null)
     {
         var windowStart = ComputeWindowStart(window, now, tz);
+
+        // Capacity weighting (D3): absent/empty map ⇒ every member Full (flat distribution). The default
+        // MUST be a compile-time constant (null), so coalesce to an empty dictionary here.
+        var tiers = tiersByUserId ?? EmptyTiers;
 
         // Aggregate effort points + completion count per user for in-window completions.
         var byUser = new Dictionary<int, (int Points, int Completions)>();
@@ -97,6 +139,15 @@ public class ChoreEquityCalculator
         // EqualSharePct: what each member's fair share would be (0 when no members).
         var equalSharePct = memberCount == 0 ? 0.0 : Math.Round(100.0 / memberCount, 1);
 
+        // Capacity-weighted EXPECTED-share denominator (D3): Σ weight across members. Guard Σ==0
+        // (impossible given Minimal=0.15>0, but explicit) by falling back to the flat 100/N distribution.
+        double totalWeight = 0.0;
+        foreach (var m in members)
+        {
+            totalWeight += WeightFor(tiers, m.UserId);
+        }
+        bool useFlatExpected = totalWeight <= 0.0;
+
         var shares = new List<MemberEquityShare>(memberCount);
 
         foreach (var m in members)
@@ -109,6 +160,14 @@ public class ChoreEquityCalculator
                 ? 0.0
                 : Math.Round(100.0 * memberPoints / householdTotal, 1);
 
+            // ExpectedSharePct (D3): 100 × weight[i] / Σweight, UNROUNDED (UI formats). The flat fallback
+            // (Σweight==0) mirrors EqualSharePct's even split. Raw — does NOT touch SharePct/EqualSharePct.
+            var expectedSharePct = memberCount == 0
+                ? 0.0
+                : useFlatExpected
+                    ? 100.0 / memberCount
+                    : 100.0 * WeightFor(tiers, m.UserId) / totalWeight;
+
             shares.Add(new MemberEquityShare(
                 UserId: m.UserId,
                 DisplayName: m.DisplayName,
@@ -116,7 +175,10 @@ public class ChoreEquityCalculator
                 PictureUrl: m.PictureUrl,
                 Points: memberPoints,
                 Completions: memberCompletions,
-                SharePct: sharePct));
+                SharePct: sharePct)
+            {
+                ExpectedSharePct = expectedSharePct,
+            });
         }
 
         return new ChoreEquityResult(

--- a/src/FamilyCoordinationApp/Services/ChorePlanningCalculator.cs
+++ b/src/FamilyCoordinationApp/Services/ChorePlanningCalculator.cs
@@ -1,0 +1,127 @@
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Services.Dtos;
+
+namespace FamilyCoordinationApp.Services;
+
+/// <summary>
+/// Pure, stateless, parameterless-ctor calculator that aggregates the household's already-attributed
+/// system-building / coordination labor into per-member, ALL-TIME, un-blended labeled tallies (Phase 15
+/// planning lanes). Mirrors the <see cref="ChoreEquityCalculator"/> idiom: it receives PRE-FETCHED,
+/// household-scoped sequences (the caller is responsible for HouseholdId scoping — M1) plus the member
+/// list, and returns one <see cref="MemberPlanningDto"/> per member.
+/// <para>
+/// There is NO window math and NO <see cref="DateTime.UtcNow"/>/<see cref="DateTime.Now"/> reached inside
+/// — planning is a STOCK (durable footprint), counted all-time regardless of the equity <c>window</c> param
+/// (D5). Four lanes, each a plain source-noun count, NEVER summed and NEVER blended with physical points
+/// (MN4):
+/// </para>
+/// <list type="bullet">
+///   <item><c>choresSetUp</c> — <see cref="Chore.EnteredByUserId"/>.</item>
+///   <item><c>recipesAdded</c> — non-deleted <see cref="Recipe"/> with a non-null author, credited to
+///   <see cref="Recipe.CreatedByUserId"/>.</item>
+///   <item><c>listItemsCurated</c> — manually-added <see cref="ShoppingListItem"/> with a non-null author,
+///   credited to <see cref="ShoppingListItem.AddedByUserId"/>.</item>
+///   <item><c>handOffs</c> — <see cref="ChoreEvent"/> hand-offs to ANOTHER member, credited to the actor
+///   (see the invariant on the loop below, D6).</item>
+/// </list>
+/// <para>
+/// Rows with a null author id are SKIPPED (no credit for unattributed rows); only members in the supplied
+/// list are credited. Every supplied member appears with a (possibly all-zero) row — mirrors the equity
+/// calculator's "all members appear" rule.
+/// </para>
+/// </summary>
+public class ChorePlanningCalculator
+{
+    /// <summary>
+    /// Compute the per-member, all-time planning tallies. All inputs are already household-scoped by the
+    /// caller (M1); the calculator counts only what it is handed and credits only members in
+    /// <paramref name="members"/>.
+    /// </summary>
+    public IReadOnlyList<MemberPlanningDto> Compute(
+        IReadOnlyList<MemberDto> members,
+        IEnumerable<Chore> chores,
+        IEnumerable<Recipe> recipes,
+        IEnumerable<ShoppingListItem> items,
+        IEnumerable<ChoreEvent> events)
+    {
+        // Pre-seed a zero row for every supplied member so members with no activity still appear.
+        var choresSetUp = new Dictionary<int, int>();
+        var recipesAdded = new Dictionary<int, int>();
+        var listItems = new Dictionary<int, int>();
+        var handOffs = new Dictionary<int, int>();
+
+        var memberIds = new HashSet<int>(members.Count);
+        foreach (var m in members)
+        {
+            memberIds.Add(m.UserId);
+        }
+
+        // chores set up — EnteredByUserId (non-nullable on Chore; still gate on membership).
+        foreach (var chore in chores)
+        {
+            Credit(choresSetUp, memberIds, chore.EnteredByUserId);
+        }
+
+        // recipes added — non-deleted recipes with a non-null author.
+        foreach (var recipe in recipes)
+        {
+            if (recipe.IsDeleted || recipe.CreatedByUserId is not { } authorId)
+            {
+                continue;
+            }
+
+            Credit(recipesAdded, memberIds, authorId);
+        }
+
+        // list items curated — manually-added items with a non-null author.
+        foreach (var item in items)
+        {
+            if (!item.IsManuallyAdded || item.AddedByUserId is not { } authorId)
+            {
+                continue;
+            }
+
+            Credit(listItems, memberIds, authorId);
+        }
+
+        // hand-offs — INVARIANT (D6): count only ChoreEvent rows where Type == HandedOff AND the target is
+        // ANOTHER member (TargetUserId != null && TargetUserId != ActorUserId), credited to the ACTOR.
+        // The HandedOff filter is PRIMARY (excludes Claimed/Dropped/AutoReleased self-noise); the
+        // actor != target clause is the guard against a self-hand-off slipping credit to everyone equally.
+        foreach (var ev in events)
+        {
+            if (ev.Type == ChoreEventType.HandedOff
+                && ev.TargetUserId is { } target
+                && target != ev.ActorUserId)
+            {
+                Credit(handOffs, memberIds, ev.ActorUserId);
+            }
+        }
+
+        var result = new List<MemberPlanningDto>(members.Count);
+        foreach (var m in members)
+        {
+            result.Add(new MemberPlanningDto(
+                UserId: m.UserId,
+                DisplayName: m.DisplayName,
+                ChoresSetUp: choresSetUp.GetValueOrDefault(m.UserId),
+                RecipesAdded: recipesAdded.GetValueOrDefault(m.UserId),
+                ListItemsCurated: listItems.GetValueOrDefault(m.UserId),
+                HandOffs: handOffs.GetValueOrDefault(m.UserId)));
+        }
+
+        return result;
+    }
+
+    /// <summary>Credit one to <paramref name="authorId"/> in <paramref name="counts"/> iff that author is a
+    /// supplied member; unattributed/non-member rows are silently skipped.</summary>
+    private static void Credit(Dictionary<int, int> counts, HashSet<int> memberIds, int authorId)
+    {
+        if (!memberIds.Contains(authorId))
+        {
+            return;
+        }
+
+        counts[authorId] = counts.GetValueOrDefault(authorId) + 1;
+    }
+}

--- a/src/FamilyCoordinationApp/Services/Dtos/ChoreEquityDtos.cs
+++ b/src/FamilyCoordinationApp/Services/Dtos/ChoreEquityDtos.cs
@@ -43,6 +43,15 @@ public sealed record ChoreEquityDto(
     /// (MN4).
     /// </summary>
     public IReadOnlyList<MemberPlanningDto> Planning { get; init; } = Array.Empty<MemberPlanningDto>();
+
+    /// <summary>
+    /// The REQUESTING user's own physical-capacity tier (<c>Full</c> / <c>Reduced</c> / <c>Minimal</c>;
+    /// <c>null</c> ⇒ Full, the pre-migration default). Phase 15 (P4): rides the equity payload so the island's
+    /// self-only capacity selector reflects current state without a separate GET. Additive <c>init</c>-only
+    /// property in the record BODY (no primary-ctor arity change) — set via object initializer / <c>with</c>.
+    /// Serializes camelCase as <c>callerCapacityTier</c>.
+    /// </summary>
+    public string? CallerCapacityTier { get; init; }
 }
 
 /// <summary>
@@ -55,7 +64,17 @@ public sealed record MemberShareDto(
     string? PictureUrl,
     int Points,
     int Completions,
-    double SharePct);
+    double SharePct)
+{
+    /// <summary>
+    /// The member's capacity-WEIGHTED fair share of the physical load (PERCENT 0–100, UNROUNDED — the island
+    /// formats; Phase 15 D1/D3). Additive <c>init</c>-only property in the record BODY (no primary-ctor arity
+    /// change) so every existing positional <c>new MemberShareDto(7 args)</c> site compiles unchanged — set
+    /// via object initializer / <c>with</c>. <c>SharePct</c> stays the RAW actual share (digest-safe). The
+    /// island draws this as each member's per-member EXPECTED reference instead of the single flat line.
+    /// </summary>
+    public double ExpectedSharePct { get; init; }
+}
 
 /// <summary>
 /// Per-member planning footprint (Phase 15). Plain source-noun count fields (P3) — un-weighted, all-time,

--- a/src/FamilyCoordinationApp/Services/Dtos/ChoreEquityDtos.cs
+++ b/src/FamilyCoordinationApp/Services/Dtos/ChoreEquityDtos.cs
@@ -31,7 +31,19 @@ public sealed record ChoreEquityDto(
     double EqualSharePct,
     int FallingBehindCount,
     int UpForGrabsCount,
-    IReadOnlyList<MemberShareDto> Members);
+    IReadOnlyList<MemberShareDto> Members)
+{
+    /// <summary>
+    /// Per-member, ALL-TIME, un-blended planning/coordination tallies (Phase 15 — the system-building
+    /// footprint that the physical-only lane misses). Additive <c>init</c>-only property in the record
+    /// BODY (NOT a primary-ctor param) so every existing <c>new ChoreEquityDto(...)</c> site compiles
+    /// unchanged — the equity endpoint sets it via object initializer / <c>with</c>. Defaults to an empty
+    /// list, so it is NEVER null; the island treats <c>planning</c> as always-present. Independent of the
+    /// <c>Window</c> param — planning is all-time regardless (D5). NEVER summed/blended with physical points
+    /// (MN4).
+    /// </summary>
+    public IReadOnlyList<MemberPlanningDto> Planning { get; init; } = Array.Empty<MemberPlanningDto>();
+}
 
 /// <summary>
 /// Per-member share in the equity distribution. <c>SharePct</c> is PERCENT 0–100 (council M5).
@@ -44,3 +56,16 @@ public sealed record MemberShareDto(
     int Points,
     int Completions,
     double SharePct);
+
+/// <summary>
+/// Per-member planning footprint (Phase 15). Plain source-noun count fields (P3) — un-weighted, all-time,
+/// NEVER summed into a blended "contribution score" (MN4). Mirrored by the island <c>types.ts</c> in
+/// lockstep with <c>equity.json</c> (M5).
+/// </summary>
+public sealed record MemberPlanningDto(
+    int UserId,
+    string DisplayName,
+    int ChoresSetUp,
+    int RecipesAdded,
+    int ListItemsCurated,
+    int HandOffs);

--- a/tests/FamilyCoordinationApp.Tests/Fixtures/ChoreEquity/equity.json
+++ b/tests/FamilyCoordinationApp.Tests/Fixtures/ChoreEquity/equity.json
@@ -33,5 +33,31 @@
       "completions": 1,
       "sharePct": 25
     }
+  ],
+  "planning": [
+    {
+      "userId": 1,
+      "displayName": "Alice",
+      "choresSetUp": 19,
+      "recipesAdded": 6,
+      "listItemsCurated": 28,
+      "handOffs": 4
+    },
+    {
+      "userId": 2,
+      "displayName": "Bob",
+      "choresSetUp": 3,
+      "recipesAdded": 2,
+      "listItemsCurated": 5,
+      "handOffs": 1
+    },
+    {
+      "userId": 3,
+      "displayName": "Carol",
+      "choresSetUp": 0,
+      "recipesAdded": 0,
+      "listItemsCurated": 0,
+      "handOffs": 0
+    }
   ]
 }

--- a/tests/FamilyCoordinationApp.Tests/Fixtures/ChoreEquity/equity.json
+++ b/tests/FamilyCoordinationApp.Tests/Fixtures/ChoreEquity/equity.json
@@ -13,7 +13,8 @@
       "pictureUrl": "https://example.com/alice.png",
       "points": 5,
       "completions": 2,
-      "sharePct": 41.7
+      "sharePct": 41.7,
+      "expectedSharePct": 60.60606060606061
     },
     {
       "userId": 2,
@@ -22,7 +23,8 @@
       "pictureUrl": null,
       "points": 4,
       "completions": 1,
-      "sharePct": 33.3
+      "sharePct": 33.3,
+      "expectedSharePct": 30.303030303030305
     },
     {
       "userId": 3,
@@ -31,7 +33,8 @@
       "pictureUrl": null,
       "points": 3,
       "completions": 1,
-      "sharePct": 25
+      "sharePct": 25,
+      "expectedSharePct": 9.090909090909092
     }
   ],
   "planning": [
@@ -59,5 +62,6 @@
       "listItemsCurated": 0,
       "handOffs": 0
     }
-  ]
+  ],
+  "callerCapacityTier": "Full"
 }

--- a/tests/FamilyCoordinationApp.Tests/Integration/EquityEndpointIntegrationTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Integration/EquityEndpointIntegrationTests.cs
@@ -25,9 +25,11 @@ public sealed class EquityEndpointIntegrationTests(PostgresContainerFixture post
     public async Task DisposeAsync() => await _factory.DisposeAsync();
 
     private sealed record MemberShare(int userId, string displayName, int points, int completions, double sharePct);
+    private sealed record MemberPlanning(
+        int userId, string displayName, int choresSetUp, int recipesAdded, int listItemsCurated, int handOffs);
     private sealed record Equity(
         string window, int totalPoints, int totalCompletions, double equalSharePct,
-        int fallingBehindCount, int upForGrabsCount, List<MemberShare> members);
+        int fallingBehindCount, int upForGrabsCount, List<MemberShare> members, List<MemberPlanning> planning);
 
     [Fact]
     public async Task Equity_AsUserA_SumsOnlyHouseholdA()
@@ -88,6 +90,27 @@ public sealed class EquityEndpointIntegrationTests(PostgresContainerFixture post
         // Same three completions are also within the all-time window (no lower bound).
         equity.totalCompletions.Should().Be(3);
         equity.totalPoints.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task Equity_PlanningIsAllTime_ByteIdenticalAcrossWindows()
+    {
+        // V5: planning lanes are ALL-TIME — the `window` param governs only the physical lane. The
+        // `planning` array must be byte-identical between ?window=week and ?window=all. Compare the raw
+        // serialized `planning` node so any drift (count, ordering, key) fails the assertion.
+        var client = _factory.CreateClientAs(ChoresWebAppFactory.UserAEmail);
+
+        var weekJson = await client.GetStringAsync("/api/chores/equity?window=week");
+        var allJson = await client.GetStringAsync("/api/chores/equity?window=all");
+
+        var weekPlanning = JsonDocument.Parse(weekJson).RootElement.GetProperty("planning").GetRawText();
+        var allPlanning = JsonDocument.Parse(allJson).RootElement.GetProperty("planning").GetRawText();
+
+        weekPlanning.Should().Be(allPlanning, "planning is all-time and must not vary with the equity window");
+
+        // Sanity: the planning array carries one row per household-A member (Alice, Amy).
+        var planning = await client.GetFromJsonAsync<Equity>("/api/chores/equity?window=week", Json);
+        planning!.planning.Should().HaveCount(2, "one planning row per household-A member");
     }
 
     [Fact]

--- a/tests/FamilyCoordinationApp.Tests/Services/CapacityAllowlistTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/CapacityAllowlistTests.cs
@@ -1,0 +1,131 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using FamilyCoordinationApp.Data;
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Endpoints;
+
+namespace FamilyCoordinationApp.Tests.Services;
+
+/// <summary>
+/// WP-04 (Phase 15) backend tests for the <c>PATCH /api/chores/me/capacity</c> setter core
+/// (<see cref="ChoresEndpoints.ApplyCapacityAsync"/>): persists a valid tier per-user, echoes it (200),
+/// rejects a non-null unknown tier without mutating (→ 400), and is scoped to the caller only (D2/MN5).
+/// Class name contains "Capacity" so the WP verification filter (<c>--filter "FullyQualifiedName~Capacity"</c>)
+/// selects it. <c>null</c> is the pre-migration default (treated as Full) — there is no client clear-to-null
+/// path, so it is not exercised here.
+/// </summary>
+public class CapacityAllowlistTests
+{
+    [Theory]
+    [InlineData("Full")]
+    [InlineData("Reduced")]
+    [InlineData("Minimal")]
+    public async Task ApplyCapacity_PersistsValidTier_AndEchoes_ForCaller(string tier)
+    {
+        var (factory, _) = NewFactory(out var options);
+        SeedUser(options, userId: 1, householdId: 1, tier: null);
+
+        var (outcome, normalized) =
+            await ChoresEndpoints.ApplyCapacityAsync(factory, userId: 1, tier, CancellationToken.None);
+
+        outcome.Should().Be(ChoresEndpoints.CapacityOutcome.Ok);
+        normalized.Should().Be(tier);
+        ReadTier(options, userId: 1).Should().Be(tier);
+    }
+
+    [Fact]
+    public async Task ApplyCapacity_PersistsViaCanonicalConstants()
+    {
+        var (factory, _) = NewFactory(out var options);
+        SeedUser(options, userId: 1, householdId: 1, tier: null);
+
+        var (outcome, normalized) =
+            await ChoresEndpoints.ApplyCapacityAsync(factory, userId: 1, CapacityTier.Reduced, CancellationToken.None);
+
+        outcome.Should().Be(ChoresEndpoints.CapacityOutcome.Ok);
+        normalized.Should().Be(CapacityTier.Reduced);
+        ReadTier(options, userId: 1).Should().Be(CapacityTier.Reduced);
+    }
+
+    [Fact]
+    public async Task ApplyCapacity_RejectsUnknownTier_WithoutMutating()
+    {
+        var (factory, _) = NewFactory(out var options);
+        SeedUser(options, userId: 1, householdId: 1, tier: CapacityTier.Full);
+
+        var (outcome, normalized) =
+            await ChoresEndpoints.ApplyCapacityAsync(factory, userId: 1, "Halftime", CancellationToken.None);
+
+        outcome.Should().Be(ChoresEndpoints.CapacityOutcome.InvalidTier);
+        normalized.Should().BeNull();
+        ReadTier(options, userId: 1).Should().Be(CapacityTier.Full); // unchanged, never coerced
+    }
+
+    [Fact]
+    public async Task ApplyCapacity_RejectsWrongCasing_WithoutCoercing()
+    {
+        // The allowlist is exact-match canonical (no ad-hoc casings, D2/A6).
+        var (factory, _) = NewFactory(out var options);
+        SeedUser(options, userId: 1, householdId: 1, tier: null);
+
+        var (outcome, _) =
+            await ChoresEndpoints.ApplyCapacityAsync(factory, userId: 1, "reduced", CancellationToken.None);
+
+        outcome.Should().Be(ChoresEndpoints.CapacityOutcome.InvalidTier);
+        ReadTier(options, userId: 1).Should().BeNull(); // unchanged
+    }
+
+    [Fact]
+    public async Task ApplyCapacity_IsScopedToCaller_DoesNotTouchOtherUser()
+    {
+        var (factory, _) = NewFactory(out var options);
+        SeedUser(options, userId: 1, householdId: 1, tier: null);
+        SeedUser(options, userId: 2, householdId: 1, tier: CapacityTier.Full);
+
+        await ChoresEndpoints.ApplyCapacityAsync(factory, userId: 1, CapacityTier.Minimal, CancellationToken.None);
+
+        ReadTier(options, userId: 1).Should().Be(CapacityTier.Minimal);
+        ReadTier(options, userId: 2).Should().Be(CapacityTier.Full); // other caller untouched (MN5)
+    }
+
+    // ─── Helpers ────────────────────────────────────────────────────────────────────
+
+    private static (IDbContextFactory<ApplicationDbContext> Factory, DbContextOptions<ApplicationDbContext> Options)
+        NewFactory(out DbContextOptions<ApplicationDbContext> options)
+    {
+        options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        var captured = options;
+        var mock = new Mock<IDbContextFactory<ApplicationDbContext>>();
+        mock.Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new ApplicationDbContext(captured));
+        return (mock.Object, options);
+    }
+
+    private static void SeedUser(DbContextOptions<ApplicationDbContext> options, int userId, int householdId, string? tier)
+    {
+        using var ctx = new ApplicationDbContext(options);
+        if (!ctx.Households.Any(h => h.Id == householdId))
+        {
+            ctx.Households.Add(new Household { Id = householdId, Name = $"H{householdId}" });
+        }
+        ctx.Users.Add(new User
+        {
+            Id = userId,
+            HouseholdId = householdId,
+            Email = $"u{userId}@b.com",
+            DisplayName = $"User{userId}",
+            PhysicalCapacityTier = tier
+        });
+        ctx.SaveChanges();
+    }
+
+    private static string? ReadTier(DbContextOptions<ApplicationDbContext> options, int userId)
+    {
+        using var ctx = new ApplicationDbContext(options);
+        return ctx.Users.Single(u => u.Id == userId).PhysicalCapacityTier;
+    }
+}

--- a/tests/FamilyCoordinationApp.Tests/Services/ChoreEquityCalculatorTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/ChoreEquityCalculatorTests.cs
@@ -287,6 +287,138 @@ public class ChoreEquityCalculatorTests
             m.SharePct.Should().BeInRange(0.0, 100.0, "sharePct is PERCENT not fraction"));
     }
 
+    // ---- Capacity weighting → ExpectedSharePct (Phase 15 WP-05, D3) --------------------------------
+
+    private static IReadOnlyDictionary<int, string?> Tiers(params (int UserId, string? Tier)[] entries) =>
+        entries.ToDictionary(e => e.UserId, e => e.Tier);
+
+    [Fact]
+    public void Compute_ExpectedSharePct_WorkedExample_FullFullMinimal()
+    {
+        // D3 worked example: members {Full, Full, Minimal} → weights {1.0, 1.0, 0.15}, Σ = 2.15.
+        //   Alice: 100 * 1.0  / 2.15 ≈ 46.5
+        //   Bob:   100 * 1.0  / 2.15 ≈ 46.5
+        //   Carol: 100 * 0.15 / 2.15 ≈ 7.0
+        // Unrounded doubles — assert ±0.1. Completions are irrelevant to ExpectedSharePct (it's
+        // capacity-only), so use any.
+        var now = Utc0(2026, 6, 15, 12);
+        var completions = new[]
+        {
+            Completion(userId: 1, Utc0(2026, 6, 15, 10), effortPoints: 4),
+        };
+        var members = new[] { Member(1, "Alice"), Member(2, "Bob"), Member(3, "Carol") };
+        var tiers = Tiers((1, "Full"), (2, "Full"), (3, "Minimal"));
+
+        var result = _calc.Compute(completions, members, EquityWindow.Week, now, Utc, tiers);
+
+        var alice = result.Members.Single(m => m.UserId == 1);
+        var bob = result.Members.Single(m => m.UserId == 2);
+        var carol = result.Members.Single(m => m.UserId == 3);
+
+        alice.ExpectedSharePct.Should().BeApproximately(46.5, 0.1);
+        bob.ExpectedSharePct.Should().BeApproximately(46.5, 0.1);
+        carol.ExpectedSharePct.Should().BeApproximately(7.0, 0.1);
+
+        // ExpectedSharePct is a closed distribution — sums to ~100.
+        result.Members.Sum(m => m.ExpectedSharePct).Should().BeApproximately(100.0, 0.01);
+    }
+
+    [Fact]
+    public void Compute_ExpectedSharePct_AbsentTierMap_FallsBackToFlatDistribution()
+    {
+        // No tiers passed (the digest call site path) ⇒ every member Full ⇒ flat 100/N each.
+        var now = Utc0(2026, 6, 15, 12);
+        var completions = new[]
+        {
+            Completion(userId: 1, Utc0(2026, 6, 15, 10), effortPoints: 5),
+            Completion(userId: 2, Utc0(2026, 6, 15, 11), effortPoints: 1),
+        };
+        var members = new[] { Member(1, "Alice"), Member(2, "Bob"), Member(3, "Carol") };
+
+        var result = _calc.Compute(completions, members, EquityWindow.Week, now, Utc);
+
+        result.Members.Should().AllSatisfy(m =>
+            m.ExpectedSharePct.Should().BeApproximately(100.0 / 3.0, 0.0001,
+                "absent tier map ⇒ all Full ⇒ flat distribution (mirrors EqualSharePct's even split)"));
+    }
+
+    [Fact]
+    public void Compute_ExpectedSharePct_NullAndUnrecognizedTiers_TreatedAsFull()
+    {
+        // A null tier and an unrecognized string both weight as Full (1.0). With one explicit Full,
+        // all three are Full ⇒ flat distribution.
+        var now = Utc0(2026, 6, 15, 12);
+        var members = new[] { Member(1, "Alice"), Member(2, "Bob"), Member(3, "Carol") };
+        var tiers = Tiers((1, "Full"), (2, null), (3, "bogus-tier"));
+
+        var result = _calc.Compute(Array.Empty<ChoreCompletion>(), members, EquityWindow.Week, now, Utc, tiers);
+
+        result.Members.Should().AllSatisfy(m =>
+            m.ExpectedSharePct.Should().BeApproximately(100.0 / 3.0, 0.0001));
+    }
+
+    [Fact]
+    public void Compute_ExpectedSharePct_AllMinimal_NoDivideByZero_EqualDistribution()
+    {
+        // All-Minimal household: weights {0.15, 0.15} → Σ = 0.30 > 0, normalizes to equal 50/50.
+        // No divide-by-zero, no NaN (the D3 Σ==0 guard is belt-and-suspenders since Minimal=0.15>0).
+        var now = Utc0(2026, 6, 15, 12);
+        var members = new[] { Member(1, "Alice"), Member(2, "Bob") };
+        var tiers = Tiers((1, "Minimal"), (2, "Minimal"));
+
+        var result = _calc.Compute(Array.Empty<ChoreCompletion>(), members, EquityWindow.Week, now, Utc, tiers);
+
+        result.Members.Should().AllSatisfy(m =>
+        {
+            m.ExpectedSharePct.Should().BeApproximately(50.0, 0.0001);
+            double.IsNaN(m.ExpectedSharePct).Should().BeFalse("ExpectedSharePct must never be NaN");
+        });
+    }
+
+    [Fact]
+    public void Compute_ExpectedSharePct_EmptyHousehold_NoThrow()
+    {
+        // Empty member list with a (non-empty but irrelevant) tier map ⇒ no members, no throw, no NaN.
+        var now = Utc0(2026, 6, 15, 12);
+        var tiers = Tiers((99, "Minimal"));
+
+        var act = () => _calc.Compute(
+            Array.Empty<ChoreCompletion>(), Array.Empty<MemberDto>(), EquityWindow.Week, now, Utc, tiers);
+
+        act.Should().NotThrow();
+        act().Members.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Compute_AddingTierMap_DoesNotChangeRawSharePctOrEqualSharePct()
+    {
+        // V1 invariant: capacity weighting touches ONLY ExpectedSharePct. SharePct / EqualSharePct are
+        // byte-identical whether or not a tier map is supplied (D1 — raw shares stay raw).
+        var now = Utc0(2026, 6, 15, 12);
+        var completions = new[]
+        {
+            Completion(userId: 1, Utc0(2026, 6, 15, 9), effortPoints: 3),
+            Completion(userId: 1, Utc0(2026, 6, 15, 10), effortPoints: 2),
+            Completion(userId: 2, Utc0(2026, 6, 15, 11), effortPoints: 4),
+            Completion(userId: 3, Utc0(2026, 6, 15, 12), effortPoints: 3),
+        };
+        var members = new[] { Member(1, "Alice"), Member(2, "Bob"), Member(3, "Carol") };
+        var tiers = Tiers((1, "Full"), (2, "Reduced"), (3, "Minimal"));
+
+        var withoutTiers = _calc.Compute(completions, members, EquityWindow.Week, now, Utc);
+        var withTiers = _calc.Compute(completions, members, EquityWindow.Week, now, Utc, tiers);
+
+        withTiers.EqualSharePct.Should().Be(withoutTiers.EqualSharePct);
+        foreach (var m in withTiers.Members)
+        {
+            var baseline = withoutTiers.Members.Single(b => b.UserId == m.UserId);
+            m.SharePct.Should().Be(baseline.SharePct, "capacity weighting must not change the RAW share (D1)");
+        }
+        // But ExpectedSharePct DID change away from flat for the non-Full members.
+        withTiers.Members.Single(m => m.UserId == 3).ExpectedSharePct
+            .Should().BeLessThan(100.0 / 3.0, "a Minimal member's expected reference is below the even split");
+    }
+
     // ---- Determinism — no DateTime.UtcNow inside (V1) -----------------------------------------------
 
     [Fact]

--- a/tests/FamilyCoordinationApp.Tests/Services/ChoreEquityDtoContractTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/ChoreEquityDtoContractTests.cs
@@ -72,6 +72,34 @@ public class ChoreEquityDtoContractTests
                 SharePct: 25.0),
         };
 
+        // Planning footprint (Phase 15): per-member, all-time, un-blended labeled tallies. Hand-picked so
+        // Alice leads every lane, Bob trails, and Carol is an all-zero row (proving zero rows still appear).
+        // These exact values appear in equity.json.
+        var planning = new List<MemberPlanningDto>
+        {
+            new(
+                UserId: 1,
+                DisplayName: "Alice",
+                ChoresSetUp: 19,
+                RecipesAdded: 6,
+                ListItemsCurated: 28,
+                HandOffs: 4),
+            new(
+                UserId: 2,
+                DisplayName: "Bob",
+                ChoresSetUp: 3,
+                RecipesAdded: 2,
+                ListItemsCurated: 5,
+                HandOffs: 1),
+            new(
+                UserId: 3,
+                DisplayName: "Carol",
+                ChoresSetUp: 0,
+                RecipesAdded: 0,
+                ListItemsCurated: 0,
+                HandOffs: 0),
+        };
+
         return new ChoreEquityDto(
             Window: "week",
             TotalPoints: 12,
@@ -79,7 +107,10 @@ public class ChoreEquityDtoContractTests
             EqualSharePct: 33.3,
             FallingBehindCount: 2,
             UpForGrabsCount: 3,
-            Members: members);
+            Members: members)
+        {
+            Planning = planning,
+        };
     }
 
     [Fact]
@@ -110,11 +141,16 @@ public class ChoreEquityDtoContractTests
         // Top-level camelCase property set is frozen (M7 — added/removed keys break this).
         root.Select(kvp => kvp.Key).Should().BeEquivalentTo(
             "window", "totalPoints", "totalCompletions", "equalSharePct",
-            "fallingBehindCount", "upForGrabsCount", "members");
+            "fallingBehindCount", "upForGrabsCount", "members", "planning");
 
         var firstMember = root["members"]!.AsArray()[0]!.AsObject();
         firstMember.Select(kvp => kvp.Key).Should().BeEquivalentTo(
             "userId", "displayName", "initials", "pictureUrl", "points", "completions", "sharePct");
+
+        // Per-member planning object key set is frozen too (Phase 15 — mirrored by island types.ts).
+        var firstPlanning = root["planning"]!.AsArray()[0]!.AsObject();
+        firstPlanning.Select(kvp => kvp.Key).Should().BeEquivalentTo(
+            "userId", "displayName", "choresSetUp", "recipesAdded", "listItemsCurated", "handOffs");
 
         // sharePct and equalSharePct are PERCENT 0–100, not fractions 0–1.
         root["equalSharePct"]!.GetValue<double>().Should().BeGreaterThan(1.0,

--- a/tests/FamilyCoordinationApp.Tests/Services/ChoreEquityDtoContractTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/ChoreEquityDtoContractTests.cs
@@ -44,6 +44,14 @@ public class ChoreEquityDtoContractTests
         //   Carol:  3 pts, 1 completion  → sharePct = round(100 * 3/12, 1) = 25.0
         //   equalSharePct = round(100/3, 1) = 33.3
         // These specific values appear in equity.json to prove the 0–100 scale is unambiguous.
+        //
+        // expectedSharePct (Phase 15 WP-05, D1/D3) is the capacity-WEIGHTED fair share — UNROUNDED
+        // (the island formats). The representative household models one of each tier:
+        //   Alice = Full (1.0), Bob = Reduced (0.5), Carol = Minimal (0.15) → Σweight = 1.65.
+        //   Alice: 100 * 1.0  / 1.65 = 60.60606060606061
+        //   Bob:   100 * 0.5  / 1.65 = 30.303030303030305
+        //   Carol: 100 * 0.15 / 1.65 = 9.090909090909092
+        // SharePct stays RAW (digest-safe); expectedSharePct is additive only.
         var members = new List<MemberShareDto>
         {
             new(
@@ -53,7 +61,10 @@ public class ChoreEquityDtoContractTests
                 PictureUrl: "https://example.com/alice.png",
                 Points: 5,
                 Completions: 2,
-                SharePct: 41.7),
+                SharePct: 41.7)
+            {
+                ExpectedSharePct = 100.0 * 1.0 / 1.65,
+            },
             new(
                 UserId: 2,
                 DisplayName: "Bob",
@@ -61,7 +72,10 @@ public class ChoreEquityDtoContractTests
                 PictureUrl: null,
                 Points: 4,
                 Completions: 1,
-                SharePct: 33.3),
+                SharePct: 33.3)
+            {
+                ExpectedSharePct = 100.0 * 0.5 / 1.65,
+            },
             new(
                 UserId: 3,
                 DisplayName: "Carol",
@@ -69,7 +83,10 @@ public class ChoreEquityDtoContractTests
                 PictureUrl: null,
                 Points: 3,
                 Completions: 1,
-                SharePct: 25.0),
+                SharePct: 25.0)
+            {
+                ExpectedSharePct = 100.0 * 0.15 / 1.65,
+            },
         };
 
         // Planning footprint (Phase 15): per-member, all-time, un-blended labeled tallies. Hand-picked so
@@ -110,6 +127,8 @@ public class ChoreEquityDtoContractTests
             Members: members)
         {
             Planning = planning,
+            // The requesting user's own tier (Phase 15 WP-05, P4); here the caller is Alice (Full).
+            CallerCapacityTier = "Full",
         };
     }
 
@@ -141,11 +160,12 @@ public class ChoreEquityDtoContractTests
         // Top-level camelCase property set is frozen (M7 — added/removed keys break this).
         root.Select(kvp => kvp.Key).Should().BeEquivalentTo(
             "window", "totalPoints", "totalCompletions", "equalSharePct",
-            "fallingBehindCount", "upForGrabsCount", "members", "planning");
+            "fallingBehindCount", "upForGrabsCount", "members", "planning", "callerCapacityTier");
 
         var firstMember = root["members"]!.AsArray()[0]!.AsObject();
         firstMember.Select(kvp => kvp.Key).Should().BeEquivalentTo(
-            "userId", "displayName", "initials", "pictureUrl", "points", "completions", "sharePct");
+            "userId", "displayName", "initials", "pictureUrl", "points", "completions", "sharePct",
+            "expectedSharePct");
 
         // Per-member planning object key set is frozen too (Phase 15 — mirrored by island types.ts).
         var firstPlanning = root["planning"]!.AsArray()[0]!.AsObject();

--- a/tests/FamilyCoordinationApp.Tests/Services/ChorePlanningCalculatorTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/ChorePlanningCalculatorTests.cs
@@ -1,0 +1,189 @@
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Services;
+using FamilyCoordinationApp.Services.Dtos;
+using FluentAssertions;
+
+namespace FamilyCoordinationApp.Tests.Services;
+
+/// <summary>
+/// Unit tests for the pure <see cref="ChorePlanningCalculator"/>. The calculator takes NO clock and NO
+/// window — planning is all-time by construction — so these are fully deterministic. No DB, no I/O. The
+/// caller is responsible for HouseholdId scoping; these tests feed already-scoped sequences.
+/// </summary>
+public class ChorePlanningCalculatorTests
+{
+    private readonly ChorePlanningCalculator _calc = new();
+
+    private static MemberDto Member(int userId, string name) =>
+        new(userId, name, name[..2].ToUpperInvariant(), PictureUrl: null);
+
+    private static Chore Chore(int enteredByUserId) =>
+        new() { HouseholdId = 1, EnteredByUserId = enteredByUserId };
+
+    private static Recipe Recipe(int? createdByUserId, bool isDeleted = false) =>
+        new() { HouseholdId = 1, CreatedByUserId = createdByUserId, IsDeleted = isDeleted };
+
+    private static ShoppingListItem Item(int? addedByUserId, bool isManuallyAdded = true) =>
+        new() { HouseholdId = 1, AddedByUserId = addedByUserId, IsManuallyAdded = isManuallyAdded };
+
+    private static ChoreEvent Event(ChoreEventType type, int actorUserId, int? targetUserId) =>
+        new() { HouseholdId = 1, Type = type, ActorUserId = actorUserId, TargetUserId = targetUserId };
+
+    private static MemberPlanningDto For(IReadOnlyList<MemberPlanningDto> rows, int userId) =>
+        rows.Single(r => r.UserId == userId);
+
+    // ---- Hand-off filter: only true assignments-to-others count, credited to the actor (V6, D6) -------
+
+    [Fact]
+    public void Compute_HandOffLane_CountsOnlyHandedOffToOthers_CreditedToActor()
+    {
+        var members = new[] { Member(1, "Alice"), Member(2, "Bob") };
+        var events = new[]
+        {
+            // Real hand-off to another member → counts, credited to the ACTOR (Alice).
+            Event(ChoreEventType.HandedOff, actorUserId: 1, targetUserId: 2),
+            // Self-hand-off (target == actor) → excluded by the actor != target guard.
+            Event(ChoreEventType.HandedOff, actorUserId: 1, targetUserId: 1),
+            // HandedOff with a null target → excluded (no real assignment-to-another).
+            Event(ChoreEventType.HandedOff, actorUserId: 2, targetUserId: null),
+            // Non-hand-off event types are excluded by the PRIMARY Type filter even with a distinct target.
+            Event(ChoreEventType.Claimed, actorUserId: 2, targetUserId: 1),
+            Event(ChoreEventType.Dropped, actorUserId: 2, targetUserId: 1),
+            Event(ChoreEventType.AutoReleased, actorUserId: 2, targetUserId: 1),
+        };
+
+        var result = _calc.Compute(members, Array.Empty<Chore>(), Array.Empty<Recipe>(), Array.Empty<ShoppingListItem>(), events);
+
+        For(result, 1).HandOffs.Should().Be(1, "only the genuine hand-off-to-another counts, credited to the actor");
+        For(result, 2).HandOffs.Should().Be(0, "the null-target and non-hand-off events contribute nothing");
+    }
+
+    // ---- Null-author rows are skipped (no credit for unattributed work) ------------------------------
+
+    [Fact]
+    public void Compute_NullAuthors_AreSkipped()
+    {
+        var members = new[] { Member(1, "Alice") };
+        var recipes = new[] { Recipe(createdByUserId: null), Recipe(createdByUserId: 1) };
+        var items = new[] { Item(addedByUserId: null), Item(addedByUserId: 1) };
+
+        var result = _calc.Compute(members, Array.Empty<Chore>(), recipes, items, Array.Empty<ChoreEvent>());
+
+        For(result, 1).RecipesAdded.Should().Be(1, "the null-author recipe is skipped");
+        For(result, 1).ListItemsCurated.Should().Be(1, "the null-author list item is skipped");
+    }
+
+    // ---- Deleted recipes + auto-generated (non-manual) list items are excluded -----------------------
+
+    [Fact]
+    public void Compute_DeletedRecipes_AndNonManualItems_AreExcluded()
+    {
+        var members = new[] { Member(1, "Alice") };
+        var recipes = new[]
+        {
+            Recipe(createdByUserId: 1, isDeleted: false),
+            Recipe(createdByUserId: 1, isDeleted: true), // excluded
+        };
+        var items = new[]
+        {
+            Item(addedByUserId: 1, isManuallyAdded: true),
+            Item(addedByUserId: 1, isManuallyAdded: false), // excluded (from meal plan, not curated)
+        };
+
+        var result = _calc.Compute(members, Array.Empty<Chore>(), recipes, items, Array.Empty<ChoreEvent>());
+
+        For(result, 1).RecipesAdded.Should().Be(1, "the deleted recipe is excluded");
+        For(result, 1).ListItemsCurated.Should().Be(1, "the non-manually-added item is excluded");
+    }
+
+    // ---- Non-member authors get no credit; only supplied members are credited ------------------------
+
+    [Fact]
+    public void Compute_OnlyCreditsSuppliedMembers()
+    {
+        var members = new[] { Member(1, "Alice") };
+        // User 99 is not in the supplied member list — their rows are silently ignored.
+        var chores = new[] { Chore(enteredByUserId: 1), Chore(enteredByUserId: 99) };
+
+        var result = _calc.Compute(members, chores, Array.Empty<Recipe>(), Array.Empty<ShoppingListItem>(), Array.Empty<ChoreEvent>());
+
+        result.Should().ContainSingle();
+        For(result, 1).ChoresSetUp.Should().Be(1, "only the supplied member's chore is credited");
+    }
+
+    // ---- Per-member zero rows appear (mirror the equity calculator's "all members appear" rule) ------
+
+    [Fact]
+    public void Compute_MemberWithNoActivity_AppearsWithAllZeroRow()
+    {
+        var members = new[] { Member(1, "Alice"), Member(2, "Bob") };
+        var chores = new[] { Chore(enteredByUserId: 1) };
+
+        var result = _calc.Compute(members, chores, Array.Empty<Recipe>(), Array.Empty<ShoppingListItem>(), Array.Empty<ChoreEvent>());
+
+        result.Should().HaveCount(2);
+        var bob = For(result, 2);
+        bob.ChoresSetUp.Should().Be(0);
+        bob.RecipesAdded.Should().Be(0);
+        bob.ListItemsCurated.Should().Be(0);
+        bob.HandOffs.Should().Be(0);
+    }
+
+    // ---- Multi-member distribution across all four lanes ---------------------------------------------
+
+    [Fact]
+    public void Compute_DistributesAllFourLanes_AcrossMembers()
+    {
+        var members = new[] { Member(1, "Alice"), Member(2, "Bob") };
+
+        var chores = new[]
+        {
+            Chore(enteredByUserId: 1), Chore(enteredByUserId: 1), Chore(enteredByUserId: 2),
+        };
+        var recipes = new[]
+        {
+            Recipe(createdByUserId: 1), Recipe(createdByUserId: 2), Recipe(createdByUserId: 2),
+        };
+        var items = new[]
+        {
+            Item(addedByUserId: 1), Item(addedByUserId: 1), Item(addedByUserId: 1), Item(addedByUserId: 2),
+        };
+        var events = new[]
+        {
+            Event(ChoreEventType.HandedOff, actorUserId: 1, targetUserId: 2),
+            Event(ChoreEventType.HandedOff, actorUserId: 2, targetUserId: 1),
+            Event(ChoreEventType.HandedOff, actorUserId: 2, targetUserId: 1),
+        };
+
+        var result = _calc.Compute(members, chores, recipes, items, events);
+
+        var alice = For(result, 1);
+        alice.ChoresSetUp.Should().Be(2);
+        alice.RecipesAdded.Should().Be(1);
+        alice.ListItemsCurated.Should().Be(3);
+        alice.HandOffs.Should().Be(1);
+
+        var bob = For(result, 2);
+        bob.ChoresSetUp.Should().Be(1);
+        bob.RecipesAdded.Should().Be(2);
+        bob.ListItemsCurated.Should().Be(1);
+        bob.HandOffs.Should().Be(2);
+    }
+
+    // ---- All-time invariance: no window, identical inputs → identical counts (V5 unit half) ----------
+
+    [Fact]
+    public void Compute_IsDeterministic_AndTakesNoWindow()
+    {
+        var members = new[] { Member(1, "Alice") };
+        var chores = new[] { Chore(enteredByUserId: 1) };
+        var recipes = new[] { Recipe(createdByUserId: 1) };
+        var items = new[] { Item(addedByUserId: 1) };
+        var events = new[] { Event(ChoreEventType.HandedOff, actorUserId: 1, targetUserId: 2) };
+
+        var r1 = _calc.Compute(members, chores, recipes, items, events);
+        var r2 = _calc.Compute(members, chores, recipes, items, events);
+
+        r1.Should().BeEquivalentTo(r2, "the calculator is pure, all-time, and takes no window or clock");
+    }
+}

--- a/tests/FamilyCoordinationApp.Tests/Services/DigestBuilderTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/DigestBuilderTests.cs
@@ -81,6 +81,32 @@ public class DigestBuilderTests
     }
 
     [Fact]
+    public void Build_DistributionUnaffectedBy_ExpectedSharePct_DigestByteIdentical()
+    {
+        // Phase 15 WP-05 (MN2/D1 seam proof): MemberEquityShare gained an additive ExpectedSharePct init
+        // property. The digest reads ONLY DisplayName / Points / SharePct by name — setting ExpectedSharePct
+        // (the capacity-weighted reference) must NOT change a single digest member line.
+        var withoutExpected = ThreeMemberEquity();
+        var withExpected = new ChoreEquityResult(
+            withoutExpected.TotalPoints,
+            withoutExpected.TotalCompletions,
+            withoutExpected.EqualSharePct,
+            withoutExpected.Members
+                // Same positional fields; only the new init property differs (arbitrary non-flat values).
+                .Select((m, i) => m with { ExpectedSharePct = 12.3 + i })
+                .ToList());
+
+        var baseline = _builder.Build("Heath", withoutExpected, MixedDueness(), upForGrabsCount: 3);
+        var withCapacity = _builder.Build("Heath", withExpected, MixedDueness(), upForGrabsCount: 3);
+
+        // The distribution member lines (DisplayName / Points / SharePct) are byte-identical.
+        withCapacity.Distribution.Should().BeEquivalentTo(baseline.Distribution,
+            "ExpectedSharePct is purely additive — the digest never reads it (MN2/D1)");
+        withCapacity.TotalPoints.Should().Be(baseline.TotalPoints);
+        withCapacity.CollectiveHeadline.Should().Be(baseline.CollectiveHeadline);
+    }
+
+    [Fact]
     public void Build_DistributionOrderedAlphabetically()
     {
         // Members arrive in points-desc order from the equity result (Alice, Bob, Carol).


### PR DESCRIPTION
## Why

The chores **Equity** lens measures contribution as a single dimension — physical board completions — and **systematically mismeasures planning/coordination labor**. A read-only prod probe (household 1) proved it: **Natalie (`mamaheath`) set up 19 of 39 chores (49%) and curated 28 of 42 manual shopping items**, yet the physical-points lens ranks her at **~3%** vs a flat 25% share. This makes the lens honest about what it measures, and credits the planning labor **already attributed in the DB** — with **no new user logging**.

## What (three independently-shippable rungs → 6 WPs)

- **Rung 1 — honest rename** (WP-01): "Equity" → **"Board load"** chip / "Physical board-load — this week" heading. Lens *id* `equity` unchanged. Copy only.
- **Rung 3 — planning footprint lanes** (WP-02/03): un-blended, **labeled tallies** ("19 chores set up · 6 recipes · 28 list items · 4 hand-offs") from authorship already in the DB (`Chore.EnteredByUserId`, `Recipe.CreatedByUserId`, `ShoppingListItem` manual adds, `ChoreEvent` hand-offs). All-time footprint. Gated on its **own** signal so it shows even when physical completions = 0 (the founding case). **No summed/blended score.**
- **Rung 2 — capacity-aware reference** (WP-04/05/06): self-set `PhysicalCapacityTier` (Full/Reduced/Minimal) → a **new** `ExpectedSharePct` per member (raw `SharePct`/`EqualSharePct` untouched, so the digest is byte-identical). Self-only PATCH `/api/chores/me/capacity`.

## Key design decisions
- Capacity-awareness is a **new field**, never a mutation of existing shares → **digest stays byte-identical** (verified).
- Planning lanes ride the existing `ChoreEquityDto` (one fetch); additive members are **non-positional `init` properties** so no existing construction site changes.
- **No lane blending** — labeled tallies only (a single "score" would re-create the indefensible exchange rate the design exists to avoid).
- Equity stays isolated from the board contract (no `board.json`/board-DTO changes).

## Deferred (out of this slice)
- Weekly Discord **digest untouched**.
- Capacity-aware **suggestion/rebalancing mechanism** → separate follow-up spec (Rung 4).
- `MealPlanEntry` creator-attribution migration — **the probe found zero meal-plan signal**, so not built.

## Verification
- ✅ `dotnet build` clean; **47/47** feature unit + contract tests pass (calculator math incl. the D3 capacity worked example, planning aggregation, hand-off filtering, contract lockstep, digest-unchanged seam, capacity allowlist).
- ✅ Contract lockstep held: `equity.json` + `ChoreEquityDtoContractTests` + island `types.ts` move together; `board.json` / board contract **untouched**.
- ✅ Island `npx svelte-check` 0/0, build clean; shopping-list island untouched.
- ✅ Migration is additive + nullable (applies on first request, no backfill).
- ⏳ **Owed (manual):** browser-verify on `:8080` (rebuilt island image) — visual render of the planning lanes + capacity selector + neutral framing. No Playwright harness for the chores island.

## Provenance
Spec bundle: `data/outputs/workshops/chores-v1.5-equity-measurement/`. Grilled to a BUILD verdict, then reviewed: 3 fresh-eyes waves + a 5-lens council (2 opus local + codex/gpt/gemini external), ~12 amendments applied. Roadmap: Phase 15. 🤖 Autonomous build.