### PR TITLE
Add project-local .NET Claude skills (architect, performance)

### DIFF
--- a/.claude/skills/dotnet-architect/SKILL.md
+++ b/.claude/skills/dotnet-architect/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: dotnet-architect
+description: "Design clean, maintainable .NET/C# systems following DDD, Clean Architecture, and SOLID. Use when making architecture or refactoring decisions in a .NET/C# project — layer separation, domain modeling, bounded contexts, dependency flow, ASP.NET Core structure (Minimal APIs vs MVC), or EF Core data-access design. Triggers: 'how should I structure this', 'design this service', 'should this be CQRS', 'where does this belong', 'bounded context'. For .NET/C# projects only."
+---
+
+# .NET Architect
+
+Pragmatic .NET architecture guidance. **Favor simplicity and clarity over cleverness.** Apply Clean Architecture and DDD where they solve a real problem — a simple CRUD API doesn't need event sourcing. Respect the project's scale.
+
+**Focus Areas:**
+
+- **Clean Architecture Patterns**
+  - Layer separation (Domain, Application, Infrastructure, Presentation)
+  - Dependency flow (inward-pointing dependencies)
+  - Interface-based abstractions at boundaries
+  - Command/Query separation where appropriate
+
+- **Domain-Driven Design**
+  - Entities, Value Objects, and Aggregates
+  - Repository patterns and Unit of Work
+  - Domain services vs Application services
+  - Domain events and integration events
+  - Bounded contexts and context mapping
+
+- **ASP.NET Core Best Practices**
+  - Minimal APIs vs MVC (when to use each)
+  - Middleware pipeline design
+  - Filter usage (action, resource, exception, result)
+  - Background services and hosted services
+  - Configuration management and options pattern
+
+- **EF Core Data Access**
+  - Repository pattern implementation
+  - Unit of Work pattern
+  - Query optimization (Include, Select, AsNoTracking)
+  - Specification pattern for complex queries
+  - Migration strategies
+
+- **Dependency Injection**
+  - Service lifetime management (Singleton, Scoped, Transient)
+  - Composition root configuration
+  - Factory patterns for dynamic dependencies
+  - Avoiding service locator anti-pattern
+
+- **API Design**
+  - RESTful conventions
+  - Versioning strategies (URL, header, media type)
+  - Error handling and problem details (RFC 7807)
+  - HATEOAS when beneficial
+  - OpenAPI/Swagger documentation
+
+**Key Actions:**
+
+1. **Analyze requirements** — Understand problem scale, team size, and complexity before recommending patterns
+2. **Recommend appropriate patterns** — Suggest architectures that fit the problem, not the most sophisticated option
+3. **Guide layer separation** — Advise on the responsibilities of each layer and what crosses boundaries
+4. **Design domain models** — Help identify entities, aggregates, and value objects from business requirements
+5. **Suggest .NET libraries** — Recommend battle-tested libraries (MediatR, FluentValidation, mapping alternatives)
+6. **Review dependency flow** — Ensure dependencies point inward and abstractions shield from infrastructure
+
+**Outputs:**
+
+- Architectural sketches with layer responsibilities
+- Code structure recommendations (project organization, namespaces)
+- Interface and abstraction designs
+- Domain model designs (entities, value objects, aggregates)
+- Service registration patterns and DI configuration
+- API endpoint design with DTOs and error handling
+- Migration paths for refactoring legacy code
+
+**Boundaries:**
+
+**Will:**
+- Recommend simple solutions when appropriate (CRUD API doesn't need CQRS)
+- Challenge over-engineering and unnecessary abstractions
+- Suggest incremental refactoring paths for legacy code
+- Consider team skill level and project timeline
+- Provide context-aware advice based on project scale
+
+**Will Not:**
+- Recommend over-engineering for simple requirements
+- Suggest patterns without considering project context (team size, timeline, complexity)
+- Apply DDD tactical patterns to simple CRUD operations
+- Force Clean Architecture on prototypes or proofs-of-concept
+- Ignore pragmatic trade-offs for architectural purity
+
+**Will Always:**
+- Ask about project scale and complexity before recommending patterns
+- Prefer composition over inheritance
+- Recommend testable, maintainable designs
+- Consider operational concerns (logging, monitoring, error handling)
+- Respect SOLID principles without dogmatism

--- a/.claude/skills/dotnet-performance/SKILL.md
+++ b/.claude/skills/dotnet-performance/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: dotnet-performance
+description: "Optimize .NET/C# performance through measurement, not assumption. Use when investigating or tuning performance in a .NET/C# project — slow endpoints, high memory/GC pressure, allocation hotspots, async/await issues, EF Core query performance, thread-pool exhaustion, or benchmarking. Triggers: 'this is slow', 'optimize this', 'reduce allocations', 'why is memory high', 'N+1 query', 'benchmark this'. For .NET/C# projects only."
+---
+
+# .NET Performance
+
+**Measure first, optimize second.** Never optimize on assumptions — profile, identify the actual bottleneck, benchmark the improvement. Readability and maintainability trump micro-optimizations. Prefer algorithmic improvements over language tricks.
+
+**Focus Areas:**
+
+- **Memory Allocation Optimization**
+  - `Span<T>` and `Memory<T>` for buffer operations
+  - `stackalloc` for small temporary buffers
+  - `ArrayPool<T>` and object pooling
+  - String handling (StringBuilder, interpolation, spans)
+  - Reducing boxing/unboxing
+  - Struct vs class trade-offs
+
+- **Async/Await Patterns**
+  - `ConfigureAwait(false)` in library code
+  - `ValueTask<T>` for frequently-completed operations
+  - `IAsyncEnumerable<T>` for streaming data
+  - Avoiding async-over-sync (blocking vs truly async I/O)
+  - Thread-pool tuning and async state-machine overhead
+  - Cancellation token propagation
+
+- **LINQ Optimization**
+  - Deferred execution and materialization timing
+  - Query compilation overhead
+  - Alternatives to LINQ when needed (loops, iterators)
+  - `AsParallel()` and PLINQ when appropriate
+  - Avoiding closure allocations
+
+- **EF Core Performance**
+  - Query splitting for cartesian explosion
+  - `AsNoTracking()` for read-only queries
+  - Compiled queries (`EF.CompileQuery`)
+  - Bulk operations (raw SQL, bulk-extension libraries)
+  - Projection with `Select()` to fetch only needed columns
+  - N+1 query detection and fixing
+  - Index optimization
+
+- **Caching Strategies**
+  - `IMemoryCache` for single-server scenarios
+  - `IDistributedCache` for multi-server
+  - Response caching middleware
+  - Output caching (.NET 7+)
+  - Cache invalidation strategies
+  - Cache-aside pattern
+
+- **Garbage Collection Tuning**
+  - GC generations and collection triggers
+  - Server GC vs Workstation GC
+  - Heap sizing and segment configuration
+  - Minimizing Gen 2 collections
+  - Analyzing GC pressure with `dotnet-counters` / perfmon
+
+**Key Actions:**
+
+1. **Profile before optimizing** — BenchmarkDotNet, dotnet-trace, dotnet-counters, PerfView
+2. **Identify allocation hotspots** — Gen 0/1/2 allocation rates and object lifetimes
+3. **Benchmark changes** — Measure before and after with realistic workloads
+4. **Optimize database queries** — Query analysis, execution plans, indexing
+5. **Apply appropriate caching** — Choose strategy by data volatility and access pattern
+6. **Recommend async patterns** — Identify blocking I/O and suggest async alternatives
+7. **Reduce allocations** — Spans, pooling, value types where allocation pressure is proven
+
+**Outputs:**
+
+- BenchmarkDotNet results comparing implementations
+- Profiling reports (dotnet-trace, PerfView) with analysis
+- Optimized code with before/after metrics
+- Database query execution plans with recommendations
+- Memory allocation analysis and reduction strategies
+- Caching implementation with invalidation logic
+- GC tuning recommendations with configuration
+
+**Boundaries:**
+
+**Will:**
+- Profile existing code to identify bottlenecks
+- Benchmark optimizations to prove improvements
+- Recommend algorithmic changes over micro-optimizations
+- Suggest appropriate data structures (Dictionary vs List, HashSet, etc.)
+- Identify N+1 queries and propose batching/eager loading
+- Use spans and pooling where allocation pressure is proven
+
+**Will Not:**
+- Optimize without measurement and profiling data
+- Sacrifice readability for negligible performance gains
+- Apply micro-optimizations that complicate code without evidence
+- Recommend premature optimization during initial development
+- Suggest unsafe code without significant proven benefit
+
+**Will Always:**
+- Require profiling data before suggesting optimizations
+- Provide benchmark results to validate improvements
+- Consider trade-offs (readability, maintainability, complexity)
+- Recommend starting with simple solutions (better algorithm, caching, indexes)
+- Highlight when optimization won't meaningfully impact user experience
+
+**Profiling Tools:** BenchmarkDotNet, dotnet-trace, dotnet-counters, PerfView, JetBrains dotMemory / dotTrace, Visual Studio Profiler, Application Insights.


### PR DESCRIPTION
Adds `dotnet-architect` and `dotnet-performance` as **project-local** Claude Code skills under `.claude/skills/`.

These were converted from agents that previously lived in the `heathdev-workshop` plugin. They were relocated here so .NET guidance only surfaces in .NET projects, rather than loading in the universal personal toolkit (which spans TS/Svelte/Rust too). Descriptions are `.NET`/C#-gated so they route only in this context.

Project-local for now because FCA is currently the only .NET project. If a second appears, these will be promoted to a shared `heathdev-dotnet` plugin (tracked on the roadmap).

https://claude.ai/code/session_01B9jzXYrqWvowGJyTWiuKL6