### PR TITLE
feat(chores): in-app Weekly Recap lens (digest content + week-over-week trend)

### DIFF
--- a/frontend/chores/src/App.svelte
+++ b/frontend/chores/src/App.svelte
@@ -229,7 +229,15 @@
     // Track the window so a switch re-runs this effect.
     const _window = store.equityWindow;
     void _window;
-    if (store.lens === 'equity' && !store.equityLoaded && !store.equityLoading) {
+    // Guard on `!equityError` so a FAILED load does not auto-retry forever: on error
+    // `equityLoaded` stays false, so without this the effect would re-fire the moment
+    // `equityLoading` clears. The explicit Retry (and a window switch) clears the error.
+    if (
+      store.lens === 'equity' &&
+      !store.equityLoaded &&
+      !store.equityLoading &&
+      !store.equityError
+    ) {
       store.loadEquity();
     }
   });
@@ -238,8 +246,15 @@
   // Load the recap payload when the Recap lens is open and the cache is stale.
   // A user who defaulted onto Recap lands here on mount and loads it the same way.
   // The store guards re-entrancy; invalidation (completions/snooze/edit) reloads it.
+  // `!recapError` guard: don't auto-retry a failed load in a loop — the Retry button
+  // (which clears the error) is the re-attempt path.
   $effect(() => {
-    if (store.lens === 'recap' && !store.recapLoaded && !store.recapLoading) {
+    if (
+      store.lens === 'recap' &&
+      !store.recapLoaded &&
+      !store.recapLoading &&
+      !store.recapError
+    ) {
       store.loadRecap();
     }
   });

--- a/frontend/chores/src/App.svelte
+++ b/frontend/chores/src/App.svelte
@@ -8,6 +8,7 @@
   import NeedsAttentionBoard from './lib/components/NeedsAttentionBoard.svelte';
   import RoomsDashboard from './lib/components/RoomsDashboard.svelte';
   import EquityBoard from './lib/components/EquityBoard.svelte';
+  import RecapBoard from './lib/components/RecapBoard.svelte';
   import QuickAddSheet, { type QuickAddValue } from './lib/components/QuickAddSheet.svelte';
   import EditChoreSheet from './lib/components/EditChoreSheet.svelte';
   import HandOffPicker from './lib/components/HandOffPicker.svelte';
@@ -232,6 +233,16 @@
       store.loadEquity();
     }
   });
+
+  // ── Recap fetch-on-open (a second cached fetcher, like equity — M11) ──────
+  // Load the recap payload when the Recap lens is open and the cache is stale.
+  // A user who defaulted onto Recap lands here on mount and loads it the same way.
+  // The store guards re-entrancy; invalidation (completions/snooze/edit) reloads it.
+  $effect(() => {
+    if (store.lens === 'recap' && !store.recapLoaded && !store.recapLoading) {
+      store.loadRecap();
+    }
+  });
 </script>
 
 <div class="ch-container">
@@ -333,6 +344,19 @@
         onRetry={() => store.loadEquity()}
         onCapacity={(t) => store.saveCapacity(t)}
         savingCapacity={store.savingCapacity}
+      />
+    {:else if store.lens === 'recap'}
+      <!--
+        Recap lens — the in-app weekly recap (GET /api/chores/recap). The $effect
+        above fetches it on open; completions/snooze/edit invalidate it (folded into
+        invalidateEquity). Shows the SAME content the Discord digest posts plus the
+        week-over-week trend. Server values only; NO client date math (MN9).
+      -->
+      <RecapBoard
+        recap={store.recap}
+        loading={store.recapLoading}
+        error={store.recapError}
+        onRetry={() => store.loadRecap()}
       />
     {/if}
   {:else if !store.loading}

--- a/frontend/chores/src/lib/api.ts
+++ b/frontend/chores/src/lib/api.ts
@@ -3,6 +3,7 @@ import type {
   ChoreDto,
   ChoreSubtaskDto,
   ChoreEquityDto,
+  ChoreRecapDto,
   EquityWindow,
   CapacityTier,
   RoomDto,
@@ -197,6 +198,14 @@ export async function getEquity(
   window: EquityWindow = 'week',
 ): Promise<ChoreEquityDto> {
   return request<ChoreEquityDto>(`${CHORES_BASE}/equity?window=${window}`);
+}
+
+// ─── Recap read (separate cached payload — like equity, its own endpoint) ─────
+// The in-app weekly recap (current-week digest content + week-over-week trend).
+// Read-only; `weeks` is the trend length (server clamps 1..26).
+
+export async function getRecap(weeks = 8): Promise<ChoreRecapDto> {
+  return request<ChoreRecapDto>(`${CHORES_BASE}/recap?weeks=${weeks}`);
 }
 
 // ─── Chore mutations (WP-11 wires these to optimistic UI + 409 retry) ───────

--- a/frontend/chores/src/lib/components/NeedsAttentionBoard.svelte
+++ b/frontend/chores/src/lib/components/NeedsAttentionBoard.svelte
@@ -66,9 +66,10 @@
     'up-for-grabs': { head: 'Nothing up for grabs.', body: 'Every chore has someone on it. Nice.' },
     mine: { head: 'Nothing on your plate.', body: "You're not holding any chores right now." },
     'needs-attention': { head: 'All clear.', body: 'No active chores right now.' },
-    // The two organizers never render this board, but the map must be total.
+    // The organizers (rooms/equity/recap) never render this board, but the map must be total.
     rooms: { head: 'All clear.', body: 'No active chores right now.' },
     equity: { head: 'All clear.', body: 'No active chores right now.' },
+    recap: { head: 'All clear.', body: 'No active chores right now.' },
   };
   let emptyCopy = $derived(EMPTY_COPY[filterLens] ?? EMPTY_COPY['needs-attention']);
 </script>

--- a/frontend/chores/src/lib/components/RecapBoard.svelte
+++ b/frontend/chores/src/lib/components/RecapBoard.svelte
@@ -1,0 +1,467 @@
+<script lang="ts">
+  import type { ChoreRecapDto } from '../types';
+
+  // ───────────────────────────────────────────────────────────────────────
+  // Recap lens — the in-app view of the weekly recap. Two parts:
+  //   1. THIS WEEK — the SAME content the Discord digest posts (collective
+  //      headline, per-member effort split, "needs attention" chores, "up for
+  //      grabs" count). So the app and the channel never tell a different story.
+  //   2. WEEK OVER WEEK — a column chart of completions per week (the trend the
+  //      digest can't show), current week highlighted as the partial last bar.
+  //
+  // ⚠ Framing (mirrors the digest, M12/MN8): collective + non-punitive. The
+  //   distribution is neutral (alphabetical, no ranking); "needs attention" names
+  //   CHORES, not people. No leaderboard.
+  // ⚠ MN9 — NO client date math. `weekStartLocal` is a "YYYY-MM-DD" string already
+  //   resolved in the household timezone server-side; we format it by SPLITTING the
+  //   parts (never `new Date('YYYY-MM-DD')`, which would shift the day in US zones).
+  // ⚠ All values are server-computed; this is a pure render plus loading/empty/error.
+  //   The store owns the fetch + cache invalidation.
+  // ───────────────────────────────────────────────────────────────────────
+
+  interface Props {
+    recap: ChoreRecapDto | null;
+    loading: boolean;
+    error: string | null;
+    /** Retry after an error (re-runs loadRecap). */
+    onRetry: () => void;
+  }
+
+  let { recap, loading, error, onRetry }: Props = $props();
+
+  const MONTHS = [
+    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+  ];
+
+  /**
+   * Format a "YYYY-MM-DD" week-start as a short "Mon D" label. MN9-safe: we parse
+   * the parts ourselves and NEVER construct a Date from a date-only string.
+   */
+  function weekLabel(iso: string): string {
+    const parts = iso.split('-');
+    const m = Number.parseInt(parts[1] ?? '', 10);
+    const d = Number.parseInt(parts[2] ?? '', 10);
+    if (!m || !d || m < 1 || m > 12) return iso;
+    return `${MONTHS[m - 1]} ${d}`;
+  }
+
+  /** Percent without trailing-zero noise (25 → "25", 41.7 → "41.7"). Values arrive 0..100. */
+  function pct(value: number): string {
+    return Number.isInteger(value) ? String(value) : value.toFixed(1);
+  }
+
+  let current = $derived(recap?.current ?? null);
+  let trend = $derived(recap?.trend ?? []);
+
+  // Show the per-member split only when there's a real multi-member week.
+  let hasDistribution = $derived(
+    current != null && current.distribution.length > 0 && current.totalCompletions > 0,
+  );
+
+  // Column-chart scaling: tallest bar = the busiest week (min 1 to avoid /0).
+  let maxCompletions = $derived(
+    Math.max(1, ...trend.map((t) => t.totalCompletions)),
+  );
+
+  // Only worth drawing the trend if there's more than the current (partial) week,
+  // or any past activity to compare against.
+  let hasTrend = $derived(trend.length > 1);
+</script>
+
+<div class="ch-recap">
+  {#if error}
+    <div class="ch-recap-error" role="alert">
+      <span>{error}</span>
+      <button type="button" class="ch-recap-retry" onclick={onRetry}>Retry</button>
+    </div>
+  {:else if loading && recap == null}
+    <div class="ch-recap-state">Loading the recap…</div>
+  {:else if current != null}
+    <!-- ── This week ─────────────────────────────────────────────────────── -->
+    <section class="ch-recap-current" aria-label="This week's recap">
+      <header class="ch-recap-head">
+        <p class="ch-recap-eyebrow">Week of {weekLabel(current.weekStartLocal)}</p>
+        <h2 class="ch-recap-headline">{current.headline}</h2>
+      </header>
+
+      <div class="ch-recap-totals">
+        <div class="ch-recap-total">
+          <span class="ch-recap-total-num">{current.totalCompletions}</span>
+          <span class="ch-recap-total-label">
+            {current.totalCompletions === 1 ? 'chore done' : 'chores done'}
+          </span>
+        </div>
+        <div class="ch-recap-total">
+          <span class="ch-recap-total-num">{current.totalPoints}</span>
+          <span class="ch-recap-total-label">
+            {current.totalPoints === 1 ? 'point' : 'points'}
+          </span>
+        </div>
+        <div class="ch-recap-total">
+          <span class="ch-recap-total-num">{current.upForGrabsCount}</span>
+          <span class="ch-recap-total-label">up for grabs</span>
+        </div>
+      </div>
+
+      {#if hasDistribution}
+        <!-- Per-member effort split — neutral (alphabetical, no ranking). Bar width
+             is the member's actual share (`sharePct`, percent 0..100 — used directly). -->
+        <ul class="ch-recap-rows" aria-label="This week's effort by person">
+          {#each current.distribution as member (member.displayName)}
+            <li class="ch-recap-row">
+              <span class="ch-recap-name">{member.displayName}</span>
+              <span class="ch-recap-track">
+                <span
+                  class="ch-recap-bar"
+                  style="width: {member.sharePct}%;"
+                  aria-hidden="true"
+                ></span>
+              </span>
+              <span class="ch-recap-figures">
+                <span class="ch-recap-share">{pct(member.sharePct)}%</span>
+                <span class="ch-recap-points">
+                  {member.points}
+                  {member.points === 1 ? 'pt' : 'pts'}
+                </span>
+              </span>
+            </li>
+          {/each}
+        </ul>
+      {:else}
+        <p class="ch-recap-empty-week">Nothing logged this week yet — it fills in as chores get done.</p>
+      {/if}
+
+      {#if current.fallingBehind.length > 0}
+        <!-- Needs attention — names CHORES, not people (M12/MN8). Same list the digest sends. -->
+        <div class="ch-recap-attention">
+          <span class="ch-recap-attention-label">⏰ Needs attention</span>
+          <ul class="ch-recap-chips">
+            {#each current.fallingBehind as name (name)}
+              <li class="ch-recap-chip">{name}</li>
+            {/each}
+          </ul>
+        </div>
+      {/if}
+    </section>
+
+    <!-- ── Week over week ────────────────────────────────────────────────── -->
+    {#if hasTrend}
+      <section class="ch-recap-trend" aria-label="Chores completed each week">
+        <header class="ch-recap-trend-head">
+          <h3 class="ch-recap-trend-title">Week over week</h3>
+          <p class="ch-recap-trend-sub">Chores completed each week — this week is the last bar.</p>
+        </header>
+        <ol class="ch-recap-chart">
+          {#each trend as week (week.weekStartLocal)}
+            <li class="ch-recap-col" class:is-current={week.isCurrent}>
+              <span class="ch-recap-col-num">{week.totalCompletions}</span>
+              <span class="ch-recap-col-track" aria-hidden="true">
+                <span
+                  class="ch-recap-col-bar"
+                  style="height: {(week.totalCompletions / maxCompletions) * 100}%;"
+                ></span>
+              </span>
+              <span class="ch-recap-col-label">
+                {week.isCurrent ? 'This week' : weekLabel(week.weekStartLocal)}
+              </span>
+            </li>
+          {/each}
+        </ol>
+      </section>
+    {/if}
+  {:else}
+    <div class="ch-recap-state">
+      <p class="ch-recap-empty-head">No recap yet.</p>
+      <p>The weekly recap fills in as chores get completed.</p>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .ch-recap {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  /* ── This week ──────────────────────────────────────────────────────────── */
+  .ch-recap-current {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding: 16px;
+    background: var(--color-action-hover);
+    border-radius: var(--radius-md);
+  }
+  .ch-recap-head {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .ch-recap-eyebrow {
+    margin: 0;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-text-muted);
+  }
+  .ch-recap-headline {
+    margin: 0;
+    font-size: 1.125rem;
+    font-weight: 600;
+    line-height: 1.3;
+    color: var(--color-text);
+  }
+
+  .ch-recap-totals {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+  .ch-recap-total {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    padding: 10px 18px;
+    background: var(--color-surface);
+    border-radius: var(--radius-sm);
+    min-width: 84px;
+  }
+  .ch-recap-total-num {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--color-text);
+    font-variant-numeric: tabular-nums;
+    line-height: 1;
+  }
+  .ch-recap-total-label {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+
+  /* Per-member effort rows (neutral single fill — no ranking color). */
+  .ch-recap-rows {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .ch-recap-row {
+    display: grid;
+    grid-template-columns: minmax(96px, 1fr) minmax(0, 2.4fr) minmax(72px, auto);
+    align-items: center;
+    gap: 12px;
+  }
+  .ch-recap-name {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--color-text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .ch-recap-track {
+    position: relative;
+    height: 16px;
+    background: var(--color-surface);
+    border-radius: 8px;
+    overflow: hidden;
+  }
+  .ch-recap-bar {
+    position: absolute;
+    inset: 0 auto 0 0;
+    height: 100%;
+    background: var(--color-primary);
+    border-radius: 8px;
+    transition: width 0.2s ease;
+  }
+  .ch-recap-figures {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    line-height: 1.2;
+    text-align: right;
+  }
+  .ch-recap-share {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--color-text);
+    font-variant-numeric: tabular-nums;
+  }
+  .ch-recap-points {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .ch-recap-empty-week {
+    margin: 0;
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+  }
+
+  /* Needs attention — chore-name chips. */
+  .ch-recap-attention {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .ch-recap-attention-label {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: var(--color-text);
+  }
+  .ch-recap-chips {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .ch-recap-chip {
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+    background: var(--color-surface);
+    border: 1px dashed var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    padding: 5px 10px;
+  }
+
+  /* ── Week over week (column chart) ──────────────────────────────────────── */
+  .ch-recap-trend {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 16px;
+    background: var(--color-action-hover);
+    border-radius: var(--radius-md);
+  }
+  .ch-recap-trend-head {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .ch-recap-trend-title {
+    margin: 0;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    color: var(--color-text);
+  }
+  .ch-recap-trend-sub {
+    margin: 0;
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .ch-recap-chart {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    align-items: flex-end;
+    gap: 6px;
+    min-height: 140px;
+  }
+  .ch-recap-col {
+    flex: 1 1 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+  }
+  .ch-recap-col-num {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: var(--color-text-muted);
+    font-variant-numeric: tabular-nums;
+  }
+  .ch-recap-col-track {
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    width: 100%;
+    height: 96px;
+  }
+  .ch-recap-col-bar {
+    width: 70%;
+    max-width: 36px;
+    min-height: 3px;
+    background: var(--color-line-strong);
+    border-radius: 4px 4px 0 0;
+    transition: height 0.2s ease;
+  }
+  /* The current (in-progress) week reads as the live bar. */
+  .ch-recap-col.is-current .ch-recap-col-bar {
+    background: var(--color-primary);
+  }
+  .ch-recap-col.is-current .ch-recap-col-num,
+  .ch-recap-col.is-current .ch-recap-col-label {
+    color: var(--color-text);
+    font-weight: 600;
+  }
+  .ch-recap-col-label {
+    font-size: 0.6875rem;
+    color: var(--color-text-muted);
+    text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 100%;
+  }
+
+  /* ── Loading / empty / error ────────────────────────────────────────────── */
+  .ch-recap-state {
+    padding: 40px 16px;
+    text-align: center;
+    color: var(--color-text-muted);
+  }
+  .ch-recap-empty-head {
+    font-size: 1.125rem;
+    font-weight: 500;
+    color: var(--color-text);
+    margin: 0 0 4px;
+  }
+  .ch-recap-error {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 16px;
+    background: rgba(229, 57, 53, 0.08);
+    border-left: 4px solid var(--color-error);
+    border-radius: var(--radius-sm);
+    color: var(--color-error);
+    font-size: 0.875rem;
+  }
+  .ch-recap-retry {
+    font: inherit;
+    border: none;
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+    padding: 4px 12px;
+    background: transparent;
+    color: var(--color-error);
+    font-weight: 500;
+  }
+  .ch-recap-retry:hover {
+    background: rgba(229, 57, 53, 0.12);
+  }
+
+  @media (max-width: 560px) {
+    .ch-recap-row {
+      grid-template-columns: 1fr;
+      gap: 6px;
+    }
+    .ch-recap-figures {
+      flex-direction: row;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 8px;
+      text-align: left;
+    }
+  }
+</style>

--- a/frontend/chores/src/lib/components/ViewSwitcher.svelte
+++ b/frontend/chores/src/lib/components/ViewSwitcher.svelte
@@ -45,12 +45,13 @@
     mine: 'Mine',
     'needs-attention': 'All',
     rooms: 'Rooms',
+    recap: 'Recap',
     equity: 'Board load',
   };
 
   // The primary segmented filters (board filters) vs the secondary organizers.
   const PRIMARY: ChoreLensId[] = ['up-for-grabs', 'mine', 'needs-attention'];
-  const SECONDARY: ChoreLensId[] = ['rooms', 'equity'];
+  const SECONDARY: ChoreLensId[] = ['rooms', 'recap', 'equity'];
 
   let isActiveDefault = $derived(active === defaultLens);
 </script>

--- a/frontend/chores/src/lib/state.svelte.ts
+++ b/frontend/chores/src/lib/state.svelte.ts
@@ -21,6 +21,7 @@ import type {
   ChoreDto,
   ChoreSubtaskDto,
   ChoreEquityDto,
+  ChoreRecapDto,
   EquityWindow,
   CapacityTier,
   RoomRollupDto,
@@ -51,6 +52,7 @@ import {
   setDefaultView,
   setCapacity,
   getEquity,
+  getRecap,
   type CreateChoreRequest,
   type UpdateChoreRequest,
   type CompleteRequest,
@@ -159,6 +161,24 @@ class BoardStore {
    *  App effect loads when `lens === 'equity' && !equityLoaded`; invalidation
    *  flips this back to false so the next view (or the active lens) reloads. */
   equityLoaded = $state(false);
+
+  // ── Recap lens (the second non-board fetcher — like equity, its own endpoint) ─
+  //
+  // The Recap lens reads a SEPARATE cached payload (GET /api/chores/recap): the
+  // current week's digest content + the week-over-week trend. Same lifecycle as
+  // equity — fetch-on-open (App.svelte $effect), and invalidated whenever a
+  // completion/snooze/edit shifts the underlying data (folded into
+  // `invalidateEquity`, since both caches go stale on the same events). All values
+  // are server-computed; NO client date math (MN9).
+
+  /** The cached recap payload. null until first loaded (or after invalidation+reload). */
+  recap = $state<ChoreRecapDto | null>(null);
+  /** True while a `loadRecap()` fetch is in flight. */
+  recapLoading = $state(false);
+  /** Human-readable recap error; null when healthy. */
+  recapError = $state<string | null>(null);
+  /** True once a recap fetch has resolved; invalidation flips it back so the App effect reloads. */
+  recapLoaded = $state(false);
 
   /**
    * The board refetch hook, wired by App.svelte (`store.setRefresh(loadBoard)`).
@@ -393,6 +413,41 @@ class BoardStore {
     this.equityLoaded = false;
     if (this.lens === 'equity') {
       void this.loadEquity();
+    }
+    // The recap reads the same completion-derived data, so it goes stale on the
+    // exact same events — cascade the invalidation (reloads now if recap is open).
+    this.invalidateRecap();
+  }
+
+  // ── Recap lens fetch + invalidation (mirrors equity) ──────────────────────
+
+  /**
+   * Fetch the recap payload (current week + week-over-week trend). Called by
+   * App.svelte's $effect when the recap lens is open and the cache is stale.
+   * Sets `recapLoaded` on success so the effect doesn't refetch every tick.
+   */
+  async loadRecap(): Promise<void> {
+    if (this.recapLoading) return;
+    this.recapLoading = true;
+    this.recapError = null;
+    try {
+      this.recap = await getRecap();
+      this.recapLoaded = true;
+    } catch (e) {
+      this.recapError =
+        e instanceof ApiError
+          ? `Couldn't load the recap (HTTP ${e.status}).`
+          : "Couldn't load the recap right now.";
+    } finally {
+      this.recapLoading = false;
+    }
+  }
+
+  /** Drop the cached recap; reload immediately if the recap lens is open. */
+  invalidateRecap(): void {
+    this.recapLoaded = false;
+    if (this.lens === 'recap') {
+      void this.loadRecap();
     }
   }
 

--- a/frontend/chores/src/lib/state.svelte.ts
+++ b/frontend/chores/src/lib/state.svelte.ts
@@ -371,6 +371,9 @@ class BoardStore {
     if (this.equityWindow === next) return;
     this.equityWindow = next;
     this.equityLoaded = false;
+    // A window switch is a fresh attempt — clear any prior error so the App effect
+    // (now guarded on `!equityError`) loads the new window instead of staying stuck.
+    this.equityError = null;
   }
 
   /**

--- a/frontend/chores/src/lib/types.ts
+++ b/frontend/chores/src/lib/types.ts
@@ -157,7 +157,8 @@ export type ChoreLensId =
   | 'mine'
   | 'needs-attention'
   | 'rooms'
-  | 'equity';
+  | 'equity'
+  | 'recap';
 
 export const CHORE_LENSES: readonly ChoreLensId[] = [
   'up-for-grabs',
@@ -165,6 +166,7 @@ export const CHORE_LENSES: readonly ChoreLensId[] = [
   'needs-attention',
   'rooms',
   'equity',
+  'recap',
 ] as const;
 
 // ─── Equity lens DTO (FROZEN — mirrors WP-02 ChoreEquityDto EXACTLY) ─────────
@@ -239,6 +241,53 @@ export interface ChoreEquityDto {
    * GET (M7). The selector writes via PATCH /me/capacity (caller-scoped only — MN5).
    */
   callerCapacityTier: CapacityTier | null;
+}
+
+// ─── Weekly recap lens DTO (mirrors ChoreRecapDtos.cs EXACTLY) ───────────────
+// Served at GET /api/chores/recap?weeks=N. JSON keys are camelCase. The `current`
+// week is the SAME content the Discord digest posts (same headline/distribution/
+// falling-behind/up-for-grabs). `trend` is week-over-week totals, oldest→newest.
+//
+// ⚠ MN9: `weekStartLocal` is a date-only string ("YYYY-MM-DD") already resolved in
+//   the household timezone server-side. NEVER `new Date('YYYY-MM-DD')` on it — render
+//   the string, or parse parts manually. `sharePct` is PERCENT 0..100 (render direct).
+
+/** One member's line in the current-week distribution (no userId/mention — neutral). */
+export interface RecapMemberLineDto {
+  displayName: string;
+  points: number;
+  /** PERCENT 0..100 (e.g. 41.7). Render directly — no client `* 100`. */
+  sharePct: number;
+}
+
+/** The current week's assembled recap — identical to the Discord digest content. */
+export interface RecapWeekDto {
+  /** Local Monday of the week, "YYYY-MM-DD" (household tz; MN9 — do not Date-parse). */
+  weekStartLocal: string;
+  /** Collective, non-punitive headline. */
+  headline: string;
+  totalCompletions: number;
+  totalPoints: number;
+  distribution: RecapMemberLineDto[];
+  /** Names of chores Overdue/DueToday (attention list, not blame). */
+  fallingBehind: string[];
+  upForGrabsCount: number;
+}
+
+/** One week's totals in the week-over-week trend (totals only — no per-member split). */
+export interface RecapTrendPointDto {
+  /** Local Monday of the week, "YYYY-MM-DD" (household tz; MN9 — do not Date-parse). */
+  weekStartLocal: string;
+  totalCompletions: number;
+  totalPoints: number;
+  /** True for the in-progress current week (the last, partial bar). */
+  isCurrent: boolean;
+}
+
+/** Full recap payload: the current week + the week-over-week trend (oldest→newest). */
+export interface ChoreRecapDto {
+  current: RecapWeekDto;
+  trend: RecapTrendPointDto[];
 }
 
 // ─── Digest settings (WP-11 — mirrors WP-06 frozen contract EXACTLY) ─────────

--- a/src/FamilyCoordinationApp/Data/Entities/ChoreEnums.cs
+++ b/src/FamilyCoordinationApp/Data/Entities/ChoreEnums.cs
@@ -122,6 +122,13 @@ public static class ChoreLens
     /// </summary>
     public const string Equity = "equity";
 
+    /// <summary>
+    /// The weekly-recap lens (in-app view of the Discord digest content + week-over-week trend). Canonical id
+    /// mirrored by the island <c>types.ts</c>/<c>CHORE_LENSES</c>. Including it in <see cref="All"/> lets a user
+    /// default their board onto Recap via <c>PATCH /api/chores/me/default-view</c>.
+    /// </summary>
+    public const string Recap = "recap";
+
     /// <summary>All valid lens ids, for allowlist validation.</summary>
     public static readonly IReadOnlyList<string> All = new[]
     {
@@ -129,7 +136,8 @@ public static class ChoreLens
         Rooms,
         UpForGrabs,
         Mine,
-        Equity
+        Equity,
+        Recap
     };
 }
 

--- a/src/FamilyCoordinationApp/Endpoints/ChoresEndpoints.cs
+++ b/src/FamilyCoordinationApp/Endpoints/ChoresEndpoints.cs
@@ -59,6 +59,8 @@ public static class ChoresEndpoints
         // v1.1 (WP-06): equity distribution lens + digest settings + dev backfill — all cookie-authed,
         // household-scoped via UserContextResolver (M1).
         group.MapGet("/equity", GetEquity);
+        // In-app weekly recap lens (digest content + week-over-week trend). Cookie-authed, household-scoped.
+        group.MapGet("/recap", GetRecap);
         group.MapGet("/digest-settings", GetDigestSettings);
         group.MapPut("/digest-settings", UpdateDigestSettings);
         group.MapPost("/seed-starter", SeedStarter);
@@ -806,6 +808,29 @@ public static class ChoresEndpoints
                 parsed = EquityWindow.Week;
                 return false;
         }
+    }
+
+    // ─── Weekly recap lens (in-app digest view + week-over-week trend) ────────────────
+
+    /// <summary>
+    /// GET /api/chores/recap?weeks=N — the in-app weekly recap (M1, household-scoped). Returns the SAME
+    /// current-week content the Discord digest posts (reusing <see cref="ChoreRecapService"/> over the shared
+    /// <c>DigestBuilder</c>/equity/status pieces) plus a week-over-week completion/point trend. Read-only — it
+    /// never sends to Discord or touches a webhook. <c>weeks</c> defaults to 8 and is clamped 1–26 by the service.
+    /// </summary>
+    private static async Task<IResult> GetRecap(
+        [FromQuery] int? weeks,
+        ClaimsPrincipal principal,
+        IChoreRecapService recapService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        // HouseholdId comes from the resolved caller, never the client (M1). weeks is clamped in the service.
+        var dto = await recapService.GetRecapAsync(user.HouseholdId, weeks ?? 8, now: null, ct);
+        return Results.Ok(dto);
     }
 
     // ─── Digest settings (v1.1 WP-06) ────────────────────────────────────────────────

--- a/src/FamilyCoordinationApp/Program.cs
+++ b/src/FamilyCoordinationApp/Program.cs
@@ -113,6 +113,9 @@ builder.Services.AddSingleton<DigestBuilder>();
 builder.Services.AddScoped<IDigestSettingsService, DigestSettingsService>();
 builder.Services.AddScoped<IDigestService, DigestService>();
 builder.Services.AddScoped<IDigestSender, DiscordWebhookDigestSender>();
+// In-app weekly recap lens: read-only sibling of the digest (same DigestBuilder/equity/status pieces),
+// adds the week-over-week trend. No webhook, no send — just GET /api/chores/recap.
+builder.Services.AddScoped<IChoreRecapService, ChoreRecapService>();
 
 // Chore/Room HTTP endpoints serialize enum DTOs (colorTier/dueState/assignmentKind/rollup status) as
 // camelCase strings so responses match the island TS unions + the WP-05 board.json fixture (council M5/M11).

--- a/src/FamilyCoordinationApp/Services/ChoreEquityCalculator.cs
+++ b/src/FamilyCoordinationApp/Services/ChoreEquityCalculator.cs
@@ -203,6 +203,19 @@ public class ChoreEquityCalculator
             return null;
         }
 
+        return WeekStartUtc(now, tz);
+    }
+
+    /// <summary>
+    /// The UTC instant of local-Monday 00:00 of the week CONTAINING <paramref name="now"/> (Monday-start week,
+    /// all math in the injected <paramref name="tz"/>; mirrors <c>MealPlanService.GetWeekStartDate</c>). Public
+    /// static so the weekly-recap trend can window arbitrary past weeks WITHOUT re-deriving the boundary math —
+    /// shift <paramref name="now"/> by ±7-day multiples and the result is each week's local Monday in UTC. This
+    /// is the SAME lower bound the <see cref="EquityWindow.Week"/> path uses, so recap weeks and the equity week
+    /// never diverge.
+    /// </summary>
+    public static DateTime WeekStartUtc(DateTime now, TimeZoneInfo tz)
+    {
         // Convert now to local calendar date in the injected timezone.
         var asUtc = DateTime.SpecifyKind(now, DateTimeKind.Utc);
         var localNow = TimeZoneInfo.ConvertTimeFromUtc(asUtc, tz);

--- a/src/FamilyCoordinationApp/Services/Digest/ChoreRecapService.cs
+++ b/src/FamilyCoordinationApp/Services/Digest/ChoreRecapService.cs
@@ -56,25 +56,34 @@ public class ChoreRecapService(
         var asOf = DateTime.SpecifyKind(now ?? timeProvider.GetUtcNow().UtcDateTime, DateTimeKind.Utc);
         weeks = Math.Clamp(weeks, MinWeeks, MaxWeeks);
 
+        // The recap only needs completions back to the oldest trend week — bound the scan to that window so a
+        // long-lived household reads O(weeks of data), not O(all history). The current-week equity compute
+        // filters to this week itself, which is inside this bound. All reads are AsNoTracking (read-only path).
+        var oldestWeekStartUtc = ChoreEquityCalculator.WeekStartUtc(asOf.AddDays(-7 * (weeks - 1)), tz);
+
         await using var context = await dbFactory.CreateDbContextAsync(ct);
 
         // Mirror DigestService.BuildModelAsync's read shape — all queries scoped to householdId (M1).
         var householdName = await context.Households
+            .AsNoTracking()
             .Where(h => h.Id == householdId)
             .Select(h => h.Name)
             .FirstOrDefaultAsync(ct) ?? string.Empty;
 
         var members = await context.Users
+            .AsNoTracking()
             .Where(u => u.HouseholdId == householdId)
             .OrderBy(u => u.DisplayName)
             .Select(u => new MemberDto(u.Id, u.DisplayName, u.Initials, u.PictureUrl))
             .ToListAsync(ct);
 
         var completions = await context.ChoreCompletions
-            .Where(c => c.HouseholdId == householdId)
+            .AsNoTracking()
+            .Where(c => c.HouseholdId == householdId && c.CompletedAt >= oldestWeekStartUtc)
             .ToListAsync(ct);
 
         var activeChores = await context.Chores
+            .AsNoTracking()
             .Where(c => c.HouseholdId == householdId && c.Status == ChoreStatus.Active)
             .ToListAsync(ct);
 
@@ -143,28 +152,30 @@ public class ChoreRecapService(
     private IReadOnlyList<RecapTrendPointDto> BuildTrend(
         IReadOnlyList<ChoreCompletion> completions, DateTime now, int weeks)
     {
+        // Bucket every completion ONCE by its local week-start (O(completions)), then emit the requested
+        // weeks from the buckets (O(weeks)) — instead of rescanning all completions per week. Both sides
+        // key on the SAME WeekStartUtc, so a completion lands in exactly the week whose boundary it matches;
+        // completions outside the requested range bucket into a key that's never emitted.
+        var byWeekStart = new Dictionary<DateTime, (int Completions, int Points)>();
+        foreach (var c in completions)
+        {
+            var at = DateTime.SpecifyKind(c.CompletedAt, DateTimeKind.Utc);
+            var weekStart = ChoreEquityCalculator.WeekStartUtc(at, tz);
+            byWeekStart.TryGetValue(weekStart, out var agg);
+            byWeekStart[weekStart] = (agg.Completions + 1, agg.Points + c.EffortPointsSnapshot);
+        }
+
         var points = new List<RecapTrendPointDto>(weeks);
+        // Oldest → newest; the last point (k == 0) is the in-progress current week.
         for (var k = weeks - 1; k >= 0; k--)
         {
             var weekStartUtc = ChoreEquityCalculator.WeekStartUtc(now.AddDays(-7 * k), tz);
-            var weekEndUtc = ChoreEquityCalculator.WeekStartUtc(now.AddDays(-7 * (k - 1)), tz);
-
-            var weekCompletions = 0;
-            var weekPoints = 0;
-            foreach (var c in completions)
-            {
-                var at = DateTime.SpecifyKind(c.CompletedAt, DateTimeKind.Utc);
-                if (at >= weekStartUtc && at < weekEndUtc)
-                {
-                    weekCompletions++;
-                    weekPoints += c.EffortPointsSnapshot;
-                }
-            }
+            byWeekStart.TryGetValue(weekStartUtc, out var agg);
 
             points.Add(new RecapTrendPointDto(
                 WeekStartLocal: LocalIsoDate(weekStartUtc),
-                TotalCompletions: weekCompletions,
-                TotalPoints: weekPoints,
+                TotalCompletions: agg.Completions,
+                TotalPoints: agg.Points,
                 IsCurrent: k == 0));
         }
         return points;

--- a/src/FamilyCoordinationApp/Services/Digest/ChoreRecapService.cs
+++ b/src/FamilyCoordinationApp/Services/Digest/ChoreRecapService.cs
@@ -1,0 +1,180 @@
+using System.Globalization;
+using Microsoft.EntityFrameworkCore;
+using FamilyCoordinationApp.Data;
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Services.Dtos;
+
+namespace FamilyCoordinationApp.Services.Digest;
+
+/// <summary>
+/// Read-only sibling of <see cref="DigestService"/> for the IN-APP weekly recap lens. It builds the SAME
+/// current-week model the Discord digest sends (reusing <see cref="DigestBuilder"/> + the shared
+/// <see cref="ChoreEquityCalculator"/> / <see cref="ChoreStatusCalculator"/> / <see cref="ChoreAttention"/>
+/// pieces, so the in-app view and the channel post never diverge), and adds the week-over-week trend the
+/// digest can't show.
+/// <para>
+/// Fully household-scoped (M1 — the id comes from the resolved caller, never the client) and read-only: it
+/// never sends, never touches a webhook, never stamps <c>LastSentAt</c>. A short-lived context per call (M2).
+/// </para>
+/// <para>
+/// Trend windowing reuses <see cref="ChoreEquityCalculator.WeekStartUtc"/>: each past week is
+/// <c>[WeekStartUtc(now − 7k), WeekStartUtc(now − 7(k−1)))</c>, so a completion lands in exactly one week and
+/// the boundaries are computed in the household-local Monday-start calendar (DST-correct, no manual offset
+/// math). The current week (k = 0) uses the same lower bound as the equity <see cref="EquityWindow.Week"/>
+/// path, so its totals match the digest exactly.
+/// </para>
+/// </summary>
+public interface IChoreRecapService
+{
+    /// <summary>
+    /// Build the recap for <paramref name="householdId"/>: the current week's assembled digest content plus a
+    /// <paramref name="weeks"/>-long week-over-week trend (clamped 1–26), oldest→newest.
+    /// </summary>
+    /// <param name="householdId">Resolved caller's household (M1 — never a client-supplied id).</param>
+    /// <param name="weeks">How many weeks of trend to return (including the current week). Clamped 1–26.</param>
+    /// <param name="now">UTC instant to evaluate against; defaults to the injected <c>TimeProvider</c> now.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<ChoreRecapDto> GetRecapAsync(int householdId, int weeks, DateTime? now = null, CancellationToken ct = default);
+}
+
+/// <inheritdoc cref="IChoreRecapService"/>
+public class ChoreRecapService(
+    IDbContextFactory<ApplicationDbContext> dbFactory,
+    ChoreEquityCalculator equity,
+    ChoreStatusCalculator status,
+    DigestBuilder builder,
+    TimeZoneInfo tz,
+    TimeProvider timeProvider) : IChoreRecapService
+{
+    private const int MinWeeks = 1;
+    private const int MaxWeeks = 26;
+
+    /// <inheritdoc />
+    public async Task<ChoreRecapDto> GetRecapAsync(
+        int householdId, int weeks, DateTime? now = null, CancellationToken ct = default)
+    {
+        var asOf = DateTime.SpecifyKind(now ?? timeProvider.GetUtcNow().UtcDateTime, DateTimeKind.Utc);
+        weeks = Math.Clamp(weeks, MinWeeks, MaxWeeks);
+
+        await using var context = await dbFactory.CreateDbContextAsync(ct);
+
+        // Mirror DigestService.BuildModelAsync's read shape — all queries scoped to householdId (M1).
+        var householdName = await context.Households
+            .Where(h => h.Id == householdId)
+            .Select(h => h.Name)
+            .FirstOrDefaultAsync(ct) ?? string.Empty;
+
+        var members = await context.Users
+            .Where(u => u.HouseholdId == householdId)
+            .OrderBy(u => u.DisplayName)
+            .Select(u => new MemberDto(u.Id, u.DisplayName, u.Initials, u.PictureUrl))
+            .ToListAsync(ct);
+
+        var completions = await context.ChoreCompletions
+            .Where(c => c.HouseholdId == householdId)
+            .ToListAsync(ct);
+
+        var activeChores = await context.Chores
+            .Where(c => c.HouseholdId == householdId && c.Status == ChoreStatus.Active)
+            .ToListAsync(ct);
+
+        var current = BuildCurrentWeek(householdName, members, completions, activeChores, asOf);
+        var trend = BuildTrend(completions, asOf, weeks);
+
+        return new ChoreRecapDto(current, trend);
+    }
+
+    /// <summary>
+    /// Assemble the current week EXACTLY as <see cref="DigestService.BuildModelAsync"/> does (same equity
+    /// compute, same snoozed-exclusion dueness loop, same <see cref="DigestBuilder"/>) so the in-app recap is
+    /// byte-for-byte the digest the channel receives, then project it to the wire DTO.
+    /// </summary>
+    private RecapWeekDto BuildCurrentWeek(
+        string householdName,
+        IReadOnlyList<MemberDto> members,
+        IReadOnlyList<ChoreCompletion> completions,
+        IReadOnlyList<Chore> activeChores,
+        DateTime now)
+    {
+        var equityResult = equity.Compute(completions, members, EquityWindow.Week, now, tz);
+
+        var choreDueness = new List<DigestChoreLine>(activeChores.Count);
+        var upForGrabsCount = 0;
+        foreach (var chore in activeChores)
+        {
+            var dueness = status.Compute(ChoreRecurrenceSnapshot.FromChore(chore), now, tz);
+
+            // Snoozed chores carry no pressure (WP-04) — excluded from BOTH the falling-behind line list and
+            // the up-for-grabs count, exactly as the digest does.
+            if (dueness.IsSnoozed)
+            {
+                continue;
+            }
+
+            choreDueness.Add(new DigestChoreLine(chore.Name, dueness.DueState));
+
+            var isClaimStale = status.IsClaimStale(chore.AssignmentKind, chore.ClaimedAt, now);
+            if (ChoreAttention.IsUpForGrabs(chore.AssignmentKind, isClaimStale))
+            {
+                upForGrabsCount++;
+            }
+        }
+
+        var model = builder.Build(householdName, equityResult, choreDueness, upForGrabsCount);
+
+        return new RecapWeekDto(
+            WeekStartLocal: LocalIsoDate(ChoreEquityCalculator.WeekStartUtc(now, tz)),
+            Headline: model.CollectiveHeadline,
+            TotalCompletions: model.TotalCompletions,
+            TotalPoints: model.TotalPoints,
+            Distribution: model.Distribution
+                .Select(m => new RecapMemberLineDto(m.DisplayName, m.Points, m.SharePct))
+                .ToList(),
+            FallingBehind: model.FallingBehind,
+            UpForGrabsCount: model.UpForGrabsCount);
+    }
+
+    /// <summary>
+    /// Bucket the household's completions into the last <paramref name="weeks"/> local weeks (oldest→newest;
+    /// the final point, k = 0, is the in-progress current week). Each week is
+    /// <c>[WeekStartUtc(now − 7k), WeekStartUtc(now − 7(k−1)))</c> — half-open so a Sunday-23:59 completion and
+    /// the following Monday-00:00 completion land in different weeks.
+    /// </summary>
+    private IReadOnlyList<RecapTrendPointDto> BuildTrend(
+        IReadOnlyList<ChoreCompletion> completions, DateTime now, int weeks)
+    {
+        var points = new List<RecapTrendPointDto>(weeks);
+        for (var k = weeks - 1; k >= 0; k--)
+        {
+            var weekStartUtc = ChoreEquityCalculator.WeekStartUtc(now.AddDays(-7 * k), tz);
+            var weekEndUtc = ChoreEquityCalculator.WeekStartUtc(now.AddDays(-7 * (k - 1)), tz);
+
+            var weekCompletions = 0;
+            var weekPoints = 0;
+            foreach (var c in completions)
+            {
+                var at = DateTime.SpecifyKind(c.CompletedAt, DateTimeKind.Utc);
+                if (at >= weekStartUtc && at < weekEndUtc)
+                {
+                    weekCompletions++;
+                    weekPoints += c.EffortPointsSnapshot;
+                }
+            }
+
+            points.Add(new RecapTrendPointDto(
+                WeekStartLocal: LocalIsoDate(weekStartUtc),
+                TotalCompletions: weekCompletions,
+                TotalPoints: weekPoints,
+                IsCurrent: k == 0));
+        }
+        return points;
+    }
+
+    /// <summary>Format a UTC week-start as a household-local ISO date (<c>yyyy-MM-dd</c>) — server-side so the
+    /// island never builds a Date from a date-only string (MN9).</summary>
+    private string LocalIsoDate(DateTime utc)
+    {
+        var local = TimeZoneInfo.ConvertTimeFromUtc(DateTime.SpecifyKind(utc, DateTimeKind.Utc), tz);
+        return local.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+    }
+}

--- a/src/FamilyCoordinationApp/Services/Dtos/ChoreRecapDtos.cs
+++ b/src/FamilyCoordinationApp/Services/Dtos/ChoreRecapDtos.cs
@@ -1,0 +1,58 @@
+namespace FamilyCoordinationApp.Services.Dtos;
+
+/// <summary>
+/// The in-app weekly recap payload (read-only). The <see cref="Current"/> week mirrors EXACTLY what the
+/// Discord digest posts (same headline / distribution / falling-behind / up-for-grabs — built from the same
+/// <c>DigestBuilder</c>), so the app view and the channel post never diverge. <see cref="Trend"/> adds the
+/// week-over-week history the digest can't show: per-week completion + point totals, oldest→newest.
+/// <para>
+/// Household-scoped (M1 — the household id comes from the resolved caller, never the client). No user ids and
+/// no @mention fields anywhere (mirrors the digest's neutral framing).
+/// </para>
+/// </summary>
+public sealed record ChoreRecapDto(
+    RecapWeekDto Current,
+    IReadOnlyList<RecapTrendPointDto> Trend);
+
+/// <summary>
+/// The current week's assembled recap — the same content the weekly Discord digest sends.
+/// </summary>
+/// <param name="WeekStartLocal">Local Monday of the week, ISO date string <c>yyyy-MM-dd</c> (computed
+/// server-side in the household timezone — the island never does date math, MN9).</param>
+/// <param name="Headline">Collective, non-punitive headline (e.g. "The … house knocked out 7 chores…").</param>
+/// <param name="TotalCompletions">Chore completions in the week.</param>
+/// <param name="TotalPoints">Effort points in the week.</param>
+/// <param name="Distribution">Per-member effort split (neutral alphabetical order; no ranking, no user id).</param>
+/// <param name="FallingBehind">Names of chores that are Overdue or DueToday (point-in-time attention list).</param>
+/// <param name="UpForGrabsCount">Count of unclaimed chores open for anyone.</param>
+public sealed record RecapWeekDto(
+    string WeekStartLocal,
+    string Headline,
+    int TotalCompletions,
+    int TotalPoints,
+    IReadOnlyList<RecapMemberLineDto> Distribution,
+    IReadOnlyList<string> FallingBehind,
+    int UpForGrabsCount);
+
+/// <summary>
+/// One member's contribution line in the current-week recap. No user id / mention field — display name and
+/// effort figures only (mirrors the digest's <c>DigestMemberLine</c>). <c>SharePct</c> is PERCENT 0–100.
+/// </summary>
+public sealed record RecapMemberLineDto(
+    string DisplayName,
+    int Points,
+    double SharePct);
+
+/// <summary>
+/// One week's totals in the week-over-week trend. Totals only (no per-member split) — the trend answers
+/// "how did the house's output move week to week", not "who did what N weeks ago".
+/// </summary>
+/// <param name="WeekStartLocal">Local Monday of the week, ISO date string <c>yyyy-MM-dd</c> (household tz).</param>
+/// <param name="TotalCompletions">Chore completions in that week.</param>
+/// <param name="TotalPoints">Effort points in that week.</param>
+/// <param name="IsCurrent">True for the in-progress current week (the last, partial bar).</param>
+public sealed record RecapTrendPointDto(
+    string WeekStartLocal,
+    int TotalCompletions,
+    int TotalPoints,
+    bool IsCurrent);

--- a/tests/FamilyCoordinationApp.Tests/Services/ChoreRecapServiceTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/ChoreRecapServiceTests.cs
@@ -1,0 +1,215 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using FamilyCoordinationApp.Data;
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Services;
+using FamilyCoordinationApp.Services.Digest;
+
+namespace FamilyCoordinationApp.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="ChoreRecapService"/> + the extracted <see cref="ChoreEquityCalculator.WeekStartUtc"/>
+/// helper. Every test injects an explicit <c>now</c> (UTC) and an explicit <see cref="TimeZoneInfo"/>, so the
+/// week-boundary math is deterministic. The trend-bucketing tests are the load-bearing ones: they pin the
+/// half-open <c>[weekStart, weekEnd)</c> windowing across the household-local Monday-start boundary (a
+/// Sunday-23:59 completion and the next Monday-00:00 completion must land in different weeks).
+/// </summary>
+public class ChoreRecapServiceTests
+{
+    private const int H1 = 1;
+    private const int Alice = 100;
+    private const int Bob = 101;
+
+    // America/Chicago is UTC−5 in June (CDT), so local-Monday-00:00 is 05:00 UTC — local and UTC week
+    // boundaries fall on different instants, which is exactly what we want to test.
+    private static readonly TimeZoneInfo Chicago = ResolveTz("America/Chicago", "Central Standard Time");
+    private static readonly TimeZoneInfo Utc = TimeZoneInfo.Utc;
+
+    private static TimeZoneInfo ResolveTz(string ianaId, string windowsId)
+    {
+        try { return TimeZoneInfo.FindSystemTimeZoneById(ianaId); }
+        catch (TimeZoneNotFoundException) { return TimeZoneInfo.FindSystemTimeZoneById(windowsId); }
+    }
+
+    private static DateTime Utc0(int y, int m, int d, int h = 0, int min = 0) =>
+        new(y, m, d, h, min, 0, DateTimeKind.Utc);
+
+    private readonly DbContextOptions<ApplicationDbContext> _options;
+
+    public ChoreRecapServiceTests()
+    {
+        _options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        using var ctx = new ApplicationDbContext(_options);
+        ctx.Households.Add(new Household { Id = H1, Name = "Smith" });
+        ctx.Users.AddRange(
+            new User { Id = Alice, HouseholdId = H1, Email = "a@x.com", DisplayName = "Alice", Initials = "AL" },
+            new User { Id = Bob, HouseholdId = H1, Email = "b@x.com", DisplayName = "Bob", Initials = "BO" });
+        ctx.SaveChanges();
+    }
+
+    private ChoreRecapService CreateService(TimeZoneInfo tz)
+    {
+        var dbFactory = new Mock<IDbContextFactory<ApplicationDbContext>>();
+        dbFactory.Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new ApplicationDbContext(_options));
+
+        return new ChoreRecapService(
+            dbFactory.Object,
+            new ChoreEquityCalculator(),
+            new ChoreStatusCalculator(),
+            new DigestBuilder(),
+            tz,
+            TimeProvider.System);
+    }
+
+    private void SeedCompletions(params ChoreCompletion[] completions)
+    {
+        using var ctx = new ApplicationDbContext(_options);
+        ctx.ChoreCompletions.AddRange(completions);
+        ctx.SaveChanges();
+    }
+
+    private static ChoreCompletion Completion(int id, int userId, DateTime completedAtUtc, int effortPoints) =>
+        new()
+        {
+            HouseholdId = H1,
+            ChoreId = 1,
+            CompletionId = id,
+            CompletedByUserId = userId,
+            CompletedAt = completedAtUtc,
+            EffortPointsSnapshot = effortPoints,
+        };
+
+    // ── WeekStartUtc (pure boundary math) ────────────────────────────────────────────
+
+    [Fact]
+    public void WeekStartUtc_Utc_SundayBelongsToPriorMonday()
+    {
+        // Sunday 2026-06-21 is in the week that STARTED Monday 2026-06-15.
+        ChoreEquityCalculator.WeekStartUtc(Utc0(2026, 6, 21, 12), Utc)
+            .Should().Be(Utc0(2026, 6, 15));
+    }
+
+    [Fact]
+    public void WeekStartUtc_Utc_MondayIsItsOwnWeekStart()
+    {
+        ChoreEquityCalculator.WeekStartUtc(Utc0(2026, 6, 15, 0), Utc)
+            .Should().Be(Utc0(2026, 6, 15));
+    }
+
+    [Fact]
+    public void WeekStartUtc_Chicago_LocalMondayMidnightIsFiveAmUtc()
+    {
+        // Mon 2026-06-15 00:00 CDT == 05:00 UTC. A "now" of Mon 00:00 local resolves to that instant.
+        ChoreEquityCalculator.WeekStartUtc(Utc0(2026, 6, 15, 5), Chicago)
+            .Should().Be(Utc0(2026, 6, 15, 5));
+    }
+
+    [Fact]
+    public void WeekStartUtc_Chicago_SundayLateLocalStillPriorWeek()
+    {
+        // Sun 2026-06-14 23:59 CDT == 06-15 04:59 UTC — still the week that started Mon 06-08 (05:00 UTC).
+        ChoreEquityCalculator.WeekStartUtc(Utc0(2026, 6, 15, 4, 59), Chicago)
+            .Should().Be(Utc0(2026, 6, 8, 5));
+    }
+
+    // ── Trend bucketing ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Trend_BucketsCompletionsByWeek_OldestToNewest_CurrentLast()
+    {
+        // now = Wed 2026-06-17 (week of Mon 06-15). weeks=3 ⇒ [06-01), [06-08), [06-15 current].
+        SeedCompletions(
+            Completion(1, Alice, Utc0(2026, 6, 16, 9), 3),   // week2 (current, Mon 06-15)
+            Completion(2, Alice, Utc0(2026, 6, 9, 9), 2),    // week1 (Mon 06-08)
+            Completion(3, Bob, Utc0(2026, 6, 11, 9), 4),     // week1 (Mon 06-08)
+            Completion(4, Bob, Utc0(2026, 5, 20, 9), 9));    // older than the 3-week window — excluded
+
+        var svc = CreateService(Utc);
+        var recap = await svc.GetRecapAsync(H1, weeks: 3, now: Utc0(2026, 6, 17, 12));
+
+        recap.Trend.Should().HaveCount(3);
+
+        recap.Trend[0].WeekStartLocal.Should().Be("2026-06-01");
+        recap.Trend[0].TotalCompletions.Should().Be(0);
+        recap.Trend[0].TotalPoints.Should().Be(0);
+        recap.Trend[0].IsCurrent.Should().BeFalse();
+
+        recap.Trend[1].WeekStartLocal.Should().Be("2026-06-08");
+        recap.Trend[1].TotalCompletions.Should().Be(2);
+        recap.Trend[1].TotalPoints.Should().Be(6);
+        recap.Trend[1].IsCurrent.Should().BeFalse();
+
+        recap.Trend[2].WeekStartLocal.Should().Be("2026-06-15");
+        recap.Trend[2].TotalCompletions.Should().Be(1);
+        recap.Trend[2].TotalPoints.Should().Be(3);
+        recap.Trend[2].IsCurrent.Should().BeTrue();
+
+        // Current week matches the last trend point (same lower bound as the equity Week path).
+        recap.Current.TotalCompletions.Should().Be(1);
+        recap.Current.TotalPoints.Should().Be(3);
+        recap.Current.WeekStartLocal.Should().Be("2026-06-15");
+    }
+
+    [Fact]
+    public async Task Trend_HalfOpenBoundary_SundayNightAndMondayMidnightSplitAcrossWeeks_Chicago()
+    {
+        // The crux: in Chicago, Mon 06-15 00:00 local == 05:00 UTC.
+        //   06-15 04:59 UTC == Sun 23:59 CDT  → belongs to the PRIOR week (Mon 06-08)
+        //   06-15 05:00 UTC == Mon 00:00 CDT  → belongs to the CURRENT week (Mon 06-15)
+        SeedCompletions(
+            Completion(1, Alice, Utc0(2026, 6, 15, 4, 59), 2),  // → week Mon 06-08
+            Completion(2, Bob, Utc0(2026, 6, 15, 5, 0), 5));    // → week Mon 06-15 (current)
+
+        var svc = CreateService(Chicago);
+        var recap = await svc.GetRecapAsync(H1, weeks: 2, now: Utc0(2026, 6, 17, 12));
+
+        recap.Trend.Should().HaveCount(2);
+
+        recap.Trend[0].WeekStartLocal.Should().Be("2026-06-08");
+        recap.Trend[0].TotalCompletions.Should().Be(1);
+        recap.Trend[0].TotalPoints.Should().Be(2);
+
+        recap.Trend[1].WeekStartLocal.Should().Be("2026-06-15");
+        recap.Trend[1].TotalCompletions.Should().Be(1);
+        recap.Trend[1].TotalPoints.Should().Be(5);
+        recap.Trend[1].IsCurrent.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Current_MirrorsDigestHeadlineAndDistribution()
+    {
+        // Two members both active in the current week (Mon 06-15): Alice 3pts, Bob 1pt ⇒ 4 total, 2 completions.
+        SeedCompletions(
+            Completion(1, Alice, Utc0(2026, 6, 16, 9), 3),
+            Completion(2, Bob, Utc0(2026, 6, 16, 10), 1));
+
+        var svc = CreateService(Utc);
+        var recap = await svc.GetRecapAsync(H1, weeks: 4, now: Utc0(2026, 6, 17, 12));
+
+        recap.Current.TotalCompletions.Should().Be(2);
+        recap.Current.TotalPoints.Should().Be(4);
+        // DigestBuilder headline format (collective, non-punitive) — proves we reuse the same builder.
+        recap.Current.Headline.Should().Contain("Smith").And.Contain("2 chores").And.Contain("4 pts");
+        // Distribution is neutral alphabetical, both members present, shares are percent 0–100.
+        recap.Current.Distribution.Should().HaveCount(2);
+        recap.Current.Distribution[0].DisplayName.Should().Be("Alice");
+        recap.Current.Distribution[0].Points.Should().Be(3);
+        recap.Current.Distribution[0].SharePct.Should().BeApproximately(75.0, 0.1);
+        recap.Current.Distribution[1].DisplayName.Should().Be("Bob");
+        recap.Current.Distribution[1].SharePct.Should().BeApproximately(25.0, 0.1);
+    }
+
+    [Fact]
+    public async Task Weeks_IsClampedToOneThroughTwentySix()
+    {
+        var svc = CreateService(Utc);
+
+        (await svc.GetRecapAsync(H1, weeks: 0, now: Utc0(2026, 6, 17, 12))).Trend.Should().HaveCount(1);
+        (await svc.GetRecapAsync(H1, weeks: 999, now: Utc0(2026, 6, 17, 12))).Trend.Should().HaveCount(26);
+    }
+}

--- a/tests/FamilyCoordinationApp.Tests/Services/ChoreRecapServiceTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/ChoreRecapServiceTests.cs
@@ -84,6 +84,31 @@ public class ChoreRecapServiceTests
             EffortPointsSnapshot = effortPoints,
         };
 
+    private void SeedChores(params Chore[] chores)
+    {
+        using var ctx = new ApplicationDbContext(_options);
+        ctx.Chores.AddRange(chores);
+        ctx.SaveChanges();
+    }
+
+    // An active, unassigned (up-for-grabs), OneOff chore due in the past (Overdue) unless snoozed forward.
+    private static Chore OverdueChore(int id, string name, DateOnly? snoozedUntil = null) =>
+        new()
+        {
+            HouseholdId = H1,
+            ChoreId = id,
+            Name = name,
+            RecurrenceMode = RecurrenceMode.OneOff,
+            AnchorDate = new DateOnly(2026, 6, 9),
+            SnoozedUntil = snoozedUntil,
+            EffortTier = EffortTier.Standard,
+            EffortPoints = 2,
+            Status = ChoreStatus.Active,
+            EnteredByUserId = Alice,
+            AssignmentKind = AssignmentKind.None,
+            CreatedAt = Utc0(2026, 6, 1),
+        };
+
     // ── WeekStartUtc (pure boundary math) ────────────────────────────────────────────
 
     [Fact]
@@ -211,5 +236,25 @@ public class ChoreRecapServiceTests
 
         (await svc.GetRecapAsync(H1, weeks: 0, now: Utc0(2026, 6, 17, 12))).Trend.Should().HaveCount(1);
         (await svc.GetRecapAsync(H1, weeks: 999, now: Utc0(2026, 6, 17, 12))).Trend.Should().HaveCount(26);
+    }
+
+    // ── Snoozed-chore exclusion (mirrors the digest, WP-04) ──────────────────────────
+
+    [Fact]
+    public async Task Current_ExcludesSnoozedChores_FromAttention()
+    {
+        // Two overdue, unassigned (up-for-grabs) chores; one is snoozed into the future. now = 2026-06-17, so
+        // SnoozedUntil 2026-06-30 makes the second chore read Scheduled/IsSnoozed (no pressure).
+        SeedChores(
+            OverdueChore(1, "Visible overdue"),
+            OverdueChore(2, "Snoozed overdue", snoozedUntil: new DateOnly(2026, 6, 30)));
+
+        var svc = CreateService(Utc);
+        var recap = await svc.GetRecapAsync(H1, weeks: 1, now: Utc0(2026, 6, 17, 12));
+
+        // The snoozed chore is excluded from BOTH the falling-behind list and the up-for-grabs count, exactly
+        // as the digest does — only the non-snoozed overdue chore is reported.
+        recap.Current.FallingBehind.Should().ContainSingle().Which.Should().Be("Visible overdue");
+        recap.Current.UpForGrabsCount.Should().Be(1);
     }
 }


### PR DESCRIPTION
## What

Adds an in-app **Weekly Recap** lens to the chores island, and (separately, on the prod host) fixes the weekly Discord digest that had never been delivering.

Roadmap quest: *Weekly Recap is not showing up in discord* — "fix that, but also be able to view recap in the app to see week-over-week progress directly."

## Why the digest wasn't reaching Discord (ops, not code)

The digest fires via external cron → `POST /api/chores/digest/run`. Diagnosed on the prod host: the per-household settings were correct (enabled, webhook set, Sunday 18:00) but it had **never sent** (`LastSentAt = NULL`) because of two un-wired host links:
1. `CHORES_DIGEST_TRIGGER_TOKEN` was empty → endpoint returned 503 ("disabled").
2. No crontab line ever fired the endpoint.

Both fixed on the host (token set in prod `.env`, app container recreated, hourly cron installed). A forced test send posted successfully to the family channel (`sent:1`). **This is host config — not part of this diff.** This PR is the in-app half.

## In-app Weekly Recap (this diff)

A read-only `recap` lens that shows the **same content the Discord digest posts** (collective headline, per-member effort split, needs-attention chores, up-for-grabs count) **plus** a week-over-week completions/points trend the digest can't show — computed on the fly from completion history, **no new tables/migration**.

**Backend**
- `ChoreRecapService` — read-only sibling of `DigestService`. The current week reuses the exact `DigestBuilder` + equity/status/attention pieces, so the app view never diverges from the channel post. The trend buckets completions into local Monday-start weeks via a half-open `[weekStart, weekEnd)` window (DST-correct).
- Extracted `ChoreEquityCalculator.WeekStartUtc` (public static, behavior-preserving) so the trend reuses the same proven boundary math as the equity Week path.
- `GET /api/chores/recap?weeks=N` — cookie-authed, household-scoped (M1), `weeks` clamped 1–26.
- `ChoreLens.Recap` added to the canonical allowlist.

**Frontend**
- New `recap` lens + `RecapBoard.svelte` (current-week card + week-over-week column chart), wired into `ViewSwitcher`, the store (its own cached fetch + invalidation, mirroring the equity lens), and `App.svelte` fetch-on-open. MN9-safe date labels (no `new Date('YYYY-MM-DD')`).

## Verification
- **567 backend tests pass**, including 8 new `ChoreRecapServiceTests` (the `WeekStartUtc` helper + tz-local week bucketing, incl. the Sun-23:59 / Mon-00:00 boundary split).
- `svelte-check` + island `vite build` clean.
- Browser-verified locally via DOM (screenshots were flaking): the lens registers in the switcher, fetch-on-open works, the endpoint returns correct data (headline / distribution / falling-behind / trend bucketing all correct), `RecapBoard` renders every section with correct labels and the current-week highlight, **0 console errors**.

The built island bundle is gitignored (rebuilt in the Docker/deploy pipeline), so this diff is source-only.

https://claude.ai/code/session_01SyLKkTvJ7kpcX9fgVH1BrF
