### PR TITLE
fix(layout): kill header flicker via server-side cookie seed

### DIFF
--- a/src/FamilyCoordinationApp/Components/App.razor
+++ b/src/FamilyCoordinationApp/Components/App.razor
@@ -28,6 +28,12 @@
                 document.documentElement.style.backgroundColor = '#121212';
             }
         })();
+        // Mirror a preference into a cookie so the server can seed it on the next
+        // request/prerender (SeedPreferencesFromCookies in MainLayout). Kept in lockstep
+        // with the localStorage writes that drive the pre-paint script above.
+        window.setPrefCookie = function (name, value) {
+            document.cookie = name + '=' + value + '; path=/; max-age=31536000; SameSite=Lax';
+        };
     </script>
     <script src="https://cdn.jsdelivr.net/npm/mobile-drag-drop@2.3.0-rc.2/index.min.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/mobile-drag-drop@2.3.0-rc.2/default.css" />

--- a/src/FamilyCoordinationApp/Components/Layout/MainLayout.razor
+++ b/src/FamilyCoordinationApp/Components/Layout/MainLayout.razor
@@ -14,9 +14,10 @@
 @inject ISnackbar Snackbar
 @inject IJSRuntime JSRuntime
 @inject ISiteAdminService SiteAdminService
+@inject IHttpContextAccessor HttpContextAccessor
 @inject ILogger<MainLayout> Logger
 
-<MudThemeProvider @bind-IsDarkMode="@_isDarkMode" Theme="@_theme" />
+<MudThemeProvider @bind-IsDarkMode="@IsDarkMode" Theme="@_theme" />
 <MudPopoverProvider />
 <MudDialogProvider />
 <MudSnackbarProvider />
@@ -24,12 +25,12 @@
 <MudLayout>
     <!-- Collapsible Drawer - hidden on mobile -->
     <MudHidden Breakpoint="Breakpoint.SmAndDown">
-        <MudDrawer @bind-Open="_drawerOpen" 
-                   ClipMode="DrawerClipMode.Always" 
+        <MudDrawer @bind-Open="DrawerOpen"
+                   ClipMode="DrawerClipMode.Always"
                    Elevation="2"
                    Variant="@DrawerVariant.Mini"
                    OpenMiniOnHover="false">
-            <NavMenu IsExpanded="_drawerOpen" />
+            <NavMenu IsExpanded="DrawerOpen" />
         </MudDrawer>
     </MudHidden>
 
@@ -54,10 +55,10 @@
                         <OnlineUsers CurrentUserId="@CurrentUserId" />
                     </MudHidden>
                     <SyncStatusIndicator />
-                    <MudIconButton Icon="@(_isDarkMode ? Icons.Material.Filled.LightMode : Icons.Material.Filled.DarkMode)"
+                    <MudIconButton Icon="@(IsDarkMode ? Icons.Material.Filled.LightMode : Icons.Material.Filled.DarkMode)"
                                    Color="Color.Inherit"
                                    OnClick="ToggleDarkMode"
-                                   Title="@(_isDarkMode ? "Switch to light mode" : "Switch to dark mode")" />
+                                   Title="@(IsDarkMode ? "Switch to light mode" : "Switch to dark mode")" />
                     @if (IsSiteAdmin)
                     {
                         <MudHidden Breakpoint="Breakpoint.SmAndDown">
@@ -201,11 +202,18 @@
     
     [PersistentState(AllowUpdates = true)]
     public bool IsSiteAdmin { get; set; }
-    
+
+    // Theme/layout prefs: seeded server-side from cookies during the initial HTTP
+    // request and round-tripped via [PersistentState] so the prerendered DOM and the
+    // interactive circuit agree on the first paint — no post-hydration correction flash.
+    [PersistentState(AllowUpdates = true)]
+    public bool IsDarkMode { get; set; }
+
+    [PersistentState(AllowUpdates = true)]
+    public bool DrawerOpen { get; set; } = true;
+
     // Non-persisted state
     private System.Timers.Timer? _heartbeatTimer;
-    private bool _isDarkMode = false;
-    private bool _drawerOpen = true;
 
     private MudTheme _theme = new()
     {
@@ -258,42 +266,40 @@
 
     protected override async Task OnInitializedAsync()
     {
+        SeedPreferencesFromCookies();
         await LoadCurrentUser();
         StartHeartbeat();
         NavigationManager.LocationChanged += OnLocationChanged;
         PollingService.OnStatusChanged += OnSyncStatusChanged;
     }
 
-    protected override async Task OnAfterRenderAsync(bool firstRender)
+    // Seed theme/drawer prefs from cookies during the initial HTTP request / prerender,
+    // BEFORE the first render, so the server paints the user's actual preference and the
+    // value survives into the interactive circuit via [PersistentState]. HttpContext is
+    // only non-null on that initial request; on interactive reconnect it's null, so we
+    // return early and the persisted value carries through — no flash either way.
+    private void SeedPreferencesFromCookies()
     {
-        if (firstRender)
+        var cookies = HttpContextAccessor.HttpContext?.Request.Cookies;
+        if (cookies is null)
         {
-            try
-            {
-                var darkMode = await JSRuntime.InvokeAsync<string>("localStorage.getItem", "darkMode");
-                if (!string.IsNullOrEmpty(darkMode) && bool.TryParse(darkMode, out var isDark))
-                {
-                    _isDarkMode = isDark;
-                }
-                
-                var drawerOpen = await JSRuntime.InvokeAsync<string>("localStorage.getItem", "drawerOpen");
-                if (!string.IsNullOrEmpty(drawerOpen) && bool.TryParse(drawerOpen, out var isOpen))
-                {
-                    _drawerOpen = isOpen;
-                }
-                
-                StateHasChanged();
-            }
-            catch
-            {
-                // localStorage not available
-            }
+            return;
+        }
+
+        if (cookies.TryGetValue("darkMode", out var darkMode) && bool.TryParse(darkMode, out var isDark))
+        {
+            IsDarkMode = isDark;
+        }
+
+        if (cookies.TryGetValue("drawerOpen", out var drawerOpen) && bool.TryParse(drawerOpen, out var isOpen))
+        {
+            DrawerOpen = isOpen;
         }
     }
 
     private void ToggleDrawer()
     {
-        _drawerOpen = !_drawerOpen;
+        DrawerOpen = !DrawerOpen;
         _ = SaveDrawerState();
     }
 
@@ -309,28 +315,36 @@
 
     private async Task SaveDrawerState()
     {
+        var value = DrawerOpen.ToString().ToLower();
         try
         {
-            await JSRuntime.InvokeVoidAsync("localStorage.setItem", "drawerOpen", _drawerOpen.ToString().ToLower());
+            // localStorage keeps the <head> pre-paint script working; the cookie is the
+            // new SSR/server-seed source of truth read by SeedPreferencesFromCookies().
+            await JSRuntime.InvokeVoidAsync("localStorage.setItem", "drawerOpen", value);
+            await JSRuntime.InvokeVoidAsync("setPrefCookie", "drawerOpen", value);
         }
         catch (Exception ex)
         {
             // JS interop can fail during prerendering or if JS is unavailable
-            Logger.LogDebug(ex, "Failed to save drawer state to localStorage");
+            Logger.LogDebug(ex, "Failed to save drawer state");
         }
     }
 
     private async Task ToggleDarkMode()
     {
-        _isDarkMode = !_isDarkMode;
+        IsDarkMode = !IsDarkMode;
+        var value = IsDarkMode.ToString().ToLower();
         try
         {
-            await JSRuntime.InvokeVoidAsync("localStorage.setItem", "darkMode", _isDarkMode.ToString().ToLower());
+            // localStorage keeps the <head> pre-paint script working; the cookie is the
+            // new SSR/server-seed source of truth read by SeedPreferencesFromCookies().
+            await JSRuntime.InvokeVoidAsync("localStorage.setItem", "darkMode", value);
+            await JSRuntime.InvokeVoidAsync("setPrefCookie", "darkMode", value);
         }
         catch (Exception ex)
         {
             // JS interop can fail during prerendering or if JS is unavailable
-            Logger.LogDebug(ex, "Failed to save dark mode preference to localStorage");
+            Logger.LogDebug(ex, "Failed to save dark mode preference");
         }
     }
 


### PR DESCRIPTION
## What

Kills the header flicker: on every load the app bar flashed light-mode + drawer-open before snapping to the user's actual preference.

## Why it flickered

`MainLayout` read the dark-mode / drawer prefs from **localStorage in `OnAfterRenderAsync`** — i.e. *after* the first paint — then corrected via `StateHasChanged`. The prerendered DOM rendered the defaults (light, drawer open), then jumped. That post-render correction is the flash.

## Fix — seed the prefs server-side

- `IsDarkMode` / `DrawerOpen` become `[PersistentState]` auto-properties (matching the existing `CurrentUserId` etc. pattern), seeded from **cookies during the initial HTTP request / prerender** (`SeedPreferencesFromCookies`). The prerendered HTML is now already correct, so there is no post-hydration correction.
- On interactive reconnect `HttpContext` is null → we return early and the persisted value carries through unchanged (no flash either way).
- `ToggleDarkMode` / `SaveDrawerState` mirror each pref into a cookie (`setPrefCookie` helper in `App.razor`) **in lockstep with the existing localStorage writes** — the latter still drives the `<head>` pre-paint script, so that path is untouched.
- First-ever visit (no cookie yet) paints the light/open defaults, as expected.

No migration. No `Program.cs` change (`AddHttpContextAccessor` already registered).

## Verification

Built the branch image and browser-verified on the local stack (`:8080`):
- **SSR A/B** — fetched the prerendered `/dashboard` HTML with `darkMode=true` vs `false` cookies: the server renders **dark** (`"Switch to light mode"`) vs **light** (`"Switch to dark mode"`) respectively. The initial HTML is already correct → no flash.
- **Live render** — with `darkMode=true; drawerOpen=false`, the hydrated DOM shows `mud-theme-dark`, body bg `#121212`, drawer `mud-drawer--closed mud-drawer-mini`. Both prefs seed end-to-end.

Gates: `dotnet build` ✓, `dotnet test` (648 pass; the only failures are the worktree-only `ApiKeySecurityTests` `.git`-is-a-file artifact, which pass in a normal checkout), format-neutral (no new whitespace deltas vs master).

https://claude.ai/code/session_01BZrsjpKLrHVzNhQueskyiU
