### PR TITLE
feat(chores): subtask drag-reorder + per-item "who ticked it"

### DIFF
--- a/frontend/chores/src/lib/api.ts
+++ b/frontend/chores/src/lib/api.ts
@@ -361,6 +361,17 @@ export async function deleteSubtask(choreId: number, subtaskId: number): Promise
   await request<void>(`${CHORES_BASE}/${choreId}/subtasks/${subtaskId}`, { method: 'DELETE' });
 }
 
+/**
+ * Re-order a chore's checklist — the full new order as a list of subtask ids. PUT → 204.
+ * Versionless / atomic on the server (mirrors reorderRooms); SortOrder is set by list position.
+ */
+export async function reorderSubtasks(choreId: number, orderedSubtaskIds: number[]): Promise<void> {
+  await request<void>(`${CHORES_BASE}/${choreId}/subtasks/reorder`, {
+    method: 'PUT',
+    ...jsonBody({ orderedSubtaskIds }),
+  });
+}
+
 /** Upload a chore photo (multipart field name `file`) → { photoPath } to pass in create/complete. */
 export async function uploadChorePhoto(
   choreId: number,

--- a/frontend/chores/src/lib/components/ChoreCard.svelte
+++ b/frontend/chores/src/lib/components/ChoreCard.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import type { ChoreDto, ColorTier, DueState, EffortTier, RecurrenceMode, RosterState } from '../types';
+  import type { ChoreDto, ChoreSubtaskDto, ColorTier, DueState, EffortTier, RecurrenceMode, RosterState } from '../types';
   import { boardStore, memberFor, roomFor } from '../state.svelte';
   import { showPhoto } from '../lightbox.svelte';
   import MemberAvatar from './MemberAvatar.svelte';
+  import { dndzone, type DndEvent } from 'svelte-dnd-action';
 
   // ───────────────────────────────────────────────────────────────────────
   // The shared chore card — used across every lens.
@@ -191,6 +192,42 @@
     newItemTitle = '';
   }
 
+  // ── Drag-reorder (svelte-dnd-action — the room-manager house pattern) ──────
+  // A local working list re-synced from the chore's subtasks except while a drag
+  // is in flight (a guard so a mid-drag board reload can't clobber the order). On
+  // drop we persist the new order via the versionless bulk reorder store path.
+  let checkRows = $state<ChoreSubtaskDto[]>([]);
+  let draggingChecklist = $state(false);
+  $effect(() => {
+    if (!draggingChecklist) checkRows = [...subtasks];
+  });
+
+  function handleChecklistConsider(e: CustomEvent<DndEvent<ChoreSubtaskDto>>) {
+    draggingChecklist = true;
+    checkRows = e.detail.items;
+  }
+  async function handleChecklistFinalize(e: CustomEvent<DndEvent<ChoreSubtaskDto>>) {
+    checkRows = e.detail.items;
+    const ordered = checkRows.map((s) => s.id);
+    try {
+      await boardStore.reorderSubtasks(chore.id, ordered);
+    } finally {
+      // Release the guard last so the resync lands on the persisted order.
+      draggingChecklist = false;
+    }
+  }
+
+  /** "Who ticked it" label for a done item — the member's initials (tooltip = name + when). */
+  function actorLabel(s: ChoreSubtaskDto): { initials: string; tooltip: string } | null {
+    if (!s.isDone || s.completedByUserId == null) return null;
+    const member = memberFor(s.completedByUserId);
+    if (!member) return null;
+    const when = formatDay(s.completedAt);
+    const you = s.completedByUserId === currentUserId;
+    const name = you ? 'you' : member.displayName;
+    return { initials: member.initials, tooltip: when ? `Done by ${name} · ${when}` : `Done by ${name}` };
+  }
+
   // ── Snooze / set-next-due (board quick-snooze) ───────────────────────────
   // The "Snooze" button reveals a small preset row; a preset or a picked date
   // calls onSnooze with the RAW request — the server resolves the floor date in
@@ -370,11 +407,26 @@
       <!--
         Per-chore checklist (Phase 14). Each row is a tappable checkbox + title;
         tapping toggles via the versionless store path. A subtle "×" removes the
-        item. The bottom row adds a new item (Enter or the + button). Subtasks are
-        a momentum aid only — they never gate the Done/Complete button.
+        item, and a done item shows "who ticked it". Rows drag to reorder
+        (svelte-dnd-action; persisted via the bulk reorder path). The add row sits
+        OUTSIDE the drag zone (every dndzone child is a draggable item). Subtasks
+        are a momentum aid only — they never gate the Done/Complete button.
       -->
-      <ul class="ch-checklist" aria-label="Checklist for {chore.name}">
-        {#each subtasks as s (s.id)}
+      <ul
+        class="ch-checklist"
+        aria-label="Checklist for {chore.name}"
+        use:dndzone={{
+          items: checkRows,
+          type: `subtasks-${chore.id}`,
+          flipDurationMs: 150,
+          dropTargetStyle: {},
+          delayTouchStart: 250,
+        }}
+        onconsider={handleChecklistConsider}
+        onfinalize={handleChecklistFinalize}
+      >
+        {#each checkRows as s (s.id)}
+          {@const actor = actorLabel(s)}
           <li class="ch-checkitem" class:ch-checkitem-done={s.isDone}>
             <button
               type="button"
@@ -387,6 +439,9 @@
               <span class="ch-check-box" aria-hidden="true">{s.isDone ? '✓' : ''}</span>
               <span class="ch-check-title">{s.title}</span>
             </button>
+            {#if actor}
+              <span class="ch-check-actor" title={actor.tooltip}>{actor.initials}</span>
+            {/if}
             <button
               type="button"
               class="ch-check-del"
@@ -399,34 +454,34 @@
             </button>
           </li>
         {/each}
-        <li class="ch-checkadd">
-          <input
-            type="text"
-            class="ch-checkadd-input"
-            bind:value={newItemTitle}
-            autocomplete="off"
-            placeholder="Add an item…"
-            aria-label="Add a checklist item"
-            onkeydown={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault();
-                submitNewItem();
-              }
-            }}
-          />
-          <button
-            type="button"
-            class="ch-checkadd-btn"
-            data-action="subtask-add"
-            onclick={submitNewItem}
-            disabled={!newItemTitle.trim()}
-            title="Add item"
-            aria-label="Add checklist item"
-          >
-            ＋
-          </button>
-        </li>
       </ul>
+      <div class="ch-checkadd">
+        <input
+          type="text"
+          class="ch-checkadd-input"
+          bind:value={newItemTitle}
+          autocomplete="off"
+          placeholder="Add an item…"
+          aria-label="Add a checklist item"
+          onkeydown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              submitNewItem();
+            }
+          }}
+        />
+        <button
+          type="button"
+          class="ch-checkadd-btn"
+          data-action="subtask-add"
+          onclick={submitNewItem}
+          disabled={!newItemTitle.trim()}
+          title="Add item"
+          aria-label="Add checklist item"
+        >
+          ＋
+        </button>
+      </div>
     {/if}
 
     <div class="ch-card-foot">
@@ -1106,6 +1161,23 @@
   .ch-check-del:hover {
     background: var(--color-action-hover);
     color: var(--color-error);
+  }
+  /* "Who ticked it" tag — the actor's initials beside a done item. */
+  .ch-check-actor {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 22px;
+    height: 22px;
+    padding: 0 6px;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    line-height: 1;
+    color: var(--color-text-muted);
+    background: var(--color-action-hover);
+    border-radius: 999px;
+    cursor: default;
   }
   .ch-checkadd {
     display: flex;

--- a/frontend/chores/src/lib/state.svelte.ts
+++ b/frontend/chores/src/lib/state.svelte.ts
@@ -48,6 +48,7 @@ import {
   createSubtask,
   updateSubtask,
   deleteSubtask,
+  reorderSubtasks,
   seedStarter as apiSeedStarter,
   setDefaultView,
   setCapacity,
@@ -1136,16 +1137,54 @@ class BoardStore {
     const item = chore.subtasks.find((s) => s.id === subtaskId);
     if (!item) return;
     const previous = item.isDone;
-    item.isDone = isDone; // optimistic — must feel instant
+    const previousActor = item.completedByUserId;
+    const previousAt = item.completedAt;
+    // Optimistic — must feel instant. Show ME as the actor immediately on a tick; clear on untick.
+    // completedAt stays null until the authoritative DTO swaps in (the store builds NO Date — MN).
+    item.isDone = isDone;
+    item.completedByUserId = isDone ? this.currentUserId : null;
+    item.completedAt = null;
     try {
       const updated = await updateSubtask(choreId, subtaskId, { isDone });
       this.replaceSubtask(choreId, updated);
     } catch {
-      // Roll back the optimistic flip, then resync to be safe.
+      // Roll back the optimistic flip + actor, then resync to be safe.
       const cur = this.choreById(choreId)?.subtasks.find((s) => s.id === subtaskId);
-      if (cur) cur.isDone = previous;
+      if (cur) {
+        cur.isDone = previous;
+        cur.completedByUserId = previousActor;
+        cur.completedAt = previousAt;
+      }
       await this.reconcile();
       showToast({ message: "Couldn't update that item — the list was refreshed.", kind: 'info' });
+    }
+  }
+
+  /**
+   * Re-order a chore's checklist (versionless). Apply the new order in place (set each
+   * sortOrder to its index so the row order is stable), persist via the bulk reorder
+   * endpoint, and reconcile + calm toast on error. Does NOT touch pendingChoreIds.
+   */
+  async reorderSubtasks(choreId: number, orderedIds: number[]): Promise<void> {
+    if (!this.board) return;
+    const chore = this.choreById(choreId);
+    if (!chore) return;
+    const byId = new Map(chore.subtasks.map((s) => [s.id, s]));
+    const reordered = orderedIds
+      .map((id) => byId.get(id))
+      .filter((s): s is ChoreSubtaskDto => s !== undefined);
+    // Guard: if the id set doesn't line up (stale), just resync rather than risk dropping items.
+    if (reordered.length !== chore.subtasks.length) {
+      await this.reconcile();
+      return;
+    }
+    reordered.forEach((s, i) => (s.sortOrder = i)); // optimistic in-place
+    chore.subtasks = reordered;
+    try {
+      await reorderSubtasks(choreId, orderedIds);
+    } catch {
+      await this.reconcile();
+      showToast({ message: "Couldn't save the new order — the list was refreshed.", kind: 'info' });
     }
   }
 

--- a/frontend/chores/src/lib/types.ts
+++ b/frontend/chores/src/lib/types.ts
@@ -53,6 +53,10 @@ export interface ChoreSubtaskDto {
   title: string;
   isDone: boolean;
   sortOrder: number;
+  /** "Who ticked it" actor — non-null IFF isDone (per-occurrence). Resolve via membersById/memberFor. */
+  completedByUserId: number | null;
+  /** ISO-8601 UTC (Z) when it was ticked; null when not done. Server-stamped — build no Date client-side. */
+  completedAt: string | null;
 }
 
 export interface ChoreDto {

--- a/src/FamilyCoordinationApp/Data/Entities/ChoreSubtask.cs
+++ b/src/FamilyCoordinationApp/Data/Entities/ChoreSubtask.cs
@@ -17,5 +17,11 @@ public class ChoreSubtask
     public int SortOrder { get; set; }
     public DateTime CreatedAt { get; set; }  // UTC
 
+    // "Who ticked it" actor stamp (Phase 14 follow-up). Per-occurrence invariant: both are non-null IFF
+    // IsDone == true — set on the false->true tick (the resolved caller), cleared on untick and on the
+    // recurring-chore reset. A plain userId (no FK to User) — resolved client-side via the board's members.
+    public int? CompletedByUserId { get; set; }
+    public DateTime? CompletedAt { get; set; }  // UTC
+
     public Chore Chore { get; set; } = default!;
 }

--- a/src/FamilyCoordinationApp/Endpoints/ChoresEndpoints.cs
+++ b/src/FamilyCoordinationApp/Endpoints/ChoresEndpoints.cs
@@ -50,6 +50,7 @@ public static class ChoresEndpoints
 
         // Phase-14 checklist (subtasks): versionless / last-write-wins — NO version field on any of these.
         group.MapPost("/{choreId:int}/subtasks", CreateSubtask);
+        group.MapPut("/{choreId:int}/subtasks/reorder", ReorderSubtasks);
         group.MapPut("/{choreId:int}/subtasks/{subtaskId:int}", UpdateSubtask);
         group.MapDelete("/{choreId:int}/subtasks/{subtaskId:int}", DeleteSubtask);
 
@@ -526,11 +527,36 @@ public static class ChoresEndpoints
 
         try
         {
-            var dto = await svc.UpdateAsync(user.HouseholdId, choreId, subtaskId, req.Title, req.IsDone, req.SortOrder, ct);
+            // user.UserId is the "who ticked it" actor captured when this flips the item to done (M1).
+            var dto = await svc.UpdateAsync(user.HouseholdId, choreId, subtaskId, user.UserId, req.Title, req.IsDone, req.SortOrder, ct);
             return Results.Ok(dto);
         }
         catch (ChoreNotFoundException) { return Results.NotFound(); }
         catch (ChoreValidationException ex) { return Results.BadRequest(new { message = ex.Message }); }
+    }
+
+    private static async Task<IResult> ReorderSubtasks(
+        int choreId,
+        ReorderSubtasksRequest req,
+        ClaimsPrincipal principal,
+        IChoreSubtaskService svc,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        // The chore must exist in the household (else 404). Mirrors the subtask CRUD scoping (M1).
+        bool choreExists;
+        await using (var context = await dbFactory.CreateDbContextAsync(ct))
+        {
+            choreExists = await context.Chores
+                .AnyAsync(c => c.HouseholdId == user.HouseholdId && c.ChoreId == choreId, ct);
+        }
+        if (!choreExists) return Results.NotFound();
+
+        await svc.ReorderAsync(user.HouseholdId, choreId, req.OrderedSubtaskIds ?? new List<int>(), ct);
+        return Results.NoContent();
     }
 
     private static async Task<IResult> DeleteSubtask(
@@ -977,6 +1003,9 @@ public static class ChoresEndpoints
 
     /// <summary>Patch a checklist item (Phase 14). Only the non-null fields apply. Versionless.</summary>
     public sealed record UpdateSubtaskRequest(string? Title, bool? IsDone, int? SortOrder);
+
+    /// <summary>Re-order a chore's checklist — the new order as a full list of subtask ids. Versionless.</summary>
+    public sealed record ReorderSubtasksRequest(List<int> OrderedSubtaskIds);
 
     public sealed record HandOffRequest(int? TargetUserId, uint Version);
 

--- a/src/FamilyCoordinationApp/Migrations/20260623223451_AddChoreSubtaskActor.Designer.cs
+++ b/src/FamilyCoordinationApp/Migrations/20260623223451_AddChoreSubtaskActor.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FamilyCoordinationApp.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FamilyCoordinationApp.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260623223451_AddChoreSubtaskActor")]
+    partial class AddChoreSubtaskActor
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/FamilyCoordinationApp/Migrations/20260623223451_AddChoreSubtaskActor.cs
+++ b/src/FamilyCoordinationApp/Migrations/20260623223451_AddChoreSubtaskActor.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FamilyCoordinationApp.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddChoreSubtaskActor : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "CompletedAt",
+                table: "ChoreSubtasks",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "CompletedByUserId",
+                table: "ChoreSubtasks",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CompletedAt",
+                table: "ChoreSubtasks");
+
+            migrationBuilder.DropColumn(
+                name: "CompletedByUserId",
+                table: "ChoreSubtasks");
+        }
+    }
+}

--- a/src/FamilyCoordinationApp/Services/ChoreBoardService.cs
+++ b/src/FamilyCoordinationApp/Services/ChoreBoardService.cs
@@ -94,7 +94,7 @@ public class ChoreBoardService(
             .ToListAsync(cancellationToken))
             .GroupBy(s => s.ChoreId)
             .ToDictionary(g => g.Key, g => g.OrderBy(s => s.SortOrder).ThenBy(s => s.SubtaskId)
-                .Select(s => new ChoreSubtaskDto(s.SubtaskId, s.Title, s.IsDone, s.SortOrder)).ToList());
+                .Select(s => new ChoreSubtaskDto(s.SubtaskId, s.Title, s.IsDone, s.SortOrder, s.CompletedByUserId, s.CompletedAt)).ToList());
 
         // Project each chore once; reuse the computed dueness for both the per-chore DTO and the rollups so
         // a chore's dueness is computed in exactly one place (no divergence between the card and the room
@@ -168,7 +168,7 @@ public class ChoreBoardService(
         // mutations do, so the post-reset unchecked checklist is reflected without a board refetch).
         var subtasks = (chore.Subtasks ?? [])
             .OrderBy(s => s.SortOrder).ThenBy(s => s.SubtaskId)
-            .Select(s => new ChoreSubtaskDto(s.SubtaskId, s.Title, s.IsDone, s.SortOrder)).ToList();
+            .Select(s => new ChoreSubtaskDto(s.SubtaskId, s.Title, s.IsDone, s.SortOrder, s.CompletedByUserId, s.CompletedAt)).ToList();
         return ToDto(chore, dueness, isClaimStale, roster, completedCount: 0, subtasks);
     }
 

--- a/src/FamilyCoordinationApp/Services/ChoreService.cs
+++ b/src/FamilyCoordinationApp/Services/ChoreService.cs
@@ -393,7 +393,11 @@ public class ChoreService(
                     .ToListAsync(cancellationToken);
                 foreach (var subtask in doneSubtasks)
                 {
+                    // A fresh occurrence ⇒ clear the done flag AND the "who ticked it" actor stamp
+                    // (per-occurrence invariant: actor non-null IFF IsDone==true).
                     subtask.IsDone = false;
+                    subtask.CompletedByUserId = null;
+                    subtask.CompletedAt = null;
                 }
             }
         }

--- a/src/FamilyCoordinationApp/Services/ChoreSubtaskService.cs
+++ b/src/FamilyCoordinationApp/Services/ChoreSubtaskService.cs
@@ -67,7 +67,7 @@ public class ChoreSubtaskService(
         return ToDto(subtask);
     }
 
-    public async Task<ChoreSubtaskDto> UpdateAsync(int householdId, int choreId, int subtaskId, string? title, bool? isDone, int? sortOrder, CancellationToken ct = default)
+    public async Task<ChoreSubtaskDto> UpdateAsync(int householdId, int choreId, int subtaskId, int actingUserId, string? title, bool? isDone, int? sortOrder, CancellationToken ct = default)
     {
         await using var context = await dbFactory.CreateDbContextAsync(ct);
 
@@ -80,7 +80,22 @@ public class ChoreSubtaskService(
         }
         if (isDone is { } done)
         {
-            subtask.IsDone = done;
+            // Per-occurrence actor invariant (CompletedByUserId/CompletedAt non-null IFF IsDone==true):
+            //  • false->true  ⇒ stamp the acting user + UtcNow.
+            //  • ->false       ⇒ clear the actor.
+            //  • true->true    ⇒ no-op (preserve the original actor/time — re-stamping would churn CompletedAt).
+            if (done && !subtask.IsDone)
+            {
+                subtask.IsDone = true;
+                subtask.CompletedByUserId = actingUserId;
+                subtask.CompletedAt = UtcNow();
+            }
+            else if (!done)
+            {
+                subtask.IsDone = false;
+                subtask.CompletedByUserId = null;
+                subtask.CompletedAt = null;
+            }
         }
         if (sortOrder is { } order)
         {
@@ -90,6 +105,28 @@ public class ChoreSubtaskService(
         await context.SaveChangesAsync(ct);
 
         return ToDto(subtask);
+    }
+
+    public async Task ReorderAsync(int householdId, int choreId, IReadOnlyList<int> orderedSubtaskIds, CancellationToken ct = default)
+    {
+        await using var context = await dbFactory.CreateDbContextAsync(ct);
+
+        // Household+chore scoped (M1). Foreign ids in the list simply find no row (ignored), mirroring
+        // RoomService.ReorderAsync. One SaveChanges; never touches Chore.Version (versionless / LWW).
+        var subtasks = await context.ChoreSubtasks
+            .Where(s => s.HouseholdId == householdId && s.ChoreId == choreId && orderedSubtaskIds.Contains(s.SubtaskId))
+            .ToListAsync(ct);
+
+        for (var index = 0; index < orderedSubtaskIds.Count; index++)
+        {
+            var subtask = subtasks.FirstOrDefault(s => s.SubtaskId == orderedSubtaskIds[index]);
+            if (subtask is not null)
+            {
+                subtask.SortOrder = index;
+            }
+        }
+
+        await context.SaveChangesAsync(ct);
     }
 
     public async Task DeleteAsync(int householdId, int choreId, int subtaskId, CancellationToken ct = default)
@@ -126,5 +163,5 @@ public class ChoreSubtaskService(
     }
 
     private static ChoreSubtaskDto ToDto(ChoreSubtask s) =>
-        new(s.SubtaskId, s.Title, s.IsDone, s.SortOrder);
+        new(s.SubtaskId, s.Title, s.IsDone, s.SortOrder, s.CompletedByUserId, s.CompletedAt);
 }

--- a/src/FamilyCoordinationApp/Services/ChoreSubtaskService.cs
+++ b/src/FamilyCoordinationApp/Services/ChoreSubtaskService.cs
@@ -111,19 +111,44 @@ public class ChoreSubtaskService(
     {
         await using var context = await dbFactory.CreateDbContextAsync(ct);
 
-        // Household+chore scoped (M1). Foreign ids in the list simply find no row (ignored), mirroring
-        // RoomService.ReorderAsync. One SaveChanges; never touches Chore.Version (versionless / LWW).
+        // Load ALL of the chore's subtasks (household+chore scoped, M1) and normalize to a CONTIGUOUS 0..N-1
+        // SortOrder over the full set — so a partial / duplicate-bearing / foreign-id client list can never
+        // leave duplicate or gapped SortOrder values (the server does not trust the client to send a clean
+        // permutation). The provided ids that belong to the chore come first (de-duplicated, in the given
+        // order), then any omitted subtasks in their current stable order; then renumber. O(N); one
+        // SaveChanges; never touches Chore.Version (versionless / LWW).
         var subtasks = await context.ChoreSubtasks
-            .Where(s => s.HouseholdId == householdId && s.ChoreId == choreId && orderedSubtaskIds.Contains(s.SubtaskId))
+            .Where(s => s.HouseholdId == householdId && s.ChoreId == choreId)
             .ToListAsync(ct);
-
-        for (var index = 0; index < orderedSubtaskIds.Count; index++)
+        if (subtasks.Count == 0)
         {
-            var subtask = subtasks.FirstOrDefault(s => s.SubtaskId == orderedSubtaskIds[index]);
-            if (subtask is not null)
+            return;
+        }
+
+        var byId = subtasks.ToDictionary(s => s.SubtaskId);
+        var ordered = new List<ChoreSubtask>(subtasks.Count);
+        var seen = new HashSet<int>();
+
+        foreach (var id in orderedSubtaskIds)
+        {
+            if (byId.TryGetValue(id, out var subtask) && seen.Add(id))
             {
-                subtask.SortOrder = index;
+                ordered.Add(subtask);
             }
+        }
+        // Any subtask the client omitted is appended in its current stable order, so `ordered` is always a
+        // full permutation of the chore's subtasks.
+        foreach (var subtask in subtasks.OrderBy(s => s.SortOrder).ThenBy(s => s.SubtaskId))
+        {
+            if (seen.Add(subtask.SubtaskId))
+            {
+                ordered.Add(subtask);
+            }
+        }
+
+        for (var index = 0; index < ordered.Count; index++)
+        {
+            ordered[index].SortOrder = index;
         }
 
         await context.SaveChangesAsync(ct);

--- a/src/FamilyCoordinationApp/Services/Dtos/ChoreDtos.cs
+++ b/src/FamilyCoordinationApp/Services/Dtos/ChoreDtos.cs
@@ -76,10 +76,13 @@ public sealed record ChoreDto(
 
 /// <summary>
 /// A lightweight checklist item on a chore (Phase 14). Wire shape camelCase: <c>{ id, title, isDone,
-/// sortOrder }</c>. Versionless / last-write-wins — there is no concurrency token on this DTO. Embedded as
-/// <see cref="ChoreDto.Subtasks"/> on the board payload (Phase-14 Unit #2).
+/// sortOrder, completedByUserId, completedAt }</c>. Versionless / last-write-wins — there is no concurrency
+/// token on this DTO. Embedded as <see cref="ChoreDto.Subtasks"/> on the board payload (Phase-14 Unit #2).
+/// <para><see cref="CompletedByUserId"/> / <see cref="CompletedAt"/> are the "who ticked it" actor stamp
+/// (Phase-14 follow-up): non-null IFF <see cref="IsDone"/> is true (per-occurrence; cleared on untick + on the
+/// recurring reset). The userId resolves to a member client-side via the board's members list (no FK).</para>
 /// </summary>
-public sealed record ChoreSubtaskDto(int Id, string Title, bool IsDone, int SortOrder);
+public sealed record ChoreSubtaskDto(int Id, string Title, bool IsDone, int SortOrder, int? CompletedByUserId, DateTime? CompletedAt);
 
 /// <summary>
 /// A member's DERIVED state on a multi-person chore's named roster, for the current occurrence (rework).

--- a/src/FamilyCoordinationApp/Services/Interfaces/IChoreSubtaskService.cs
+++ b/src/FamilyCoordinationApp/Services/Interfaces/IChoreSubtaskService.cs
@@ -23,11 +23,20 @@ public interface IChoreSubtaskService
 
     /// <summary>
     /// Updates a checklist item — only the non-null fields are applied (title trimmed + validated if supplied).
-    /// No version check; touches ONLY the subtask row (never the chore).
+    /// No version check; touches ONLY the subtask row (never the chore). When <paramref name="isDone"/> flips
+    /// the item to done, <paramref name="actingUserId"/> is captured as the "who ticked it" actor (with a UTC
+    /// timestamp); un-ticking clears the actor. Per-occurrence invariant: actor set IFF IsDone == true.
     /// </summary>
     /// <exception cref="ChoreNotFoundException">No such subtask in the household/chore.</exception>
     /// <exception cref="ChoreValidationException">A supplied title is blank or too long.</exception>
-    Task<ChoreSubtaskDto> UpdateAsync(int householdId, int choreId, int subtaskId, string? title, bool? isDone, int? sortOrder, CancellationToken ct = default);
+    Task<ChoreSubtaskDto> UpdateAsync(int householdId, int choreId, int subtaskId, int actingUserId, string? title, bool? isDone, int? sortOrder, CancellationToken ct = default);
+
+    /// <summary>
+    /// Re-orders a chore's checklist: sets <c>SortOrder = index</c> for each id in <paramref name="orderedSubtaskIds"/>
+    /// in ONE write (mirrors <c>IRoomService.ReorderAsync</c>). Household+chore scoped (M1); ids not belonging
+    /// to the chore are ignored. Versionless — never touches <c>Chore.Version</c>.
+    /// </summary>
+    Task ReorderAsync(int householdId, int choreId, IReadOnlyList<int> orderedSubtaskIds, CancellationToken ct = default);
 
     /// <summary>Deletes a checklist item.</summary>
     /// <exception cref="ChoreNotFoundException">No such subtask in the household/chore.</exception>

--- a/src/FamilyCoordinationApp/Services/Interfaces/IChoreSubtaskService.cs
+++ b/src/FamilyCoordinationApp/Services/Interfaces/IChoreSubtaskService.cs
@@ -32,9 +32,12 @@ public interface IChoreSubtaskService
     Task<ChoreSubtaskDto> UpdateAsync(int householdId, int choreId, int subtaskId, int actingUserId, string? title, bool? isDone, int? sortOrder, CancellationToken ct = default);
 
     /// <summary>
-    /// Re-orders a chore's checklist: sets <c>SortOrder = index</c> for each id in <paramref name="orderedSubtaskIds"/>
-    /// in ONE write (mirrors <c>IRoomService.ReorderAsync</c>). Household+chore scoped (M1); ids not belonging
-    /// to the chore are ignored. Versionless — never touches <c>Chore.Version</c>.
+    /// Re-orders a chore's checklist to a CONTIGUOUS 0..N-1 <c>SortOrder</c> in ONE write. The result is always
+    /// a full permutation of the chore's subtasks: the provided ids that belong to the chore are placed first
+    /// (de-duplicated, in the given order), then any OMITTED subtasks are appended in their current stable
+    /// order, and all rows are renumbered — so a partial / duplicate / foreign-id list can never leave
+    /// duplicate or gapped SortOrder. Household+chore scoped (M1); foreign ids are ignored. Versionless —
+    /// never touches <c>Chore.Version</c>.
     /// </summary>
     Task ReorderAsync(int householdId, int choreId, IReadOnlyList<int> orderedSubtaskIds, CancellationToken ct = default);
 

--- a/tests/FamilyCoordinationApp.Tests/Fixtures/ChoreBoard/board.json
+++ b/tests/FamilyCoordinationApp.Tests/Fixtures/ChoreBoard/board.json
@@ -38,13 +38,17 @@
           "id": 1,
           "title": "Sweep first",
           "isDone": true,
-          "sortOrder": 0
+          "sortOrder": 0,
+          "completedByUserId": 100,
+          "completedAt": "2026-05-27T09:00:00Z"
         },
         {
           "id": 2,
           "title": "Mop",
           "isDone": false,
-          "sortOrder": 1
+          "sortOrder": 1,
+          "completedByUserId": null,
+          "completedAt": null
         }
       ]
     },

--- a/tests/FamilyCoordinationApp.Tests/Integration/ChoreSubtaskTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Integration/ChoreSubtaskTests.cs
@@ -24,8 +24,10 @@ public sealed class ChoreSubtaskTests(PostgresContainerFixture postgres) : IAsyn
     public async Task DisposeAsync() => await _factory.DisposeAsync();
 
     private sealed record Chore(int id, string name, uint version);
-    private sealed record Subtask(int id, string title, bool isDone, int sortOrder);
+    private sealed record Subtask(int id, string title, bool isDone, int sortOrder, int? completedByUserId, string? completedAt);
+    private sealed record ChoreWithSubtasks(int id, List<Subtask> subtasks);
     private sealed record Board(List<Chore> chores);
+    private sealed record BoardWithSubtasks(List<ChoreWithSubtasks> chores);
 
     private HttpClient ClientA => _factory.CreateClientAs(ChoresWebAppFactory.UserAEmail);
     private HttpClient ClientB => _factory.CreateClientAs(ChoresWebAppFactory.UserBEmail);
@@ -89,6 +91,56 @@ public sealed class ChoreSubtaskTests(PostgresContainerFixture postgres) : IAsyn
         // DELETE → 204.
         var del = await client.DeleteAsync($"/api/chores/{chore.id}/subtasks/{created.id}");
         del.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task Subtask_Tick_CapturesActor_ThenUntick_ClearsIt_ThroughHttp()
+    {
+        var client = ClientA;
+        var chore = await CreateFlexibleChoreAsync(client, "Actor checklist chore");
+
+        var createResp = await client.PostAsJsonAsync($"/api/chores/{chore.id}/subtasks", new { title = "Who ticks" }, Json);
+        var created = await createResp.Content.ReadFromJsonAsync<Subtask>(Json);
+        created!.completedByUserId.Should().BeNull("a freshly created item has no actor");
+
+        // Tick → the resolved caller is captured as the actor with a timestamp (invariant: actor IFF isDone).
+        var tick = await client.PutAsJsonAsync($"/api/chores/{chore.id}/subtasks/{created.id}", new { isDone = true }, Json);
+        tick.StatusCode.Should().Be(HttpStatusCode.OK);
+        var ticked = await tick.Content.ReadFromJsonAsync<Subtask>(Json);
+        ticked!.completedByUserId.Should().NotBeNull("ticking captures the acting user");
+        ticked.completedAt.Should().NotBeNullOrEmpty("ticking stamps a UTC time");
+
+        // Untick → the actor clears.
+        var untick = await client.PutAsJsonAsync($"/api/chores/{chore.id}/subtasks/{created.id}", new { isDone = false }, Json);
+        var unticked = await untick.Content.ReadFromJsonAsync<Subtask>(Json);
+        unticked!.completedByUserId.Should().BeNull("unticking clears the actor");
+        unticked.completedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Subtask_Reorder_PersistsNewOrder_ThroughHttp()
+    {
+        var client = ClientA;
+        var chore = await CreateFlexibleChoreAsync(client, "Reorder checklist chore");
+
+        var ids = new List<int>();
+        foreach (var title in new[] { "First", "Second", "Third" })
+        {
+            var resp = await client.PostAsJsonAsync($"/api/chores/{chore.id}/subtasks", new { title }, Json);
+            ids.Add((await resp.Content.ReadFromJsonAsync<Subtask>(Json))!.id);
+        }
+
+        // New order: Third, First, Second.
+        var reordered = new[] { ids[2], ids[0], ids[1] };
+        var reorder = await client.PutAsJsonAsync(
+            $"/api/chores/{chore.id}/subtasks/reorder", new { orderedSubtaskIds = reordered }, Json);
+        reorder.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        // The board reflects the new SortOrder (ascending) — the projection orders by it.
+        var board = await client.GetFromJsonAsync<BoardWithSubtasks>("/api/chores/board", Json);
+        var onBoard = board!.chores.Single(c => c.id == chore.id);
+        onBoard.subtasks.OrderBy(s => s.sortOrder).Select(s => s.id)
+            .Should().Equal(reordered, "reorder persists SortOrder by list position");
     }
 
     [Fact]

--- a/tests/FamilyCoordinationApp.Tests/Services/ChoreBoardDtoContractTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/ChoreBoardDtoContractTests.cs
@@ -71,7 +71,10 @@ public class ChoreBoardDtoContractTests
                 RequiredCount: 1,
                 CompletedCount: 0,
                 Roster: [new RosterMemberDto(101, RosterState.In)],
-                Subtasks: [new ChoreSubtaskDto(1, "Sweep first", true, 0), new ChoreSubtaskDto(2, "Mop", false, 1)]),
+                Subtasks: [
+                    // A done item carries the actor stamp; an open item carries nulls (per-occurrence invariant).
+                    new ChoreSubtaskDto(1, "Sweep first", true, 0, 100, new DateTime(2026, 5, 27, 9, 0, 0, DateTimeKind.Utc)),
+                    new ChoreSubtaskDto(2, "Mop", false, 1, null, null)]),
 
             // Due today, assigned (sticky), in the Kitchen room.
             new(
@@ -264,11 +267,17 @@ public class ChoreBoardDtoContractTests
         // Roster member state serializes as a camelCase enum string ("assigned" | "in" | "done").
         firstChore["roster"]!.AsArray()[0]!.AsObject()["state"]!.GetValue<string>().Should().Be("in");
 
-        // Subtasks: a per-chore checklist item is { id, title, isDone, sortOrder } (camelCase), and an empty
-        // checklist serializes as []. Chore 1 carries two items; chore 2 carries none.
+        // Subtasks: a per-chore checklist item is { id, title, isDone, sortOrder, completedByUserId,
+        // completedAt } (camelCase), and an empty checklist serializes as []. Chore 1 carries two items;
+        // chore 2 carries none. The actor stamp is non-null IFF isDone is true (per-occurrence invariant).
         var firstSubtask = firstChore["subtasks"]!.AsArray()[0]!.AsObject();
-        firstSubtask.Select(kvp => kvp.Key).Should().BeEquivalentTo("id", "title", "isDone", "sortOrder");
+        firstSubtask.Select(kvp => kvp.Key).Should().BeEquivalentTo(
+            "id", "title", "isDone", "sortOrder", "completedByUserId", "completedAt");
         firstSubtask["isDone"]!.GetValue<bool>().Should().BeTrue();
+        firstSubtask["completedByUserId"]!.GetValue<int>().Should().Be(100);
+        var openSubtask = firstChore["subtasks"]!.AsArray()[1]!.AsObject();
+        openSubtask["completedByUserId"].Should().BeNull();
+        openSubtask["completedAt"].Should().BeNull();
 
         var assignedChore = root["chores"]!.AsArray()[1]!.AsObject();
         assignedChore["dueState"]!.GetValue<string>().Should().Be("dueToday");

--- a/tests/FamilyCoordinationApp.Tests/Services/ChoreSubtaskResetTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/ChoreSubtaskResetTests.cs
@@ -102,11 +102,25 @@ public class ChoreSubtaskResetTests : IDisposable
                 Title = $"Item {order}",
                 IsDone = done,
                 SortOrder = order,
-                CreatedAt = NowBase
+                CreatedAt = NowBase,
+                // A done item carries the actor stamp (invariant: actor non-null IFF IsDone) so the reset
+                // assertions can verify it is cleared alongside IsDone.
+                CompletedByUserId = done ? Alice : null,
+                CompletedAt = done ? NowBase : null
             });
             order++;
         }
         await ctx.SaveChangesAsync();
+    }
+
+    private async Task<List<int?>> LoadActorsAsync(int choreId)
+    {
+        await using var ctx = new ApplicationDbContext(_options);
+        return await ctx.ChoreSubtasks
+            .Where(s => s.HouseholdId == HouseholdId && s.ChoreId == choreId)
+            .OrderBy(s => s.SortOrder)
+            .Select(s => s.CompletedByUserId)
+            .ToListAsync();
     }
 
     private async Task<List<bool>> LoadDoneFlagsAsync(int choreId)
@@ -145,6 +159,10 @@ public class ChoreSubtaskResetTests : IDisposable
 
         var flags = await LoadDoneFlagsAsync(created.ChoreId);
         flags.Should().AllBeEquivalentTo(false, "a satisfying completion of a recurring chore resets the checklist");
+
+        // The actor stamp clears alongside IsDone — a fresh occurrence has no "who ticked it" (invariant).
+        var actors = await LoadActorsAsync(created.ChoreId);
+        actors.Should().AllBeEquivalentTo((int?)null, "the reset clears the per-occurrence actor stamp");
     }
 
     // (b) Multi-person chore (RequiredCount=2): first (partial) contribution leaves subtasks untouched; the

--- a/tests/FamilyCoordinationApp.Tests/Services/ChoreSubtaskServiceTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/ChoreSubtaskServiceTests.cs
@@ -18,6 +18,7 @@ public class ChoreSubtaskServiceTests : IDisposable
     private const int HouseholdId = 1;
     private const int OtherHouseholdId = 2;
     private const int Alice = 1;
+    private const int Bob = 2;
 
     private static readonly DateTime NowBase = new(2026, 6, 1, 12, 0, 0, DateTimeKind.Utc);
 
@@ -189,12 +190,58 @@ public class ChoreSubtaskServiceTests : IDisposable
     {
         var created = await _service.CreateAsync(HouseholdId, _choreInHouseholdId, "Toggle me");
 
-        var updated = await _service.UpdateAsync(HouseholdId, _choreInHouseholdId, created.Id, title: null, isDone: true, sortOrder: null);
+        var updated = await _service.UpdateAsync(HouseholdId, _choreInHouseholdId, created.Id, Alice, title: null, isDone: true, sortOrder: null);
         updated.IsDone.Should().BeTrue();
         (await ReloadAsync(created.Id))!.IsDone.Should().BeTrue();
 
-        var back = await _service.UpdateAsync(HouseholdId, _choreInHouseholdId, created.Id, title: null, isDone: false, sortOrder: null);
+        var back = await _service.UpdateAsync(HouseholdId, _choreInHouseholdId, created.Id, Alice, title: null, isDone: false, sortOrder: null);
         back.IsDone.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Update_Ticking_CapturesActor_AndUnticking_ClearsIt()
+    {
+        var created = await _service.CreateAsync(HouseholdId, _choreInHouseholdId, "Who did it");
+
+        // false -> true: stamp the acting user + UtcNow.
+        var ticked = await _service.UpdateAsync(HouseholdId, _choreInHouseholdId, created.Id, Alice, title: null, isDone: true, sortOrder: null);
+        ticked.CompletedByUserId.Should().Be(Alice);
+        ticked.CompletedAt.Should().Be(NowBase);
+        var afterTick = await ReloadAsync(created.Id);
+        afterTick!.CompletedByUserId.Should().Be(Alice);
+        afterTick.CompletedAt.Should().Be(NowBase);
+
+        // -> false: clear the actor (per-occurrence invariant: actor set IFF IsDone).
+        var unticked = await _service.UpdateAsync(HouseholdId, _choreInHouseholdId, created.Id, Alice, title: null, isDone: false, sortOrder: null);
+        unticked.CompletedByUserId.Should().BeNull();
+        unticked.CompletedAt.Should().BeNull();
+        var afterUntick = await ReloadAsync(created.Id);
+        afterUntick!.CompletedByUserId.Should().BeNull();
+        afterUntick.CompletedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Update_RetickingAlreadyDone_PreservesOriginalActor()
+    {
+        var created = await _service.CreateAsync(HouseholdId, _choreInHouseholdId, "Stable actor");
+        await _service.UpdateAsync(HouseholdId, _choreInHouseholdId, created.Id, Alice, title: null, isDone: true, sortOrder: null);
+
+        // A second isDone:true write by a different user must NOT re-stamp (true->true is a no-op for the actor).
+        var again = await _service.UpdateAsync(HouseholdId, _choreInHouseholdId, created.Id, Bob, title: null, isDone: true, sortOrder: null);
+        again.CompletedByUserId.Should().Be(Alice, "re-ticking an already-done item preserves the original actor");
+        again.CompletedAt.Should().Be(NowBase);
+    }
+
+    [Fact]
+    public async Task Update_RenameOnly_DoesNotTouchActor()
+    {
+        var created = await _service.CreateAsync(HouseholdId, _choreInHouseholdId, "Done item");
+        await _service.UpdateAsync(HouseholdId, _choreInHouseholdId, created.Id, Alice, title: null, isDone: true, sortOrder: null);
+
+        // A title-only update (isDone == null) leaves the actor stamp intact.
+        var renamed = await _service.UpdateAsync(HouseholdId, _choreInHouseholdId, created.Id, Bob, title: "Renamed", isDone: null, sortOrder: null);
+        renamed.CompletedByUserId.Should().Be(Alice);
+        renamed.CompletedAt.Should().Be(NowBase);
     }
 
     [Fact]
@@ -202,7 +249,7 @@ public class ChoreSubtaskServiceTests : IDisposable
     {
         var created = await _service.CreateAsync(HouseholdId, _choreInHouseholdId, "Old name");
 
-        var updated = await _service.UpdateAsync(HouseholdId, _choreInHouseholdId, created.Id, title: "  New name  ", isDone: null, sortOrder: null);
+        var updated = await _service.UpdateAsync(HouseholdId, _choreInHouseholdId, created.Id, Alice, title: "  New name  ", isDone: null, sortOrder: null);
         updated.Title.Should().Be("New name", "title is trimmed on update");
         (await ReloadAsync(created.Id))!.Title.Should().Be("New name");
     }
@@ -211,7 +258,7 @@ public class ChoreSubtaskServiceTests : IDisposable
     public async Task Update_BlankTitle_Throws()
     {
         var created = await _service.CreateAsync(HouseholdId, _choreInHouseholdId, "Valid");
-        var act = async () => await _service.UpdateAsync(HouseholdId, _choreInHouseholdId, created.Id, title: "   ", isDone: null, sortOrder: null);
+        var act = async () => await _service.UpdateAsync(HouseholdId, _choreInHouseholdId, created.Id, Alice, title: "   ", isDone: null, sortOrder: null);
         await act.Should().ThrowAsync<ChoreValidationException>();
     }
 
@@ -219,7 +266,7 @@ public class ChoreSubtaskServiceTests : IDisposable
     public async Task Update_OnlyAppliesNonNullFields()
     {
         var created = await _service.CreateAsync(HouseholdId, _choreInHouseholdId, "Keep title");
-        await _service.UpdateAsync(HouseholdId, _choreInHouseholdId, created.Id, title: null, isDone: true, sortOrder: 5);
+        await _service.UpdateAsync(HouseholdId, _choreInHouseholdId, created.Id, Alice, title: null, isDone: true, sortOrder: 5);
 
         var reloaded = await ReloadAsync(created.Id);
         reloaded!.Title.Should().Be("Keep title", "a null title leaves the field unchanged");
@@ -230,8 +277,39 @@ public class ChoreSubtaskServiceTests : IDisposable
     [Fact]
     public async Task Update_MissingSubtask_ThrowsNotFound()
     {
-        var act = async () => await _service.UpdateAsync(HouseholdId, _choreInHouseholdId, subtaskId: 9999, title: "X", isDone: null, sortOrder: null);
+        var act = async () => await _service.UpdateAsync(HouseholdId, _choreInHouseholdId, subtaskId: 9999, actingUserId: Alice, title: "X", isDone: null, sortOrder: null);
         await act.Should().ThrowAsync<ChoreNotFoundException>();
+    }
+
+    // ---- REORDER ------------------------------------------------------------
+
+    [Fact]
+    public async Task Reorder_ReassignsSortOrderByPosition()
+    {
+        var a = await _service.CreateAsync(HouseholdId, _choreInHouseholdId, "A"); // sortOrder 0
+        var b = await _service.CreateAsync(HouseholdId, _choreInHouseholdId, "B"); // sortOrder 1
+        var c = await _service.CreateAsync(HouseholdId, _choreInHouseholdId, "C"); // sortOrder 2
+
+        // New order: C, A, B.
+        await _service.ReorderAsync(HouseholdId, _choreInHouseholdId, new[] { c.Id, a.Id, b.Id });
+
+        (await ReloadAsync(c.Id))!.SortOrder.Should().Be(0);
+        (await ReloadAsync(a.Id))!.SortOrder.Should().Be(1);
+        (await ReloadAsync(b.Id))!.SortOrder.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Reorder_IgnoresForeignIds()
+    {
+        var a = await _service.CreateAsync(HouseholdId, _choreInHouseholdId, "A");
+        var b = await _service.CreateAsync(HouseholdId, _choreInHouseholdId, "B");
+
+        // 9999 is not a subtask of this chore — it is skipped, and the present ids re-index by position.
+        var act = async () => await _service.ReorderAsync(HouseholdId, _choreInHouseholdId, new[] { b.Id, 9999, a.Id });
+        await act.Should().NotThrowAsync();
+
+        (await ReloadAsync(b.Id))!.SortOrder.Should().Be(0);
+        (await ReloadAsync(a.Id))!.SortOrder.Should().Be(2);
     }
 
     // ---- DELETE -------------------------------------------------------------

--- a/tests/FamilyCoordinationApp.Tests/Services/ChoreSubtaskServiceTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/ChoreSubtaskServiceTests.cs
@@ -299,17 +299,39 @@ public class ChoreSubtaskServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task Reorder_IgnoresForeignIds()
+    public async Task Reorder_IgnoresForeignIds_AndRenumbersContiguously()
     {
         var a = await _service.CreateAsync(HouseholdId, _choreInHouseholdId, "A");
         var b = await _service.CreateAsync(HouseholdId, _choreInHouseholdId, "B");
 
-        // 9999 is not a subtask of this chore — it is skipped, and the present ids re-index by position.
+        // 9999 is not a subtask of this chore — it is skipped, and the present ids renumber CONTIGUOUSLY
+        // (no gap left by the foreign id).
         var act = async () => await _service.ReorderAsync(HouseholdId, _choreInHouseholdId, new[] { b.Id, 9999, a.Id });
         await act.Should().NotThrowAsync();
 
         (await ReloadAsync(b.Id))!.SortOrder.Should().Be(0);
-        (await ReloadAsync(a.Id))!.SortOrder.Should().Be(2);
+        (await ReloadAsync(a.Id))!.SortOrder.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Reorder_PartialList_AppendsOmitted_AndRenumbersWithoutDuplicates()
+    {
+        var a = await _service.CreateAsync(HouseholdId, _choreInHouseholdId, "A"); // sortOrder 0
+        var b = await _service.CreateAsync(HouseholdId, _choreInHouseholdId, "B"); // sortOrder 1
+        var c = await _service.CreateAsync(HouseholdId, _choreInHouseholdId, "C"); // sortOrder 2
+
+        // A buggy/partial client list with only one id (and a duplicate of it) must NOT leave duplicate
+        // SortOrders: the provided id goes first, the omitted ones append in current order, all renumbered.
+        await _service.ReorderAsync(HouseholdId, _choreInHouseholdId, new[] { c.Id, c.Id });
+
+        var orders = new[]
+        {
+            (await ReloadAsync(c.Id))!.SortOrder, // provided → 0
+            (await ReloadAsync(a.Id))!.SortOrder, // omitted, current order → 1
+            (await ReloadAsync(b.Id))!.SortOrder, // omitted, current order → 2
+        };
+        orders.Should().Equal(0, 1, 2);
+        orders.Should().OnlyHaveUniqueItems("normalization guarantees a contiguous, duplicate-free SortOrder");
     }
 
     // ---- DELETE -------------------------------------------------------------


### PR DESCRIPTION
## What

The Phase-14 deferred follow-up, both halves in one PR:

- **P1 — drag-reorder** a chore's checklist (no migration).
- **P2 — per-item "who ticked it"** actor stamp (additive migration + the M9 board-contract lockstep).

## P1 — drag-reorder

- New **bulk** endpoint `PUT /api/chores/{choreId}/subtasks/reorder` + `IChoreSubtaskService.ReorderAsync` — mirrors `RoomService.ReorderAsync`. Re-indexes `SortOrder` over the chore's checklist in one `SaveChanges`. Household-scoped (M1); versionless (never touches `Chore.Version`).
- Island: `api.reorderSubtasks` + a versionless `boardStore.reorderSubtasks` (optimistic in-place, reconcile on error); `ChoreCard`'s checklist gains `svelte-dnd-action` (the room-manager pattern: local working list + `dragging` guard). The add row sits **outside** the drag zone.

## P2 — per-item actor

- `ChoreSubtask` gains nullable `CompletedByUserId` + `CompletedAt` (migration `AddChoreSubtaskActor`). **Per-occurrence invariant**: actor set *iff* `IsDone` — stamped on the false→true tick (the resolved caller + `UtcNow`), cleared on untick and on the recurring reset in `ChoreService.CompleteAsync`. Re-ticking an already-done item is a no-op (preserves the original actor). No FK — resolved client-side via the board's members.
- **M9 four-way lockstep** updated together: `ChoreSubtaskDto` + `board.json` fixture + the contract test (`BuildRepresentativeBoard` + the frozen key list) + island `types.ts`; the three DTO construction sites carry the new fields.
- Island: `toggleSubtask` shows me as the actor optimistically; `ChoreCard` renders a "who ticked it" initials tag (tooltip = name + date) on done items.

Last-write-wins throughout — subtask writes never bump `Chore.Version` (D5).

## Council

Ran a multi-model review (codex/gpt/gemini). After filtering noise (codex reviewed the wrong tree; gemini's `$derived.by` "Critical" is valid Svelte 5 + svelte-check passed), the one converged finding was real: `ReorderAsync` only re-indexed the ids present in the request, so a partial / duplicate client list could leave **duplicate `SortOrder`**. Hardened it to **normalize to a full contiguous permutation** (O(N), dedup, append-omitted) — last commit, with new tests. The island already guards this, but the server shouldn't trust the client.

## Verification

Built the branch image; browser-verified on the local stack (`:8080`) — migration auto-applied; created a chore + 3 subtasks and confirmed:
- **Actor**: ticking stamps `completedByUserId` + `completedAt` (UI tag "JH" / "Done by you · Jun 23", and the DB row); unticking clears both (UI + DB).
- **Reorder**: a `PUT /reorder` persists the new order in the board projection **and** the DB `SortOrder`, and the rendered checklist reflects it; the actor stamp survives a reorder.
- **dndzone** is wired on the checklist `<ul>`; the add row is a `<div>` outside the zone.

Gates: `dotnet build` (+ island bundle copy) ✓, `svelte-check` 0/0 ✓, `vite build` ✓, full unit/contract suite ✓ (incl. the M9 contract test), and **4/4 `ChoreSubtaskTests` integration tests green against real Postgres** (actor capture + reorder persistence). Format-neutral vs master.

https://claude.ai/code/session_01BZrsjpKLrHVzNhQueskyiU
