### PR TITLE
feat(meal-plan): strangle Meal Plan into a Svelte island

### DIFF
--- a/.planning/meal-plan-island-spec.md
+++ b/.planning/meal-plan-island-spec.md
@@ -1,0 +1,212 @@
+# Spec — Meal Plan → Svelte island (strangler)
+
+**Quest:** Spine `773aac12-af21-4e9e-8788-f55c3170f10b` (campaign "Family Coordination App", horizon `now`).
+**Decisions (operator, 2026-06-23):** spec-first **focused**; **parity-first** — migrate the current click-slot→picker surface as-is. Drag-to-assign is deferred to quest `1656427f` (provisional, `later`).
+**Status:** spec → build.
+
+---
+
+## 1. Goal & scope
+
+Replace the Blazor `MealPlan.razor` circuit-bound surface with a Svelte 5 island that talks to the server over plain HTTP/JSON — killing the tab-away / SignalR-circuit-drop failure mode (same motivation as the shopping-list + chores islands). **Behavior parity** with today's page; **no new UX**.
+
+**In scope (parity):**
+- Weekly view: calendar grid (desktop, md+) / day list (mobile, sm-) toggled by viewport.
+- Week navigation: prev / next / jump-to-today. Monday-start weeks.
+- Slot → recipe picker (3 modes: search existing recipe, custom-meal text, quick-create new recipe).
+- Remove an entry (with a confirm).
+- View a recipe's detail (read-only modal: image, times, servings, ingredients, instructions).
+- View a custom-meal's notes (read-only).
+- Cross-user freshness: a change by another member appears within ~20s while visible, immediately on tab refocus (mirror chores `liveness.ts`; **not** Blazor `DataNotifier`).
+
+**Out of scope (this island):**
+- Drag-to-assign (recipe→slot, move between slots) → deferred quest `1656427f`. The current page has **no** drag; adding it is new UX, not migration.
+- Editing a meal entry in place (today you remove + re-add — keep that).
+- "Planned by" avatars (today's UI shows none; `MealPlanEntry.UpdatedByUserId` exists if a future affordance wants it).
+
+---
+
+## 2. Pattern being mirrored (the template)
+
+The **chores island** is the canonical, freshest end-to-end example. Mirror it; do not invent.
+- `frontend/chores/` — Vite/Svelte-5 island (`main.ts` mount/heal/dark-mode, `App.svelte`, `lib/{types,api,state.svelte,liveness,dates}.ts`, `lib/components/*`, `styles/{app,tokens}.css`).
+- `Endpoints/ChoresEndpoints.cs` — `/api/chores` group behind `.RequireAuthorization().DisableAntiforgery()`, every handler resolving household/user via `UserContextResolver` (M1, never client-supplied).
+- `Services/Dtos/ChoreDtos.cs` ↔ `Fixtures/ChoreBoard/board.json` ↔ `ChoreBoardDtoContractTests` ↔ island `types.ts` — the **M9 four-way lockstep**.
+- `Components/Pages/Chores.razor` — host: feature flag, `#…-root` data attributes, `/islands/…/index.js` import + global mounter, version cache-bust, `ensureIslandStylesheet`.
+- `CopyChoresIsland` MSBuild target in the `.csproj`.
+
+**What meal-plan drops vs chores (it is much simpler):** no claim state machine, no roster, no equity/recap/digest, no rooms, no xmin optimistic-concurrency dance. The closest chores analog is the **versionless subtasks path** (last-write-wins, reconcile-on-error).
+
+---
+
+## 3. Endpoint surface — `/api/meal-plan`
+
+New file `Endpoints/MealPlanEndpoints.cs`, group `app.MapGroup("/api/meal-plan").RequireAuthorization().DisableAntiforgery()`. Every handler resolves the caller via `UserContextResolver.ResolveUserAsync(principal, dbFactory, ct)` → `HouseholdId`/`UserId` server-side (M1). All reads/writes filter by `HouseholdId`.
+
+| Method & route | Body | Returns | Notes |
+|---|---|---|---|
+| `GET /board?weekStart=YYYY-MM-DD` | — | `MealPlanBoardDto` | Server **snaps `weekStart` to that week's Monday** (`IMealPlanService.GetWeekStartDate`). Missing/unparseable → current week (server today, household tz). **Read-only — does NOT create a plan**: no plan for the week ⇒ `mealPlanId:null, entries:[]`. |
+| `POST /entries` | `AddEntryRequest` | `MealPlanEntryDto` (201) | Resolves household+user, delegates to `AddMealAsync` (GetOrCreates the week's plan). Both `recipeId`+`customMealName` set, or neither ⇒ **400**. |
+| `DELETE /entries/{mealPlanId:int}/{entryId:int}` | — | 204 | `RemoveMealAsync`. Not found ⇒ 404 (may surface as empty 400 — see §9.1; island just refetches). |
+| `GET /recipes?q=…` | — | `MealRecipeSummaryDto[]` | Picker autocomplete. `IRecipeService.GetRecipesAsync(householdId, q, ct)`. Empty `q` ⇒ all (matches current `MinCharacters=0`). |
+| `POST /recipes` | `QuickCreateRecipeRequest` | `MealRecipeSummaryDto` (201) | "New Recipe" tab. `CreateRecipeAsync(new Recipe{ HouseholdId=resolved, Name, RecipeType, CreatedByUserId=user, CreatedAt=UtcNow })`. Island then POSTs an entry with the new id (two calls — mirrors today's flow). |
+| `GET /recipes/{recipeId:int}` | — | `RecipeDetailDto` | Recipe-detail modal (read-only, lazy on view-click → keeps the board lean). `GetRecipeAsync`; not found ⇒ 404. |
+
+**Request DTOs:**
+```csharp
+public sealed record AddEntryRequest(
+    DateOnly Date, MealType MealType, int? RecipeId, string? CustomMealName, string? Notes);
+public sealed record QuickCreateRecipeRequest(string Name, RecipeType RecipeType);
+```
+`Date` is the slot's calendar position the user clicked — legitimate client-supplied data (slot identity), not date-math. The server derives the week from it. The XOR (`RecipeId` ⊕ `CustomMealName`) is already enforced in `AddMealAsync`; map its `InvalidOperationException` → 400 (introduce a small typed `MealPlanValidationException`, or catch the existing exception at the endpoint).
+
+---
+
+## 4. Board DTO contract (M9 lockstep)
+
+New file `Services/Dtos/MealPlanDtos.cs`. **All enums are real enum *types* on the DTO** → they serialize **camelCase** through the globally-registered `JsonStringEnumConverter(CamelCase)`. This deliberately avoids the chores `recurrenceMode`/`effortTier` PascalCase-plain-string trap (those were `.ToString()`'d). `DateOnly` serializes as `"YYYY-MM-DD"`.
+
+```csharp
+public sealed record MealPlanBoardDto(
+    DateOnly WeekStartDate,                       // the Monday, echoed
+    int? MealPlanId,                              // null when no plan yet
+    IReadOnlyList<MealPlanEntryDto> Entries);
+
+public sealed record MealPlanEntryDto(
+    int MealPlanId,
+    int EntryId,
+    DateOnly Date,
+    MealType MealType,                            // "breakfast"|"lunch"|"dinner"|"snack"
+    MealRecipeSummaryDto? Recipe,                 // null for custom meals
+    string? CustomMealName,
+    string? Notes);
+
+public sealed record MealRecipeSummaryDto(
+    int RecipeId, string Name, string? ImagePath, RecipeType RecipeType);
+
+public sealed record RecipeDetailDto(
+    int RecipeId, string Name, string? ImagePath, RecipeType RecipeType,
+    int? PrepTimeMinutes, int? CookTimeMinutes, int? Servings,
+    string? Instructions, IReadOnlyList<RecipeIngredientDto> Ingredients);
+
+public sealed record RecipeIngredientDto(
+    decimal? Quantity, string? Unit, string Name, string? Notes, int SortOrder);
+```
+
+Projection lives in **one place** — a new `IMealPlanBoardService` (mirrors `IChoreBoardService`): `GetBoardAsync(householdId, weekStart, ct)` (read-only) and the per-entry projection reused by `POST /entries`' response, so the card view and the mutation response can't drift (M9 spirit). Recipe summary/detail projections live alongside.
+
+**TS mirror** (`frontend/meal-plan/src/lib/types.ts`) — camelCase keys:
+```ts
+export type MealType = 'breakfast' | 'lunch' | 'dinner' | 'snack';
+export type RecipeType =
+  'main'|'side'|'appetizer'|'dessert'|'beverage'|'sauce'|'breakfast'|'snack'|'other';
+export interface MealRecipeSummaryDto { recipeId:number; name:string; imagePath:string|null; recipeType:RecipeType }
+export interface MealPlanEntryDto {
+  mealPlanId:number; entryId:number; date:string;  // "YYYY-MM-DD" — NEVER new Date() it
+  mealType:MealType; recipe:MealRecipeSummaryDto|null; customMealName:string|null; notes:string|null }
+export interface MealPlanBoardDto { weekStartDate:string; mealPlanId:number|null; entries:MealPlanEntryDto[] }
+export interface RecipeIngredientDto { quantity:number|null; unit:string|null; name:string; notes:string|null; sortOrder:number }
+export interface RecipeDetailDto {
+  recipeId:number; name:string; imagePath:string|null; recipeType:RecipeType;
+  prepTimeMinutes:number|null; cookTimeMinutes:number|null; servings:number|null;
+  instructions:string|null; ingredients:RecipeIngredientDto[] }
+export interface ShellContext { householdId:number; userId:number; userName:string }
+```
+
+---
+
+## 5. Concurrency — versionless / last-write-wins
+
+Parity ops are **add** and **remove** (no in-place edit). So the wire contract carries **no `version`/xmin token** — mirror the chores *subtasks* path, not its xmin path. This answers the handoff's open question ("does a meal slot need xmin?") → **no, for parity.** (`MealPlanEntry.Version` exists on the entity but is unused here; the deferred drag-drop "move" quest can revisit if it needs it.)
+
+Conflict story: two members editing the same week → last write wins; the 20s liveness poll + refocus-refetch reconciles. Removing an already-removed entry → 404/empty-400 → island refetches the week. This matches today's Blazor behavior (also last-write-wins via DataNotifier).
+
+---
+
+## 6. Island structure — `frontend/meal-plan/`
+
+Copy the chores scaffold, strip what parity doesn't need (**no `svelte-dnd-action`**, no equity/recap/rooms/digest).
+
+- **Build config:** `package.json` (name `meal-plan-island`, deps: just svelte + vite toolchain — drop `svelte-dnd-action`), `tsconfig.json`, `svelte.config.js`, `vite.config.ts` (port **5175**, `outDir:dist`, `input:src/main.ts`, `entryFileNames:index.js`, css→`index.css`, `/api` proxy → `:5000`), `index.html` (dev auto-mount).
+- **`src/main.ts`** — copy chores verbatim, rename: root id `meal-plan-root`, global `window.MealPlanIsland = { mount, destroy }`, `ch-dark-mode` → `mp-dark-mode`. **Keep the `.NET 10` circuit-resume self-heal machinery as-is** — it's load-bearing reliability; do not reinvent.
+- **`src/lib/types.ts`** — §4.
+- **`src/lib/api.ts`** — `getBoard(weekStart)`, `addEntry(body)`, `removeEntry(mealPlanId, entryId)`, `searchRecipes(q)`, `quickCreateRecipe(body)`, `getRecipeDetail(id)`. Reuse the chores `ApiError` + `request<T>` (`credentials:'include'`); since versionless, no 409 branch needed — any non-2xx 4xx ⇒ client rejection ⇒ refetch.
+- **`src/lib/state.svelte.ts`** — `MealPlanStore` (class-instance export — Svelte-5 rune rule):
+  - `weekStart = $state<string>` (the Monday "YYYY-MM-DD"), `board = $state<MealPlanBoardDto|null>`, `loading`, `error`, `currentUserId`.
+  - `entriesByDayMeal = $derived` — `Map<\`${date}|${mealType}\`, MealPlanEntryDto[]>` for slot lookup.
+  - `changeWeek(deltaWeeks|targetMonday)` → recompute weekStart (§ dates), refetch board.
+  - `addEntry(...)` — POST then merge returned entry into `board.entries` (await-then-insert; add is infrequent). On 4xx/network: reconcile + calm toast.
+  - `removeEntry(mealPlanId, entryId)` — optimistic splice, DELETE, reconcile-on-error.
+  - `setRefresh` / `reconcile` (re-GET the current week) shared by liveness + error reconcile (copy chores shape).
+- **`src/lib/dates.ts`** — week helpers. **MN4/global-CORRECTION:** never `new Date('YYYY-MM-DD')`. Step weeks via `Date.UTC(y,m,d,12)` (noon UTC, DST-safe) → format the YYYY-MM-DD string + the "MMM d – MMM d, yyyy" label + weekday/day labels. The server re-snaps `weekStart` to Monday on every board GET, so client stepping can't corrupt the boundary.
+- **`src/lib/liveness.ts`** — copy chores verbatim (20s visible-only poll + `visibilitychange` immediate refetch).
+- **`src/App.svelte`** — read `ShellContext` from root data-attrs; init week = current; load board; render `WeekNav` + (`CalendarGrid` md+ / `DayList` sm-) via a CSS/match-media split; mount `Toasts`; wire liveness to `reconcile`.
+- **`src/lib/components/`:**
+  - `WeekNav.svelte` — prev/next/jump-to-today + week-range label + "This week" chip.
+  - `CalendarGrid.svelte` — 7-col × 3-row (Breakfast/Lunch/Dinner) grid (desktop). *(Snack: today's grid renders only B/L/D rows even though the enum has Snack; preserve that — Snack reachable only if data exists. Match current `WeeklyCalendarView`.)*
+  - `DayList.svelte` — per-day expandable sections (mobile), B/L/D rows.
+  - `MealSlot.svelte` — empty (＋) or entries (recipe card w/ image+name+type chip, or custom-meal w/ notes) + remove (×) + "add side/dessert".
+  - `RecipePickerSheet.svelte` — replaces `RecipePickerDialog` MudDialog. 3 modes: **search** (debounced `searchRecipes`, image+name rows), **custom meal** (name + notes), **new recipe** (name + type select → `quickCreateRecipe` → add entry). Notes field shared across modes.
+  - `RecipeDetailSheet.svelte` — lazy `getRecipeDetail(id)` → image, time/servings chips, ingredients (format `qty unit name (notes)`), instructions (sanitized markdown → reuse a tiny client renderer or render server-sanitized HTML; today it's `MarkdownHelper.ToSafeHtml` server-side — **decide:** return pre-sanitized `instructionsHtml` from the detail endpoint to avoid shipping a markdown lib client-side). → **Resolve in WP-1:** add `InstructionsHtml` (server-sanitized) to `RecipeDetailDto`, drop raw `Instructions`, render via `{@html}`.
+  - `CustomMealSheet` — fold into `RecipeDetailSheet` (read-only notes view) or a tiny dedicated view.
+  - `Toasts.svelte` + `toasts.svelte.ts` — copy chores.
+- **`src/styles/{app,tokens}.css`** — copy chores (MudBlazor token bridge + dark-mode); rename the `mp-dark-mode` scope.
+
+---
+
+## 7. Host page + build wiring
+
+- **`Components/Pages/MealPlan.razor`** — mirror `Chores.razor`. Feature flag **`MEAL_PLAN_USE_ISLAND`** (config-or-env, same helper shape). **Flag ON → island** (`#meal-plan-root` w/ `data-household-id`/`data-user-id`/`data-user-name`, `/islands/meal-plan/index.js` import + `MealPlanIsland.mount`, version cache-bust, `ensureIslandStylesheet`). **Flag OFF → the existing Blazor page body** (keep `IMealPlanService`/dialogs intact as the zero-regression fallback during migration — flip the flag to switch; delete the Blazor path in a later cleanup). Mirror `IAsyncDisposable` teardown + `JSDisconnectedException` guard.
+- **`CopyMealPlanIsland`** MSBuild target in `FamilyCoordinationApp.csproj` — copy of `CopyChoresIsland`, `frontend/meal-plan/dist/**` → `wwwroot/islands/meal-plan/`, `Condition="Exists(... frontend/meal-plan/dist)"`, `BeforeTargets="AssignTargetPaths"`.
+- **Dockerfile** — add a `mealplan-node-build` stage (copy of `chores-node-build`): `npm ci && npm run build` in `frontend/meal-plan/`; the .NET stage `COPY --from=mealplan-node-build … frontend/meal-plan/dist`. *(Verify exact stage names in the Dockerfile during WP-5.)*
+- **`Program.cs`** — register `IMealPlanBoardService`; call `app.MapMealPlanEndpoints()`. (`IMealPlanService`, `IRecipeService` already registered.) Confirm the global JSON options register `JsonStringEnumConverter(CamelCase)` (the contract test depends on it).
+- **`ensureIslandStylesheet` / `import` JS helpers** — reuse the existing ones `Chores.razor` calls (locate in `wwwroot` during WP-5; do not duplicate).
+
+---
+
+## 8. Contract & integration tests (M9)
+
+- **`MealPlanBoardDtoContractTests`** (mirror `ChoreBoardDtoContractTests`): build a representative `MealPlanBoardDto` (a week with a recipe entry w/ image, a recipe entry w/o image, a custom-meal entry w/ notes, entries across multiple days + meal types, a non-null `mealPlanId`); serialize with the **same global `JsonSerializerOptions`** (`JsonSerializerDefaults.Web` + `JsonStringEnumConverter(CamelCase)`, `WriteIndented`); assert byte-equality against checked-in `Fixtures/MealPlanBoard/board.json`. The island `types.ts` mirrors that fixture → any shape/casing drift breaks the test. (Optional second fixture for `RecipeDetailDto`; lower priority — read-only, low-risk.)
+- **Endpoint integration (real Postgres, mirror chores endpoint tests):** board read for a week (empty + populated); add-entry round-trip (recipe + custom); add-entry XOR validation → 400; remove → 204 then gone; remove-missing → 404; recipe search; quick-create then board reflects it; **cross-household isolation** — a user in household A cannot read or mutate household B's plan/entries (M1).
+
+---
+
+## 9. Gotchas to carry (from shopping-list + chores)
+
+1. **WP-08 4xx quirk** — the app's `UseStatusCodePagesWithReExecute` re-executes empty-body 404s as empty **400s**. Island treats **any 4xx** as a non-retryable rejection → refetch the week + calm toast. (No 409 here — versionless — so even simpler than chores.)
+2. **Casing** — `MealType`/`RecipeType` are real enums on the DTO ⇒ **camelCase** via the global converter; `DateOnly` ⇒ `"YYYY-MM-DD"`. Document at the top of `types.ts`.
+3. **Dates (MN4 / global CORRECTION)** — never `new Date('YYYY-MM-DD')`. Week-stepping uses `Date.UTC(...,12)` for **display only**; the server is authoritative on the week's Monday.
+4. **Multi-tenant (M1)** — household/user always server-resolved; every query filters `HouseholdId`; cross-household integration test is mandatory.
+5. **Island resilience** — reuse `main.ts`'s mount/heal/dark-mode self-heal verbatim (the `.NET 10` circuit-resume root-replacement fix). Load-bearing; don't reinvent.
+6. **DbContextFactory** — services inject `IDbContextFactory<ApplicationDbContext>`, short-lived contexts (already true of `MealPlanService`/`RecipeService`).
+
+---
+
+## 10. Build sequence (work packages)
+
+- **WP-1 — Backend.** `MealPlanDtos.cs`, `IMealPlanBoardService`+impl (board read + entry/summary/detail projections; resolve `InstructionsHtml` server-sanitized), `MealPlanEndpoints.cs` (6 routes), `Program.cs` wiring, `MealPlanValidationException`→400 mapping.
+- **WP-2 — Tests.** `MealPlanBoardDtoContractTests` + `Fixtures/MealPlanBoard/board.json`; endpoint integration (real PG) incl. cross-household isolation.
+- **WP-3 — Island scaffold.** `frontend/meal-plan/` config + `types.ts` + `api.ts` + `main.ts` + `styles/` + `App.svelte` skeleton. `svelte-check` 0/0, `vite build` green.
+- **WP-4 — Island UI.** store + `WeekNav`/`CalendarGrid`/`DayList`/`MealSlot`/`RecipePickerSheet`/`RecipeDetailSheet`/`Toasts` + liveness. `svelte-check` 0/0, `vite build`.
+- **WP-5 — Host + build wiring.** `MealPlan.razor` flag + mount (keep Blazor fallback), `CopyMealPlanIsland`, Dockerfile `mealplan-node-build` stage.
+- **WP-6 — Verify.** Browser-verify on `:8080` (rebuild `familyapp:latest`, swap app container, DOM+psql — Chrome screenshots flake on this stack; memory `fca-local-browser-verify-recipe`); flip `MEAL_PLAN_USE_ISLAND=true` and exercise add/remove/picker/detail/week-nav.
+
+---
+
+## 11. Gates (chores precedent; worktree baseline = memory `fca-worktree-gate-baseline`)
+
+- `dotnet build` clean.
+- `dotnet test` full suite green incl. new contract + integration tests. *Baseline if working in a worktree:* 2 `ApiKeySecurityTests` fail (`.git` is a file) + 49 pre-existing `dotnet format` whitespace errors on master — "green" = **no NEW failures**.
+- `svelte-check` 0 errors / 0 warnings in `frontend/meal-plan/`.
+- `vite build` → `dist/index.js` + `dist/index.css`.
+- Real-Postgres integration for the new endpoints passes.
+- Browser-verify on `:8080` (island path) confirms parity.
+
+---
+
+## 12. Open items (non-blocking — resolve in-build)
+
+- **Instructions rendering** — decided: server returns sanitized `InstructionsHtml` on `RecipeDetailDto` (reuse `MarkdownHelper.ToSafeHtml`), island `{@html}`s it → no client markdown lib. (WP-1.)
+- **Snack row** — preserve current behavior (grid shows B/L/D; Snack only if data exists). (WP-4.)
+- **Exact Dockerfile stage names** — confirm against the real Dockerfile. (WP-5.)
+- **`ensureIslandStylesheet`/import helper location** — locate the existing `wwwroot` helpers Chores.razor uses. (WP-5.)

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,15 @@ RUN if [ -f package-lock.json ]; then npm ci; else npm install --no-audit --no-f
 COPY frontend/chores/ ./
 RUN npm run build
 
+# Stage 1c: Build the Svelte meal-plan island (strangler; parallel to the others).
+# Emits ./dist/ which the .NET stage copies into wwwroot/islands/meal-plan/.
+FROM node:20-alpine AS mealplan-node-build
+WORKDIR /frontend
+COPY frontend/meal-plan/package.json frontend/meal-plan/package-lock.json* ./
+RUN if [ -f package-lock.json ]; then npm ci; else npm install --no-audit --no-fund; fi
+COPY frontend/meal-plan/ ./
+RUN npm run build
+
 # Stage 2: Build the .NET app.
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
@@ -29,6 +38,7 @@ RUN dotnet restore FamilyCoordinationApp/FamilyCoordinationApp.csproj
 COPY src/FamilyCoordinationApp/ ./FamilyCoordinationApp/
 COPY --from=node-build /frontend/dist/ ./FamilyCoordinationApp/wwwroot/islands/shopping-list/
 COPY --from=chores-node-build /frontend/dist/ ./FamilyCoordinationApp/wwwroot/islands/chores/
+COPY --from=mealplan-node-build /frontend/dist/ ./FamilyCoordinationApp/wwwroot/islands/meal-plan/
 
 # Explicitly set working directory to project folder before publish
 WORKDIR /src/FamilyCoordinationApp

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -60,6 +60,7 @@ build_island() {
 }
 build_island "./frontend/shopping-list" "shopping-list"
 build_island "./frontend/chores" "chores"
+build_island "./frontend/meal-plan" "meal-plan"
 echo ""
 
 # Step 3: Publish locally

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       GEMINI_MODEL: ${GEMINI_MODEL:-}
       SHOPPING_LIST_USE_ISLAND: ${SHOPPING_LIST_USE_ISLAND:-false}
       CHORES_USE_ISLAND: ${CHORES_USE_ISLAND:-false}
+      MEAL_PLAN_USE_ISLAND: ${MEAL_PLAN_USE_ISLAND:-false}
       # Chores v1.1 digest. The token gates POST /api/chores/digest/run (cron trigger); unset ⇒ endpoint
       # returns 503 (feature off). MUST be mapped here — .env is only used for ${VAR} substitution, not
       # auto-injected, so the documented go-live step (set CHORES_DIGEST_TRIGGER_TOKEN) is inert without this.

--- a/frontend/meal-plan/.gitignore
+++ b/frontend/meal-plan/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.log
+.DS_Store

--- a/frontend/meal-plan/index.html
+++ b/frontend/meal-plan/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Meal Plan (dev)</title>
+  </head>
+  <body>
+    <!-- Dev-only host. In production the Razor shell (MealPlan.razor) provides these attrs. -->
+    <div
+      id="meal-plan-root"
+      data-household-id="1"
+      data-user-id="1"
+      data-user-name="Dev User"
+    ></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/frontend/meal-plan/package-lock.json
+++ b/frontend/meal-plan/package-lock.json
@@ -1,0 +1,1541 @@
+{
+  "name": "meal-plan-island",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "meal-plan-island",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@sveltejs/vite-plugin-svelte": "^5.0.3",
+        "@tsconfig/svelte": "^5.0.4",
+        "svelte": "^5.19.0",
+        "svelte-check": "^4.1.4",
+        "tslib": "^2.8.1",
+        "typescript": "~5.7.2",
+        "vite": "^6.0.7"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sveltejs/acorn-typescript": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.10.tgz",
+      "integrity": "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8.9.0"
+      }
+    },
+    "node_modules/@sveltejs/load-config": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@sveltejs/load-config/-/load-config-0.2.0.tgz",
+      "integrity": "sha512-1LgZ/qUqSoq+QorD83lk2hka79Px0wXNW2q5V1nZlxGhQgw1jrsIbVz5YiCeucVLo4XvFLjXukUaQjIiqowkcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-5.1.1.tgz",
+      "integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
+        "debug": "^4.4.1",
+        "deepmerge": "^4.3.1",
+        "kleur": "^4.1.5",
+        "magic-string": "^0.30.17",
+        "vitefu": "^1.0.6"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22"
+      },
+      "peerDependencies": {
+        "svelte": "^5.0.0",
+        "vite": "^6.0.0"
+      }
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte-inspector": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-4.0.1.tgz",
+      "integrity": "sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.7"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22"
+      },
+      "peerDependencies": {
+        "@sveltejs/vite-plugin-svelte": "^5.0.0",
+        "svelte": "^5.0.0",
+        "vite": "^6.0.0"
+      }
+    },
+    "node_modules/@tsconfig/svelte": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-5.0.8.tgz",
+      "integrity": "sha512-UkNnw1/oFEfecR8ypyHIQuWYdkPvHiwcQ78sh+ymIiYoF+uc5H1UBetbjyqT+vgGJ3qQN6nhucJviX6HesWtKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
+      "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/devalue": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esrap": {
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.12.tgz",
+      "integrity": "sha512-On0QbLyaiAkVC4eXtgnXK9Kh2opit+3rcUSOc45DqJ2s/X2eXAHsGOKRSJ6IDagQEW5vPyivANfXUiqgXC67Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/types": "^8.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/is-reference": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.6"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/locate-character": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/svelte": {
+      "version": "5.56.4",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.4.tgz",
+      "integrity": "sha512-/d0QHehmRuJW8gVz395MTkPcPozxzdjBMBE8oEYGz8O3b9KTMzzQ9ZHJQLuFKOHOPQbU6kx/X4iid/EBBzH7iw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.4",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@sveltejs/acorn-typescript": "^1.0.10",
+        "@types/estree": "^1.0.5",
+        "@types/trusted-types": "^2.0.7",
+        "acorn": "^8.12.1",
+        "aria-query": "5.3.1",
+        "axobject-query": "^4.1.0",
+        "clsx": "^2.1.1",
+        "devalue": "^5.8.1",
+        "esm-env": "^1.2.1",
+        "esrap": "^2.2.12",
+        "is-reference": "^3.0.3",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.11",
+        "zimmerframe": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/svelte-check": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.7.0.tgz",
+      "integrity": "sha512-XChCqdDg29UWOWai2I1s2Ss003piZ9mae2y2KXwoOX01W75mg7/fwLLnx9Yruk9asHkxHPDdSfEfsJh5tr9JvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "@sveltejs/load-config": "^0.2.0",
+        "chokidar": "^4.0.1",
+        "fdir": "^6.2.0",
+        "picocolors": "^1.0.0",
+        "sade": "^1.7.4"
+      },
+      "bin": {
+        "svelte-check": "bin/svelte-check"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "svelte": "^4.0.0 || ^5.0.0-next.0",
+        "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitefu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+      "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "tests/deps/*",
+        "tests/projects/*",
+        "tests/projects/workspace/packages/*"
+      ],
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zimmerframe": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
+      "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/frontend/meal-plan/package.json
+++ b/frontend/meal-plan/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "meal-plan-island",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "check": "svelte-check --tsconfig ./tsconfig.json"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^5.0.3",
+    "@tsconfig/svelte": "^5.0.4",
+    "svelte": "^5.19.0",
+    "svelte-check": "^4.1.4",
+    "tslib": "^2.8.1",
+    "typescript": "~5.7.2",
+    "vite": "^6.0.7"
+  }
+}

--- a/frontend/meal-plan/src/App.svelte
+++ b/frontend/meal-plan/src/App.svelte
@@ -1,0 +1,274 @@
+<script lang="ts">
+  import type { MealPlanEntryDto, MealType, ShellContext } from './lib/types';
+  import { mealPlanStore } from './lib/state.svelte';
+  import { startLiveness, type LivenessHandle } from './lib/liveness';
+  import { weekdayShort, monthDay, todayMonday } from './lib/dates';
+  import WeekNav from './lib/components/WeekNav.svelte';
+  import CalendarGrid from './lib/components/CalendarGrid.svelte';
+  import DayList from './lib/components/DayList.svelte';
+  import RecipePickerSheet, { type PickerResult } from './lib/components/RecipePickerSheet.svelte';
+  import RecipeDetailSheet from './lib/components/RecipeDetailSheet.svelte';
+  import ConfirmDialog from './lib/components/ConfirmDialog.svelte';
+  import Toasts from './lib/components/Toasts.svelte';
+
+  // ───────────────────────────────────────────────────────────────────────
+  // Root of the meal-plan island. Reads the ShellContext from #meal-plan-root
+  // data-attrs, fetches the current week's board into the shared store, and
+  // renders WeekNav + (CalendarGrid on md+ / DayList on sm-). Every slot is a
+  // client-side grouping of the one board payload (store.entriesByDayMeal).
+  // Versionless — add + remove only; on any 4xx/network the store reconciles.
+  // No `new Date('YYYY-MM-DD')` anywhere — week stepping goes through dates.ts.
+  // ───────────────────────────────────────────────────────────────────────
+
+  interface Props {
+    ctx: ShellContext;
+  }
+
+  let { ctx }: Props = $props();
+
+  const store = mealPlanStore;
+
+  let liveness: LivenessHandle | null = null;
+
+  // Responsive split mirrors the Blazor MudHidden breakpoint (Sm = 960px). We
+  // watch matchMedia rather than relying on CSS alone so we only mount one tree.
+  let isDesktop = $state(true);
+  let mediaQuery: MediaQueryList | null = null;
+  function syncMedia(): void {
+    if (mediaQuery) isDesktop = mediaQuery.matches;
+  }
+
+  // ── Picker (add) state ────────────────────────────────────────────────────
+  let pickerOpen = $state(false);
+  let pickerSlot = $state<{ date: string; mealType: MealType } | null>(null);
+  let pickerSlotLabel = $derived(
+    pickerSlot
+      ? `${weekdayShort(pickerSlot.date)} ${monthDay(pickerSlot.date)} — ${mealLabel(pickerSlot.mealType)}`
+      : '',
+  );
+
+  // ── Detail / custom-meal view state ───────────────────────────────────────
+  let detailOpen = $state(false);
+  let detailMode = $state<'recipe' | 'custom'>('recipe');
+  let detailRecipeId = $state<number | null>(null);
+  let detailRecipeName = $state('');
+  let detailCustomEntry = $state<MealPlanEntryDto | null>(null);
+
+  // ── Remove-confirm state ──────────────────────────────────────────────────
+  let confirmOpen = $state(false);
+  let confirmEntry = $state<MealPlanEntryDto | null>(null);
+  let confirmMessage = $derived(
+    confirmEntry ? `Remove this meal from ${monthDay(confirmEntry.date)}?` : '',
+  );
+
+  function mealLabel(m: MealType): string {
+    return m.charAt(0).toUpperCase() + m.slice(1);
+  }
+
+  async function loadBoard(): Promise<void> {
+    await store.loadBoard();
+  }
+
+  // ── Slot handlers ──────────────────────────────────────────────────────────
+  function handleSlotAdd(date: string, mealType: MealType): void {
+    pickerSlot = { date, mealType };
+    pickerOpen = true;
+  }
+
+  async function handlePickerConfirm(result: PickerResult): Promise<void> {
+    const slot = pickerSlot;
+    if (!slot) return;
+    pickerOpen = false;
+    pickerSlot = null;
+    await store.addEntry({
+      date: slot.date,
+      mealType: slot.mealType,
+      recipeId: result.recipeId ?? null,
+      customMealName: result.customMealName ?? null,
+      notes: result.notes ?? null,
+    });
+  }
+
+  function handleViewRecipe(entry: MealPlanEntryDto): void {
+    if (!entry.recipe) return;
+    detailMode = 'recipe';
+    detailRecipeId = entry.recipe.recipeId;
+    detailRecipeName = entry.recipe.name;
+    detailCustomEntry = null;
+    detailOpen = true;
+  }
+
+  function handleViewCustom(entry: MealPlanEntryDto): void {
+    detailMode = 'custom';
+    detailCustomEntry = entry;
+    detailRecipeId = null;
+    detailOpen = true;
+  }
+
+  function handleRemove(entry: MealPlanEntryDto): void {
+    confirmEntry = entry;
+    confirmOpen = true;
+  }
+
+  async function handleConfirmRemove(): Promise<void> {
+    const entry = confirmEntry;
+    confirmOpen = false;
+    confirmEntry = null;
+    if (entry) await store.removeEntry(entry.mealPlanId, entry.entryId);
+  }
+
+  $effect(() => {
+    store.init(ctx);
+    store.setRefresh(loadBoard);
+
+    mediaQuery = window.matchMedia('(min-width: 960px)');
+    syncMedia();
+    mediaQuery.addEventListener('change', syncMedia);
+
+    loadBoard();
+    // Liveness: ~20s poll while visible + immediate refetch on refocus; pauses
+    // while hidden. NOT Blazor DataNotifier/PollingService (MN2).
+    liveness = startLiveness(() => store.reconcile());
+
+    return () => {
+      liveness?.stop();
+      liveness = null;
+      mediaQuery?.removeEventListener('change', syncMedia);
+      mediaQuery = null;
+    };
+  });
+</script>
+
+<div class="mp-container">
+  <header class="mp-header">
+    <h1 class="mp-title">Meal Plan</h1>
+    <span class="mp-user">{ctx.userName}</span>
+  </header>
+
+  <WeekNav
+    weekStart={store.weekStart}
+    onPrev={() => store.changeWeek(-1)}
+    onNext={() => store.changeWeek(1)}
+    onToday={() => store.changeWeek(todayMonday())}
+  />
+
+  {#if store.error}
+    <div class="mp-inline-error" role="alert">
+      <span>{store.error}</span>
+      <button type="button" class="mp-retry" onclick={loadBoard}>Retry</button>
+    </div>
+  {/if}
+
+  {#if store.loading && !store.board}
+    <div class="mp-loading">Loading the meal plan…</div>
+  {:else if store.board}
+    {#if isDesktop}
+      <CalendarGrid
+        weekStart={store.weekStart}
+        onSlotAdd={handleSlotAdd}
+        onRemove={handleRemove}
+        onViewRecipe={handleViewRecipe}
+        onViewCustom={handleViewCustom}
+      />
+    {:else}
+      <DayList
+        weekStart={store.weekStart}
+        onSlotAdd={handleSlotAdd}
+        onRemove={handleRemove}
+        onViewRecipe={handleViewRecipe}
+        onViewCustom={handleViewCustom}
+      />
+    {/if}
+  {:else if !store.loading}
+    <div class="mp-empty">No meal plan data.</div>
+  {/if}
+</div>
+
+<RecipePickerSheet
+  open={pickerOpen}
+  slotLabel={pickerSlotLabel}
+  onClose={() => {
+    pickerOpen = false;
+    pickerSlot = null;
+  }}
+  onConfirm={handlePickerConfirm}
+/>
+
+<RecipeDetailSheet
+  open={detailOpen}
+  mode={detailMode}
+  recipeId={detailRecipeId}
+  recipeName={detailRecipeName}
+  customEntry={detailCustomEntry}
+  onClose={() => (detailOpen = false)}
+/>
+
+<ConfirmDialog
+  open={confirmOpen}
+  title="Remove Meal"
+  message={confirmMessage}
+  onCancel={() => {
+    confirmOpen = false;
+    confirmEntry = null;
+  }}
+  onConfirm={handleConfirmRemove}
+/>
+
+<Toasts />
+
+<style>
+  .mp-container {
+    max-width: 1280px;
+    margin: 0 auto;
+    padding: 24px 16px 96px;
+  }
+  .mp-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 16px;
+  }
+  .mp-title {
+    margin: 0;
+    font-size: 2.125rem;
+    font-weight: 400;
+    color: var(--color-text);
+  }
+  .mp-user {
+    color: var(--color-text-muted);
+    font-size: 0.875rem;
+  }
+  .mp-loading,
+  .mp-empty {
+    padding: 48px 16px;
+    text-align: center;
+    color: var(--color-text-muted);
+  }
+  .mp-inline-error {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 16px;
+    margin-bottom: 16px;
+    background: rgba(229, 57, 53, 0.08);
+    border-left: 4px solid var(--color-error);
+    border-radius: var(--radius-sm);
+    color: var(--color-error);
+    font-size: 0.875rem;
+  }
+  .mp-retry {
+    font: inherit;
+    border: none;
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+    padding: 4px 12px;
+    background: transparent;
+    color: var(--color-error);
+    font-weight: 500;
+  }
+  .mp-retry:hover {
+    background: rgba(229, 57, 53, 0.12);
+  }
+</style>

--- a/frontend/meal-plan/src/lib/api.ts
+++ b/frontend/meal-plan/src/lib/api.ts
@@ -1,0 +1,114 @@
+import type {
+  MealPlanBoardDto,
+  MealPlanEntryDto,
+  MealRecipeSummaryDto,
+  RecipeDetailDto,
+  MealType,
+  RecipeType,
+} from './types';
+
+const BASE = '/api/meal-plan';
+
+/**
+ * Thrown on any non-2xx response. `status` lets callers react to a rejection.
+ *
+ * ⚠ WP-08 finding (carried from chores/shopping-list): the app re-executes
+ * empty-body API 404s through a Blazor `/not-found` page, so a server-side
+ * "not found" can arrive on the wire as an empty **400**, not 404. Since the
+ * meal-plan island is VERSIONLESS (no 409 concurrency dance), the rule is even
+ * simpler: treat ANY 4xx as a non-retryable client rejection → refetch the
+ * week + calm toast. There is no retry branch.
+ */
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+
+  /**
+   * A non-retryable client rejection: validation / not found (which may surface
+   * as an empty 400 per the WP-08 re-execution behavior). Any 4xx.
+   */
+  get isClientRejection(): boolean {
+    return this.status >= 400 && this.status < 500;
+  }
+}
+
+async function request<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    // Same-origin cookie auth — the host page is already authenticated.
+    credentials: 'include',
+    headers: { Accept: 'application/json', ...(init?.headers ?? {}) },
+    ...init,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new ApiError(res.status, text || res.statusText);
+  }
+  if (res.status === 204) return undefined as T;
+  return (await res.json()) as T;
+}
+
+function jsonBody(body: unknown): RequestInit {
+  return {
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  };
+}
+
+// ─── Board read ─────────────────────────────────────────────────────────────
+// The server re-snaps `weekStart` to that week's Monday and echoes it back as
+// `weekStartDate`, so client stepping is display-only (the server is the
+// authority on the week boundary). A "YYYY-MM-DD" is always sent.
+
+export async function getBoard(weekStart: string): Promise<MealPlanBoardDto> {
+  return request<MealPlanBoardDto>(`${BASE}/board?weekStart=${encodeURIComponent(weekStart)}`);
+}
+
+// ─── Entries (add / remove — versionless) ────────────────────────────────────
+
+/** Body for POST /entries — supply EXACTLY one of recipeId / customMealName. */
+export interface AddEntryBody {
+  /** "YYYY-MM-DD" — the slot's calendar position (server derives the week). */
+  date: string;
+  mealType: MealType;
+  recipeId?: number | null;
+  customMealName?: string | null;
+  notes?: string | null;
+}
+
+/** Add a meal to a slot → the created entry (201). */
+export async function addEntry(body: AddEntryBody): Promise<MealPlanEntryDto> {
+  return request<MealPlanEntryDto>(`${BASE}/entries`, { method: 'POST', ...jsonBody(body) });
+}
+
+/** Remove an entry. DELETE → 204 (no body); a missing entry → 404/empty-400. */
+export async function removeEntry(mealPlanId: number, entryId: number): Promise<void> {
+  await request<void>(`${BASE}/entries/${mealPlanId}/${entryId}`, { method: 'DELETE' });
+}
+
+// ─── Recipes (picker search / quick-create / detail) ─────────────────────────
+
+/** Picker autocomplete. Empty `q` ⇒ all (matches the current MinCharacters=0). */
+export async function searchRecipes(q: string): Promise<MealRecipeSummaryDto[]> {
+  return request<MealRecipeSummaryDto[]>(`${BASE}/recipes?q=${encodeURIComponent(q)}`);
+}
+
+/** Body for POST /recipes — quick-create a bare recipe (details added later). */
+export interface QuickCreateRecipeBody {
+  name: string;
+  recipeType: RecipeType;
+}
+
+/** "New Recipe" tab → the created recipe summary (201). The caller then adds an entry with the new id. */
+export async function quickCreateRecipe(body: QuickCreateRecipeBody): Promise<MealRecipeSummaryDto> {
+  return request<MealRecipeSummaryDto>(`${BASE}/recipes`, { method: 'POST', ...jsonBody(body) });
+}
+
+/** Recipe-detail modal (read-only, lazy on view-click → keeps the board lean). */
+export async function getRecipeDetail(recipeId: number): Promise<RecipeDetailDto> {
+  return request<RecipeDetailDto>(`${BASE}/recipes/${recipeId}`);
+}

--- a/frontend/meal-plan/src/lib/components/CalendarGrid.svelte
+++ b/frontend/meal-plan/src/lib/components/CalendarGrid.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+  // ───────────────────────────────────────────────────────────────────────
+  // Desktop calendar grid (md+). Mirrors the Blazor WeeklyCalendarView: a
+  // 60px label column + 7 day columns; header row of weekday + date (today
+  // highlighted); meal rows for Breakfast / Lunch / Dinner ONLY. Snack stays
+  // implicit (the enum has it, but the grid never renders a Snack row — only
+  // reachable if data carries one, matching the current page).
+  // ───────────────────────────────────────────────────────────────────────
+  import type { MealPlanEntryDto, MealType } from '../types';
+  import { mealPlanStore, MEAL_ROWS } from '../state.svelte';
+  import { weekDays, weekdayShort, monthDay, isToday } from '../dates';
+  import MealSlot from './MealSlot.svelte';
+
+  interface Props {
+    weekStart: string;
+    onSlotAdd: (date: string, mealType: MealType) => void;
+    onRemove: (entry: MealPlanEntryDto) => void;
+    onViewRecipe: (entry: MealPlanEntryDto) => void;
+    onViewCustom: (entry: MealPlanEntryDto) => void;
+  }
+
+  let { weekStart, onSlotAdd, onRemove, onViewRecipe, onViewCustom }: Props = $props();
+
+  const store = mealPlanStore;
+  let days = $derived(weekDays(weekStart));
+
+  const MEAL_LABELS: Record<MealType, string> = {
+    breakfast: 'Breakfast',
+    lunch: 'Lunch',
+    dinner: 'Dinner',
+    snack: 'Snack',
+  };
+</script>
+
+<div class="mp-grid">
+  <div class="mp-grid-corner"></div>
+  {#each days as day (day)}
+    <div class="mp-day-header" class:today={isToday(day)}>
+      <span class="mp-day-name">{weekdayShort(day)}</span>
+      <span class="mp-day-date">{monthDay(day)}</span>
+    </div>
+  {/each}
+
+  {#each MEAL_ROWS as mealType (mealType)}
+    <div class="mp-meal-label">
+      <span>{MEAL_LABELS[mealType]}</span>
+    </div>
+    {#each days as day (day)}
+      <div class="mp-grid-cell">
+        <MealSlot
+          entries={store.entriesFor(day, mealType)}
+          onAdd={() => onSlotAdd(day, mealType)}
+          {onRemove}
+          {onViewRecipe}
+          {onViewCustom}
+        />
+      </div>
+    {/each}
+  {/each}
+</div>
+
+<style>
+  .mp-grid {
+    display: grid;
+    grid-template-columns: 60px repeat(7, minmax(0, 1fr));
+    gap: 4px;
+    width: 100%;
+  }
+  .mp-day-header {
+    text-align: center;
+    padding: 8px 4px;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    border-radius: var(--radius-sm);
+  }
+  .mp-day-header.today {
+    background: var(--color-primary);
+  }
+  .mp-day-header.today .mp-day-name,
+  .mp-day-header.today .mp-day-date {
+    color: #fff;
+  }
+  .mp-day-name {
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: var(--color-text);
+  }
+  .mp-day-date {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .mp-meal-label {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    writing-mode: vertical-rl;
+    text-orientation: mixed;
+    transform: rotate(180deg);
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .mp-grid-cell {
+    min-width: 0;
+    overflow: hidden;
+  }
+</style>

--- a/frontend/meal-plan/src/lib/components/ConfirmDialog.svelte
+++ b/frontend/meal-plan/src/lib/components/ConfirmDialog.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+  // ───────────────────────────────────────────────────────────────────────
+  // A tiny confirm dialog — replaces the Blazor DialogService.ShowMessageBox
+  // used to confirm a meal removal ("Remove this meal from MMM d?"). Hosted in
+  // App.svelte; opened with a message + a confirm callback.
+  // ───────────────────────────────────────────────────────────────────────
+  interface Props {
+    open: boolean;
+    title: string;
+    message: string;
+    confirmLabel?: string;
+    cancelLabel?: string;
+    onCancel: () => void;
+    onConfirm: () => void;
+  }
+
+  let {
+    open,
+    title,
+    message,
+    confirmLabel = 'Remove',
+    cancelLabel = 'Cancel',
+    onCancel,
+    onConfirm,
+  }: Props = $props();
+
+  let dialogEl: HTMLDialogElement | null = $state(null);
+
+  $effect(() => {
+    if (!dialogEl) return;
+    if (open && !dialogEl.open) {
+      dialogEl.showModal();
+    } else if (!open && dialogEl.open) {
+      dialogEl.close();
+    }
+  });
+</script>
+
+<dialog bind:this={dialogEl} onclose={onCancel} class="mp-confirm">
+  {#if open}
+    <div class="mp-confirm-body">
+      <h2>{title}</h2>
+      <p class="mp-confirm-msg">{message}</p>
+      <div class="mp-confirm-actions">
+        <button type="button" class="mp-btn-ghost" onclick={onCancel}>{cancelLabel}</button>
+        <button type="button" class="mp-btn-solid" onclick={onConfirm}>{confirmLabel}</button>
+      </div>
+    </div>
+  {/if}
+</dialog>
+
+<style>
+  .mp-confirm[open] {
+    position: fixed;
+    inset: 0;
+    margin: auto;
+    border: none;
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text);
+    padding: 0;
+    width: min(400px, calc(100vw - 32px));
+    box-shadow: var(--shadow-4);
+  }
+  .mp-confirm::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+  }
+  .mp-confirm-body {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 24px;
+  }
+  .mp-confirm h2 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 500;
+  }
+  .mp-confirm-msg {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+  .mp-confirm-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 8px;
+  }
+  .mp-btn-ghost,
+  .mp-btn-solid {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    border: none;
+    cursor: pointer;
+    min-height: 40px;
+    font-weight: 500;
+  }
+  .mp-btn-ghost {
+    background: transparent;
+    color: var(--color-primary);
+  }
+  .mp-btn-ghost:hover {
+    background: var(--color-action-hover);
+  }
+  .mp-btn-solid {
+    background: var(--color-primary);
+    color: #fff;
+  }
+  .mp-btn-solid:hover {
+    background: var(--color-primary-hover);
+  }
+</style>

--- a/frontend/meal-plan/src/lib/components/DayList.svelte
+++ b/frontend/meal-plan/src/lib/components/DayList.svelte
@@ -1,0 +1,147 @@
+<script lang="ts">
+  // ───────────────────────────────────────────────────────────────────────
+  // Mobile day list (sm-). Mirrors the Blazor WeeklyListView: one expandable
+  // section per day (native <details>), with the weekday + date, a "Today"
+  // chip, and a "N meals" count in the summary; expanding shows B/L/D rows.
+  // Today's section is expanded by default and left-accented.
+  // ───────────────────────────────────────────────────────────────────────
+  import type { MealPlanEntryDto, MealType } from '../types';
+  import { mealPlanStore, MEAL_ROWS } from '../state.svelte';
+  import { weekDays, weekdayLong, monthDay, isToday } from '../dates';
+  import MealSlot from './MealSlot.svelte';
+
+  interface Props {
+    weekStart: string;
+    onSlotAdd: (date: string, mealType: MealType) => void;
+    onRemove: (entry: MealPlanEntryDto) => void;
+    onViewRecipe: (entry: MealPlanEntryDto) => void;
+    onViewCustom: (entry: MealPlanEntryDto) => void;
+  }
+
+  let { weekStart, onSlotAdd, onRemove, onViewRecipe, onViewCustom }: Props = $props();
+
+  const store = mealPlanStore;
+  let days = $derived(weekDays(weekStart));
+
+  const MEAL_LABELS: Record<MealType, string> = {
+    breakfast: 'Breakfast',
+    lunch: 'Lunch',
+    dinner: 'Dinner',
+    snack: 'Snack',
+  };
+</script>
+
+<div class="mp-daylist">
+  {#each days as day (day)}
+    {@const today = isToday(day)}
+    <details class="mp-day-panel" class:today open={today}>
+      <summary class="mp-day-summary">
+        <span class="mp-day-summary-main">
+          <span class="mp-day-summary-name">{weekdayLong(day)}</span>
+          <span class="mp-day-summary-date">{monthDay(day)}</span>
+        </span>
+        {#if today}
+          <span class="mp-day-summary-chip">Today</span>
+        {/if}
+        <span class="mp-day-summary-count">{store.dayCount(day)} meals</span>
+      </summary>
+      <div class="mp-day-body">
+        {#each MEAL_ROWS as mealType (mealType)}
+          <div class="mp-day-row">
+            <span class="mp-day-row-label">{MEAL_LABELS[mealType]}</span>
+            <div class="mp-day-row-slot">
+              <MealSlot
+                entries={store.entriesFor(day, mealType)}
+                onAdd={() => onSlotAdd(day, mealType)}
+                {onRemove}
+                {onViewRecipe}
+                {onViewCustom}
+              />
+            </div>
+          </div>
+        {/each}
+      </div>
+    </details>
+  {/each}
+</div>
+
+<style>
+  .mp-daylist {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .mp-day-panel {
+    background: var(--color-surface);
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-1);
+    overflow: hidden;
+  }
+  .mp-day-panel.today {
+    border-left: 3px solid var(--color-primary);
+  }
+  .mp-day-summary {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 14px 16px;
+    cursor: pointer;
+    list-style: none;
+  }
+  .mp-day-summary::-webkit-details-marker {
+    display: none;
+  }
+  .mp-day-summary-main {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    flex: 1;
+    min-width: 0;
+  }
+  .mp-day-summary-name {
+    font-size: 1rem;
+    font-weight: 500;
+    color: var(--color-text);
+  }
+  .mp-day-summary-date {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .mp-day-summary-chip {
+    font-size: 0.6875rem;
+    font-weight: 500;
+    color: #fff;
+    background: var(--color-primary);
+    border-radius: 12px;
+    padding: 2px 10px;
+    flex-shrink: 0;
+  }
+  .mp-day-summary-count {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    flex-shrink: 0;
+  }
+  .mp-day-body {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 0 16px 14px;
+  }
+  .mp-day-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+  }
+  .mp-day-row-label {
+    width: 80px;
+    flex-shrink: 0;
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--color-text-muted);
+    padding-top: 8px;
+  }
+  .mp-day-row-slot {
+    flex: 1;
+    min-width: 0;
+  }
+</style>

--- a/frontend/meal-plan/src/lib/components/MealSlot.svelte
+++ b/frontend/meal-plan/src/lib/components/MealSlot.svelte
@@ -1,0 +1,295 @@
+<script lang="ts">
+  // ───────────────────────────────────────────────────────────────────────
+  // One meal slot (a day × meal-type cell). Mirrors the Blazor MealSlot:
+  //   • EMPTY  → a dashed box with a ＋ that opens the picker.
+  //   • ENTRIES → a card per entry:
+  //       – recipe: image (or a book placeholder) + name + a type chip
+  //         (hidden for `main`, matching the Blazor RecipeType.Main guard);
+  //         clicking it opens the recipe detail sheet.
+  //       – custom meal: a restaurant icon + name + notes; clicking opens the
+  //         custom-meal notes view (RecipeDetailSheet's custom mode).
+  //     each entry has a × remove; below the entries an "add side/dessert" row
+  //     re-opens the picker for the same slot.
+  // ───────────────────────────────────────────────────────────────────────
+  import type { MealPlanEntryDto } from '../types';
+  import { recipeTypeLabel } from '../recipeType';
+
+  interface Props {
+    entries: MealPlanEntryDto[];
+    /** Open the picker for this slot (＋ / add side-dessert). */
+    onAdd: () => void;
+    /** Remove an entry (confirms in the parent). */
+    onRemove: (entry: MealPlanEntryDto) => void;
+    /** View a recipe entry's detail. */
+    onViewRecipe: (entry: MealPlanEntryDto) => void;
+    /** View a custom-meal entry's notes. */
+    onViewCustom: (entry: MealPlanEntryDto) => void;
+  }
+
+  let { entries, onAdd, onRemove, onViewRecipe, onViewCustom }: Props = $props();
+
+  let hasEntries = $derived(entries.length > 0);
+</script>
+
+{#if !hasEntries}
+  <button type="button" class="mp-slot mp-slot-empty" aria-label="Add a meal" onclick={onAdd}>
+    <svg viewBox="0 0 24 24" width="28" height="28" aria-hidden="true">
+      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" fill="currentColor" />
+    </svg>
+  </button>
+{:else}
+  <div class="mp-slot mp-slot-filled">
+    <div class="mp-slot-entries">
+      {#each entries as entry (entry.entryId)}
+        {#if entry.recipe}
+          <div class="mp-entry">
+            <button
+              type="button"
+              class="mp-entry-main"
+              onclick={() => onViewRecipe(entry)}
+              title={entry.recipe.name}
+            >
+              {#if entry.recipe.imagePath}
+                <img src={entry.recipe.imagePath} alt={entry.recipe.name} class="mp-entry-image" />
+              {:else}
+                <span class="mp-entry-placeholder" aria-label="Recipe (no image)">
+                  <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+                    <path
+                      d="M18 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 18H6V4h7v7l2.5-1.5L17 11V4h1v16z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </span>
+              {/if}
+              <span class="mp-entry-details">
+                <span class="mp-entry-name">{entry.recipe.name}</span>
+                {#if entry.recipe.recipeType !== 'main'}
+                  <span class="mp-entry-chip">{recipeTypeLabel(entry.recipe.recipeType)}</span>
+                {/if}
+              </span>
+            </button>
+            <button
+              type="button"
+              class="mp-entry-remove"
+              aria-label="Remove this meal"
+              onclick={() => onRemove(entry)}
+            >
+              <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
+                <path
+                  d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </div>
+        {:else if entry.customMealName}
+          <div class="mp-entry">
+            <button
+              type="button"
+              class="mp-entry-main"
+              onclick={() => onViewCustom(entry)}
+              title={entry.notes ? `${entry.customMealName}\n\nNotes: ${entry.notes}` : entry.customMealName}
+            >
+              <span class="mp-entry-custom-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" width="18" height="18">
+                  <path
+                    d="M11 9H9V2H7v7H5V2H3v7c0 2.12 1.66 3.84 3.75 3.97V22h2.5v-9.03C11.34 12.84 13 11.12 13 9V2h-2v7zm5-3v8h2.5v8H21V2c-2.76 0-5 2.24-5 4z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </span>
+              <span class="mp-entry-details">
+                <span class="mp-entry-name">{entry.customMealName}</span>
+                {#if entry.notes}
+                  <span class="mp-entry-notes">{entry.notes}</span>
+                {/if}
+              </span>
+            </button>
+            <button
+              type="button"
+              class="mp-entry-remove"
+              aria-label="Remove this meal"
+              onclick={() => onRemove(entry)}
+            >
+              <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
+                <path
+                  d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </div>
+        {/if}
+      {/each}
+
+      <button type="button" class="mp-slot-add-more" onclick={onAdd}>
+        <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
+          <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" fill="currentColor" />
+        </svg>
+        Add side/dessert
+      </button>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .mp-slot {
+    min-height: 80px;
+    width: 100%;
+    border-radius: var(--radius-sm);
+  }
+
+  .mp-slot-empty {
+    display: grid;
+    place-items: center;
+    border: 2px dashed var(--color-line-strong);
+    background: transparent;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    padding: 0;
+    transition: background-color 0.2s ease;
+  }
+  .mp-slot-empty:hover {
+    background: var(--color-action-hover);
+  }
+
+  .mp-slot-filled {
+    background: var(--color-surface);
+    box-shadow: var(--shadow-2);
+  }
+  .mp-slot-entries {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 8px;
+  }
+
+  .mp-entry {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    border-radius: var(--radius-sm);
+    position: relative;
+    transition: background-color 0.2s ease;
+  }
+  .mp-entry:hover {
+    background: var(--color-action-hover);
+  }
+
+  .mp-entry-main {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex: 1;
+    min-width: 0;
+    text-align: left;
+    font: inherit;
+    color: inherit;
+    background: transparent;
+    border: none;
+    padding: 6px 8px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+  }
+
+  .mp-entry-image,
+  .mp-entry-placeholder,
+  .mp-entry-custom-icon {
+    width: 40px;
+    height: 40px;
+    border-radius: var(--radius-sm);
+    flex-shrink: 0;
+  }
+  .mp-entry-image {
+    object-fit: cover;
+  }
+  .mp-entry-placeholder {
+    display: grid;
+    place-items: center;
+    background: var(--color-secondary);
+    color: #fff;
+  }
+  .mp-entry-custom-icon {
+    display: grid;
+    place-items: center;
+    background: var(--color-primary);
+    color: #fff;
+  }
+
+  .mp-entry-details {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .mp-entry-name {
+    line-height: 1.2;
+    font-size: 0.875rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .mp-entry-chip {
+    align-self: flex-start;
+    font-size: 0.65rem;
+    line-height: 1;
+    padding: 3px 6px;
+    border-radius: 9px;
+    color: var(--color-text-muted);
+    border: 1px solid var(--color-line);
+  }
+  .mp-entry-notes {
+    font-size: 0.75rem;
+    font-style: italic;
+    color: var(--color-text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .mp-entry-remove {
+    flex-shrink: 0;
+    display: grid;
+    place-items: center;
+    width: 32px;
+    height: 32px;
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.2s ease, color 0.15s, background-color 0.15s;
+  }
+  .mp-entry:hover .mp-entry-remove,
+  .mp-entry-remove:focus-visible {
+    opacity: 1;
+  }
+  .mp-entry-remove:hover {
+    color: var(--color-error);
+    background: var(--color-action-hover);
+  }
+
+  .mp-slot-add-more {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    font: inherit;
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    padding: 6px;
+    border: 1px dashed var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: transparent;
+    cursor: pointer;
+    margin-top: 4px;
+    opacity: 0.6;
+    transition: opacity 0.2s ease, background-color 0.15s;
+  }
+  .mp-slot-add-more:hover {
+    opacity: 1;
+    background: var(--color-action-hover);
+  }
+</style>

--- a/frontend/meal-plan/src/lib/components/RecipeDetailSheet.svelte
+++ b/frontend/meal-plan/src/lib/components/RecipeDetailSheet.svelte
@@ -1,0 +1,368 @@
+<script lang="ts">
+  // ───────────────────────────────────────────────────────────────────────
+  // Recipe detail (read-only) — replaces the Blazor RecipeDetailDialog. Also
+  // hosts the custom-meal notes view (the Blazor page used a MessageBox for
+  // that; we fold it in here per the spec). Two modes:
+  //   • mode='recipe'  → lazy getRecipeDetail(recipeId): image, prep/cook/
+  //     servings chips, ingredients (qty unit name (notes)), instructions via
+  //     {@html} (server-sanitized — NO client markdown lib).
+  //   • mode='custom'  → the entry's name + notes + date/meal context.
+  // ───────────────────────────────────────────────────────────────────────
+  import type { MealPlanEntryDto, RecipeDetailDto, RecipeIngredientDto } from '../types';
+  import { getRecipeDetail, ApiError } from '../api';
+  import { dayLong } from '../dates';
+
+  type Mode = 'recipe' | 'custom';
+
+  interface Props {
+    open: boolean;
+    mode: Mode;
+    /** The recipe id to load (mode='recipe'). */
+    recipeId: number | null;
+    /** Fallback title while the recipe loads (the entry's recipe name). */
+    recipeName: string;
+    /** The custom-meal entry (mode='custom'). */
+    customEntry: MealPlanEntryDto | null;
+    onClose: () => void;
+  }
+
+  let { open, mode, recipeId, recipeName, customEntry, onClose }: Props = $props();
+
+  let dialogEl: HTMLDialogElement | null = $state(null);
+  let detail = $state<RecipeDetailDto | null>(null);
+  let loading = $state(false);
+  let error = $state<string | null>(null);
+
+  // Track the id we last fetched so re-opening the same recipe reuses it, but a
+  // different recipe refetches. Reset on a custom-mode open.
+  let loadedId = $state<number | null>(null);
+
+  async function load(id: number): Promise<void> {
+    loading = true;
+    error = null;
+    try {
+      detail = await getRecipeDetail(id);
+      loadedId = id;
+    } catch (e) {
+      error =
+        e instanceof ApiError
+          ? `Couldn't load this recipe (HTTP ${e.status}).`
+          : "Couldn't load this recipe right now.";
+    } finally {
+      loading = false;
+    }
+  }
+
+  $effect(() => {
+    if (!dialogEl) return;
+    if (open && !dialogEl.open) {
+      if (mode === 'recipe' && recipeId != null && recipeId !== loadedId) {
+        detail = null;
+        void load(recipeId);
+      }
+      dialogEl.showModal();
+    } else if (!open && dialogEl.open) {
+      dialogEl.close();
+    }
+  });
+
+  function formatIngredient(ing: RecipeIngredientDto): string {
+    const parts: string[] = [];
+    if (ing.quantity != null) {
+      // Trim trailing zeros (mirrors the Blazor "0.##").
+      parts.push(String(Number(ing.quantity.toFixed(2))));
+    }
+    if (ing.unit) parts.push(ing.unit);
+    parts.push(ing.name);
+    if (ing.notes) parts.push(`(${ing.notes})`);
+    return parts.join(' ');
+  }
+
+  let title = $derived(
+    mode === 'custom' ? (customEntry?.customMealName ?? 'Custom meal') : (detail?.name ?? recipeName),
+  );
+  let hasMeta = $derived(
+    detail != null &&
+      (detail.prepTimeMinutes != null ||
+        detail.cookTimeMinutes != null ||
+        detail.servings != null),
+  );
+</script>
+
+<dialog bind:this={dialogEl} onclose={onClose} class="mp-dialog">
+  {#if open}
+    <header class="mp-dialog-head">
+      <h2>{title}</h2>
+      <button type="button" class="mp-dialog-x" aria-label="Close" onclick={onClose}>
+        <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true">
+          <path
+            d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+            fill="currentColor"
+          />
+        </svg>
+      </button>
+    </header>
+
+    <div class="mp-dialog-body">
+      {#if mode === 'custom'}
+        <div class="mp-custom-view">
+          {#if customEntry?.notes}
+            <div class="mp-custom-notes">
+              <span class="mp-custom-label">Notes</span>
+              <p class="mp-custom-notes-text">{customEntry.notes}</p>
+            </div>
+          {/if}
+          {#if customEntry}
+            <p class="mp-custom-context">{dayLong(customEntry.date)}</p>
+          {/if}
+          {#if !customEntry?.notes}
+            <p class="mp-empty-note">No notes for this meal.</p>
+          {/if}
+        </div>
+      {:else if loading}
+        <div class="mp-detail-loading">Loading recipe…</div>
+      {:else if error}
+        <div class="mp-detail-error" role="alert">
+          <span>{error}</span>
+          {#if recipeId != null}
+            <button type="button" class="mp-retry" onclick={() => recipeId != null && load(recipeId)}>
+              Retry
+            </button>
+          {/if}
+        </div>
+      {:else if detail}
+        {#if detail.imagePath}
+          <img src={detail.imagePath} alt={detail.name} class="mp-detail-image" />
+        {/if}
+
+        {#if hasMeta}
+          <div class="mp-detail-chips">
+            {#if detail.prepTimeMinutes != null}
+              <span class="mp-detail-chip">Prep: {detail.prepTimeMinutes} min</span>
+            {/if}
+            {#if detail.cookTimeMinutes != null}
+              <span class="mp-detail-chip">Cook: {detail.cookTimeMinutes} min</span>
+            {/if}
+            {#if detail.servings != null}
+              <span class="mp-detail-chip">Servings: {detail.servings}</span>
+            {/if}
+          </div>
+        {/if}
+
+        {#if detail.ingredients.length > 0}
+          <h3 class="mp-detail-subhead">Ingredients</h3>
+          <ul class="mp-detail-ingredients">
+            {#each detail.ingredients as ing (ing.sortOrder)}
+              <li>{formatIngredient(ing)}</li>
+            {/each}
+          </ul>
+        {/if}
+
+        {#if detail.instructionsHtml.trim()}
+          <h3 class="mp-detail-subhead">Instructions</h3>
+          <!-- Server-sanitized HTML (MarkdownHelper.ToSafeHtml). No client markdown lib. -->
+          <div class="mp-detail-instructions">{@html detail.instructionsHtml}</div>
+        {/if}
+      {/if}
+    </div>
+
+    <footer class="mp-dialog-actions">
+      <button type="button" class="mp-btn-ghost" onclick={onClose}>Close</button>
+    </footer>
+  {/if}
+</dialog>
+
+<style>
+  /* Gate layout to [open] so the closed dialog never paints a click-eating overlay. */
+  .mp-dialog[open] {
+    position: fixed;
+    inset: 0;
+    margin: auto;
+    border: none;
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text);
+    padding: 0;
+    width: min(620px, calc(100vw - 32px));
+    max-height: calc(100vh - 32px);
+    box-shadow: var(--shadow-4);
+    display: flex;
+    flex-direction: column;
+  }
+  .mp-dialog::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+  }
+  .mp-dialog-head {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 16px 16px 12px 24px;
+    border-bottom: 1px solid var(--color-line);
+  }
+  .mp-dialog-head h2 {
+    margin: 0;
+    flex: 1;
+    min-width: 0;
+    font-size: 1.25rem;
+    font-weight: 500;
+    overflow-wrap: anywhere;
+  }
+  .mp-dialog-x {
+    flex-shrink: 0;
+    display: grid;
+    place-items: center;
+    width: 36px;
+    height: 36px;
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+  }
+  .mp-dialog-x:hover {
+    background: var(--color-action-hover);
+    color: var(--color-text);
+  }
+  .mp-dialog-body {
+    overflow-y: auto;
+    padding: 16px 24px;
+    flex: 1;
+  }
+  .mp-dialog-actions {
+    display: flex;
+    justify-content: flex-end;
+    padding: 12px 24px calc(16px + env(safe-area-inset-bottom, 0px));
+    border-top: 1px solid var(--color-line);
+  }
+
+  .mp-detail-image {
+    width: 100%;
+    height: 200px;
+    object-fit: cover;
+    border-radius: var(--radius-sm);
+    margin-bottom: 16px;
+  }
+  .mp-detail-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 16px;
+  }
+  .mp-detail-chip {
+    font-size: 0.8125rem;
+    padding: 4px 12px;
+    border-radius: 14px;
+    background: var(--color-action-hover);
+    color: var(--color-text);
+  }
+  .mp-detail-subhead {
+    margin: 16px 0 8px;
+    font-size: 1rem;
+    font-weight: 500;
+  }
+  .mp-detail-ingredients {
+    margin: 0;
+    padding-left: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 0.9375rem;
+  }
+  .mp-detail-instructions {
+    line-height: 1.6;
+    font-size: 0.9375rem;
+  }
+  .mp-detail-instructions :global(ol),
+  .mp-detail-instructions :global(ul) {
+    margin-left: 1.5rem;
+    margin-bottom: 1rem;
+  }
+  .mp-detail-instructions :global(li) {
+    margin-bottom: 0.5rem;
+  }
+  .mp-detail-instructions :global(p) {
+    margin: 0 0 0.75rem;
+  }
+
+  .mp-detail-loading {
+    padding: 32px 0;
+    text-align: center;
+    color: var(--color-text-muted);
+  }
+  .mp-detail-error {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 12px 16px;
+    background: rgba(229, 57, 53, 0.08);
+    border-left: 4px solid var(--color-error);
+    border-radius: var(--radius-sm);
+    color: var(--color-error);
+    font-size: 0.875rem;
+  }
+  .mp-retry {
+    font: inherit;
+    border: none;
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+    padding: 4px 12px;
+    background: transparent;
+    color: var(--color-error);
+    font-weight: 500;
+  }
+  .mp-retry:hover {
+    background: rgba(229, 57, 53, 0.12);
+  }
+
+  /* ── Custom-meal notes view ──────────────────────────────────────────── */
+  .mp-custom-view {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .mp-custom-notes {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .mp-custom-label {
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-text-muted);
+  }
+  .mp-custom-notes-text {
+    margin: 0;
+    font-size: 0.9375rem;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+  }
+  .mp-custom-context {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+  .mp-empty-note {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+
+  .mp-btn-ghost {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    border: none;
+    cursor: pointer;
+    min-height: 44px;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+    background: transparent;
+    color: var(--color-primary);
+  }
+  .mp-btn-ghost:hover {
+    background: var(--color-action-hover);
+  }
+</style>

--- a/frontend/meal-plan/src/lib/components/RecipePickerSheet.svelte
+++ b/frontend/meal-plan/src/lib/components/RecipePickerSheet.svelte
@@ -1,0 +1,536 @@
+<script lang="ts">
+  // ───────────────────────────────────────────────────────────────────────
+  // Recipe picker — replaces the Blazor RecipePickerDialog (MudDialog). A
+  // bottom sheet from a slot's ＋, with 3 segmented modes + a shared Notes field:
+  //   • Search   — debounced searchRecipes(q), image+name rows, pick one.
+  //   • Custom   — a free-text meal name (+ the shared notes).
+  //   • New      — name + RecipeType select → quickCreateRecipe → then add the
+  //                entry with the new recipeId (two calls — mirrors today's flow).
+  // On confirm the parent runs store.addEntry(...) for the open slot.
+  //
+  // Empty `q` ⇒ all (MinCharacters=0 parity). No date math here — the slot's
+  // date/mealType are passed straight through by the parent.
+  // ───────────────────────────────────────────────────────────────────────
+  import type { MealRecipeSummaryDto, RecipeType } from '../types';
+  import { searchRecipes, quickCreateRecipe, ApiError } from '../api';
+  import { RECIPE_TYPES, recipeTypeLabel } from '../recipeType';
+
+  type Mode = 'search' | 'custom' | 'new';
+
+  /** What the parent needs to add the entry once the sheet confirms. */
+  export interface PickerResult {
+    recipeId?: number;
+    customMealName?: string;
+    notes?: string | null;
+  }
+
+  interface Props {
+    open: boolean;
+    /** A human label for the slot being filled, e.g. "Mon — Dinner". */
+    slotLabel: string;
+    onClose: () => void;
+    onConfirm: (result: PickerResult) => void | Promise<void>;
+  }
+
+  let { open, slotLabel, onClose, onConfirm }: Props = $props();
+
+  let dialogEl: HTMLDialogElement | null = $state(null);
+
+  let mode = $state<Mode>('search');
+  let notes = $state('');
+
+  // ── Search mode ──────────────────────────────────────────────────────────
+  let query = $state('');
+  let results = $state<MealRecipeSummaryDto[]>([]);
+  let searching = $state(false);
+  /** True when the last search request FAILED (vs. genuinely returned nothing) — drives an honest error row. */
+  let searchError = $state(false);
+  let selectedRecipe = $state<MealRecipeSummaryDto | null>(null);
+  let searchToken = 0; // guards out-of-order debounced responses
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // ── Custom mode ──────────────────────────────────────────────────────────
+  let customMealName = $state('');
+
+  // ── New-recipe mode ──────────────────────────────────────────────────────
+  let newRecipeName = $state('');
+  let newRecipeType = $state<RecipeType>('main');
+  let creating = $state(false);
+
+  let localError = $state<string | null>(null);
+  let submitting = $state(false);
+
+  const MODES: { id: Mode; label: string }[] = [
+    { id: 'search', label: 'Pick Recipe' },
+    { id: 'custom', label: 'Custom Meal' },
+    { id: 'new', label: 'New Recipe' },
+  ];
+
+  function reset(): void {
+    mode = 'search';
+    notes = '';
+    query = '';
+    results = [];
+    searching = false;
+    searchError = false;
+    selectedRecipe = null;
+    customMealName = '';
+    newRecipeName = '';
+    newRecipeType = 'main';
+    creating = false;
+    localError = null;
+    submitting = false;
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+      debounceTimer = null;
+    }
+  }
+
+  async function runSearch(q: string): Promise<void> {
+    const token = ++searchToken;
+    searching = true;
+    searchError = false;
+    try {
+      const found = await searchRecipes(q);
+      // Drop a stale response (a newer keystroke superseded this one).
+      if (token === searchToken) results = found;
+    } catch {
+      // A failed search is NOT "no results" — surface it distinctly (council R1).
+      if (token === searchToken) {
+        results = [];
+        searchError = true;
+      }
+    } finally {
+      if (token === searchToken) searching = false;
+    }
+  }
+
+  function onQueryInput(): void {
+    selectedRecipe = null;
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => void runSearch(query), 300);
+  }
+
+  $effect(() => {
+    if (!dialogEl) return;
+    if (open && !dialogEl.open) {
+      reset();
+      dialogEl.showModal();
+      // Prime the list with all recipes (MinCharacters=0 parity).
+      void runSearch('');
+    } else if (!open && dialogEl.open) {
+      dialogEl.close();
+    }
+  });
+
+  let canConfirm = $derived(
+    mode === 'search'
+      ? selectedRecipe != null
+      : mode === 'custom'
+        ? customMealName.trim().length > 0
+        : newRecipeName.trim().length > 0,
+  );
+
+  async function confirm(): Promise<void> {
+    if (!canConfirm || submitting) return;
+    localError = null;
+    const trimmedNotes = notes.trim() || null;
+
+    if (mode === 'search' && selectedRecipe) {
+      submitting = true;
+      try {
+        await onConfirm({ recipeId: selectedRecipe.recipeId, notes: trimmedNotes });
+      } finally {
+        submitting = false;
+      }
+      return;
+    }
+
+    if (mode === 'custom') {
+      const trimmed = customMealName.trim();
+      if (!trimmed) return;
+      submitting = true;
+      try {
+        await onConfirm({ customMealName: trimmed, notes: trimmedNotes });
+      } finally {
+        submitting = false;
+      }
+      return;
+    }
+
+    // mode === 'new': quick-create the recipe, then add the entry with its id.
+    const name = newRecipeName.trim();
+    if (!name) return;
+    creating = true;
+    submitting = true;
+    try {
+      const created = await quickCreateRecipe({ name, recipeType: newRecipeType });
+      await onConfirm({ recipeId: created.recipeId, notes: trimmedNotes });
+    } catch (e) {
+      localError =
+        e instanceof ApiError
+          ? "Couldn't create that recipe — please try again."
+          : "Couldn't create that recipe right now.";
+    } finally {
+      creating = false;
+      submitting = false;
+    }
+  }
+
+  function pick(recipe: MealRecipeSummaryDto): void {
+    selectedRecipe = selectedRecipe?.recipeId === recipe.recipeId ? null : recipe;
+  }
+</script>
+
+<dialog bind:this={dialogEl} onclose={onClose} class="mp-sheet">
+  <div class="mp-sheet-inner">
+    <header class="mp-sheet-head">
+      <h2>Select Meal</h2>
+      {#if slotLabel}
+        <span class="mp-sheet-slot">{slotLabel}</span>
+      {/if}
+    </header>
+
+    <div class="mp-sheet-body">
+      <div class="mp-segmented" role="group" aria-label="Meal source">
+        {#each MODES as m (m.id)}
+          <button
+            type="button"
+            class="mp-seg"
+            class:active={mode === m.id}
+            aria-pressed={mode === m.id}
+            onclick={() => (mode = m.id)}
+          >
+            {m.label}
+          </button>
+        {/each}
+      </div>
+
+      {#if mode === 'search'}
+        <label class="mp-field">
+          <span class="mp-field-label">Search recipes</span>
+          <input
+            type="text"
+            bind:value={query}
+            oninput={onQueryInput}
+            autocomplete="off"
+            placeholder="Type to search…"
+          />
+        </label>
+        <div class="mp-results" role="listbox" aria-label="Recipes">
+          {#if searching && results.length === 0}
+            <p class="mp-results-empty">Searching…</p>
+          {:else if searchError}
+            <p class="mp-results-empty">Couldn't load recipes — please try again.</p>
+          {:else if results.length === 0}
+            <p class="mp-results-empty">No recipes found.</p>
+          {:else}
+            {#each results as recipe (recipe.recipeId)}
+              <button
+                type="button"
+                class="mp-result"
+                class:selected={selectedRecipe?.recipeId === recipe.recipeId}
+                role="option"
+                aria-selected={selectedRecipe?.recipeId === recipe.recipeId}
+                onclick={() => pick(recipe)}
+              >
+                {#if recipe.imagePath}
+                  <img src={recipe.imagePath} alt={recipe.name} class="mp-result-image" />
+                {:else}
+                  <span class="mp-result-placeholder" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" width="18" height="18">
+                      <path
+                        d="M11 9H9V2H7v7H5V2H3v7c0 2.12 1.66 3.84 3.75 3.97V22h2.5v-9.03C11.34 12.84 13 11.12 13 9V2h-2v7zm5-3v8h2.5v8H21V2c-2.76 0-5 2.24-5 4z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                  </span>
+                {/if}
+                <span class="mp-result-name">{recipe.name}</span>
+              </button>
+            {/each}
+          {/if}
+        </div>
+      {:else if mode === 'custom'}
+        <label class="mp-field">
+          <span class="mp-field-label">Custom meal name</span>
+          <input
+            type="text"
+            bind:value={customMealName}
+            autocomplete="off"
+            placeholder="e.g. Leftovers, Eating out, Takeout"
+          />
+        </label>
+      {:else}
+        <p class="mp-hint">Quick-add a recipe. You can add ingredients and details later.</p>
+        <label class="mp-field">
+          <span class="mp-field-label">Recipe name</span>
+          <input
+            type="text"
+            bind:value={newRecipeName}
+            autocomplete="off"
+            placeholder="e.g. Mom's Lasagna"
+          />
+        </label>
+        <label class="mp-field">
+          <span class="mp-field-label">Type</span>
+          <select bind:value={newRecipeType} class="mp-select">
+            {#each RECIPE_TYPES as t (t)}
+              <option value={t}>{recipeTypeLabel(t)}</option>
+            {/each}
+          </select>
+        </label>
+      {/if}
+
+      <label class="mp-field">
+        <span class="mp-field-label">Notes (optional)</span>
+        <textarea
+          bind:value={notes}
+          rows="2"
+          placeholder="e.g. Make extra for tomorrow, use up leftover chicken"
+        ></textarea>
+      </label>
+
+      {#if localError}
+        <p class="mp-sheet-error" role="alert">{localError}</p>
+      {/if}
+    </div>
+
+    <footer class="mp-sheet-actions">
+      <button type="button" class="mp-btn-ghost" onclick={onClose} disabled={submitting}>
+        Cancel
+      </button>
+      <button type="button" class="mp-btn-primary" onclick={confirm} disabled={!canConfirm || submitting}>
+        {#if mode === 'new'}
+          {creating ? 'Creating…' : 'Create & Add'}
+        {:else}
+          {submitting ? 'Adding…' : 'Add'}
+        {/if}
+      </button>
+    </footer>
+  </div>
+</dialog>
+
+<style>
+  .mp-sheet {
+    border: none;
+    padding: 0;
+    background: var(--color-surface);
+    color: var(--color-text);
+    box-shadow: var(--shadow-4);
+    width: min(520px, 100vw);
+    max-height: 90vh;
+    /* Bottom sheet on mobile; centered card on wide screens. */
+    margin: auto auto 0;
+    border-radius: var(--radius-md) var(--radius-md) 0 0;
+  }
+  @media (min-width: 600px) {
+    .mp-sheet {
+      margin: auto;
+      border-radius: var(--radius-md);
+    }
+  }
+  .mp-sheet::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+  }
+  .mp-sheet-inner {
+    display: flex;
+    flex-direction: column;
+    max-height: 90vh;
+  }
+  .mp-sheet-head {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    padding: 20px 24px 8px;
+  }
+  .mp-sheet-head h2 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 500;
+  }
+  .mp-sheet-slot {
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+  }
+  .mp-sheet-body {
+    overflow-y: auto;
+    padding: 8px 24px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .mp-segmented {
+    display: flex;
+    gap: 6px;
+  }
+  .mp-seg {
+    flex: 1;
+    font: inherit;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    border: 1px solid var(--color-line-strong);
+    background: transparent;
+    color: var(--color-text-muted);
+    padding: 8px 10px;
+    min-height: 40px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: background-color 0.15s, color 0.15s, border-color 0.15s;
+  }
+  .mp-seg.active {
+    background: var(--color-primary);
+    border-color: var(--color-primary);
+    color: #fff;
+  }
+  .mp-seg:hover:not(.active) {
+    background: var(--color-action-hover);
+    color: var(--color-text);
+  }
+
+  .mp-field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .mp-field-label {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--color-text-muted);
+  }
+  .mp-field input[type='text'],
+  .mp-select,
+  .mp-field textarea {
+    font: inherit;
+    color: inherit;
+    padding: 10px 12px;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    min-height: 44px;
+  }
+  .mp-field textarea {
+    resize: vertical;
+    min-height: 60px;
+  }
+  .mp-field input[type='text']:focus,
+  .mp-select:focus,
+  .mp-field textarea:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -1px;
+    border-color: var(--color-primary);
+  }
+
+  .mp-results {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    max-height: 280px;
+    overflow-y: auto;
+  }
+  .mp-results-empty {
+    margin: 0;
+    padding: 16px 4px;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+  .mp-result {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    text-align: left;
+    font: inherit;
+    color: inherit;
+    background: transparent;
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-sm);
+    padding: 8px 12px;
+    min-height: 56px;
+    cursor: pointer;
+    transition: background-color 0.15s, border-color 0.15s;
+  }
+  .mp-result:hover {
+    background: var(--color-action-hover);
+    border-color: var(--color-line-strong);
+  }
+  .mp-result.selected {
+    border-color: var(--color-primary);
+    background: var(--color-action-hover);
+  }
+  .mp-result-image,
+  .mp-result-placeholder {
+    width: 40px;
+    height: 40px;
+    border-radius: var(--radius-sm);
+    flex-shrink: 0;
+  }
+  .mp-result-image {
+    object-fit: cover;
+  }
+  .mp-result-placeholder {
+    display: grid;
+    place-items: center;
+    background: var(--color-action-hover);
+    color: var(--color-text-muted);
+  }
+  .mp-result-name {
+    flex: 1;
+    min-width: 0;
+    font-size: 0.9375rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .mp-hint {
+    margin: 0;
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+  }
+  .mp-sheet-error {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--color-error);
+  }
+
+  .mp-sheet-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 16px 24px calc(20px + env(safe-area-inset-bottom, 0px));
+    border-top: 1px solid var(--color-line);
+  }
+  .mp-btn-ghost,
+  .mp-btn-primary {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    border: none;
+    cursor: pointer;
+    min-height: 44px;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+  }
+  .mp-btn-ghost {
+    background: transparent;
+    color: var(--color-primary);
+  }
+  .mp-btn-ghost:hover:not(:disabled) {
+    background: var(--color-action-hover);
+  }
+  .mp-btn-primary {
+    background: var(--color-primary);
+    color: #fff;
+    box-shadow: var(--shadow-1);
+  }
+  .mp-btn-primary:hover:not(:disabled) {
+    background: var(--color-primary-hover);
+  }
+  .mp-btn-primary:disabled,
+  .mp-btn-ghost:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+</style>

--- a/frontend/meal-plan/src/lib/components/Toasts.svelte
+++ b/frontend/meal-plan/src/lib/components/Toasts.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+  // The toast region. Mirrors the chores island's Toasts component, re-scoped
+  // to `mp-`. Mounted once at the App root.
+  import { toasts, dismissToast } from '../toasts.svelte';
+</script>
+
+<div class="mp-toast-region" role="status" aria-live="polite">
+  {#each toasts() as toast (toast.id)}
+    <div class="mp-toast mp-toast-{toast.kind}">
+      <span class="mp-toast-msg">{toast.message}</span>
+      <button
+        type="button"
+        class="mp-toast-close"
+        aria-label="Dismiss"
+        onclick={() => dismissToast(toast.id)}
+      >
+        ×
+      </button>
+    </div>
+  {/each}
+</div>
+
+<style>
+  .mp-toast-region {
+    position: fixed;
+    left: 50%;
+    bottom: 24px;
+    transform: translateX(-50%);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    z-index: 1100;
+    pointer-events: none;
+    max-width: min(560px, calc(100vw - 32px));
+  }
+  /* Mobile: clear the MainLayout bottom nav so toasts aren't hidden behind it. */
+  @media (max-width: 960px) {
+    .mp-toast-region {
+      bottom: calc(80px + env(safe-area-inset-bottom, 0px));
+    }
+  }
+  .mp-toast {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 12px 10px 16px;
+    border-radius: var(--radius-sm);
+    color: #fff;
+    background: #323232;
+    box-shadow: var(--shadow-4);
+    font-size: 0.875rem;
+    pointer-events: auto;
+    animation: mp-toast-in 0.2s ease-out;
+  }
+  .mp-toast-success {
+    background: var(--color-success);
+  }
+  .mp-toast-error {
+    background: var(--color-error);
+  }
+  .mp-toast-msg {
+    flex: 1;
+    min-width: 0;
+  }
+  .mp-toast-close {
+    background: transparent;
+    border: none;
+    color: rgba(255, 255, 255, 0.8);
+    font-size: 1.25rem;
+    line-height: 1;
+    padding: 0 4px;
+    cursor: pointer;
+  }
+  .mp-toast-close:hover {
+    color: #fff;
+  }
+  @keyframes mp-toast-in {
+    from {
+      opacity: 0;
+      transform: translateY(8px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+</style>

--- a/frontend/meal-plan/src/lib/components/WeekNav.svelte
+++ b/frontend/meal-plan/src/lib/components/WeekNav.svelte
@@ -1,0 +1,144 @@
+<script lang="ts">
+  // ───────────────────────────────────────────────────────────────────────
+  // Week navigation — mirrors the Blazor MealPlanNavigation: prev / next
+  // chevrons, the centered week-range label, a "This week" chip when on the
+  // current week, and a "Jump to Today" button (disabled on the current week).
+  //
+  // Stepping is DISPLAY-ONLY (the server re-snaps the week to Monday on every
+  // board GET). No `new Date('YYYY-MM-DD')` — the label comes from dates.ts.
+  // ───────────────────────────────────────────────────────────────────────
+  import { weekRangeLabel, todayMonday } from '../dates';
+
+  interface Props {
+    /** The week's Monday "YYYY-MM-DD". */
+    weekStart: string;
+    onPrev: () => void;
+    onNext: () => void;
+    onToday: () => void;
+  }
+
+  let { weekStart, onPrev, onNext, onToday }: Props = $props();
+
+  let isCurrentWeek = $derived(weekStart === todayMonday());
+  let rangeLabel = $derived(weekRangeLabel(weekStart));
+</script>
+
+<nav class="mp-nav" aria-label="Week navigation">
+  <div class="mp-nav-header">
+    <button type="button" class="mp-nav-chevron" aria-label="Previous week" onclick={onPrev}>
+      <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+        <path d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z" fill="currentColor" />
+      </svg>
+    </button>
+
+    <div class="mp-nav-center">
+      <h2 class="mp-nav-range">{rangeLabel}</h2>
+      {#if isCurrentWeek}
+        <span class="mp-nav-chip">This week</span>
+      {/if}
+    </div>
+
+    <button type="button" class="mp-nav-chevron" aria-label="Next week" onclick={onNext}>
+      <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+        <path d="M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z" fill="currentColor" />
+      </svg>
+    </button>
+  </div>
+
+  <div class="mp-nav-actions">
+    <button
+      type="button"
+      class="mp-nav-today"
+      onclick={onToday}
+      disabled={isCurrentWeek}
+    >
+      <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+        <path
+          d="M19 3h-1V1h-2v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2V5a2 2 0 0 0-2-2zm0 16H5V8h14v11zM7 10h5v5H7z"
+          fill="currentColor"
+        />
+      </svg>
+      Jump to Today
+    </button>
+  </div>
+</nav>
+
+<style>
+  .mp-nav {
+    margin-bottom: 24px;
+  }
+  .mp-nav-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+  }
+  .mp-nav-center {
+    flex: 1;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+  }
+  .mp-nav-range {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 400;
+    color: var(--color-text);
+  }
+  .mp-nav-chip {
+    display: inline-block;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: #fff;
+    background: var(--color-primary);
+    border-radius: 12px;
+    padding: 2px 10px;
+  }
+  .mp-nav-chevron {
+    display: grid;
+    place-items: center;
+    width: 44px;
+    height: 44px;
+    border: none;
+    border-radius: 50%;
+    background: transparent;
+    color: var(--color-primary);
+    cursor: pointer;
+    flex-shrink: 0;
+    transition: background-color 0.15s;
+  }
+  .mp-nav-chevron:hover {
+    background: var(--color-action-hover);
+  }
+  .mp-nav-actions {
+    display: flex;
+    justify-content: center;
+    margin-top: 12px;
+  }
+  .mp-nav-today {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font: inherit;
+    font-size: 0.875rem;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+    color: var(--color-primary);
+    background: transparent;
+    border: none;
+    border-radius: var(--radius-sm);
+    padding: 8px 16px;
+    min-height: 40px;
+    cursor: pointer;
+    transition: background-color 0.15s;
+  }
+  .mp-nav-today:hover:not(:disabled) {
+    background: var(--color-action-hover);
+  }
+  .mp-nav-today:disabled {
+    color: var(--color-text-disabled);
+    cursor: not-allowed;
+  }
+</style>

--- a/frontend/meal-plan/src/lib/dates.ts
+++ b/frontend/meal-plan/src/lib/dates.ts
@@ -1,0 +1,130 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Week helpers for the meal-plan island.
+//
+// ⚠ GLOBAL PROJECT RULE / MN4: NEVER `new Date('YYYY-MM-DD')`. The string form
+// parses as UTC midnight, which renders as the PREVIOUS day in US timezones —
+// a wrong-week bug. We instead:
+//   • parse a "YYYY-MM-DD" by SPLITTING on '-' into integer parts, and
+//   • build dates with `Date.UTC(y, m, d, 12)` — NOON UTC, far enough from
+//     either midnight that no DST shift can cross a day boundary — then read
+//     the UTC parts back. Stepping by whole weeks is exact this way.
+//
+// All of this is DISPLAY-ONLY: the server re-snaps `weekStart` to that week's
+// Monday on every board GET, so client stepping can never corrupt the boundary.
+// ─────────────────────────────────────────────────────────────────────────
+
+const WEEKDAY_SHORT = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const MONTH_SHORT = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+];
+
+/** Parse a "YYYY-MM-DD" string into [year, month(1-12), day] integers. No Date built. */
+function parseParts(dateStr: string): [number, number, number] {
+  const [y, m, d] = dateStr.split('-').map((s) => Number(s));
+  return [y, m, d];
+}
+
+/** A noon-UTC Date for "YYYY-MM-DD" — DST-safe for whole-day/-week math only. */
+function utcNoon(dateStr: string): Date {
+  const [y, m, d] = parseParts(dateStr);
+  return new Date(Date.UTC(y, m - 1, d, 12));
+}
+
+/** Format a noon-UTC Date back to "YYYY-MM-DD" (reads UTC parts — never local). */
+function formatUtc(date: Date): string {
+  const y = date.getUTCFullYear();
+  const m = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const d = String(date.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * The Monday of the week containing `dateStr` ("YYYY-MM-DD"). Mirrors the
+ * server's GetWeekStartDate: `diff = (7 + (dow - Monday)) % 7`, then subtract.
+ * The server re-snaps anyway; this keeps the client label correct between GETs.
+ */
+export function mondayOf(dateStr: string): string {
+  const d = utcNoon(dateStr);
+  // getUTCDay(): Sunday=0 … Saturday=6. Monday=1.
+  const diff = (7 + (d.getUTCDay() - 1)) % 7;
+  d.setUTCDate(d.getUTCDate() - diff);
+  return formatUtc(d);
+}
+
+/** A "YYYY-MM-DD" `n` weeks from `mondayStr` (n may be negative). */
+export function addWeeks(mondayStr: string, n: number): string {
+  const d = utcNoon(mondayStr);
+  d.setUTCDate(d.getUTCDate() + n * 7);
+  return formatUtc(d);
+}
+
+/** Monday of the LOCAL current week, as "YYYY-MM-DD". The one place we read "today". */
+export function todayMonday(): string {
+  const now = new Date();
+  // Build today's string from LOCAL parts (the household's calendar day), then
+  // snap to Monday via the UTC-noon helpers. No `new Date('YYYY-MM-DD')`.
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, '0');
+  const d = String(now.getDate()).padStart(2, '0');
+  return mondayOf(`${y}-${m}-${d}`);
+}
+
+/** The 7 "YYYY-MM-DD" day strings of the week starting at `mondayStr`. */
+export function weekDays(mondayStr: string): string[] {
+  const base = utcNoon(mondayStr);
+  const out: string[] = [];
+  for (let i = 0; i < 7; i++) {
+    const d = new Date(base.getTime());
+    d.setUTCDate(d.getUTCDate() + i);
+    out.push(formatUtc(d));
+  }
+  return out;
+}
+
+/** Short weekday label, e.g. "Mon" (for a "YYYY-MM-DD"). */
+export function weekdayShort(dateStr: string): string {
+  return WEEKDAY_SHORT[utcNoon(dateStr).getUTCDay()];
+}
+
+/** Full weekday label, e.g. "Monday". */
+export function weekdayLong(dateStr: string): string {
+  const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+  return days[utcNoon(dateStr).getUTCDay()];
+}
+
+/** "MMM d" label, e.g. "Jun 23". */
+export function monthDay(dateStr: string): string {
+  const d = utcNoon(dateStr);
+  return `${MONTH_SHORT[d.getUTCMonth()]} ${d.getUTCDate()}`;
+}
+
+/** Full day label, e.g. "Monday, June 23". */
+export function dayLong(dateStr: string): string {
+  const months = [
+    'January', 'February', 'March', 'April', 'May', 'June',
+    'July', 'August', 'September', 'October', 'November', 'December',
+  ];
+  const d = utcNoon(dateStr);
+  return `${weekdayLong(dateStr)}, ${months[d.getUTCMonth()]} ${d.getUTCDate()}`;
+}
+
+/**
+ * Week-range label, e.g. "Jun 23 – Jun 29, 2025" (matches the Blazor
+ * MealPlanNavigation's "MMM d - MMM d, yyyy"). `mondayStr` is the week's Monday.
+ */
+export function weekRangeLabel(mondayStr: string): string {
+  const endDate = utcNoon(mondayStr);
+  endDate.setUTCDate(endDate.getUTCDate() + 6);
+  const endStr = formatUtc(endDate);
+  return `${monthDay(mondayStr)} – ${monthDay(endStr)}, ${endDate.getUTCFullYear()}`;
+}
+
+/** Is `dateStr` the local current day? (drives the "today" highlight). */
+export function isToday(dateStr: string): boolean {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, '0');
+  const d = String(now.getDate()).padStart(2, '0');
+  return dateStr === `${y}-${m}-${d}`;
+}

--- a/frontend/meal-plan/src/lib/liveness.ts
+++ b/frontend/meal-plan/src/lib/liveness.ts
@@ -1,0 +1,73 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Liveness — lightweight collaboration refresh for the meal-plan island.
+//
+// A change made by another household member should appear within ~20s while
+// the tab is VISIBLE, and immediately when the tab regains focus. We do this
+// with a plain interval + `visibilitychange`, NOT Blazor's DataNotifier /
+// PresenceService / PollingService (those are SignalR-circuit-bound — MN2).
+//
+// The poll PAUSES while the tab is hidden (D11): no interval ticks fire when
+// `document.hidden` is true, and on re-show we refetch once immediately, then
+// resume the interval. This keeps background tabs quiet.
+// ─────────────────────────────────────────────────────────────────────────
+
+const POLL_INTERVAL_MS = 20_000;
+
+export interface LivenessHandle {
+  /** Tear down the interval + visibility listener. Call on unmount. */
+  stop(): void;
+}
+
+/**
+ * Start polling. `refresh` is the board reload (App.svelte's loader). It is
+ * only invoked while the document is visible. Returns a handle whose `stop()`
+ * removes the interval + listener.
+ */
+export function startLiveness(refresh: () => void): LivenessHandle {
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  function tick() {
+    // Guard: never poll while hidden (the interval is cleared on hide, but this
+    // is belt-and-suspenders in case a tick is queued at the moment of hiding).
+    if (document.visibilityState === 'visible') {
+      refresh();
+    }
+  }
+
+  function startInterval() {
+    if (timer != null) return;
+    timer = setInterval(tick, POLL_INTERVAL_MS);
+  }
+
+  function stopInterval() {
+    if (timer != null) {
+      clearInterval(timer);
+      timer = null;
+    }
+  }
+
+  function handleVisibility() {
+    if (document.visibilityState === 'visible') {
+      // Re-show: refetch immediately, then resume the interval.
+      refresh();
+      startInterval();
+    } else {
+      // Hidden: pause polling entirely.
+      stopInterval();
+    }
+  }
+
+  document.addEventListener('visibilitychange', handleVisibility);
+
+  // Begin polling only if we start visible.
+  if (document.visibilityState === 'visible') {
+    startInterval();
+  }
+
+  return {
+    stop() {
+      stopInterval();
+      document.removeEventListener('visibilitychange', handleVisibility);
+    },
+  };
+}

--- a/frontend/meal-plan/src/lib/recipeType.ts
+++ b/frontend/meal-plan/src/lib/recipeType.ts
@@ -1,0 +1,33 @@
+// Display labels for the RecipeType union (mirrors the Blazor GetRecipeTypeLabel
+// in RecipePickerDialog) + the picker's select option order.
+import type { RecipeType } from './types';
+
+export const RECIPE_TYPE_LABELS: Record<RecipeType, string> = {
+  main: 'Main Dish',
+  side: 'Side Dish',
+  appetizer: 'Appetizer',
+  dessert: 'Dessert',
+  beverage: 'Beverage',
+  sauce: 'Sauce/Condiment',
+  breakfast: 'Breakfast',
+  snack: 'Snack',
+  other: 'Other',
+};
+
+/** The select option order — matches the C# enum declaration order. */
+export const RECIPE_TYPES: RecipeType[] = [
+  'main',
+  'side',
+  'appetizer',
+  'dessert',
+  'beverage',
+  'sauce',
+  'breakfast',
+  'snack',
+  'other',
+];
+
+/** Short chip label shown on a slot card (the type chip is hidden for `main`). */
+export function recipeTypeLabel(type: RecipeType): string {
+  return RECIPE_TYPE_LABELS[type] ?? type;
+}

--- a/frontend/meal-plan/src/lib/state.svelte.ts
+++ b/frontend/meal-plan/src/lib/state.svelte.ts
@@ -1,0 +1,205 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Board store — the single source of truth for the meal-plan island.
+//
+// One `MealPlanBoardDto` (the current week) is fetched and held here. The
+// calendar grid + day list are CLIENT-SIDE groupings of that one payload via
+// `entriesByDayMeal`.
+//
+// ⚠ Svelte 5 rune rule (global CORRECTION): never `export` a reassigned
+// `$state`/`$derived` from a module. We wrap the mutable state in a class
+// instance and export the instance — the runes live as `$state`/`$derived`
+// fields on the object, which is the supported pattern.
+//
+// Parity-first ⇒ VERSIONLESS / last-write-wins. The only ops are add + remove;
+// there is no xmin token, no 409 branch. On any 4xx/network error we reconcile
+// (re-GET the current week) + surface a calm toast. NO `new Date('YYYY-MM-DD')`
+// anywhere — week stepping goes through lib/dates.ts (MN4).
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { MealPlanBoardDto, MealPlanEntryDto, MealType, ShellContext } from './types';
+import { ApiError, addEntry, getBoard, removeEntry, type AddEntryBody } from './api';
+import { addWeeks, mondayOf, todayMonday } from './dates';
+import { showToast } from './toasts.svelte';
+
+/** The board's three rendered meal rows (Snack is implicit — only shown if data exists). */
+export const MEAL_ROWS: MealType[] = ['breakfast', 'lunch', 'dinner'];
+
+class MealPlanStore {
+  /** The week's Monday "YYYY-MM-DD". Client stepping is display-only — the server re-snaps on GET. */
+  weekStart = $state<string>(todayMonday());
+  /** The one fetched payload for `weekStart`. null until the first load resolves. */
+  board = $state<MealPlanBoardDto | null>(null);
+  loading = $state(true);
+  /** Human-readable error message; null when healthy. */
+  error = $state<string | null>(null);
+  /** This household member's userId — set once on init from the shell context. */
+  currentUserId = $state(0);
+
+  /**
+   * The board refetch hook, wired by App.svelte (`store.setRefresh(loadBoard)`).
+   * Shared by liveness AND the error-reconcile path so a post-mutation refetch
+   * reuses the exact same loader.
+   */
+  private refresh: (() => Promise<void>) | null = null;
+
+  /**
+   * Slot lookup: `${date}|${mealType}` → the entries in that slot. Empty map
+   * until the board loads. A slot with no entries simply isn't a key.
+   */
+  entriesByDayMeal = $derived.by(() => {
+    const map = new Map<string, MealPlanEntryDto[]>();
+    for (const e of this.board?.entries ?? []) {
+      const key = `${e.date}|${e.mealType}`;
+      const bucket = map.get(key);
+      if (bucket) bucket.push(e);
+      else map.set(key, [e]);
+    }
+    return map;
+  });
+
+  /** Entries for one slot (empty array when none). */
+  entriesFor(date: string, mealType: MealType): MealPlanEntryDto[] {
+    return this.entriesByDayMeal.get(`${date}|${mealType}`) ?? [];
+  }
+
+  /** Count of all entries on a given day (for the mobile day-list "N meals" label). */
+  dayCount(date: string): number {
+    return (this.board?.entries ?? []).filter((e) => e.date === date).length;
+  }
+
+  /** Seed the viewing user's id (drives "you"-style affordances if ever needed). */
+  init(ctx: ShellContext): void {
+    this.currentUserId = ctx.userId;
+  }
+
+  /** Wire the board refetch (App.svelte's loader). Used for liveness + error reconcile. */
+  setRefresh(refresh: () => Promise<void>): void {
+    this.refresh = refresh;
+  }
+
+  /** Replace the board payload (the server echoes the snapped Monday — adopt it). */
+  setBoard(next: MealPlanBoardDto): void {
+    this.board = next;
+    // Adopt the server's authoritative Monday so the label can't drift from the
+    // data (e.g. if the client and server disagreed on the week boundary).
+    this.weekStart = next.weekStartDate;
+    this.error = null;
+  }
+
+  /** Re-GET the current week. Shared by liveness + error reconcile. */
+  async reconcile(): Promise<void> {
+    if (this.refresh) await this.refresh();
+  }
+
+  /**
+   * Fetch the board for the CURRENT `weekStart`. App.svelte wires this as the
+   * loader (and as the liveness/reconcile refresh). Keeps the spinner only for
+   * the first load; liveness refreshes are silent.
+   */
+  async loadBoard(): Promise<void> {
+    try {
+      if (this.board == null) this.loading = true;
+      this.error = null;
+      this.setBoard(await getBoard(this.weekStart));
+    } catch (e) {
+      if (e instanceof ApiError) {
+        this.error = `Failed to load the meal plan (HTTP ${e.status}).`;
+      } else {
+        this.error = e instanceof Error ? e.message : String(e);
+      }
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  /**
+   * Step the week. A number = relative weeks (−1 prev / +1 next); a string =
+   * an explicit target date (snapped to its Monday — used by "jump to today").
+   * Recomputes `weekStart` via dates.ts then refetches.
+   */
+  async changeWeek(deltaOrMonday: number | string): Promise<void> {
+    this.weekStart =
+      typeof deltaOrMonday === 'number'
+        ? addWeeks(this.weekStart, deltaOrMonday)
+        : mondayOf(deltaOrMonday);
+    await this.loadBoard();
+  }
+
+  /**
+   * Add a meal to a slot. Add is infrequent, so we AWAIT the POST then merge the
+   * returned authoritative entry into `board.entries` (no temp id). On any
+   * 4xx/network error: reconcile (re-GET the week) + a calm toast.
+   */
+  async addEntry(body: AddEntryBody): Promise<void> {
+    if (!this.board) return;
+    // Capture the week the add targets. If the user navigates to another week while the POST is in flight,
+    // we must NOT merge this (off-week) entry into the now-current board (council R1). It is persisted
+    // server-side and will appear when its week is viewed.
+    const targetWeek = this.weekStart;
+    try {
+      const created = await addEntry(body);
+      if (!this.board || this.weekStart !== targetWeek) return;
+      // The POST may have GetOrCreated the week's plan, so the board's
+      // mealPlanId could have been null — adopt the entry's plan id.
+      if (this.board.mealPlanId == null) {
+        this.board.mealPlanId = created.mealPlanId;
+      }
+      this.board.entries = [...this.board.entries, created];
+    } catch (e) {
+      await this.reconcile();
+      const msg =
+        e instanceof ApiError
+          ? "Couldn't add that meal — the plan was refreshed."
+          : "Couldn't add that meal right now.";
+      showToast({ message: msg, kind: 'info' });
+    }
+  }
+
+  /**
+   * Remove an entry — optimistic splice, then DELETE. On any error reconcile +
+   * calm toast. A missing entry (already removed by someone else) → 404/empty-400
+   * → the refetch shows the true state.
+   */
+  async removeEntry(mealPlanId: number, entryId: number): Promise<void> {
+    if (!this.board) return;
+    const idx = this.board.entries.findIndex(
+      (e) => e.mealPlanId === mealPlanId && e.entryId === entryId,
+    );
+    if (idx < 0) return;
+    const removed = this.board.entries[idx];
+    // Optimistic splice.
+    this.board.entries = this.board.entries.filter(
+      (e) => !(e.mealPlanId === mealPlanId && e.entryId === entryId),
+    );
+    try {
+      await removeEntry(mealPlanId, entryId);
+    } catch (e) {
+      if (e instanceof ApiError) {
+        // Any 4xx (incl. the empty-400-from-404 quirk) — resync to truth.
+        await this.reconcile();
+        showToast({ message: 'That meal changed — the plan was refreshed.', kind: 'info' });
+      } else {
+        // Network/5xx: the refetch may not have restored it; put it back AT ITS ORIGINAL INDEX (council R1 —
+        // appending would reorder the slot's entries on a failed delete).
+        if (
+          this.board &&
+          !this.board.entries.some(
+            (x) => x.mealPlanId === mealPlanId && x.entryId === entryId,
+          )
+        ) {
+          const restored = [...this.board.entries];
+          restored.splice(Math.min(idx, restored.length), 0, removed);
+          this.board.entries = restored;
+        }
+        showToast({ message: 'Something went wrong. Please try again.', kind: 'error' });
+      }
+    }
+  }
+}
+
+/**
+ * The single shared store instance. Components import this and read its
+ * `$state`/`$derived` fields reactively. We export the INSTANCE (not the runes
+ * themselves) so the rune-export rule is respected.
+ */
+export const mealPlanStore = new MealPlanStore();

--- a/frontend/meal-plan/src/lib/toasts.svelte.ts
+++ b/frontend/meal-plan/src/lib/toasts.svelte.ts
@@ -1,0 +1,47 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Transient toast notices for the meal-plan island (mirrors the chores
+// island's toast store). Used for non-alarming 4xx/network surfacing and the
+// "someone changed this — refreshed" reconcile notice. Kept deliberately
+// small: a module-level `$state` list + helpers.
+//
+// ⚠ Svelte 5 rune rule: we never export a reassigned `$state` rune directly.
+// The list lives inside a module-private `$state` object; callers read it via
+// the `toasts()` accessor and mutate it only through the exported functions.
+// ─────────────────────────────────────────────────────────────────────────
+
+export type ToastKind = 'info' | 'success' | 'error';
+
+export interface Toast {
+  id: number;
+  message: string;
+  kind: ToastKind;
+  durationMs: number;
+}
+
+let nextId = 1;
+const store = $state<{ items: Toast[] }>({ items: [] });
+
+/** The live toast list (reactive — read inside markup). */
+export function toasts(): readonly Toast[] {
+  return store.items;
+}
+
+/** Push a toast. Auto-dismisses after `durationMs` (default 3.5s). */
+export function showToast(toast: { message: string; kind: ToastKind; durationMs?: number }): number {
+  const id = nextId++;
+  const full: Toast = {
+    id,
+    message: toast.message,
+    kind: toast.kind,
+    durationMs: toast.durationMs ?? 3500,
+  };
+  store.items = [...store.items, full];
+  if (full.durationMs > 0) {
+    setTimeout(() => dismissToast(id), full.durationMs);
+  }
+  return id;
+}
+
+export function dismissToast(id: number): void {
+  store.items = store.items.filter((t) => t.id !== id);
+}

--- a/frontend/meal-plan/src/lib/types.ts
+++ b/frontend/meal-plan/src/lib/types.ts
@@ -1,0 +1,91 @@
+// ─────────────────────────────────────────────────────────────────────────
+// TS mirror of the meal-plan board DTO contract (M9 four-way lockstep with
+// Services/Dtos/MealPlanDtos.cs ↔ Fixtures/MealPlanBoard/board.json ↔
+// MealPlanBoardDtoContractTests). A shape/casing change updates all four.
+//
+// ⚠ CASING: `MealType` / `RecipeType` are real enum TYPES on the C# DTO → they
+//   serialize as camelCase string unions via the globally-registered
+//   JsonStringEnumConverter(CamelCase). `DateOnly` serializes as "YYYY-MM-DD".
+//
+// ⚠ DATES: every `date` / `weekStartDate` below is a "YYYY-MM-DD" STRING.
+//   NEVER `new Date('YYYY-MM-DD')` for logic — UTC-parsing shifts the day
+//   backward in US timezones (global CORRECTION / MN4). Use lib/dates.ts, which
+//   parses by splitting on '-' and steps weeks via Date.UTC(...,12).
+//
+// Versionless / last-write-wins: parity ops are add + remove only, so there is
+// NO version/xmin token anywhere on this contract.
+// ─────────────────────────────────────────────────────────────────────────
+
+export type MealType = 'breakfast' | 'lunch' | 'dinner' | 'snack';
+
+export type RecipeType =
+  | 'main'
+  | 'side'
+  | 'appetizer'
+  | 'dessert'
+  | 'beverage'
+  | 'sauce'
+  | 'breakfast'
+  | 'snack'
+  | 'other';
+
+/** The lightweight recipe shape a slot card renders (the board payload stays lean). */
+export interface MealRecipeSummaryDto {
+  recipeId: number;
+  name: string;
+  imagePath: string | null;
+  recipeType: RecipeType;
+}
+
+/** One planned meal. Exactly one of `recipe` / `customMealName` is set. */
+export interface MealPlanEntryDto {
+  mealPlanId: number;
+  entryId: number;
+  /** "YYYY-MM-DD" — the slot's calendar position. NEVER new Date() it for logic. */
+  date: string;
+  mealType: MealType;
+  recipe: MealRecipeSummaryDto | null;
+  customMealName: string | null;
+  notes: string | null;
+}
+
+/** The week board: the Monday it covers, the plan id (null when none yet), and its entries. */
+export interface MealPlanBoardDto {
+  /** "YYYY-MM-DD" — the Monday, echoed by the server. */
+  weekStartDate: string;
+  mealPlanId: number | null;
+  entries: MealPlanEntryDto[];
+}
+
+/** One ingredient line, pre-ordered by `sortOrder`. */
+export interface RecipeIngredientDto {
+  quantity: number | null;
+  unit: string | null;
+  name: string;
+  notes: string | null;
+  sortOrder: number;
+}
+
+/**
+ * Read-only recipe detail for the in-island view modal. `instructionsHtml` is
+ * server-sanitized (MarkdownHelper.ToSafeHtml) so the island ships no Markdown
+ * library — render via {@html}.
+ */
+export interface RecipeDetailDto {
+  recipeId: number;
+  name: string;
+  imagePath: string | null;
+  recipeType: RecipeType;
+  prepTimeMinutes: number | null;
+  cookTimeMinutes: number | null;
+  servings: number | null;
+  instructionsHtml: string;
+  ingredients: RecipeIngredientDto[];
+}
+
+/** The shell context the Razor host hands the island via root data-attrs. */
+export interface ShellContext {
+  householdId: number;
+  userId: number;
+  userName: string;
+}

--- a/frontend/meal-plan/src/main.ts
+++ b/frontend/meal-plan/src/main.ts
@@ -1,0 +1,204 @@
+import { mount as svelteMount, unmount } from 'svelte';
+import App from './App.svelte';
+import './styles/app.css';
+import type { ShellContext } from './lib/types';
+
+type MountedApp = ReturnType<typeof svelteMount>;
+
+interface Instance {
+  app: MountedApp;
+  /** The exact node we mounted into — lets us detect a Blazor resume that
+   *  replaced or emptied the root out from under us. */
+  el: HTMLElement;
+}
+
+// Blazor Server inserts component output via DOM diff, and inline <script>
+// tags in that output are NOT executed by the browser. The Razor shell
+// (MealPlan.razor) uses IJSRuntime.InvokeAsync("import", ...) to load this
+// module, then calls the global mounter below. Exposing a named entry on
+// window is the simplest way to survive enhanced-nav round-trips.
+declare global {
+  interface Window {
+    MealPlanIsland?: {
+      mount(rootId: string): void;
+      destroy(rootId: string): void;
+    };
+  }
+}
+
+const ROOT_ID = 'meal-plan-root';
+
+const instances = new Map<string, Instance>();
+
+// Roots the Razor shell has asked us to mount. We re-assert these when the page
+// is restored so a Blazor circuit resume / enhanced-nav merge that wiped our
+// content can't leave the island permanently blank (see reassertMounts below).
+const desiredRoots = new Set<string>();
+
+function readContext(el: HTMLElement): ShellContext {
+  const householdId = Number(el.dataset.householdId ?? '0');
+  const userId = Number(el.dataset.userId ?? '0');
+  const userName = el.dataset.userName ?? '';
+  if (!householdId || !userId) {
+    throw new Error('meal-plan: missing data-household-id / data-user-id');
+  }
+  return { householdId, userId, userName };
+}
+
+// Track dark-mode state and mirror it as a class on the island root so the
+// CSS override wins even when MudBlazor's runtime toggle doesn't propagate
+// the class down to us (we've seen it stay on <html> at load but go missing
+// after runtime toggles, leaving the island stuck in light mode).
+const darkObservers = new Map<string, () => void>();
+
+function isDarkActive(): boolean {
+  if (document.documentElement.classList.contains('mud-theme-dark')) return true;
+  if (document.body?.classList.contains('mud-theme-dark')) return true;
+  try {
+    if (localStorage.getItem('darkMode') === 'true') return true;
+  } catch { /* storage blocked */ }
+  return false;
+}
+
+function syncDarkClass(el: HTMLElement) {
+  el.classList.toggle('mp-dark-mode', isDarkActive());
+}
+
+function installDarkObserver(rootId: string, el: HTMLElement) {
+  syncDarkClass(el);
+  const htmlObs = new MutationObserver(() => syncDarkClass(el));
+  htmlObs.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
+  const bodyObs = new MutationObserver(() => syncDarkClass(el));
+  if (document.body) bodyObs.observe(document.body, { attributes: true, attributeFilter: ['class'] });
+  const storageHandler = (e: StorageEvent) => {
+    if (e.key === 'darkMode') syncDarkClass(el);
+  };
+  window.addEventListener('storage', storageHandler);
+  darkObservers.set(rootId, () => {
+    htmlObs.disconnect();
+    bodyObs.disconnect();
+    window.removeEventListener('storage', storageHandler);
+  });
+}
+
+/**
+ * A mount is healthy only if the CURRENT root element is the exact node we
+ * mounted into, it's still in the document, and it still holds our rendered
+ * children. Blazor's .NET 10 circuit resume (the path that fires on a mobile
+ * background→return) REPLACES the root node and re-runs the host component's
+ * lifecycle — a fresh firstRender re-calls mount(). The old mount-once guard
+ * (`instances.has`) refused to re-mount into that new node, leaving the board
+ * blank until a full reload. Comparing the live node to the one we mounted into
+ * lets the re-invoked mount() rebuild instead of no-op.
+ */
+function isHealthy(rootId: string): boolean {
+  const inst = instances.get(rootId);
+  if (!inst) return false;
+  const el = document.getElementById(rootId);
+  return el != null && el === inst.el && el.isConnected && el.childElementCount > 0;
+}
+
+function mountRoot(rootId: string) {
+  desiredRoots.add(rootId);
+  // Already mounted AND still intact — nothing to do.
+  if (isHealthy(rootId)) return;
+  // A stale prior mount (root emptied / replaced / detached): tear it down first
+  // so we don't leak the Svelte instance or its observers before remounting.
+  if (instances.has(rootId)) destroyRoot(rootId, /* internal */ true);
+  const el = document.getElementById(rootId) as HTMLElement | null;
+  if (!el) {
+    console.warn('[meal-plan-island] root element not found:', rootId);
+    return;
+  }
+  installDarkObserver(rootId, el);
+  const app = svelteMount(App, { target: el, props: { ctx: readContext(el) } });
+  instances.set(rootId, { app, el });
+  ensureHealObserver();
+}
+
+function destroyRoot(rootId: string, internal = false) {
+  const inst = instances.get(rootId);
+  if (!inst) {
+    if (!internal) desiredRoots.delete(rootId);
+    return;
+  }
+  // Blazor's circuit resume disposes the OLD page component AFTER it has already
+  // re-initialised the new one — whose firstRender re-calls mount(), which we use
+  // to rebuild into the freshly-replaced root. That trailing destroy() targets a
+  // SUPERSEDED component and would otherwise tear our live island back down.
+  // Ignore an external destroy while the current mount is healthy; a genuine
+  // navigation-away leaves no healthy root (the page is gone), so real teardown
+  // still runs then. `internal` is our own self-heal replacing a stale mount — it
+  // must always proceed.
+  if (!internal && isHealthy(rootId)) return;
+  if (!internal) desiredRoots.delete(rootId);
+  unmount(inst.app);
+  instances.delete(rootId);
+  const disposer = darkObservers.get(rootId);
+  if (disposer) {
+    disposer();
+    darkObservers.delete(rootId);
+  }
+}
+
+window.MealPlanIsland = { mount: mountRoot, destroy: destroyRoot };
+
+// ── Resilience: self-heal after a Blazor circuit resume ────────────────────
+// Mobile browsers background the tab on an app/tab switch; Blazor Server's .NET
+// 10 circuit pause/resume then reconciles the DOM on return and can REPLACE the
+// island root — sometimes re-invoking our mount() (handled in mountRoot), and
+// sometimes NOT (observed: nondeterministic). Either way the swap is a DOM
+// mutation, so we watch a STABLE anchor (document.body — Blazor replaces a chunk
+// of the island's ancestors, so observing the root or its parent misses it) and
+// rebuild any desired root that has gone unhealthy.
+//
+// The heal runs SYNCHRONOUSLY in the observer microtask — NOT via
+// requestAnimationFrame, which is paused while the tab is hidden (the wipe can
+// land a beat after the tab is technically still settling). `healing` guards
+// re-entrancy (mountRoot mutates the DOM, which re-queues this callback); once
+// the root is healthy again the next pass no-ops, so it can't loop. The cost on
+// every unrelated DOM change is one getElementById + isHealthy per desired root
+// (normally one), which is negligible.
+let healObserver: MutationObserver | null = null;
+let healing = false;
+function runHeal() {
+  if (healing) return;
+  healing = true;
+  try {
+    for (const rootId of desiredRoots) {
+      // Only rebuild when the root EXISTS but is stale/empty. A missing root is
+      // a navigation-away (or mid-reconcile) — not ours to remount; the next
+      // mutation re-checks once the fresh root lands.
+      if (document.getElementById(rootId) && !isHealthy(rootId)) mountRoot(rootId);
+    }
+  } finally {
+    healing = false;
+  }
+}
+function ensureHealObserver() {
+  if (healObserver || !document.body) return;
+  healObserver = new MutationObserver(runHeal);
+  healObserver.observe(document.body, { childList: true, subtree: true });
+}
+
+// bfcache restore re-attaches the frozen DOM without any mutation, so the body
+// observer won't fire — re-assert directly on pageshow as a cheap belt.
+window.addEventListener('pageshow', () => {
+  ensureHealObserver();
+  for (const rootId of desiredRoots) {
+    if (document.getElementById(rootId) && !isHealthy(rootId)) mountRoot(rootId);
+  }
+});
+
+// Standalone dev auto-mount: if the root is already on the page when the
+// module loads (Vite's index.html), mount immediately. In production the
+// Razor shell calls window.MealPlanIsland.mount() explicitly via JS interop.
+function autoMountIfReady() {
+  const el = document.getElementById(ROOT_ID);
+  if (el) mountRoot(ROOT_ID);
+}
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', autoMountIfReady);
+} else {
+  autoMountIfReady();
+}

--- a/frontend/meal-plan/src/styles/app.css
+++ b/frontend/meal-plan/src/styles/app.css
@@ -1,0 +1,33 @@
+@import './tokens.css';
+
+/*
+ * The island renders inside the host page, which also loads Bootstrap + MudBlazor.
+ * Bootstrap defines .row / .container globally, and those names collide with
+ * ambient island styles. We avoid the collision by prefixing all island class
+ * names with `mp-` (meal-plan) rather than overriding globals here.
+ */
+
+#meal-plan-root {
+  font-family: var(--font-family);
+  color: var(--color-text);
+  background: var(--color-background);
+  min-height: 100%;
+}
+
+#meal-plan-root,
+#meal-plan-root *,
+#meal-plan-root *::before,
+#meal-plan-root *::after {
+  box-sizing: border-box;
+}
+
+/*
+ * Suppress the outer Blazor ReconnectModal while the island is on the page.
+ * It's a showModal() <dialog>, which blocks all interaction behind it —
+ * including our HTTP-driven island that doesn't need the circuit to work.
+ * This CSS only ships on the meal-plan page (via <HeadContent>), so other
+ * pages still get the normal reconnect UX.
+ */
+#components-reconnect-modal {
+  display: none !important;
+}

--- a/frontend/meal-plan/src/styles/tokens.css
+++ b/frontend/meal-plan/src/styles/tokens.css
@@ -1,0 +1,95 @@
+/*
+ * Design tokens mirrored from the MudBlazor theme used elsewhere in the app
+ * (kept in sync with frontend/chores/src/styles/tokens.css).
+ * Light mode = :root. Dark mode = html.mud-theme-dark (set by App.razor)
+ * plus #meal-plan-root.mp-dark-mode (mirrored by main.ts's dark observer).
+ */
+
+:root {
+  /* brand */
+  --color-primary: rgb(46, 125, 50);
+  --color-primary-hover: rgb(36, 97, 39);
+  --color-primary-soft: rgb(58, 156, 63);
+  --color-secondary: rgb(255, 111, 0);
+
+  /* surfaces */
+  --color-surface: rgb(255, 255, 255);
+  --color-background: rgb(250, 250, 250);
+  --color-appbar: rgb(46, 125, 50);
+  --color-drawer: rgb(245, 245, 245);
+
+  /* text */
+  --color-text: rgb(66, 66, 66);
+  --color-text-muted: rgba(0, 0, 0, 0.54);
+  --color-text-disabled: rgba(0, 0, 0, 0.38);
+
+  /* structure */
+  --color-line: rgba(0, 0, 0, 0.12);
+  --color-line-strong: rgb(189, 189, 189);
+  --color-divider: rgb(224, 224, 224);
+  --color-action-hover: rgba(0, 0, 0, 0.06);
+  --color-action-disabled: rgba(0, 0, 0, 0.26);
+
+  /* semantic */
+  --color-success: rgb(67, 160, 71);
+  --color-error: rgb(229, 57, 53);
+  --color-warning: rgb(251, 140, 0);
+  --color-info: rgb(30, 136, 229);
+
+  /* typography */
+  --font-family: Roboto, Helvetica, Arial, sans-serif;
+
+  /* shape */
+  --radius-sm: 4px;
+  --radius-md: 4px;
+
+  /* elevation (MudBlazor 1, 2, 4) */
+  --shadow-1:
+    0 2px 1px -1px rgba(0, 0, 0, 0.2),
+    0 1px 1px 0 rgba(0, 0, 0, 0.14),
+    0 1px 3px 0 rgba(0, 0, 0, 0.12);
+  --shadow-2:
+    0 3px 1px -2px rgba(0, 0, 0, 0.2),
+    0 2px 2px 0 rgba(0, 0, 0, 0.14),
+    0 1px 5px 0 rgba(0, 0, 0, 0.12);
+  --shadow-4:
+    0 2px 4px -1px rgba(0, 0, 0, 0.2),
+    0 4px 5px 0 rgba(0, 0, 0, 0.14),
+    0 1px 10px 0 rgba(0, 0, 0, 0.12);
+}
+
+/*
+ * Dark-mode override. MudBlazor v8 + the App.razor bootstrap script both
+ * toggle `mud-theme-dark` on <html>, but runtime theme toggles sometimes
+ * land on <body> or deeper. Matching the bare class is a superset that
+ * works regardless of where the ancestor lives.
+ */
+.mud-theme-dark,
+html.mud-theme-dark,
+body.mud-theme-dark,
+#meal-plan-root.mp-dark-mode {
+  --color-primary: rgb(102, 187, 106);
+  --color-primary-hover: rgb(77, 172, 82);
+  --color-primary-soft: rgb(128, 198, 132);
+  --color-secondary: rgb(255, 183, 77);
+
+  --color-surface: rgb(30, 30, 30);
+  --color-background: rgb(18, 18, 18);
+  --color-appbar: rgb(26, 26, 26);
+  --color-drawer: rgb(26, 26, 26);
+
+  --color-text: rgba(255, 255, 255, 0.87);
+  --color-text-muted: rgba(255, 255, 255, 0.6);
+  --color-text-disabled: rgba(255, 255, 255, 0.2);
+
+  --color-line: rgba(255, 255, 255, 0.12);
+  --color-line-strong: rgba(255, 255, 255, 0.3);
+  --color-divider: rgba(255, 255, 255, 0.12);
+  --color-action-hover: rgba(173, 173, 177, 0.06);
+  --color-action-disabled: rgba(255, 255, 255, 0.26);
+
+  --color-success: rgb(102, 187, 106);
+  --color-error: rgb(239, 83, 80);
+  --color-warning: rgb(255, 167, 38);
+  --color-info: rgb(66, 165, 245);
+}

--- a/frontend/meal-plan/src/vite-env.d.ts
+++ b/frontend/meal-plan/src/vite-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="svelte" />
+/// <reference types="vite/client" />

--- a/frontend/meal-plan/svelte.config.js
+++ b/frontend/meal-plan/svelte.config.js
@@ -1,0 +1,8 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+export default {
+  preprocess: vitePreprocess(),
+  compilerOptions: {
+    runes: true,
+  },
+};

--- a/frontend/meal-plan/tsconfig.json
+++ b/frontend/meal-plan/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "@tsconfig/svelte/tsconfig.json",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowJs": false,
+    "checkJs": false,
+    "isolatedModules": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitAny": true,
+    "skipLibCheck": true,
+    "types": ["svelte", "vite/client"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.svelte", "src/vite-env.d.ts"]
+}

--- a/frontend/meal-plan/vite.config.ts
+++ b/frontend/meal-plan/vite.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+
+// The meal-plan island is embedded into a Razor shell at /meal-plan.
+// Build output goes to ./dist/ — the CopyMealPlanIsland MSBuild target in
+// FamilyCoordinationApp.csproj copies this into wwwroot/islands/meal-plan/.
+// Keeping the output local here makes the Docker build cleaner
+// (the mealplan-node-build stage emits dist/, the .NET stage reads it via COPY --from).
+// Mirrors frontend/chores/vite.config.ts (output index.js + index.css).
+export default defineConfig({
+  plugins: [svelte()],
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    rollupOptions: {
+      input: 'src/main.ts',
+      output: {
+        entryFileNames: 'index.js',
+        chunkFileNames: 'chunks/[name]-[hash].js',
+        assetFileNames: (info) =>
+          info.name?.endsWith('.css') ? 'index.css' : 'assets/[name]-[hash][extname]',
+      },
+    },
+    sourcemap: true,
+  },
+  server: {
+    port: 5175,
+    // Dev server proxies /api to the running .NET app so `npm run dev` works
+    // standalone against a locally-running Blazor host on :5000.
+    proxy: {
+      '/api': {
+        target: 'http://localhost:5000',
+        changeOrigin: false,
+      },
+    },
+  },
+});

--- a/src/FamilyCoordinationApp/Components/MealPlan/MealPlanBlazor.razor
+++ b/src/FamilyCoordinationApp/Components/MealPlan/MealPlanBlazor.razor
@@ -1,0 +1,221 @@
+@using FamilyCoordinationApp.Data
+@using FamilyCoordinationApp.Data.Entities
+@using FamilyCoordinationApp.Services
+@using FamilyCoordinationApp.Components.MealPlan
+@using Microsoft.EntityFrameworkCore
+@using MudBlazor
+@implements IDisposable
+
+@inject IMealPlanService MealPlanService
+@inject IDialogService DialogService
+@inject AuthenticationStateProvider AuthStateProvider
+@inject IDbContextFactory<ApplicationDbContext> DbFactory
+@inject DataNotifier Notifier
+
+@*
+    The original Blazor meal-plan UI, extracted verbatim from MealPlan.razor so the page can become a thin
+    island host (mirrors ShoppingList.razor → ShoppingListBlazor). This is the flag-OFF fallback during the
+    strangler migration; delete it once MEAL_PLAN_USE_ISLAND is the only path.
+*@
+
+<PageTitle>Meal Plan - Family Kitchen</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.ExtraLarge" Class="py-4">
+    <MudText Typo="Typo.h4" Class="mb-4">Meal Plan</MudText>
+
+    <!-- IMPORTANT: Use explicit event handler, NOT @bind-WeekStartDate -->
+    <!-- @bind uses WeekStartDateChanged internally but doesn't trigger our reload logic -->
+    <MealPlanNavigation WeekStartDate="@_weekStartDate"
+                        WeekStartDateChanged="@HandleWeekChanged" />
+
+    @if (_loading)
+    {
+        <MudProgressLinear Indeterminate="true" Class="my-4" />
+    }
+    else
+    {
+        <!-- Desktop: Calendar Grid (md and up) -->
+        <MudHidden Breakpoint="Breakpoint.SmAndDown">
+            <WeeklyCalendarView WeekStartDate="@_weekStartDate"
+                                Entries="@_entries"
+                                OnSlotClick="HandleSlotClick"
+                                OnRemoveEntry="HandleRemoveEntry"
+                                OnViewRecipe="HandleViewRecipe"
+                                OnViewCustomMeal="HandleViewCustomMeal" />
+        </MudHidden>
+
+        <!-- Mobile: List View (sm and down) -->
+        <MudHidden Breakpoint="Breakpoint.MdAndUp">
+            <WeeklyListView WeekStartDate="@_weekStartDate"
+                            Entries="@_entries"
+                            OnSlotClick="HandleSlotClick"
+                            OnRemoveEntry="HandleRemoveEntry"
+                            OnViewRecipe="HandleViewRecipe"
+                            OnViewCustomMeal="HandleViewCustomMeal" />
+        </MudHidden>
+    }
+</MudContainer>
+
+@code {
+    private DateOnly _weekStartDate;
+    private List<MealPlanEntry> _entries = new();
+    private bool _loading = true;
+    private int _householdId;
+    private int _userId;
+
+    protected override async Task OnInitializedAsync()
+    {
+        Notifier.OnMealPlanChanged += OnDataChanged;
+
+        // Get current week's Monday
+        var today = DateOnly.FromDateTime(DateTime.Today);
+        _weekStartDate = MealPlanService.GetWeekStartDate(today);
+
+        // Get user context
+        await LoadUserContextAsync();
+
+        await LoadMealPlanAsync();
+    }
+
+    private async Task LoadUserContextAsync()
+    {
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        var email = authState.User.FindFirst(System.Security.Claims.ClaimTypes.Email)?.Value;
+
+        await using var context = await DbFactory.CreateDbContextAsync();
+        var user = await context.Users.FirstOrDefaultAsync(u => u.Email == email);
+        if (user == null)
+        {
+            throw new InvalidOperationException("User not found. Please log in again.");
+        }
+        _householdId = user.HouseholdId;
+        _userId = user.Id;
+    }
+
+    private void OnDataChanged(int householdId)
+    {
+        // Security: Only respond to changes for our household
+        if (householdId != _householdId)
+            return;
+
+        InvokeAsync(async () =>
+        {
+            await LoadMealPlanAsync();
+            StateHasChanged();
+        });
+    }
+
+    private async Task LoadMealPlanAsync()
+    {
+        _loading = true;
+        StateHasChanged();
+
+        try
+        {
+            var mealPlan = await MealPlanService.GetOrCreateMealPlanAsync(_householdId, _weekStartDate);
+            _entries = mealPlan.Entries.ToList();
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+
+    // CRITICAL: This handler updates the week AND reloads data
+    // Called explicitly via WeekStartDateChanged="@HandleWeekChanged"
+    private async Task HandleWeekChanged(DateOnly newWeekStart)
+    {
+        _weekStartDate = newWeekStart;
+        await LoadMealPlanAsync();
+    }
+
+    private async Task HandleSlotClick((DateOnly Date, MealType MealType) slot)
+    {
+        var parameters = new DialogParameters<RecipePickerDialog>
+        {
+            { x => x.HouseholdId, _householdId },
+            { x => x.UserId, _userId }
+        };
+
+        var options = new DialogOptions
+        {
+            CloseOnEscapeKey = true,
+            BackdropClick = false,
+            MaxWidth = MaxWidth.Small,
+            FullWidth = true
+        };
+
+        var dialog = await DialogService.ShowAsync<RecipePickerDialog>("Select Meal", parameters, options);
+        var result = await dialog.Result;
+
+        if (result != null && !result.Canceled && result.Data is RecipePickerDialog.MealSelection selection)
+        {
+            await MealPlanService.AddMealAsync(
+                _householdId,
+                slot.Date,
+                slot.MealType,
+                selection.RecipeId,
+                selection.CustomMealName,
+                selection.Notes,
+                _userId);
+
+            await LoadMealPlanAsync();
+        }
+    }
+
+    private async Task HandleRemoveEntry(MealPlanEntry entry)
+    {
+        var confirmed = await DialogService.ShowMessageBox(
+            "Remove Meal",
+            $"Remove this meal from {entry.Date:MMM d}?",
+            yesText: "Remove",
+            cancelText: "Cancel");
+
+        if (confirmed == true)
+        {
+            await MealPlanService.RemoveMealAsync(_householdId, entry.MealPlanId, entry.EntryId);
+            await LoadMealPlanAsync();
+        }
+    }
+
+    private async Task HandleViewRecipe(Recipe recipe)
+    {
+        var parameters = new DialogParameters<RecipeDetailDialog>
+        {
+            { x => x.Recipe, recipe }
+        };
+
+        var options = new DialogOptions
+        {
+            CloseOnEscapeKey = true,
+            MaxWidth = MaxWidth.Medium,
+            FullWidth = true
+        };
+
+        await DialogService.ShowAsync<RecipeDetailDialog>(recipe.Name, parameters, options);
+    }
+
+    private async Task HandleViewCustomMeal(MealPlanEntry entry)
+    {
+        var content = new List<string> { $"**{entry.CustomMealName}**" };
+
+        if (!string.IsNullOrWhiteSpace(entry.Notes))
+        {
+            content.Add($"\n📝 Notes:\n{entry.Notes}");
+        }
+
+        content.Add($"\n📅 {entry.Date:dddd, MMMM d}");
+        content.Add($"🍽️ {entry.MealType}");
+
+        await DialogService.ShowMessageBox(
+            "Custom Meal",
+            (MarkupString)MarkdownHelper.ToSafeHtml(string.Join("\n", content)),
+            yesText: "Close");
+    }
+
+    public void Dispose()
+    {
+        Notifier.OnMealPlanChanged -= OnDataChanged;
+    }
+}

--- a/src/FamilyCoordinationApp/Components/Pages/MealPlan.razor
+++ b/src/FamilyCoordinationApp/Components/Pages/MealPlan.razor
@@ -1,217 +1,125 @@
 @page "/meal-plan"
 @using FamilyCoordinationApp.Data
-@using FamilyCoordinationApp.Data.Entities
-@using FamilyCoordinationApp.Services
 @using FamilyCoordinationApp.Components.MealPlan
+@using Microsoft.AspNetCore.Components.Web
 @using Microsoft.EntityFrameworkCore
-@using MudBlazor
+@using Microsoft.JSInterop
+@using System.Security.Claims
 @attribute [Authorize]
-@implements IDisposable
+@implements IAsyncDisposable
 
-@inject IMealPlanService MealPlanService
-@inject IDialogService DialogService
+@inject IConfiguration Config
 @inject AuthenticationStateProvider AuthStateProvider
 @inject IDbContextFactory<ApplicationDbContext> DbFactory
-@inject DataNotifier Notifier
+@inject IJSRuntime JS
+@inject IWebHostEnvironment HostEnv
 
-<PageTitle>Meal Plan - Family Kitchen</PageTitle>
+@*
+    Thin island host (strangler). Flag ON (MEAL_PLAN_USE_ISLAND=true) → mount the Svelte island; flag OFF →
+    the existing Blazor UI (<MealPlanBlazor/>) as the zero-regression fallback. Mirrors ShoppingList.razor /
+    Chores.razor. Flip the flag to switch; delete MealPlanBlazor once the island is the only path.
+*@
 
-<MudContainer MaxWidth="MaxWidth.ExtraLarge" Class="py-4">
-    <MudText Typo="Typo.h4" Class="mb-4">Meal Plan</MudText>
+@if (_useIsland && _shell is not null)
+{
+    <PageTitle>Meal Plan - Family Kitchen</PageTitle>
 
-    <!-- IMPORTANT: Use explicit event handler, NOT @bind-WeekStartDate -->
-    <!-- @bind uses WeekStartDateChanged internally but doesn't trigger our reload logic -->
-    <MealPlanNavigation WeekStartDate="@_weekStartDate"
-                        WeekStartDateChanged="@HandleWeekChanged" />
+    <HeadContent>
+        <link rel="stylesheet" href="/islands/meal-plan/index.css?v=@IslandVersion" />
+    </HeadContent>
 
-    @if (_loading)
-    {
-        <MudProgressLinear Indeterminate="true" Class="my-4" />
-    }
-    else
-    {
-        <!-- Desktop: Calendar Grid (md and up) -->
-        <MudHidden Breakpoint="Breakpoint.SmAndDown">
-            <WeeklyCalendarView WeekStartDate="@_weekStartDate"
-                                Entries="@_entries"
-                                OnSlotClick="HandleSlotClick"
-                                OnRemoveEntry="HandleRemoveEntry"
-                                OnViewRecipe="HandleViewRecipe"
-                                OnViewCustomMeal="HandleViewCustomMeal" />
-        </MudHidden>
-
-        <!-- Mobile: List View (sm and down) -->
-        <MudHidden Breakpoint="Breakpoint.MdAndUp">
-            <WeeklyListView WeekStartDate="@_weekStartDate"
-                            Entries="@_entries"
-                            OnSlotClick="HandleSlotClick"
-                            OnRemoveEntry="HandleRemoveEntry"
-                            OnViewRecipe="HandleViewRecipe"
-                            OnViewCustomMeal="HandleViewCustomMeal" />
-        </MudHidden>
-    }
-</MudContainer>
+    <div id="meal-plan-root"
+         data-household-id="@_shell.HouseholdId"
+         data-user-id="@_shell.UserId"
+         data-user-name="@_shell.UserName"></div>
+}
+else
+{
+    <MealPlanBlazor />
+}
 
 @code {
-    private DateOnly _weekStartDate;
-    private List<MealPlanEntry> _entries = new();
-    private bool _loading = true;
-    private int _householdId;
-    private int _userId;
+    private bool _useIsland;
+    private ShellData? _shell;
+    private IJSObjectReference? _islandModule;
 
     protected override async Task OnInitializedAsync()
     {
-        Notifier.OnMealPlanChanged += OnDataChanged;
+        _useIsland = IsIslandEnabled();
+        if (!_useIsland) return;
 
-        // Get current week's Monday
-        var today = DateOnly.FromDateTime(DateTime.Today);
-        _weekStartDate = MealPlanService.GetWeekStartDate(today);
-
-        // Get user context
-        await LoadUserContextAsync();
-
-        await LoadMealPlanAsync();
-    }
-
-    private async Task LoadUserContextAsync()
-    {
         var authState = await AuthStateProvider.GetAuthenticationStateAsync();
-        var email = authState.User.FindFirst(System.Security.Claims.ClaimTypes.Email)?.Value;
+        var email = authState.User.FindFirst(ClaimTypes.Email)?.Value;
+        var userName = authState.User.FindFirst(ClaimTypes.Name)?.Value ?? string.Empty;
 
         await using var context = await DbFactory.CreateDbContextAsync();
         var user = await context.Users.FirstOrDefaultAsync(u => u.Email == email);
-        if (user == null)
+        if (user is null)
         {
             throw new InvalidOperationException("User not found. Please log in again.");
         }
-        _householdId = user.HouseholdId;
-        _userId = user.Id;
+
+        _shell = new ShellData(user.HouseholdId, user.Id, userName);
     }
 
-    private void OnDataChanged(int householdId)
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        // Security: Only respond to changes for our household
-        if (householdId != _householdId)
-            return;
-            
-        InvokeAsync(async () =>
-        {
-            await LoadMealPlanAsync();
-            StateHasChanged();
-        });
+        if (!firstRender || !_useIsland || _shell is null) return;
+
+        // Blazor enhanced navigation does not apply this page's <HeadContent>, so the island stylesheet is
+        // missing on in-app navigation. (Re)inject it here (idempotent) — OnAfterRender runs for both full
+        // loads and enhanced nav, so the island is styled either way.
+        await JS.InvokeVoidAsync("ensureIslandStylesheet", $"/islands/meal-plan/index.css?v={IslandVersion}");
+
+        // Load the Svelte bundle as an ES module, then call its exposed mounter. mountRoot is idempotent and
+        // re-mounts against the fresh <div id="meal-plan-root">.
+        _islandModule = await JS.InvokeAsync<IJSObjectReference>(
+            "import", $"/islands/meal-plan/index.js?v={IslandVersion}");
+        await JS.InvokeVoidAsync("MealPlanIsland.mount", "meal-plan-root");
     }
 
-    private async Task LoadMealPlanAsync()
-    {
-        _loading = true;
-        StateHasChanged();
+    // Cache-bust the island URLs per deploy via the published bundle's mtime (mirrors ShoppingList.razor).
+    private static string? _islandVersion;
+    private string IslandVersion => _islandVersion ??= ComputeIslandVersion();
 
+    private string ComputeIslandVersion()
+    {
         try
         {
-            var mealPlan = await MealPlanService.GetOrCreateMealPlanAsync(_householdId, _weekStartDate);
-            _entries = mealPlan.Entries.ToList();
+            var path = Path.Combine(HostEnv.WebRootPath, "islands", "meal-plan", "index.js");
+            return new DateTimeOffset(File.GetLastWriteTimeUtc(path)).ToUnixTimeSeconds().ToString();
         }
-        finally
+        catch
         {
-            _loading = false;
-            StateHasChanged();
-        }
-    }
-
-    // CRITICAL: This handler updates the week AND reloads data
-    // Called explicitly via WeekStartDateChanged="@HandleWeekChanged"
-    private async Task HandleWeekChanged(DateOnly newWeekStart)
-    {
-        _weekStartDate = newWeekStart;
-        await LoadMealPlanAsync();
-    }
-
-    private async Task HandleSlotClick((DateOnly Date, MealType MealType) slot)
-    {
-        var parameters = new DialogParameters<RecipePickerDialog>
-        {
-            { x => x.HouseholdId, _householdId },
-            { x => x.UserId, _userId }
-        };
-
-        var options = new DialogOptions
-        {
-            CloseOnEscapeKey = true,
-            BackdropClick = false,
-            MaxWidth = MaxWidth.Small,
-            FullWidth = true
-        };
-
-        var dialog = await DialogService.ShowAsync<RecipePickerDialog>("Select Meal", parameters, options);
-        var result = await dialog.Result;
-
-        if (result != null && !result.Canceled && result.Data is RecipePickerDialog.MealSelection selection)
-        {
-            await MealPlanService.AddMealAsync(
-                _householdId,
-                slot.Date,
-                slot.MealType,
-                selection.RecipeId,
-                selection.CustomMealName,
-                selection.Notes,
-                _userId);
-
-            await LoadMealPlanAsync();
+            return "0";
         }
     }
 
-    private async Task HandleRemoveEntry(MealPlanEntry entry)
+    private bool IsIslandEnabled()
     {
-        var confirmed = await DialogService.ShowMessageBox(
-            "Remove Meal",
-            $"Remove this meal from {entry.Date:MMM d}?",
-            yesText: "Remove",
-            cancelText: "Cancel");
-
-        if (confirmed == true)
+        var configValue = Config["MEAL_PLAN_USE_ISLAND"];
+        if (!string.IsNullOrEmpty(configValue))
         {
-            await MealPlanService.RemoveMealAsync(_householdId, entry.MealPlanId, entry.EntryId);
-            await LoadMealPlanAsync();
+            return configValue.Equals("true", StringComparison.OrdinalIgnoreCase);
+        }
+
+        var envValue = Environment.GetEnvironmentVariable("MEAL_PLAN_USE_ISLAND");
+        return string.Equals(envValue, "true", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_islandModule is null) return;
+        try
+        {
+            await JS.InvokeVoidAsync("MealPlanIsland.destroy", "meal-plan-root");
+            await _islandModule.DisposeAsync();
+        }
+        catch (JSDisconnectedException)
+        {
+            // Circuit already gone (user navigated away after disconnect) — nothing to clean up.
         }
     }
 
-    private async Task HandleViewRecipe(Recipe recipe)
-    {
-        var parameters = new DialogParameters<RecipeDetailDialog>
-        {
-            { x => x.Recipe, recipe }
-        };
-
-        var options = new DialogOptions
-        {
-            CloseOnEscapeKey = true,
-            MaxWidth = MaxWidth.Medium,
-            FullWidth = true
-        };
-
-        await DialogService.ShowAsync<RecipeDetailDialog>(recipe.Name, parameters, options);
-    }
-
-    private async Task HandleViewCustomMeal(MealPlanEntry entry)
-    {
-        var content = new List<string> { $"**{entry.CustomMealName}**" };
-        
-        if (!string.IsNullOrWhiteSpace(entry.Notes))
-        {
-            content.Add($"\n📝 Notes:\n{entry.Notes}");
-        }
-
-        content.Add($"\n📅 {entry.Date:dddd, MMMM d}");
-        content.Add($"🍽️ {entry.MealType}");
-
-        await DialogService.ShowMessageBox(
-            "Custom Meal",
-            (MarkupString)MarkdownHelper.ToSafeHtml(string.Join("\n", content)),
-            yesText: "Close");
-    }
-
-    public void Dispose()
-    {
-        Notifier.OnMealPlanChanged -= OnDataChanged;
-    }
+    private sealed record ShellData(int HouseholdId, int UserId, string UserName);
 }

--- a/src/FamilyCoordinationApp/Endpoints/MealPlanEndpoints.cs
+++ b/src/FamilyCoordinationApp/Endpoints/MealPlanEndpoints.cs
@@ -1,0 +1,231 @@
+using System.Globalization;
+using System.Security.Claims;
+using FamilyCoordinationApp.Data;
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Services.Dtos;
+using FamilyCoordinationApp.Services.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace FamilyCoordinationApp.Endpoints;
+
+/// <summary>
+/// Minimal-API surface for the meal-plan island (strangler — mirrors <see cref="ChoresEndpoints"/>): a
+/// <c>/api/meal-plan</c> group behind <c>.RequireAuthorization().DisableAntiforgery()</c>, every handler
+/// resolving the HouseholdId/UserId from the authenticated caller (M1, never client-supplied) via
+/// <see cref="UserContextResolver"/>. Writes delegate to <see cref="IMealPlanService"/> / <see cref="IRecipeService"/>;
+/// the board read + per-entry projection delegate to <see cref="IMealPlanBoardService"/> (ONE projection — no
+/// card/response drift, M9).
+///
+/// <para>Parity-first: the ops are add + remove only ⇒ versionless / last-write-wins (no xmin token on the
+/// wire). A remove of a missing entry → 404 (may surface as an empty 400 via the app-global
+/// <c>UseStatusCodePagesWithReExecute</c> quirk — the island treats any 4xx as a non-retryable refetch).</para>
+/// </summary>
+public static class MealPlanEndpoints
+{
+    public static IEndpointRouteBuilder MapMealPlanEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/meal-plan")
+            .RequireAuthorization()
+            // Mirrors the shopping-list/chores island groups: the island calls these with same-origin
+            // credentialed fetch + JSON bodies (never HTML form posts) and the auth cookie is SameSite, so the
+            // antiforgery token — which the SPA island can't readily supply — is not the CSRF control here.
+            // Kept consistent with the other island endpoint groups.
+            .DisableAntiforgery();
+
+        group.MapGet("/board", GetBoard);
+        group.MapPost("/entries", AddEntry);
+        group.MapDelete("/entries/{mealPlanId:int}/{entryId:int}", RemoveEntry);
+
+        group.MapGet("/recipes", SearchRecipes);
+        group.MapPost("/recipes", QuickCreateRecipe);
+        group.MapGet("/recipes/{recipeId:int}", GetRecipeDetail);
+
+        return app;
+    }
+
+    // ─── Board ──────────────────────────────────────────────────────────────────
+
+    private static async Task<IResult> GetBoard(
+        [FromQuery] string? weekStart,
+        ClaimsPrincipal principal,
+        IMealPlanService mealPlanService,
+        IMealPlanBoardService boardService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        // Snap to the week's Monday SERVER-side (the client may send any date in the week; this is the only
+        // authority on the week boundary). Missing/unparseable ⇒ current week (matches the Blazor page's
+        // DateTime.Today). The island always sends a "YYYY-MM-DD", so the fallback is rarely hit.
+        var baseDate = DateOnly.TryParseExact(weekStart, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed)
+            ? parsed
+            : DateOnly.FromDateTime(DateTime.Today);
+        var monday = mealPlanService.GetWeekStartDate(baseDate);
+
+        var board = await boardService.GetBoardAsync(user.HouseholdId, monday, ct);
+        return Results.Ok(board);
+    }
+
+    // ─── Entries (add / remove — versionless) ────────────────────────────────────
+
+    private static async Task<IResult> AddEntry(
+        AddEntryRequest req,
+        ClaimsPrincipal principal,
+        IMealPlanService mealPlanService,
+        IMealPlanBoardService boardService,
+        IRecipeService recipeService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        // XOR: exactly one of recipeId / customMealName. The service also guards (throws
+        // InvalidOperationException), but validate here for a clean 400 rather than a 500.
+        var hasRecipe = req.RecipeId.HasValue;
+        var hasCustom = !string.IsNullOrWhiteSpace(req.CustomMealName);
+        if (hasRecipe == hasCustom)
+        {
+            return Results.BadRequest(new { message = "Provide exactly one of recipeId or customMealName." });
+        }
+
+        // Validate recipe ownership BEFORE creating anything (council R1). The household-scoped lookup makes a
+        // cross-household recipe id a clean not-found (M1, no leak), and validating up front avoids both an
+        // FK-violation 500 AND an orphan MealPlan row — GetOrCreateMealPlanAsync commits the week's plan in its
+        // own SaveChanges, so a bad recipeId reaching the entry insert would leave an empty plan behind. The
+        // loaded recipe is reused for the response projection (AddMealAsync doesn't load the nav).
+        Recipe? recipe = null;
+        if (req.RecipeId.HasValue)
+        {
+            recipe = await recipeService.GetRecipeAsync(user.HouseholdId, req.RecipeId.Value, ct);
+            if (recipe is null)
+            {
+                return Results.NotFound(new { message = "Recipe not found." });
+            }
+        }
+
+        var entry = await mealPlanService.AddMealAsync(
+            user.HouseholdId,
+            req.Date,
+            req.MealType,
+            req.RecipeId,
+            hasCustom ? req.CustomMealName!.Trim() : null,
+            string.IsNullOrWhiteSpace(req.Notes) ? null : req.Notes.Trim(),
+            user.UserId,
+            ct);
+
+        var dto = boardService.ProjectEntry(entry, recipe);
+        return Results.Created($"/api/meal-plan/entries/{entry.MealPlanId}/{entry.EntryId}", dto);
+    }
+
+    private static async Task<IResult> RemoveEntry(
+        int mealPlanId,
+        int entryId,
+        ClaimsPrincipal principal,
+        IMealPlanService mealPlanService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        try
+        {
+            // Household-scoped — a cross-household id finds nothing ⇒ throws ⇒ 404 (M1).
+            await mealPlanService.RemoveMealAsync(user.HouseholdId, mealPlanId, entryId, ct);
+            return Results.NoContent();
+        }
+        catch (InvalidOperationException)
+        {
+            // Non-empty body so the app-global UseStatusCodePagesWithReExecute does NOT re-execute this
+            // through the Blazor /not-found page (an empty DELETE 404 would surface as a 405 on the wire).
+            return Results.NotFound(new { message = "Meal entry not found." });
+        }
+    }
+
+    // ─── Recipes (picker search / quick-create / detail) ─────────────────────────
+
+    private static async Task<IResult> SearchRecipes(
+        [FromQuery] string? q,
+        ClaimsPrincipal principal,
+        IRecipeService recipeService,
+        IMealPlanBoardService boardService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        var recipes = await recipeService.GetRecipesAsync(user.HouseholdId, q, ct);
+        var summaries = recipes.Select(boardService.ToRecipeSummary).ToList();
+        return Results.Ok(summaries);
+    }
+
+    private static async Task<IResult> QuickCreateRecipe(
+        QuickCreateRecipeRequest req,
+        ClaimsPrincipal principal,
+        IRecipeService recipeService,
+        IMealPlanBoardService boardService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        if (string.IsNullOrWhiteSpace(req.Name))
+        {
+            return Results.BadRequest(new { message = "Recipe name is required." });
+        }
+
+        var recipe = new Recipe
+        {
+            HouseholdId = user.HouseholdId,
+            Name = req.Name.Trim(),
+            RecipeType = req.RecipeType,
+            CreatedByUserId = user.UserId,
+            CreatedAt = DateTime.UtcNow,
+        };
+
+        var created = await recipeService.CreateRecipeAsync(recipe, ct);
+        var summary = boardService.ToRecipeSummary(created);
+        return Results.Created($"/api/meal-plan/recipes/{created.RecipeId}", summary);
+    }
+
+    private static async Task<IResult> GetRecipeDetail(
+        int recipeId,
+        ClaimsPrincipal principal,
+        IRecipeService recipeService,
+        IMealPlanBoardService boardService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        var recipe = await recipeService.GetRecipeAsync(user.HouseholdId, recipeId, ct);
+        // Non-empty body so the status-code re-execute middleware leaves this as a clean 404 (see RemoveEntry).
+        if (recipe is null) return Results.NotFound(new { message = "Recipe not found." });
+
+        return Results.Ok(boardService.ToRecipeDetail(recipe));
+    }
+
+    // ─── Request DTOs ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Add a meal to a slot. <see cref="Date"/> is the slot's calendar position ("YYYY-MM-DD"); the server
+    /// derives the week from it. Supply EXACTLY one of <see cref="RecipeId"/> / <see cref="CustomMealName"/>.
+    /// Versionless — no concurrency token.
+    /// </summary>
+    public sealed record AddEntryRequest(
+        DateOnly Date,
+        MealType MealType,
+        int? RecipeId,
+        string? CustomMealName,
+        string? Notes);
+
+    /// <summary>Quick-create a bare recipe from the picker's "New Recipe" tab (details added later).</summary>
+    public sealed record QuickCreateRecipeRequest(string Name, RecipeType RecipeType);
+}

--- a/src/FamilyCoordinationApp/FamilyCoordinationApp.csproj
+++ b/src/FamilyCoordinationApp/FamilyCoordinationApp.csproj
@@ -53,6 +53,23 @@
           SkipUnchangedFiles="true" />
   </Target>
 
+  <!--
+    Copy the built meal-plan island into wwwroot before build (strangler). Run `npm run build` in
+    frontend/meal-plan/ first (or let the Docker build do it via the mealplan-node-build stage). If dist/
+    doesn't exist, the target is skipped silently and the island endpoint 404s — MealPlan.razor renders the
+    Blazor fallback via the MEAL_PLAN_USE_ISLAND toggle. Parallel to CopyChoresIsland.
+  -->
+  <Target Name="CopyMealPlanIsland"
+          BeforeTargets="AssignTargetPaths"
+          Condition="Exists('$(MSBuildThisFileDirectory)..\..\frontend\meal-plan\dist')">
+    <ItemGroup>
+      <_MealPlanIslandFiles Include="$(MSBuildThisFileDirectory)..\..\frontend\meal-plan\dist\**\*.*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_MealPlanIslandFiles)"
+          DestinationFiles="@(_MealPlanIslandFiles->'$(MSBuildThisFileDirectory)wwwroot\islands\meal-plan\%(RecursiveDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true" />
+  </Target>
+
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.4.0" />
     <PackageReference Include="blazor-dragdrop" Version="2.6.1" />

--- a/src/FamilyCoordinationApp/Program.cs
+++ b/src/FamilyCoordinationApp/Program.cs
@@ -87,6 +87,8 @@ builder.Services.AddScoped<IRecipeService, RecipeService>();
 builder.Services.AddScoped<ICategoryService, CategoryService>();
 builder.Services.AddScoped<IDraftService, DraftService>();
 builder.Services.AddScoped<IMealPlanService, MealPlanService>();
+// Meal-plan island (strangler): read-only board + entry/recipe projection (mirrors IChoreBoardService).
+builder.Services.AddScoped<IMealPlanBoardService, MealPlanBoardService>();
 builder.Services.AddScoped<IShoppingListService, ShoppingListService>();
 builder.Services.AddScoped<UnitConverter>();
 builder.Services.AddScoped<IShoppingListGenerator, ShoppingListGenerator>();
@@ -396,6 +398,7 @@ app.MapRazorComponents<App>()
 app.MapShoppingListEndpoints();
 app.MapChoresEndpoints();
 app.MapRoomsEndpoints();
+app.MapMealPlanEndpoints();
 
 // Health check endpoint for Docker
 app.MapGet("/health", () => Results.Ok("healthy"));

--- a/src/FamilyCoordinationApp/Services/Dtos/MealPlanDtos.cs
+++ b/src/FamilyCoordinationApp/Services/Dtos/MealPlanDtos.cs
@@ -1,0 +1,66 @@
+using FamilyCoordinationApp.Data.Entities;
+
+namespace FamilyCoordinationApp.Services.Dtos;
+
+// ─────────────────────────────────────────────────────────────────────────
+// Meal-plan island board DTOs (strangler — mirrors the chores M9 lockstep).
+// Source of truth for the island TS contract: tests/FamilyCoordinationApp.Tests/
+// Fixtures/MealPlanBoard/board.json + frontend/meal-plan/src/lib/types.ts. A
+// shape/casing change updates THIS file, that fixture, and types.ts in lockstep
+// (MealPlanBoardDtoContractTests is the tripwire).
+//
+// ⚠ CASING: both enums below (MealType, RecipeType) are real enum TYPES on the
+//   DTO → they serialize as camelCase strings via the globally-registered
+//   JsonStringEnumConverter(CamelCase) (Program.cs ConfigureHttpJsonOptions).
+//   This deliberately avoids the chores recurrenceMode/effortTier PascalCase
+//   plain-string trap. DateOnly serializes as "YYYY-MM-DD".
+//
+// Parity-first (no drag-drop) ⇒ versionless / last-write-wins: NO xmin token on
+// the wire. MealPlanEntry.Version exists on the entity but is unused here.
+// ─────────────────────────────────────────────────────────────────────────
+
+/// <summary>The week board: the Monday it covers, the plan id (null when none yet), and its entries.</summary>
+public sealed record MealPlanBoardDto(
+    DateOnly WeekStartDate,
+    int? MealPlanId,
+    IReadOnlyList<MealPlanEntryDto> Entries);
+
+/// <summary>One planned meal. Exactly one of <see cref="Recipe"/> / <see cref="CustomMealName"/> is set.</summary>
+public sealed record MealPlanEntryDto(
+    int MealPlanId,
+    int EntryId,
+    DateOnly Date,
+    MealType MealType,
+    MealRecipeSummaryDto? Recipe,
+    string? CustomMealName,
+    string? Notes);
+
+/// <summary>The lightweight recipe shape a slot card renders (board payload stays lean).</summary>
+public sealed record MealRecipeSummaryDto(
+    int RecipeId,
+    string Name,
+    string? ImagePath,
+    RecipeType RecipeType);
+
+/// <summary>
+/// Read-only recipe detail for the in-island view modal. <see cref="InstructionsHtml"/> is server-sanitized
+/// (<see cref="MarkdownHelper.ToSafeHtml"/>) so the island ships no Markdown library — render via {@html}.
+/// </summary>
+public sealed record RecipeDetailDto(
+    int RecipeId,
+    string Name,
+    string? ImagePath,
+    RecipeType RecipeType,
+    int? PrepTimeMinutes,
+    int? CookTimeMinutes,
+    int? Servings,
+    string InstructionsHtml,
+    IReadOnlyList<RecipeIngredientDto> Ingredients);
+
+/// <summary>One ingredient line, pre-ordered by sort order.</summary>
+public sealed record RecipeIngredientDto(
+    decimal? Quantity,
+    string? Unit,
+    string Name,
+    string? Notes,
+    int SortOrder);

--- a/src/FamilyCoordinationApp/Services/Interfaces/IMealPlanBoardService.cs
+++ b/src/FamilyCoordinationApp/Services/Interfaces/IMealPlanBoardService.cs
@@ -1,0 +1,31 @@
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Services.Dtos;
+
+namespace FamilyCoordinationApp.Services.Interfaces;
+
+/// <summary>
+/// Read + projection for the meal-plan island board (mirrors <c>IChoreBoardService</c>). The ONE place the
+/// board read model and the per-entry mutation response are projected, so the slot card and the add-entry
+/// response cannot drift (M9). All reads are household-scoped (M1).
+/// </summary>
+public interface IMealPlanBoardService
+{
+    /// <summary>
+    /// The read-only board for a week. <paramref name="weekStart"/> MUST already be the week's Monday
+    /// (the endpoint snaps it via <see cref="IMealPlanService.GetWeekStartDate"/>). No plan for the week ⇒
+    /// <c>MealPlanId = null, Entries = []</c> (a GET never creates a plan).
+    /// </summary>
+    Task<MealPlanBoardDto> GetBoardAsync(int householdId, DateOnly weekStart, CancellationToken ct = default);
+
+    /// <summary>
+    /// Project a single entry. <paramref name="recipe"/> is the entry's recipe when it is a recipe meal
+    /// (the caller supplies it — the entity nav is not always loaded), or <c>null</c> for a custom meal.
+    /// </summary>
+    MealPlanEntryDto ProjectEntry(MealPlanEntry entry, Recipe? recipe);
+
+    /// <summary>The lean recipe summary a slot card / picker row renders.</summary>
+    MealRecipeSummaryDto ToRecipeSummary(Recipe recipe);
+
+    /// <summary>Full read-only recipe detail (instructions pre-sanitized to HTML).</summary>
+    RecipeDetailDto ToRecipeDetail(Recipe recipe);
+}

--- a/src/FamilyCoordinationApp/Services/MealPlanBoardService.cs
+++ b/src/FamilyCoordinationApp/Services/MealPlanBoardService.cs
@@ -1,0 +1,67 @@
+using FamilyCoordinationApp.Data;
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Services.Dtos;
+using FamilyCoordinationApp.Services.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace FamilyCoordinationApp.Services;
+
+/// <summary>
+/// Read + projection for the meal-plan island board (mirrors <see cref="ChoreBoardService"/>). Owns the ONE
+/// entry projection shared by the board read and the add-entry response so the two cannot drift (M9). All
+/// reads create short-lived contexts via the factory (Blazor Server circuit safety) and filter by
+/// <c>HouseholdId</c> (M1).
+/// </summary>
+public class MealPlanBoardService(IDbContextFactory<ApplicationDbContext> dbFactory) : IMealPlanBoardService
+{
+    public async Task<MealPlanBoardDto> GetBoardAsync(int householdId, DateOnly weekStart, CancellationToken ct = default)
+    {
+        await using var context = await dbFactory.CreateDbContextAsync(ct);
+
+        // Read-only — a GET never creates a plan (creation happens lazily on the first AddMeal). Filtered
+        // include orders the entries (Date, then MealType) the same way MealPlanService does.
+        var plan = await context.MealPlans
+            .AsNoTracking()
+            .Where(mp => mp.HouseholdId == householdId && mp.WeekStartDate == weekStart)
+            .Include(mp => mp.Entries.OrderBy(e => e.Date).ThenBy(e => e.MealType))
+                .ThenInclude(e => e.Recipe)
+            .FirstOrDefaultAsync(ct);
+
+        if (plan is null)
+        {
+            return new MealPlanBoardDto(weekStart, null, Array.Empty<MealPlanEntryDto>());
+        }
+
+        var entries = plan.Entries
+            .Select(e => ProjectEntry(e, e.Recipe))
+            .ToList();
+
+        return new MealPlanBoardDto(weekStart, plan.MealPlanId, entries);
+    }
+
+    public MealPlanEntryDto ProjectEntry(MealPlanEntry entry, Recipe? recipe) => new(
+        entry.MealPlanId,
+        entry.EntryId,
+        entry.Date,
+        entry.MealType,
+        recipe is null ? null : ToRecipeSummary(recipe),
+        entry.CustomMealName,
+        entry.Notes);
+
+    public MealRecipeSummaryDto ToRecipeSummary(Recipe recipe) =>
+        new(recipe.RecipeId, recipe.Name, recipe.ImagePath, recipe.RecipeType);
+
+    public RecipeDetailDto ToRecipeDetail(Recipe recipe) => new(
+        recipe.RecipeId,
+        recipe.Name,
+        recipe.ImagePath,
+        recipe.RecipeType,
+        recipe.PrepTimeMinutes,
+        recipe.CookTimeMinutes,
+        recipe.Servings,
+        MarkdownHelper.ToSafeHtml(recipe.Instructions),
+        recipe.Ingredients
+            .OrderBy(i => i.SortOrder)
+            .Select(i => new RecipeIngredientDto(i.Quantity, i.Unit, i.Name, i.Notes, i.SortOrder))
+            .ToList());
+}

--- a/tests/FamilyCoordinationApp.Tests/Fixtures/MealPlanBoard/board.json
+++ b/tests/FamilyCoordinationApp.Tests/Fixtures/MealPlanBoard/board.json
@@ -1,0 +1,43 @@
+{
+  "weekStartDate": "2026-06-01",
+  "mealPlanId": 5,
+  "entries": [
+    {
+      "mealPlanId": 5,
+      "entryId": 1,
+      "date": "2026-06-01",
+      "mealType": "breakfast",
+      "recipe": {
+        "recipeId": 10,
+        "name": "Overnight Oats",
+        "imagePath": "/uploads/1/oats.jpg",
+        "recipeType": "breakfast"
+      },
+      "customMealName": null,
+      "notes": null
+    },
+    {
+      "mealPlanId": 5,
+      "entryId": 2,
+      "date": "2026-06-01",
+      "mealType": "dinner",
+      "recipe": {
+        "recipeId": 11,
+        "name": "Spaghetti Bolognese",
+        "imagePath": null,
+        "recipeType": "main"
+      },
+      "customMealName": null,
+      "notes": "Double batch for leftovers"
+    },
+    {
+      "mealPlanId": 5,
+      "entryId": 3,
+      "date": "2026-06-02",
+      "mealType": "lunch",
+      "recipe": null,
+      "customMealName": "Leftovers",
+      "notes": "Sunday's roast"
+    }
+  ]
+}

--- a/tests/FamilyCoordinationApp.Tests/Integration/MealPlanEndpointTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Integration/MealPlanEndpointTests.cs
@@ -1,0 +1,298 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+
+namespace FamilyCoordinationApp.Tests.Integration;
+
+/// <summary>
+/// End-to-end coverage of the meal-plan island endpoints through the real HTTP pipeline against real Postgres
+/// (reuses <see cref="ChoresWebAppFactory"/>'s two-household seed). Proves: the read-only board (empty + populated),
+/// add recipe / add custom round-trips + the add→board reflection, the XOR validation (400), remove (204) then
+/// gone, a missing remove rejected (4xx), recipe search + quick-create, recipe detail, the 401 gate, and the M1
+/// cross-household isolation invariant (a household-B caller never sees or mutates household-A's plan). Parity is
+/// versionless — no xmin token anywhere on the wire.
+/// </summary>
+[Collection(IntegrationCollection.Name)]
+[Trait("kind", "integration")]
+public sealed class MealPlanEndpointTests(PostgresContainerFixture postgres) : IAsyncLifetime
+{
+    private readonly ChoresWebAppFactory _factory = new(postgres);
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    public async Task InitializeAsync() => await _factory.EnsureSeededAsync();
+
+    public async Task DisposeAsync() => await _factory.DisposeAsync();
+
+    // Wire shapes (subset — camelCase via JsonSerializerDefaults.Web).
+    private sealed record RecipeSummary(int recipeId, string name, string? imagePath, string recipeType);
+    private sealed record Entry(
+        int mealPlanId, int entryId, string date, string mealType,
+        RecipeSummary? recipe, string? customMealName, string? notes);
+    private sealed record Board(string weekStartDate, int? mealPlanId, List<Entry> entries);
+    private sealed record IngredientLine(decimal? quantity, string? unit, string name, string? notes, int sortOrder);
+    private sealed record RecipeDetail(
+        int recipeId, string name, string? imagePath, string recipeType,
+        int? prepTimeMinutes, int? cookTimeMinutes, int? servings,
+        string instructionsHtml, List<IngredientLine> ingredients);
+
+    private HttpClient ClientA => _factory.CreateClientAs(ChoresWebAppFactory.UserAEmail);
+    private HttpClient ClientB => _factory.CreateClientAs(ChoresWebAppFactory.UserBEmail);
+
+    // All weekStart values below are Mondays in June 2026 (the server snaps to Monday anyway); each test uses
+    // a DISTINCT week so the class's shared database can't let tests interfere.
+    private async Task<RecipeSummary> QuickCreateRecipeAsync(HttpClient client, string name, string type = "main")
+    {
+        var resp = await client.PostAsJsonAsync("/api/meal-plan/recipes", new { name, recipeType = type }, Json);
+        resp.StatusCode.Should().Be(HttpStatusCode.Created);
+        var summary = await resp.Content.ReadFromJsonAsync<RecipeSummary>(Json);
+        summary.Should().NotBeNull();
+        return summary!;
+    }
+
+    private async Task<Entry> AddEntryAsync(HttpClient client, object body)
+    {
+        var resp = await client.PostAsJsonAsync("/api/meal-plan/entries", body, Json);
+        resp.StatusCode.Should().Be(HttpStatusCode.Created);
+        var entry = await resp.Content.ReadFromJsonAsync<Entry>(Json);
+        entry.Should().NotBeNull();
+        return entry!;
+    }
+
+    [Fact]
+    public async Task Board_EmptyWeek_ReturnsNullPlanAndNoEntries()
+    {
+        // A week never written to ⇒ no plan exists ⇒ a GET must NOT create one (mealPlanId null, entries []).
+        var board = await ClientA.GetFromJsonAsync<Board>("/api/meal-plan/board?weekStart=2026-06-29", Json);
+
+        board.Should().NotBeNull();
+        board!.weekStartDate.Should().Be("2026-06-29");
+        board.mealPlanId.Should().BeNull();
+        board.entries.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Board_SnapsWeekStartToMonday_ServerSide()
+    {
+        // Send a mid-week date (2026-06-03 is a Wednesday); the board must echo that week's Monday (2026-06-01).
+        var board = await ClientA.GetFromJsonAsync<Board>("/api/meal-plan/board?weekStart=2026-06-03", Json);
+
+        board.Should().NotBeNull();
+        board!.weekStartDate.Should().Be("2026-06-01");
+    }
+
+    [Fact]
+    public async Task AddRecipeEntry_RoundTrips_AndAppearsOnBoard()
+    {
+        var client = ClientA;
+        var recipe = await QuickCreateRecipeAsync(client, "Test Pancakes", "breakfast");
+
+        var entry = await AddEntryAsync(client, new
+        {
+            date = "2026-06-01",
+            mealType = "breakfast",
+            recipeId = recipe.recipeId,
+            customMealName = (string?)null,
+            notes = (string?)null
+        });
+
+        entry.recipe.Should().NotBeNull();
+        entry.recipe!.recipeId.Should().Be(recipe.recipeId);
+        entry.mealType.Should().Be("breakfast");
+        entry.customMealName.Should().BeNull();
+
+        var board = await client.GetFromJsonAsync<Board>("/api/meal-plan/board?weekStart=2026-06-01", Json);
+        board!.mealPlanId.Should().NotBeNull();
+        board.entries.Should().Contain(e =>
+            e.entryId == entry.entryId && e.recipe != null && e.recipe.recipeId == recipe.recipeId);
+    }
+
+    [Fact]
+    public async Task AddCustomMeal_RoundTrips()
+    {
+        var entry = await AddEntryAsync(ClientA, new
+        {
+            date = "2026-06-08",
+            mealType = "lunch",
+            recipeId = (int?)null,
+            customMealName = "Eating out",
+            notes = "birthday"
+        });
+
+        entry.recipe.Should().BeNull();
+        entry.customMealName.Should().Be("Eating out");
+        entry.notes.Should().Be("birthday");
+        entry.mealType.Should().Be("lunch");
+    }
+
+    [Fact]
+    public async Task AddEntry_BothRecipeAndCustom_Returns400()
+    {
+        var resp = await ClientA.PostAsJsonAsync("/api/meal-plan/entries", new
+        {
+            date = "2026-06-01",
+            mealType = "dinner",
+            recipeId = 1,
+            customMealName = "Both set",
+            notes = (string?)null
+        }, Json);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task AddEntry_NeitherRecipeNorCustom_Returns400()
+    {
+        var resp = await ClientA.PostAsJsonAsync("/api/meal-plan/entries", new
+        {
+            date = "2026-06-01",
+            mealType = "dinner",
+            recipeId = (int?)null,
+            customMealName = (string?)null,
+            notes = (string?)null
+        }, Json);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task AddEntry_NonexistentRecipe_Returns404()
+    {
+        var resp = await ClientA.PostAsJsonAsync("/api/meal-plan/entries", new
+        {
+            date = "2026-06-01",
+            mealType = "dinner",
+            recipeId = 999999,
+            customMealName = (string?)null,
+            notes = (string?)null
+        }, Json);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task AddEntry_CrossHouseholdRecipe_Returns404_NotALeak()
+    {
+        // A recipe owned by household B must be unreachable from household A (M1): the household-scoped
+        // GetRecipeAsync misses it, so the add is rejected up front with a clean 404 — never an FK-violation
+        // 500, never a cross-tenant entry, and never an orphan MealPlan row.
+        var bRecipe = await QuickCreateRecipeAsync(ClientB, "B's private recipe", "main");
+
+        var resp = await ClientA.PostAsJsonAsync("/api/meal-plan/entries", new
+        {
+            date = "2026-06-01",
+            mealType = "dinner",
+            recipeId = bRecipe.recipeId,
+            customMealName = (string?)null,
+            notes = (string?)null
+        }, Json);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task RemoveEntry_DeletesIt_ThenGoneFromBoard()
+    {
+        var client = ClientA;
+        var entry = await AddEntryAsync(client, new
+        {
+            date = "2026-06-15",
+            mealType = "dinner",
+            recipeId = (int?)null,
+            customMealName = "To delete",
+            notes = (string?)null
+        });
+
+        var del = await client.DeleteAsync($"/api/meal-plan/entries/{entry.mealPlanId}/{entry.entryId}");
+        del.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var board = await client.GetFromJsonAsync<Board>("/api/meal-plan/board?weekStart=2026-06-15", Json);
+        board!.entries.Should().NotContain(e => e.entryId == entry.entryId);
+    }
+
+    [Fact]
+    public async Task RemoveMissingEntry_IsRejected()
+    {
+        // No such entry ⇒ RemoveMealAsync throws ⇒ a clean 404 (the non-empty body bypasses the app-global
+        // status-code re-execute, so this is a true 404 — not the empty-body 405 the rewrite would produce).
+        var del = await ClientA.DeleteAsync("/api/meal-plan/entries/999999/999999");
+
+        del.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task RecipeSearch_FindsQuickCreatedRecipe()
+    {
+        var client = ClientA;
+        var created = await QuickCreateRecipeAsync(client, "Zucchini Bread", "dessert");
+        created.recipeId.Should().BeGreaterThan(0);
+        created.recipeType.Should().Be("dessert");
+
+        var results = await client.GetFromJsonAsync<List<RecipeSummary>>("/api/meal-plan/recipes?q=Zucchini", Json);
+        results.Should().NotBeNull();
+        results!.Should().Contain(r => r.recipeId == created.recipeId && r.name == "Zucchini Bread");
+    }
+
+    [Fact]
+    public async Task RecipeDetail_ReturnsRecipe()
+    {
+        var client = ClientA;
+        var created = await QuickCreateRecipeAsync(client, "Detail Recipe", "main");
+
+        var detail = await client.GetFromJsonAsync<RecipeDetail>($"/api/meal-plan/recipes/{created.recipeId}", Json);
+
+        detail.Should().NotBeNull();
+        detail!.recipeId.Should().Be(created.recipeId);
+        detail.name.Should().Be("Detail Recipe");
+        detail.recipeType.Should().Be("main");
+        // A quick-created recipe has no ingredients/instructions: [] + "" (ToSafeHtml(null) ⇒ string.Empty).
+        detail.ingredients.Should().NotBeNull().And.BeEmpty();
+        detail.instructionsHtml.Should().Be(string.Empty);
+    }
+
+    [Fact]
+    public async Task RecipeDetail_Missing_IsRejected()
+    {
+        var resp = await ClientA.GetAsync("/api/meal-plan/recipes/999999");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Board_Unauthenticated_Returns401()
+    {
+        var client = _factory.CreateAnonymousClient();
+
+        var resp = await client.GetAsync("/api/meal-plan/board?weekStart=2026-06-01");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task CrossHousehold_Isolation_BCannotSeeOrDeleteAEntry()
+    {
+        // Household A plans a private meal in a week of its own.
+        var aEntry = await AddEntryAsync(ClientA, new
+        {
+            date = "2026-06-22",
+            mealType = "dinner",
+            recipeId = (int?)null,
+            customMealName = "A's private meal",
+            notes = (string?)null
+        });
+
+        // Household B's board for the SAME week is its OWN (empty) plan — A's entry must not bleed in (M1).
+        var bBoard = await ClientB.GetFromJsonAsync<Board>("/api/meal-plan/board?weekStart=2026-06-22", Json);
+        bBoard!.entries.Should().NotContain(e =>
+            e.entryId == aEntry.entryId && e.customMealName == "A's private meal");
+
+        // B cannot delete A's entry: RemoveMealAsync scopes to B's household ⇒ no match ⇒ a clean 404 (the
+        // non-empty body bypasses the status-code re-execute, so the contract is a deterministic 404).
+        var del = await ClientB.DeleteAsync($"/api/meal-plan/entries/{aEntry.mealPlanId}/{aEntry.entryId}");
+        del.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        // A's entry survives the cross-household delete attempt.
+        var aBoardAfter = await ClientA.GetFromJsonAsync<Board>("/api/meal-plan/board?weekStart=2026-06-22", Json);
+        aBoardAfter!.entries.Should().Contain(e => e.entryId == aEntry.entryId);
+    }
+}

--- a/tests/FamilyCoordinationApp.Tests/Integration/PostgresContainerFixture.cs
+++ b/tests/FamilyCoordinationApp.Tests/Integration/PostgresContainerFixture.cs
@@ -26,9 +26,29 @@ public sealed class PostgresContainerFixture : IAsyncLifetime
         .Build();
 
     /// <summary>
-    /// The Npgsql connection string for the running throwaway database (the default <c>family_test</c> DB).
+    /// The Npgsql connection string for the running throwaway database (the default <c>family_test</c> DB),
+    /// with BOUNDED pooling applied (see <see cref="ApplyPoolLimits"/>). Per-DB strings from
+    /// <see cref="CreateDatabaseConnectionStringAsync"/> inherit these limits (they are built from this string).
     /// </summary>
-    public string ConnectionString => _container.GetConnectionString();
+    public string ConnectionString => ApplyPoolLimits(_container.GetConnectionString());
+
+    /// <summary>
+    /// Cap pool size and prune idle connections aggressively. The whole integration collection shares ONE
+    /// container, but each test class boots its own WebApplicationFactory against its own database — i.e. its
+    /// own Npgsql pool keyed by the connection string. With the defaults (100 max per pool, 300s idle lifetime)
+    /// the per-class pools accumulate idle connections across the suite and can blow past Postgres
+    /// <c>max_connections</c> (100) → <c>53300: sorry, too many clients already</c>. A small per-pool cap plus
+    /// fast idle pruning keeps the suite well under the cap (tests are sequential + low-concurrency, so a small
+    /// pool is ample — the 2-writer concurrency tests need only a couple of connections). Pruning only ever
+    /// closes IDLE connections, never in-use ones, so it cannot affect a running operation.
+    /// </summary>
+    private static string ApplyPoolLimits(string raw) =>
+        new NpgsqlConnectionStringBuilder(raw)
+        {
+            MaxPoolSize = 10,
+            ConnectionIdleLifetime = 2,
+            ConnectionPruningInterval = 1,
+        }.ConnectionString;
 
     /// <summary>
     /// Create a brand-new, uniquely-named database on the shared container and return its connection string.

--- a/tests/FamilyCoordinationApp.Tests/Services/MealPlanBoardDtoContractTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/MealPlanBoardDtoContractTests.cs
@@ -1,0 +1,158 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Services.Dtos;
+
+namespace FamilyCoordinationApp.Tests.Services;
+
+/// <summary>
+/// Contract / consumer-audit tests for the meal-plan board DTO (M9 — mirrors <see cref="ChoreBoardDtoContractTests"/>).
+/// Serializes a representative <see cref="MealPlanBoardDto"/> with the SAME <see cref="JsonSerializerOptions"/>
+/// the app registers globally (camelCase properties + <see cref="JsonStringEnumConverter"/> with camelCase
+/// naming — Program.cs ConfigureHttpJsonOptions) and asserts it matches the checked-in
+/// <c>Fixtures/MealPlanBoard/board.json</c> fixture EXACTLY. The island's <c>types.ts</c> mirrors this fixture;
+/// any DTO shape/casing change (field rename, enum casing drift, added/removed property) breaks this test →
+/// forcing the island contract to update in lockstep.
+/// </summary>
+public class MealPlanBoardDtoContractTests
+{
+    /// <summary>
+    /// The canonical board-DTO serialization options. The app's <c>ConfigureHttpJsonOptions</c> registers the
+    /// equivalent camelCase <see cref="JsonStringEnumConverter"/> globally, so HTTP responses match this fixture.
+    /// </summary>
+    public static readonly JsonSerializerOptions BoardJsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+    };
+
+    private static readonly string FixturePath =
+        Path.Combine(AppContext.BaseDirectory, "Fixtures", "MealPlanBoard", "board.json");
+
+    /// <summary>
+    /// A representative week board covering: a recipe entry WITH an image, a recipe entry WITHOUT an image (and
+    /// with notes), a custom-meal entry, multiple meal types (breakfast/dinner/lunch), multiple days, and a
+    /// non-null <c>mealPlanId</c>. Static values only — no clocks — so the serialization is byte-deterministic.
+    /// </summary>
+    public static MealPlanBoardDto BuildRepresentativeBoard()
+    {
+        var entries = new List<MealPlanEntryDto>
+        {
+            // Recipe entry WITH image, no notes — breakfast, day 1.
+            new(
+                MealPlanId: 5,
+                EntryId: 1,
+                Date: new DateOnly(2026, 6, 1),
+                MealType: MealType.Breakfast,
+                Recipe: new MealRecipeSummaryDto(10, "Overnight Oats", "/uploads/1/oats.jpg", RecipeType.Breakfast),
+                CustomMealName: null,
+                Notes: null),
+
+            // Recipe entry WITHOUT image, with notes — dinner, day 1, a Main dish.
+            new(
+                MealPlanId: 5,
+                EntryId: 2,
+                Date: new DateOnly(2026, 6, 1),
+                MealType: MealType.Dinner,
+                Recipe: new MealRecipeSummaryDto(11, "Spaghetti Bolognese", null, RecipeType.Main),
+                CustomMealName: null,
+                Notes: "Double batch for leftovers"),
+
+            // Custom meal entry — lunch, day 2.
+            new(
+                MealPlanId: 5,
+                EntryId: 3,
+                Date: new DateOnly(2026, 6, 2),
+                MealType: MealType.Lunch,
+                Recipe: null,
+                CustomMealName: "Leftovers",
+                Notes: "Sunday's roast"),
+        };
+
+        return new MealPlanBoardDto(
+            WeekStartDate: new DateOnly(2026, 6, 1),
+            MealPlanId: 5,
+            Entries: entries);
+    }
+
+    [Fact]
+    public void SerializedBoard_MatchesContractFixture()
+    {
+        var board = BuildRepresentativeBoard();
+
+        var actualJson = JsonSerializer.Serialize(board, BoardJsonOptions);
+
+        File.Exists(FixturePath).Should().BeTrue(
+            $"the board.json contract fixture must be checked in at {FixturePath}");
+        var expectedJson = File.ReadAllText(FixturePath);
+
+        // Compare via parsed JSON nodes (whitespace/line-ending tolerant) so the assertion is about the
+        // contract shape + values, not file formatting.
+        Normalize(actualJson).Should().Be(Normalize(expectedJson),
+            "the serialized board DTO must match the checked-in contract fixture; if this fails after a "
+            + "deliberate DTO change, update board.json AND the island types.ts interface in lockstep (M9)");
+    }
+
+    [Fact]
+    public void SerializedBoard_UsesCamelCaseKeys_AndCamelCaseEnumStrings()
+    {
+        var board = BuildRepresentativeBoard();
+        var json = JsonSerializer.Serialize(board, BoardJsonOptions);
+        var root = JsonNode.Parse(json)!.AsObject();
+
+        // Top-level camelCase property set is frozen (M9 — added/removed keys break this).
+        root.Select(kvp => kvp.Key).Should().BeEquivalentTo(
+            "weekStartDate", "mealPlanId", "entries");
+
+        // DateOnly serializes as "YYYY-MM-DD".
+        root["weekStartDate"]!.GetValue<string>().Should().Be("2026-06-01");
+
+        var firstEntry = root["entries"]!.AsArray()[0]!.AsObject();
+        firstEntry.Select(kvp => kvp.Key).Should().BeEquivalentTo(
+            "mealPlanId", "entryId", "date", "mealType", "recipe", "customMealName", "notes");
+
+        // MealType serializes as a camelCase enum string (NOT an integer, NOT PascalCase).
+        firstEntry["mealType"]!.GetValue<string>().Should().Be("breakfast");
+        firstEntry["date"]!.GetValue<string>().Should().Be("2026-06-01");
+        firstEntry["customMealName"].Should().BeNull();
+        firstEntry["notes"].Should().BeNull();
+
+        var firstRecipe = firstEntry["recipe"]!.AsObject();
+        firstRecipe.Select(kvp => kvp.Key).Should().BeEquivalentTo(
+            "recipeId", "name", "imagePath", "recipeType");
+        // RecipeType is also a camelCase enum string.
+        firstRecipe["recipeType"]!.GetValue<string>().Should().Be("breakfast");
+
+        // Second entry: a recipe with a null image + a Main dish + notes.
+        var secondEntry = root["entries"]!.AsArray()[1]!.AsObject();
+        secondEntry["mealType"]!.GetValue<string>().Should().Be("dinner");
+        secondEntry["recipe"]!.AsObject()["imagePath"].Should().BeNull();
+        secondEntry["recipe"]!.AsObject()["recipeType"]!.GetValue<string>().Should().Be("main");
+        secondEntry["notes"]!.GetValue<string>().Should().Be("Double batch for leftovers");
+
+        // Third entry: a custom meal (recipe null, customMealName set).
+        var thirdEntry = root["entries"]!.AsArray()[2]!.AsObject();
+        thirdEntry["mealType"]!.GetValue<string>().Should().Be("lunch");
+        thirdEntry["recipe"].Should().BeNull();
+        thirdEntry["customMealName"]!.GetValue<string>().Should().Be("Leftovers");
+    }
+
+    /// <summary>A deliberate rename of any contract field must break the fixture test (tripwire).</summary>
+    [Fact]
+    public void RenamingAField_BreaksTheFixture()
+    {
+        var board = BuildRepresentativeBoard();
+        var json = JsonSerializer.Serialize(board, BoardJsonOptions);
+
+        // Simulate a drift: rename "mealType" -> "meal". The mutated payload must NOT match the fixture.
+        var drifted = json.Replace("\"mealType\"", "\"meal\"");
+        var expectedJson = File.ReadAllText(FixturePath);
+
+        Normalize(drifted).Should().NotBe(Normalize(expectedJson));
+    }
+
+    private static string Normalize(string json) =>
+        JsonNode.Parse(json)!.ToJsonString(new JsonSerializerOptions { WriteIndented = false });
+}


### PR DESCRIPTION
## What

Strangler-fig migration of the Blazor Server **Meal Plan** surface to a **Svelte 5 island** — the 3rd island after shopping-list and chores. This removes the most interaction-heavy remaining Blazor page from the SignalR circuit, killing the tab-away / circuit-drop dead-tap failure mode.

**Decisions:** parity-first (no drag-drop — the current page is click-to-add, not drag; drag-to-assign is deferred), **versionless / last-write-wins** (the ops are add + remove only, so no xmin token on the wire).

## Backend

- **6 endpoints** under `/api/meal-plan` (`MealPlanEndpoints.cs`): week board read, add/remove entry, recipe search / quick-create / detail.
- `MealPlanDtos.cs` + a single-projection `IMealPlanBoardService` (one place projects the board read *and* the add response — no card/response drift, M9).
- **Multi-tenant (M1):** household/user resolved server-side via `UserContextResolver`, never client-supplied; every query filters by `HouseholdId`. Recipe ownership is validated before add, so a missing or cross-household `recipeId` is a clean **404** instead of an FK-violation 500 (and never leaves an orphan `MealPlan` row).
- Not-found responses carry a non-empty body so the app-global status-code re-execute leaves them as clean 404s (an empty DELETE 404 would surface as a 405).

## Island

- `frontend/meal-plan/` mirrors the chores island (no dnd / equity / rooms), **including the .NET 10 circuit-resume self-heal mount machinery** in `main.ts`.
- Versionless optimistic store; week stepping via `Date.UTC(…,12)` (never `new Date('YYYY-MM-DD')`).

## Host + build

- `MealPlan.razor` is now a thin host behind the **`MEAL_PLAN_USE_ISLAND`** flag; the existing Blazor UI is preserved as `MealPlanBlazor.razor` (zero-regression fallback — flip the flag to switch, delete later).
- `CopyMealPlanIsland` MSBuild target, Dockerfile `mealplan-node-build` stage, `docker-build.sh` + `docker-compose.yml` flag.

## The M9 four-way lockstep

`MealPlanDtos.cs` ↔ `Fixtures/MealPlanBoard/board.json` ↔ `MealPlanBoardDtoContractTests` ↔ island `types.ts`.

## Tests & verification

- **3 contract + 15 integration** tests (real Postgres) incl. cross-household isolation and recipe-ownership; **581 unit** tests green; `svelte-check` 0/0; `vite build`; `dotnet build` clean.
- **Browser-verified live on `:8080`** (rebuilt image, flag on, DOM + psql): island mounts, reads/renders real data, add → POST 201, remove → DELETE 204, week navigation.

## Review

Reviewed by `review-council` (codex / gpt / gemini, high effort) + adversarial challenge. Applied fixes: recipe-ownership pre-validation (+ tests), in-flight week-change guard on add, delete-rollback ordering, honest recipe-search error state. Items left as-is with rationale: the JS interop global-mount pattern (mirrors the prod-proven chores/shopping-list islands, browser-verified) and `.DisableAntiforgery()` (consistent with the other island groups; same-origin cookie + JSON, documented in-code).

Spec: `.planning/meal-plan-island-spec.md`.

https://claude.ai/code/session_01BZrsjpKLrHVzNhQueskyiU
