### PR TITLE
fix(islands): stop runaway board-fetch loop in chores + meal-plan

### DIFF
--- a/frontend/chores/src/App.svelte
+++ b/frontend/chores/src/App.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from 'svelte';
   import type { ChoreDto, ShellContext } from './lib/types';
   import { getBoard, uploadChorePhoto, createSubtask, ApiError } from './lib/api';
   import { boardStore } from './lib/state.svelte';
@@ -203,15 +204,22 @@
   }
 
   $effect(() => {
-    // Seed the viewing user's id once mounted (drives the Mine lens + "You").
-    store.currentUserId = ctx.userId;
-    // Wire the board refetch so the mutation layer can reconcile after a 409 /
-    // other 4xx (shares the SAME loader as liveness).
-    store.setRefresh(loadBoard);
-    loadBoard();
-    // Liveness: ~20s poll while visible + immediate refetch on refocus; pauses
-    // while hidden. NOT Blazor DataNotifier/PollingService (MN2).
-    liveness = startLiveness(loadBoard);
+    // One-time mount setup. MUST run exactly once — `loadBoard()` synchronously
+    // reads `store.board` (the spinner-on-first-load check) and its async
+    // `setBoard` REWRITES it, so WITHOUT untrack the effect would subscribe to the
+    // very state it updates → an infinite fetch→setBoard→re-run loop (~tens of
+    // req/s). `untrack` gives the body no reactive deps; liveness drives refreshes.
+    untrack(() => {
+      // Seed the viewing user's id once mounted (drives the Mine lens + "You").
+      store.currentUserId = ctx.userId;
+      // Wire the board refetch so the mutation layer can reconcile after a 409 /
+      // other 4xx (shares the SAME loader as liveness).
+      store.setRefresh(loadBoard);
+      loadBoard();
+      // Liveness: ~20s poll while visible + immediate refetch on refocus; pauses
+      // while hidden. NOT Blazor DataNotifier/PollingService (MN2).
+      liveness = startLiveness(loadBoard);
+    });
     return () => {
       liveness?.stop();
       liveness = null;

--- a/frontend/meal-plan/src/App.svelte
+++ b/frontend/meal-plan/src/App.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from 'svelte';
   import type { MealPlanEntryDto, MealType, ShellContext } from './lib/types';
   import { mealPlanStore } from './lib/state.svelte';
   import { startLiveness, type LivenessHandle } from './lib/liveness';
@@ -118,17 +119,25 @@
   }
 
   $effect(() => {
-    store.init(ctx);
-    store.setRefresh(loadBoard);
+    // One-time mount setup. MUST run exactly once — `loadBoard()` synchronously
+    // reads `store.board`/`store.weekStart` (the spinner-on-first-load check), and
+    // its async `setBoard` REWRITES them, so WITHOUT untrack the effect would
+    // subscribe to the very state it updates → an infinite fetch→setBoard→re-run
+    // loop (~tens of req/s). `untrack` gives the body no reactive deps, so it runs
+    // once; liveness + the matchMedia listener drive all later refreshes.
+    untrack(() => {
+      store.init(ctx);
+      store.setRefresh(loadBoard);
 
-    mediaQuery = window.matchMedia('(min-width: 960px)');
-    syncMedia();
-    mediaQuery.addEventListener('change', syncMedia);
+      mediaQuery = window.matchMedia('(min-width: 960px)');
+      syncMedia();
+      mediaQuery.addEventListener('change', syncMedia);
 
-    loadBoard();
-    // Liveness: ~20s poll while visible + immediate refetch on refocus; pauses
-    // while hidden. NOT Blazor DataNotifier/PollingService (MN2).
-    liveness = startLiveness(() => store.reconcile());
+      loadBoard();
+      // Liveness: ~20s poll while visible + immediate refetch on refocus; pauses
+      // while hidden. NOT Blazor DataNotifier/PollingService (MN2).
+      liveness = startLiveness(() => store.reconcile());
+    });
 
     return () => {
       liveness?.stop();


### PR DESCRIPTION
## Incident

After #51 merged and the meal-plan island went live, the page constantly re-rendered ("reloading"), most visibly on a week with items. Root cause turned out to be a **runaway board-fetch loop** — and it was a *pre-existing* bug in the island pattern: **chores** had the same loop silently since it shipped (and only **shopping-list** was correct).

**Prod is already mitigated** (meal-plan flag set to `false` → Blazor fallback). This PR fixes the root cause so the island can be safely re-enabled, and fixes chores at the same time.

## Root cause

The one-time setup `$effect` in `chores` and `meal-plan` `App.svelte` called `loadBoard()` directly. `loadBoard`'s synchronous prefix reads `store.board` (`if (store.board == null) loading = true`) **before** its `await`, so the effect took a reactive dependency on `store.board` — which its own async `setBoard()` then **rewrites**. That closes the loop:

```
effect runs → loadBoard() reads store.board → await getBoard() → setBoard() writes store.board
   → effect's dependency changed → effect re-runs → loadBoard() → … (~30–46 req/s per client)
```

Measured on the local stack: **meal-plan ~46 board GETs/sec, chores ~29/sec**, per client.

## Fix

Wrap each one-time setup effect body in `untrack(...)` so it has **no reactive dependencies** and runs exactly once on mount. Liveness (~20s poll) + user actions drive all later refreshes — unchanged.

`shopping-list` needed no change: it already wraps its initial load in an `(async () => { … })()` IIFE, so its reactive reads happen *after* the first `await` and are never tracked. (This is the same property `untrack` gives the other two.)

## Verification (local `:8080`)

| | before | after |
|---|---|---|
| meal-plan background board GETs | ~46/s | **0/s** |
| chores background board GETs | ~29/s | **0/s** |
| meal-plan one week-nav | (lost in the loop) | **exactly 1 GET** |

Both islands still mount + render. `svelte-check` 0/0 and `vite build` green for both.

## Rollout

After merge + deploy, re-enable meal-plan in prod (`MEAL_PLAN_USE_ISLAND=true` in `~/familyapp/.env.local` + app restart). Chores/shopping-list are unaffected by the flag and simply stop their background hammering once this deploys.

https://claude.ai/code/session_01BZrsjpKLrHVzNhQueskyiU
