### PR TITLE
feat(recipes): strangle Recipes + RecipeEdit into a Svelte island

### DIFF
--- a/.planning/recipes-island-spec.md
+++ b/.planning/recipes-island-spec.md
@@ -1,0 +1,389 @@
+# Spec — Recipes + RecipeEdit → Svelte island (strangler)
+
+**Quest:** Spine `10d187a0-3bce-43f8-bc09-ada75ac35b43` (campaign "Family Coordination App", horizon `now`).
+**Decisions (operator, 2026-06-23):** **spec-first (deep)**; **combined** — one island bundle serving both `/recipes` (list) and `/recipes/new` + `/recipes/edit/{id}` (edit), one PR, one `RECIPES_USE_ISLAND` flag; **parity-first** — migrate today's surface as-is, harvest enhancements as provisional quests.
+**Status:** spec (awaiting review gate).
+**Template:** mirrors the shipped meal-plan island (`frontend/meal-plan/`) + its spec (`.planning/meal-plan-island-spec.md`). The chores island is the secondary reference (it has the `svelte-dnd-action` drag pattern recipes re-uses).
+
+---
+
+## 1. Goal & scope
+
+Replace the two Blazor circuit-bound recipe surfaces (`Components/Pages/Recipes.razor`, 961 lines; `Components/Pages/RecipeEdit.razor`, 619 lines) with **one** Svelte 5 island that talks to the server over plain HTTP/JSON — killing the tab-away / SignalR-circuit-drop failure mode (same motivation as shopping-list + chores + meal-plan). **Behavior parity** with today; **no new UX**.
+
+This is the **meatiest** island so far: two routes, a full edit form, natural-language ingredient parsing, drag-reorder, image upload + picker, URL import (scrape→JSON-LD→parse), bulk-paste, autosave drafts, connected-household sharing, and a live servings scaler. The greenfield `/api/recipes` surface (**20 routes** over **existing** server services) is the bulk of the design.
+
+### In scope (parity)
+
+**List surface (`/recipes`):**
+- Recipe grid of cards (image / placeholder, name, type chip, "imported" cloud icon, author avatar, first-3-ingredient preview + "+N more"). `Recipes.razor:200-214`, `RecipeCard.razor`.
+- Search by name / ingredients / type — **server-side**, debounced (300ms). `Recipes.razor:82-89`, `RecipeService.GetRecipesAsync`.
+- Favorites: per-card heart toggle + a "Favorites" filter chip (client-side over the loaded set). `Recipes.razor:92-99,700-720`.
+- Connected-household selector (chips): view a connected household's shared recipes **read-only** + "Copy to My Recipes". `Recipes.razor:55-79,591-648,764-786`.
+- Detail **drawer** (slide-out, read-only): image, author, prep/cook chips, **live servings scaler** (rescales ingredient quantities client-side), description, ingredients, instructions (server-sanitized HTML), source link, and action buttons (Edit / Add to Meal Plan [stub] / Delete; or **Copy** for connected). `Recipes.razor:223-416`.
+- Delete confirm dialog. `Recipes.razor:418-433,800-828`.
+- Import-from-URL dialog (scrape pipeline, duplicate detection, "import anyway", error → manual-entry fallback, YouTube). `ImportRecipeDialog.razor`.
+- "Add Recipe" → navigate to `/recipes/new`.
+
+**Edit surface (`/recipes/new`, `/recipes/edit/{id}`):**
+- Basic info: name (required), description, prep/cook time, servings, source URL, recipe type. `RecipeEdit.razor:73-131`.
+- Image: file **upload** + **remove** + "Choose Existing" (household image **picker** grid). `RecipeEdit.razor:133-177`, `ImagePickerDialog.razor`.
+- Ingredient **entry**: natural-language parse (Enter/Tab parses raw → editable qty/unit/name/category/notes fields), unit autocomplete, ingredient-name autocomplete (server suggestions), category select. `IngredientEntry.razor`.
+- Ingredient **list**: **drag-reorder**, edit (remove + re-add), delete-with-undo. `IngredientList.razor`.
+- **Bulk-paste**: multi-line textarea → parsed preview → import. `BulkPasteDialog.razor`.
+- Instructions: markdown textarea. `RecipeEdit.razor:191-200`.
+- **Autosave drafts** (2s debounce) + a "Draft saved" indicator + restore-on-load + nav-lock for unsaved changes. `RecipeEdit.razor:368-403,297-333`, `DraftService`.
+- Save / Cancel / Delete.
+
+**Cross-cutting:**
+- Cross-user freshness on the **list**: another member's add/edit/delete appears within ~20s while visible + immediately on refocus (mirror meal-plan `liveness.ts`; **not** Blazor `DataNotifier`).
+- Dark-mode bridge, MudBlazor token CSS, the `.NET 10` circuit-resume self-heal mount machinery — copied verbatim from meal-plan, re-scoped.
+
+### Out of scope (this island)
+- Any new UX. Drag-to-reorder already exists in `IngredientList` (parity-keep); we do **not** add drag elsewhere.
+- "Add to Meal Plan" stays a stub info-toast (today it's "feature in development", `Recipes.razor:830-834`).
+- The meal-plan island's `/api/meal-plan/recipes/*` picker endpoints stay as-is (see D11). We do not relocate or break them.
+- Optimistic-concurrency (xmin) on recipe edit — parity is last-write-wins (D9). Harvested as a provisional quest.
+
+---
+
+## 2. Pattern being mirrored (the template)
+
+The **meal-plan island** is the freshest, most complete end-to-end example (`frontend/meal-plan/`). Mirror it; do not invent. What recipes ADDS beyond meal-plan:
+
+| Concern | meal-plan | recipes |
+|---|---|---|
+| Routes per island | 1 (`/meal-plan`) | **2** (`/recipes` list + `/recipes/new`+`/edit/{id}` edit) — one bundle, view chosen by root data-attr (D1) |
+| Drag | none (dropped `svelte-dnd-action`) | **re-adds `svelte-dnd-action`** for ingredient reorder (mirror chores) |
+| Forms | small picker sheet | **full edit form** + autosave drafts |
+| NL parsing | none | **server `parse-ingredient`** endpoint (D2) |
+| File upload | none | **multipart image upload** endpoint (D6) |
+| External I/O | none | **URL import** pipeline endpoint (Polly, ≤60s) (D7) |
+| Concurrency | versionless | versionless (parity; xmin available but unused — D9) |
+
+What recipes KEEPS identical to meal-plan (copy verbatim, re-scope `mp-`→`rc-`, `meal-plan`→`recipes`, `MealPlanIsland`→`RecipesIsland`, `mp-dark-mode`→`rc-dark-mode`):
+- `src/main.ts` — mount/destroy + the **circuit-resume self-heal** (`isHealthy`/`MutationObserver`/`pageshow`) + dark-class observer. Load-bearing reliability — do **not** reinvent.
+- `src/lib/liveness.ts` — 20s visible-only poll + `visibilitychange` immediate refetch (list view only).
+- `src/lib/toasts.svelte.ts` + `lib/components/Toasts.svelte` — toast store + region.
+- `src/lib/api.ts` — `ApiError` + `request<T>` (`credentials:'include'`, any-4xx = client rejection).
+- `src/styles/{tokens,app}.css` — MudBlazor token bridge + dark-mode scoping.
+- The **`untrack()` one-time-load pattern** in `App.svelte` (§ Loop safety) — **non-negotiable**.
+
+---
+
+## 3. Endpoint surface — `/api/recipes`
+
+New file `Endpoints/RecipesEndpoints.cs`, group:
+```csharp
+app.MapGroup("/api/recipes").RequireAuthorization().DisableAntiforgery()
+```
+Every handler resolves the caller via `UserContextResolver.ResolveUserAsync(principal, dbFactory, ct)` → `(HouseholdId, UserId)` **server-side (M1, never client-supplied)** (`Endpoints/UserContextResolver.cs:23-38`). Every read/write filters by `HouseholdId`. Register with `app.MapRecipesEndpoints();` in `Program.cs` (after `MapMealPlanEndpoints()`, `Program.cs:401`). All services it needs are already DI-registered (`Program.cs:83-95`).
+
+| # | Method & route | Body | Returns | Delegates to / notes |
+|---|---|---|---|---|
+| 1 | `GET /` `?q=` | — | `RecipeListDto` | Own household. `RecipeService.GetRecipesAsync(hh, q)` + `GetFavoriteRecipeIdsAsync(uid, hh)` in one response. `q` server-filters name/desc/type/ingredient (parity). Empty `q` ⇒ all. |
+| 2 | `GET /{recipeId:int}` | — | `RecipeFullDto` | Read drawer **and** edit-load (superset, D3). `GetRecipeAsync`; not found ⇒ 404 (non-empty body). |
+| 3 | `POST /` | `RecipeWriteRequest` | `RecipeFullDto` (201) | Create. `CreateRecipeAsync(new Recipe{…, HouseholdId=hh, CreatedByUserId=uid})`. Name required ⇒ else 400. |
+| 4 | `PUT /{recipeId:int}` | `RecipeWriteRequest` | `RecipeFullDto` (200) | Update. `UpdateRecipeAsync` replaces ingredients wholesale. **Two verified service traps:** (a) it does **NOT** assign `RecipeType` (`RecipeService.cs:94-104`) — a latent Blazor bug; this WP adds `existing.RecipeType = recipe.RecipeType;` (D12); (b) it returns the in-memory `existing` whose `Ingredients` nav is **stale** after RemoveRange/Add (`:106-132`) → the endpoint **re-fetches** `GetRecipeAsync(hh, recipeId, ct)` and projects THAT, never the `UpdateRecipeAsync` return. Missing ⇒ throws `InvalidOperationException` (`:89-92`) → **catch** → `Results.NotFound(new { message })` (M1: cross-household id = clean not-found). Sets `UpdatedByUserId=uid`. |
+| 5 | `DELETE /{recipeId:int}` | — | 204 | Soft delete (`IsDeleted=true`). `DeleteRecipeAsync` **throws `InvalidOperationException` on missing** (`RecipeService.cs:142-145`) → **catch** → `Results.NotFound(new { message })` (non-empty body — mirror `MealPlanEndpoints.RemoveEntry`). |
+| 6 | `POST /{recipeId:int}/favorite` | — | `{ isFavorite: bool }` | **`GetRecipeAsync(hh, recipeId, ct)` FIRST → 404 if null**, THEN `ToggleFavoriteAsync` + return `IsFavoriteAsync`. (A bare toggle inserts a `UserFavorite` directly → FK-violation 500 on a missing/cross-household id, `RecipeService.cs:206-230`; the pre-check yields a clean 404 + enforces M1.) |
+| 7 | `GET /ingredient-suggestions` `?prefix=` | — | `string[]` | `GetIngredientSuggestionsAsync(hh, prefix)`. `<2` chars ⇒ `[]` (service guards). |
+| 8 | `POST /parse-ingredient` | `{ text }` | `ParsedIngredientDto` | Server NL parse (D2). **`ParseIngredient` THROWS `ArgumentException` on empty** (`IngredientParser.cs:46`) — `string.IsNullOrWhiteSpace`-guard BEFORE calling and return 400; do **not** rely on a catch (an uncaught throw is a 500). Then `IIngredientParser.ParseIngredient(text)` + `ICategoryInferenceService.InferCategory(name)` → `suggestedCategory`. |
+| 9 | `POST /parse-ingredients` | `{ lines: string[] }` | `ParsedIngredientDto[]` | Bulk-paste preview — parse each non-blank line server-side (one round-trip). |
+| 10 | `GET /categories` | — | `CategoryDto[]` (`{ name }`) | `ICategoryService.GetCategoriesAsync(hh)` for the entry category select. |
+| 11 | `POST /images` | `multipart/form-data` (`file`) | `{ imagePath }` (201) | `IImageService.SaveImageAsync(IFormFile, hh)` (existing `IFormFile` overload, `ImageService.cs:47`). 10 MB / jpg·png·gif·webp; else 400. |
+| 12 | `GET /images` | — | `string[]` | `IImageService.ListImagesAsync(hh)` (returns `IEnumerable<string>` — `.ToArray()`) for the picker grid. |
+| 13 | `POST /import` | `{ url, force?: bool }` | `RecipeImportResultDto` | `ImportFromUrlAsync` returns an **UNSAVED** `Recipe` (`RecipeImportResult.Recipe`, in-memory, `RecipeId==0`); on success the endpoint **must** `CreateRecipeAsync(result.Recipe!, ct)` and return the **assigned** `recipeId` (never `result.Recipe.RecipeId` before saving). Dup-check is **endpoint-level**: query own recipes for `SourceUrl == url` (exact string, mirror `ImportRecipeDialog.razor:140-147`; the global query filter already excludes deleted) → return `existingRecipeId`/`Name`; `force:true` bypasses **only** that endpoint check (`ImportFromUrlAsync` has **no** `force` param). ≤60s (Polly, D7). |
+| 14 | `GET /connections` | — | `ConnectedHouseholdDto[]` | `IHouseholdConnectionService.GetConnectedHouseholdsAsync(hh)` → `{ householdId, householdName }`. |
+| 15 | `GET /connected/{chId:int}` `?q=` | — | `RecipeListDto` (favoriteRecipeIds `[]`) | Connected household's shared recipes (read-only). **Validate connection first** (`AreHouseholdsConnectedAsync(chId, hh, ct)` — symmetric, `IHouseholdConnectionService.cs:13` ⇒ else 403); then `GetRecipesFromConnectedHouseholdAsync(hh, chId, q)` (already excludes `CreatedBy` → null author) → `ToListItem`. **Returns the same `RecipeListDto` shape as #1** (empty `favoriteRecipeIds`) so the one list store consumes both without a shape branch. |
+| 16 | `GET /connected/{chId:int}/{recipeId:int}` | — | `RecipeFullDto` | Read-only detail of a connected recipe. Validate connection ⇒ else 403; then `recipeService.GetRecipeAsync(chId, recipeId, ct)` (connected id passed as `householdId` — the only fetch method; M1-safe since chId is connection-gated) → `ToFull(recipe, includeAuthor:false)` (strip author for privacy). |
+| 17 | `POST /connected/{chId:int}/{recipeId:int}/copy` | — | `{ recipeId }` (201) | Validate connection ⇒ else 403; `CopyRecipeFromConnectedHouseholdAsync(chId, recipeId, hh, uid)`. |
+| 18 | `GET /draft` `?recipeId=` | — | `RecipeDraftData` (200) or **204** | `DraftService.GetDraftAsync`. Omitted `recipeId` ⇒ new-recipe draft (**0 sentinel**, see below). **204 No-Content when no draft** (the island's `request<T>` treats 204 as null — `Results.Json(null)` writes an empty body that breaks `res.json()`, so don't use it). |
+| 19 | `PUT /draft` | `SaveDraftRequest` (**FLAT**: `{ recipeId?, name, …draftFields, ingredients[] }`) | 204 | `DraftService.SaveDraftAsync`. **Body is flat**, not `{ recipeId, draft:{…} }`. |
+| 20 | `DELETE /draft` `?recipeId=` | — | 204 | `DraftService.DeleteDraftAsync`. Idempotent. |
+
+> **Build-time finding (drafts).** `RecipeDraft`'s composite PK is `(HouseholdId, UserId, RecipeId)` (`RecipeDraftConfiguration.cs:12`) with no FK on `RecipeId` — so a **null** `RecipeId` (new-recipe draft) throws `"primary key property 'RecipeId' is null"` (a latent bug — new-recipe autosave silently never worked in Blazor). The endpoints coalesce `recipeId ?? 0` (a safe sentinel; real recipe ids start at 1). The draft body is **flat** (`SaveDraftRequest` = recipeId + the draft fields + ingredients), mirroring the proven-binding `RecipeWriteRequest` shape, mapped to `DraftService.RecipeDraftData` in the handler.
+
+**Request DTOs** (`RecipesEndpoints.cs`):
+```csharp
+public sealed record RecipeWriteRequest(
+    string Name, string? Description, string? Instructions, string? SourceUrl,
+    int? Servings, int? PrepTimeMinutes, int? CookTimeMinutes,
+    RecipeType RecipeType, string? ImagePath,
+    IReadOnlyList<RecipeIngredientWrite> Ingredients);
+public sealed record RecipeIngredientWrite(
+    string Name, decimal? Quantity, string? Unit, string Category,
+    string? Notes, string? GroupName, int SortOrder);
+public sealed record ParseIngredientRequest(string Text);
+public sealed record ParseIngredientsRequest(IReadOnlyList<string> Lines);
+public sealed record SaveDraftRequest(int? RecipeId, RecipeDraftData Draft);  // reuse DraftService's record — NOT a new payload type
+public sealed record ImportRequest(string Url, bool Force = false);
+```
+`ImagePath` is a path the island already obtained from endpoint #11 (upload-then-reference, mirrors `RecipeEdit.razor:458-471`). `RecipeId` is NEVER in a write body — it's the route param (#4) or omitted (#3); the server assigns new ids via `GetNextRecipeIdAsync` (`RecipeService.CreateRecipeAsync`).
+
+---
+
+## 4. DTO contract (M9 lockstep)
+
+New file `Services/Dtos/RecipeDtos.cs` + a new **single-projection** service `IRecipeProjectionService` (mirrors `IMealPlanBoardService`'s one-projection rule) with `ToListItem`, `ToFull(recipe, includeAuthor)` (the flag strips `createdByName`/`createdByPictureUrl` for connected-household reads — privacy), `ToParsed`. **All enums are real enum *types* on the DTO** ⇒ camelCase via the globally-registered `JsonStringEnumConverter(CamelCase)` (`Program.cs:125-127`). `decimal?`/`int?` serialize as JSON number-or-null. **No `DateOnly`/dates on the recipe contract** (recipes have no week boundary — the date trap doesn't apply here, but the rule still holds for any date field added later).
+
+```csharp
+// ── List ──────────────────────────────────────────────────────────────────
+public sealed record RecipeListDto(
+    IReadOnlyList<RecipeListItemDto> Recipes,
+    IReadOnlyList<int> FavoriteRecipeIds);          // own-household only; [] for connected
+
+public sealed record RecipeListItemDto(
+    int RecipeId, string Name, RecipeType RecipeType,
+    string? ImagePath, bool HasSourceUrl,           // bool, NOT the url (card only shows the icon)
+    string? CreatedByName, string? CreatedByPictureUrl,   // User has PictureUrl + Initials, NO color field (User.cs) → card renders pic-or-initials; both null when connected (privacy) or deleted user
+    IReadOnlyList<string> IngredientPreview,        // first 3 ingredient names (card preview)
+    int IngredientCount);                           // for the "+N more" suffix
+
+// ── Full (read drawer + edit form — superset, D3) ──────────────────────────
+public sealed record RecipeFullDto(
+    int RecipeId, string Name, RecipeType RecipeType,
+    string? Description,
+    string? Instructions,                           // RAW markdown — for the edit textarea
+    string InstructionsHtml,                        // server-sanitized — for the read drawer ({@html})
+    string? ImagePath, string? SourceUrl,
+    int? PrepTimeMinutes, int? CookTimeMinutes, int? Servings,
+    string? CreatedByName, string? CreatedByPictureUrl,  // both null when connected (includeAuthor:false) / deleted user
+    string? SharedFromHouseholdName,                // attribution for copied recipes
+    IReadOnlyList<RecipeIngredientFullDto> Ingredients);
+
+public sealed record RecipeIngredientFullDto(
+    int IngredientId, decimal? Quantity, string? Unit, string Name,
+    string Category, string? Notes, string? GroupName, int SortOrder);
+
+// ── Parse / categories / import / connections / draft ──────────────────────
+public sealed record ParsedIngredientDto(
+    decimal? Quantity, string? Unit, string Name, string? Notes,
+    bool IsComplete, string SuggestedCategory);
+public sealed record CategoryDto(string Name);
+public sealed record ConnectedHouseholdDto(int HouseholdId, string HouseholdName);
+// ↑ intentionally drops ConnectedHouseholdInfo.ConnectedAt (3rd field) — not shown in the selector.
+public sealed record RecipeImportResultDto(
+    bool Success, int? RecipeId, string? ErrorMessage, string? ErrorType,
+    int? ExistingRecipeId, string? ExistingRecipeName,
+    PartialRecipeDataDto? PartialData);
+public sealed record PartialRecipeDataDto(
+    string? Name, string? Description, string? Instructions,
+    IReadOnlyList<string>? IngredientStrings, string? ImageUrl,
+    int? PrepTimeMinutes, int? CookTimeMinutes, int? Servings);
+// Drafts reuse DraftService's EXISTING records directly — `RecipeDraftData` (DraftService.cs) for
+// BOTH the PUT body and the GET response, and `IngredientDraftData` for its lines. No new draft DTO:
+// they have no enums and already serialize camelCase via the web defaults (fresh-eyes P1-3).
+```
+
+**Why a separate `RecipeFullDto` and NOT the meal-plan `RecipeDetailDto`** (D11): the meal-plan one is deliberately lean (board-card view); the recipes edit form needs raw markdown, description, source URL, and per-ingredient `Category`/`GroupName`/`IngredientId`. Extending the meal-plan DTO would break its just-shipped M9 contract (`MealPlanBoardDtoContractTests` + `Fixtures/MealPlanBoard/board.json` + meal-plan `types.ts`). Parity-first + minimize-churn ⇒ **keep them separate**; one richer projection for recipes, the lean one stays meal-plan's.
+
+**TS mirror** (`frontend/recipes/src/lib/types.ts`) — camelCase keys, doc-commented:
+```ts
+export type RecipeType =
+  'main'|'side'|'appetizer'|'dessert'|'beverage'|'sauce'|'breakfast'|'snack'|'other';
+export interface RecipeListItemDto {
+  recipeId:number; name:string; recipeType:RecipeType; imagePath:string|null;
+  hasSourceUrl:boolean; createdByName:string|null; createdByPictureUrl:string|null;
+  ingredientPreview:string[]; ingredientCount:number }
+export interface RecipeListDto { recipes:RecipeListItemDto[]; favoriteRecipeIds:number[] }
+export interface RecipeIngredientFullDto {
+  ingredientId:number; quantity:number|null; unit:string|null; name:string;
+  category:string; notes:string|null; groupName:string|null; sortOrder:number }
+export interface RecipeFullDto {
+  recipeId:number; name:string; recipeType:RecipeType; description:string|null;
+  instructions:string|null; instructionsHtml:string; imagePath:string|null;
+  sourceUrl:string|null; prepTimeMinutes:number|null; cookTimeMinutes:number|null;
+  servings:number|null; createdByName:string|null; createdByPictureUrl:string|null;
+  sharedFromHouseholdName:string|null; ingredients:RecipeIngredientFullDto[] }
+export interface ParsedIngredientDto {
+  quantity:number|null; unit:string|null; name:string; notes:string|null;
+  isComplete:boolean; suggestedCategory:string }
+export interface ConnectedHouseholdDto { householdId:number; householdName:string }
+export interface RecipeImportResultDto {
+  success:boolean; recipeId:number|null; errorMessage:string|null; errorType:string|null;
+  existingRecipeId:number|null; existingRecipeName:string|null; partialData:PartialRecipeDataDto|null }
+export interface RecipeDraftData {  // mirrors DraftService.RecipeDraftData — reused as the PUT body AND GET response
+  name:string; description:string|null; instructions:string|null; imagePath:string|null;
+  sourceUrl:string|null; servings:number|null; prepTimeMinutes:number|null; cookTimeMinutes:number|null;
+  ingredients:IngredientDraftData[] }
+export interface IngredientDraftData {
+  name:string; quantity:number|null; unit:string|null; category:string;
+  notes:string|null; groupName:string|null; sortOrder:number }
+// … PartialRecipeDataDto, CategoryDto similarly
+export type IslandView = 'list' | 'edit';
+export interface ShellContext {
+  householdId:number; userId:number; userName:string;
+  view:IslandView; recipeId:number|null }   // recipeId set only for edit of an existing recipe
+```
+
+---
+
+## 5. Decisions
+
+**D1 — Multi-route island: one bundle, view chosen by root data-attr.** Two Razor host pages (`Recipes.razor`, `RecipeEdit.razor`) both import the **same** `/islands/recipes/index.js` and mount the same `window.RecipesIsland`; the root element carries `data-view="list"|"edit"` (+ `data-recipe-id` for edit). `main.ts` reads `view` from the root dataset and mounts the matching root component (`ListApp.svelte` or `EditApp.svelte`). *Alt considered:* a client-side SPA router inside one mount — rejected: diverges from the meal-plan/chores one-host-page pattern, and the strangler intentionally keeps the Blazor shell + routing. *Tradeoff:* cross-view transitions are full navigations (D8), not SPA pushes — acceptable for parity (today each is a separate Blazor page).
+
+**D2 — NL ingredient parser: server endpoint, not a TS port.** `IIngredientParser.ParseIngredient` is a ~250-line pure C# function (Unicode-fraction normalization, range/fraction/unit/notes extraction) with no external deps (`IngredientParser.cs`). Porting it to TS risks parity drift on every edge case and duplicates logic. Instead, `POST /parse-ingredient` on blur/Enter (one cheap round-trip per ingredient add). *Tradeoff:* a network hop per ingredient vs offline parse — fine; ingredient adds are deliberate and infrequent, and the island is online by definition. Bulk-paste uses `POST /parse-ingredients` (one round-trip for all lines).
+
+**D3 — Recipe detail: one superset endpoint serving both the read drawer and the edit load.** `GET /api/recipes/{id}` returns `RecipeFullDto` with **both** `instructionsHtml` (sanitized, for the drawer's `{@html}`) and raw `instructions` (for the edit textarea), plus full ingredient fields. *Alt:* two endpoints (lean detail + edit). Rejected: one projection = M9 (no drift between drawer and edit), and the extra payload (raw markdown + categories) is negligible. The drawer simply ignores the edit-only fields. *Parity note:* the list payload (`RecipeListItemDto`) is deliberately **lean** (no full ingredients/instructions), so the drawer **lazy-fetches** detail on open (endpoint #2; #16 for connected) — the meal-plan `RecipeDetailSheet` pattern. Today's Blazor drawer reuses the already-loaded full `Recipe` (`Recipes.razor:722-727`); the lazy fetch is an intentional, benign divergence (leaner list + one detail GET on click), not a regression.
+
+**D4 — Drag-reorder: re-add `svelte-dnd-action`.** The ingredient list reorders by drag today (`IngredientList.razor` MudDropContainer). Mirror the **chores** island's `svelte-dnd-action` usage (the only island that kept it; meal-plan dropped it). Add it to `frontend/recipes/package.json`. Reorder updates `SortOrder` client-side; persistence is part of the recipe save (PUT replaces ingredients with their new order) — **no per-reorder endpoint** (parity: today reorder is in-memory until Save).
+
+**D5 — Concurrency: versionless / last-write-wins (parity).** The `Recipe` entity HAS an xmin `[Timestamp] Version` (`Recipe.cs`), but today's `UpdateRecipeAsync` loads-and-overwrites without checking it — last-write-wins. Mirror that: no version token on the `/api/recipes` wire. *Tradeoff:* two members editing the same recipe ⇒ last save wins (a full-form clobber is more consequential than a meal-slot, but matching today is the parity bar). → **Harvested as provisional quest** "Recipe edit optimistic concurrency (xmin)" (§13).
+
+**D6 — Image upload: multipart endpoint via the existing `IFormFile` overload.** `POST /api/recipes/images` (multipart/form-data) → `IImageService.SaveImageAsync(IFormFile, hh)` (already exists, `ImageService.cs:47`; the Blazor `IBrowserFile` overload is circuit-only and unusable from an endpoint). Returns `{ imagePath: "/uploads/{hh}/{guid}.ext" }`. The island uploads first, then includes the returned path in the create/update body — mirrors `RecipeEdit.razor:458-471`. 10 MB + jpg/png/gif/webp validation is in the service; map a validation failure to 400. Group already has `.DisableAntiforgery()`.
+
+**D7 — URL import: scrape→create→return id (then navigate to edit).** Mirror `ImportRecipeDialog`: `POST /api/recipes/import { url }` → dup-check by `SourceUrl` (return `existingRecipeId`/`Name` if found, unless `force:true`) → `ImportFromUrlAsync` → on success `CreateRecipeAsync` → return the new `recipeId`; the island then navigates to `/recipes/edit/{id}` to review (D8). On failure, return `errorType` + `partialData` so the dialog can offer "Add Manually". *Tradeoff:* a scrape→preview-in-island→confirm flow would be nicer but is **new UX** — deferred. ≤60s (Polly: 3 retries, 30s/attempt, 60s total — `Program.cs` RecipeScraper client). The dialog shows a spinner; YouTube imports warn "this may take a moment".
+
+**D8 — Cross-view navigation: full-document nav via `window.location.assign`.** When the island moves between views (list→edit, list→new, edit→list on save/cancel, import→edit), it sets `window.location.assign('/recipes/edit/3')` etc. Each destination is a clean island mount. *Alt:* call Blazor's global `Blazor.navigateTo` for enhanced (no-reload) nav — rejected as fragile cross-framework coupling; flagged as a possible later enhancement. *Tradeoff:* a full reload per transition (slightly heavier than Blazor's enhanced nav) — acceptable parity; robust, and sidesteps circuit-state edge cases. `[DECISION: D8 — low confidence; if reload feel is poor in WP-Verify, revisit Blazor.navigateTo.]`
+
+**D9 — List search: server-side, debounced (parity).** Each debounced (300ms) search calls `GET /api/recipes?q=` (mirrors today's `OnDebounceIntervalElapsed`→`LoadRecipes`). Server matches name/description/type/ingredient-name (`GetRecipesAsync`). The **favorites filter** is client-side over the loaded set (mirrors `FilteredRecipes`), and the **favoriteRecipeIds** come down with the same payload (one round-trip vs Blazor's two). *Alt:* load-all-once + client filter (the shopping-list/chores "one payload" M11). Rejected: ingredient-search is already server-side, and a household's full recipe set with all ingredients could be a large payload; server-search keeps the list lean and preserves search semantics exactly. Liveness re-runs the *current* search query.
+
+**D10 — Autosave drafts: keep `DraftService`, 2s debounce, server-side.** Mirror `RecipeEdit.razor:368-403`: a 2s debounce after edits `PUT /api/recipes/draft`; on edit-page load `GET /api/recipes/draft?recipeId=` and restore if present (toast "Restored from draft"); on successful Save/Delete, `DELETE /api/recipes/draft`. Draft JSON is stored camelCase by `DraftService` already. The nav-lock (warn on unsaved changes) maps to a `beforeunload` handler in the island (replaces Blazor `NavigationLock`).
+
+**D11 — Keep the meal-plan `/api/meal-plan/recipes/*` endpoints + DTOs separate.** Do not relocate or merge. They serve the meal-plan picker with a lean shape and have a shipped contract test. The recipes island owns `/api/recipes/*` + `RecipeDtos.cs`. The only shared *concept* is the recipe entity; the projections differ by need. (Answers the handoff's "relocate/share vs separate" question.)
+
+**D12 — Fix the confirmed `UpdateRecipeAsync` `RecipeType` drop (tiny, justified parity-correctness scope).** `UpdateRecipeAsync` (`RecipeService.cs:94-104`) updates every scalar **except `RecipeType`** — so a type change has been **silently ignored in production Blazor** (the edit form has a type selector, `RecipeEdit.razor:122-130`). This is a latent bug, not intended behavior; strict "parity" would replicate a broken edit. Add the one line `existing.RecipeType = recipe.RecipeType;` in WP-2 and assert it with an integration test (§9). The only other caller is the Blazor edit page, which benefits identically. (Surfaced by the council's codex lens; verified at source.)
+
+---
+
+## 6. Island structure — `frontend/recipes/`
+
+Copy the meal-plan scaffold; re-scope; add `svelte-dnd-action`. Renames (from the frontend-source survey): root ids `recipes-list-root` / `recipes-edit-root`, global `window.RecipesIsland`, dark class `rc-dark-mode`, CSS prefix `rc-`, store `recipesStore`.
+
+- **Build config:** `package.json` (name `recipes-island`; deps: svelte + vite toolchain **+ `svelte-dnd-action`**), `tsconfig.json`, `svelte.config.js`, `vite.config.ts` (port **5176**, `outDir:dist`, `input:src/main.ts`, `entryFileNames:index.js`, css→`index.css`, `/api` proxy→`:5000`), `index.html` (dev auto-mount — mount whichever root is present).
+- **`src/main.ts`** — copy meal-plan verbatim; rename. **Branch on `data-view`:** `readContext` reads `view` + `recipeId` from the root dataset; `mountRoot` mounts `ListApp` for `view==='list'` else `EditApp`. Support **both** root ids (`recipes-list-root`, `recipes-edit-root`) in `desiredRoots`/auto-mount. Keep the self-heal + dark observer **unchanged**.
+- **`src/lib/types.ts`** — §4.
+- **`src/lib/api.ts`** — copy meal-plan's `request<T>`/`ApiError`; `BASE='/api/recipes'`; add functions for all 20 routes (`listRecipes(q)`, `getRecipe(id)`, `createRecipe(body)`, `updateRecipe(id,body)`, `deleteRecipe(id)`, `toggleFavorite(id)`, `ingredientSuggestions(prefix)`, `parseIngredient(text)`, `parseIngredients(lines)`, `getCategories()`, `uploadImage(file)` [FormData, no JSON content-type], `listImages()`, `importRecipe(url,force)`, `getConnections()`, `listConnectedRecipes(chId,q)`, `getConnectedRecipe(chId,id)`, `copyConnectedRecipe(chId,id)`, `getDraft(recipeId?)`, `saveDraft(body)`, `deleteDraft(recipeId?)`). Any 4xx ⇒ `ApiError` (caller reconciles + calm toast).
+- **`src/lib/liveness.ts`** — copy verbatim. Wired **only** in `ListApp` (the edit form is single-user — no poll; autosave-drafts is the persistence path there).
+- **`src/lib/toasts.svelte.ts` + `components/Toasts.svelte`** — copy + re-scope `rc-`.
+- **`src/lib/quantity.ts`** — NEW: port the quantity formatters + scaling math. **Two distinct formatters — do NOT merge them:** (a) `formatScaledQuantity` for the drawer's *scaled* values — RANGE thresholds (`Recipes.razor:897-905`): ¼=`[0.2,0.3)`, ⅓=`[0.3,0.4)`, ½=`[0.45,0.55)`, ⅔=`[0.6,0.7)`, ¾=`[0.7,0.8)`, whole when `==floor`, else `0.##`; (b) `formatExactQuantity` for the ingredient-list display — EXACT-equality checks (`IngredientList.razor:106-132`): `0.25→"1/4"`, `0.5→"1/2"`, `0.75→"3/4"`, `1/3`, `2/3`, plus mixed-number forms (`"1 1/2"`), else `0.##`. Scaling: `getScalingFactor = scaledServings/servings`, `getScaledQuantity = qty*factor` (`Recipes.razor:875-885`). Client-only, no endpoint.
+- **`src/lib/recipeListStore.svelte.ts`** + **`src/lib/recipeEditStore.svelte.ts`** — TWO separate files (one class-instance store each — Svelte-5 rune rule: export the instance, never a reassigned `$state`). **Split across two files so WP-5 (list) and WP-6 (edit) own disjoint files** — no shared-file collision (council).
+  - **`RecipeListStore`** (`recipeListStore.svelte.ts`) — `query`, `recipes = $state<RecipeListItemDto[]>`, `favoriteIds = $state<Set<number>>`, `showFavoritesOnly`, `selectedConnectedId = $state<number|null>`, `connections`, `loading`, `error`, `currentUserId`. `displayed = $derived` (favorites filter over `recipes`). `load()` — `selectedConnectedId==null` ⇒ GET #1, set `recipes`+`favoriteIds`; else GET #15 (also a `RecipeListDto`, `favoriteRecipeIds` always `[]`), set `recipes`, clear `favoriteIds`. The favorites chip + per-card heart are **hidden whenever `selectedConnectedId!=null`**. `search(q)`, `toggleFavorite(id)` (optimistic Set toggle + POST + reconcile-on-error; disabled in connected mode), `setRefresh`/`reconcile` (liveness + error reconcile, like meal-plan). **All HTTP awaited; reconcile re-runs the current query.**
+  - **`RecipeEditStore`** (`recipeEditStore.svelte.ts`) — `form = $state<RecipeEditModel>`, `ingredients = $state<RecipeIngredientFullDto[]>`, `loading`, `saving`, `dirty`, `autosaveStatus = $state<'none'|'saving'|'saved'>`, **`error = $state<string|null>`** (the save/delete failure path §8). `load(recipeId|null)` (draft-first then recipe-or-blank, mirror `RecipeEdit.razor:297-360`); `addIngredient`/`addBulk`/`removeIngredient`(undo)/`reorder`(updates `sortOrder`); `scheduleAutosave()` (2s debounce → `saveDraft` with current `form`+`ingredients`); `save()`/`delete()` → **on any 4xx (incl. the 404-as-400 quirk): set `error`, toast "this recipe changed", `window.location.assign('/recipes')`** (concurrent delete / last-write-wins, §8); **on success:** `deleteDraft` + `window.location.assign('/recipes')` (D8). `uploadImage(file)` → endpoint #11 → set `form.imagePath`.
+    - **`RecipeEditModel`** + the **form→`RecipeWriteRequest` mapper** (made explicit per the council): `{ name, description, instructions, sourceUrl, prepTimeMinutes, cookTimeMinutes, servings, recipeType, imagePath }`. On save: **trim `name`; block save if blank** (mirror `RecipeEdit.razor:506-510`); **blank strings → null** for optional text fields; new-recipe defaults `recipeType='main'`, `servings=4` (`RecipeEdit.razor:352-357`); each ingredient carries `category` (fallback to the first category, else `'Pantry'`) and a **recomputed `sortOrder`** (0..n in list order); `ingredientId` is server-assigned (send `0` on create).
+- **`src/ListApp.svelte`** — read `ShellContext` from `recipes-list-root` data-attrs; the **`untrack()` one-time load** (§ Loop safety); render header (Add / Import buttons), connected-household chip selector, search field, favorites chip, the card grid (`RecipeCard`), the detail **drawer** (`RecipeDetailDrawer`), delete confirm (`ConfirmDialog`), import dialog (`ImportDialog`), `Toasts`; wire `liveness` → `reconcile`.
+- **`src/EditApp.svelte`** — read context (incl. `recipeId`) from `recipes-edit-root`; the **`untrack()` one-time load** calls `store.load(recipeId)`; render the form (`BasicInfoSection`, `ImageSection`, `IngredientEntry`, `IngredientList`, instructions textarea), the autosave indicator, image picker (`ImagePickerDialog`), bulk-paste (`BulkPasteDialog`), Save/Cancel/Delete; install the `beforeunload` nav-lock when `dirty`. **No liveness** (single-user form).
+- **`src/lib/components/`** (re-scope `rc-`, Svelte-5 `$props`/`$state`/`$derived`):
+  - `RecipeCard.svelte` — image/placeholder, name, type chip, "imported" icon, author avatar (or "deleted user"), ingredient preview, favorite heart (hidden when read-only/connected). Click → open drawer.
+  - `RecipeDetailDrawer.svelte` — slide-out + scrim. Lazy detail fetch on open — `getRecipe(id)` (#2) for own recipes, **`getConnectedRecipe(selectedConnectedId, id)` (#16) in connected mode**. Image, author, prep/cook chips, **servings scaler** (+/- → rescale ingredient qty via `quantity.ts`), description, ingredients, `{@html} instructionsHtml`, source link (safe-url guard), actions (Edit→nav / Add-to-Meal-Plan stub toast / Delete→confirm; or **Copy** for connected). Mirror `Recipes.razor:223-416`.
+  - `ConnectedHouseholdSelector.svelte` — "My Recipes" + a chip per connection + a "manage connections" link. Mirror `Recipes.razor:55-79`.
+  - `ImportDialog.svelte` — URL field, supported-sites note, spinner (YouTube variant), dup-warning ("View Existing" / "Import Anyway"=force), error + "Add Manually". Mirror `ImportRecipeDialog.razor`. On success → nav to `/recipes/edit/{id}`.
+  - `ConfirmDialog.svelte` — copy meal-plan's (delete confirm).
+  - `BasicInfoSection.svelte` / `ImageSection.svelte` — form fields + image upload/remove/"choose existing".
+  - `IngredientEntry.svelte` — raw input; on Enter/Tab → `parseIngredient` → reveal editable qty/unit/name/category/notes; unit autocomplete (static list, `IngredientEntry.razor:103-107`); name autocomplete (`ingredientSuggestions`); category select (`getCategories`); "Bulk Paste" button → `BulkPasteDialog`. Mirror `IngredientEntry.razor`.
+  - `IngredientList.svelte` — **`svelte-dnd-action`** reorder (updates `sortOrder`), edit (remove+re-add), delete-with-undo toast, category chip + color. Mirror `IngredientList.razor`.
+  - `ImagePickerDialog.svelte` — grid of `listImages()`, select, confirm. Mirror `ImagePickerDialog.razor`.
+  - `BulkPasteDialog.svelte` — textarea → `parseIngredients(lines)` → preview rows (qty/unit/name/notes, incomplete warning) → import. Mirror `BulkPasteDialog.razor`.
+- **`src/styles/{tokens,app}.css`** — copy meal-plan; re-scope `rc-`/`#recipes-list-root,#recipes-edit-root` + `rc-dark-mode`. **No `dates.ts`** (recipes have no week math).
+
+---
+
+## 7. Host pages + build wiring
+
+- **`Components/Pages/Recipes.razor`** — mirror `MealPlan.razor`. Flag **`RECIPES_USE_ISLAND`** (same `IsIslandEnabled()` config-or-env helper, `MealPlan.razor:98-108`). **ON →** `<div id="recipes-list-root" data-household-id data-user-id data-user-name data-view="list">`, `<HeadContent>` `index.css?v=`, `OnAfterRenderAsync` `ensureIslandStylesheet` + `import('/islands/recipes/index.js?v=')` + `RecipesIsland.mount("recipes-list-root")`, `IslandVersion` cache-bust, `IAsyncDisposable`+`JSDisconnectedException` teardown calling `RecipesIsland.destroy`. **OFF →** the existing Blazor body (keep `IRecipeService`/dialogs intact as the zero-regression fallback; delete in a later cleanup).
+- **`Components/Pages/RecipeEdit.razor`** — same, for both `@page "/recipes/new"` and `@page "/recipes/edit/{RecipeId:int}"`. ON → `<div id="recipes-edit-root" data-household-id="@_shell.HouseholdId" data-user-id="@_shell.UserId" data-user-name="@_shell.UserName" data-view="edit" data-recipe-id="@(RecipeId?.ToString() ?? "")">` + mount `"recipes-edit-root"`. OFF → existing Blazor edit form. (Same full data-attr set as the list root — identity is server-resolved per M1, but the island still reads the shell context.)
+- **`CopyRecipesIsland`** MSBuild target in `FamilyCoordinationApp.csproj` — copy of `CopyMealPlanIsland` (`.csproj:56-71`): `frontend/recipes/dist/**` → `wwwroot/islands/recipes/`, `BeforeTargets="AssignTargetPaths"`, `Condition="Exists('…/frontend/recipes/dist')"`, `SkipUnchangedFiles`.
+- **Dockerfile** — edit the **multi-stage `Dockerfile`** (used by prod deploy + CI): add a `recipes-node-build` stage (copy of `mealplan-node-build`, `Dockerfile:20-27`): `node:20-alpine`, `npm ci`/`npm install`, `npm run build` in `frontend/recipes/`; then `COPY --from=recipes-node-build /frontend/dist/ ./FamilyCoordinationApp/wwwroot/islands/recipes/` in the .NET build stage (next to `Dockerfile:41`). **Do NOT touch `Dockerfile.runtime-only`** (the local `docker-build.sh` path) — it has no node stages and relies on `docker-build.sh`'s `build_island` + the `CopyRecipesIsland` MSBuild target during `dotnet publish`.
+- **`docker-build.sh`** — add `build_island "./frontend/recipes" "recipes"` (after the meal-plan line, `docker-build.sh:~64`).
+- **`Program.cs`** — `app.MapRecipesEndpoints();` (after `MapMealPlanEndpoints()`, `:401`); register `IRecipeProjectionService`. Already registered: core services `:83-95`; `IRecipeImportService` + scraper + the `RecipeScraper` HttpClient/Polly `:139-159`; `IHouseholdConnectionService` `:95`. Confirm `JsonStringEnumConverter(CamelCase)` is registered (it is, `:125-127`).
+- **Feature flag** — add `RECIPES_USE_ISLAND` to `docker-compose.yml` `app.environment` (`${RECIPES_USE_ISLAND:-false}`, next to the other three) and the repo's **`.env`** (local dev = `true`; the three existing island flags live there, `.env:19,21,26` — none are in `.env.example`, so match that). **Prod** flips it in the host's `~/familyapp/.env.local` (deploy regenerates `.env` from it; per the kickoff handoff) — ship **OFF** first, flip after verify. There is **no** `.env.local` in the repo.
+- **`ensureIslandStylesheet` / `import` glue** — reuse the existing `window.ensureIslandStylesheet` in `Components/App.razor:47-64`; do not duplicate.
+
+---
+
+## 8. Concurrency — versionless / last-write-wins
+
+Mirrors meal-plan + parity (D5). No version/xmin on the `/api/recipes` wire. Conflict story: two members editing the same recipe → last save wins; the list's 20s liveness reconciles the *card grid*, and the edit form's autosave-draft is per-user (no cross-user merge). Deleting/editing an already-deleted recipe → 404/empty-400 → the island reconciles (list refetch) or surfaces a calm "this recipe changed" toast and returns to the list. Matches today's Blazor (`UpdateRecipeAsync` overwrites; `DataNotifier` last-write-wins).
+
+---
+
+## 9. Contract & integration tests (M9)
+
+- **`RecipeListDtoContractTests`** (mirror `MealPlanBoardDtoContractTests`): build a representative `RecipeListDto` (recipes with/without image, with/without source URL, with ingredient previews + counts, varied `RecipeType`, one with `createdByName` null = deleted user, plus a non-empty `favoriteRecipeIds`); serialize with the **same global options** (`JsonSerializerDefaults.Web` + `JsonStringEnumConverter(CamelCase)`, `WriteIndented`); assert byte-equality against checked-in `Fixtures/RecipeList/list.json`. The island `types.ts` mirrors the fixture.
+- **`RecipeFullDtoContractTests`** + `Fixtures/RecipeFull/recipe.json`: a recipe with ingredients incl `category`/`groupName`/`ingredientId`, both `instructions` (raw) + `instructionsHtml` (sanitized), `sharedFromHouseholdName` set, optional fields null — to lock the edit/drawer superset shape + camelCase enum.
+- **Endpoint integration (real Postgres, mirror chores/meal-plan endpoint tests):** list (empty + populated + with `q` matching name vs ingredient); detail round-trip; **create** → list reflects it + ids assigned; **update** replaces ingredients + order; **delete** soft-deletes (gone from list, `IsDeleted` row remains); favorite **toggle** flips both ways; ingredient-suggestions (`<2` chars ⇒ `[]`); parse-ingredient + parse-ingredients shape; image upload (multipart) returns a path + the file lands under `/uploads/{hh}/`; import dup-detection (returns existing) + `force`; categories; connections list; connected list/detail/copy; draft get/put/delete round-trip; **`update` changes `recipeType`** (regression-guards D12) and the **PUT response body reflects the new ingredients/order** (catches the stale-return trap — proves the endpoint projects from a re-fetch); **favorite / update / delete of a missing or cross-household id ⇒ 404, not 500**; **cross-household isolation (M1)** — a user in household A cannot read/update/delete/favorite/copy household B's recipe, and cannot read B's images/drafts/connected recipes without a real connection (403 on unconnected `/connected/*`).
+
+---
+
+## 10. Loop safety (⚠ the #1 regression risk — bake in from day one)
+
+Memory `svelte5-setup-effect-async-loader-loop`: a one-time setup `$effect` that synchronously reads `$state`/`$derived` it (transitively) writes subscribes to that state → infinite fetch→write→re-run loop (~30–46 req/s). It broke meal-plan visibly and chores silently (PR #52). **Both** `ListApp.svelte` and `EditApp.svelte` have a setup effect that calls a loader (`store.load(...)`) whose sync prefix reads then writes store state.
+
+**Fix preemptively** — copy the meal-plan `App.svelte` pattern verbatim: wrap the **entire** setup-effect body in `untrack(() => { … })` so it has zero reactive deps and runs exactly once; liveness (list) + user actions drive later refreshes:
+```svelte
+import { untrack } from 'svelte';
+$effect(() => {
+  untrack(() => {
+    store.init(ctx);
+    store.setRefresh(load);   // (list)
+    load();                   // reads then writes store state — MUST be inside untrack
+    liveness = startLiveness(() => store.reconcile());  // (list only)
+  });
+  return () => { liveness?.stop(); /* + beforeunload cleanup on edit */ };
+});
+```
+
+**MANDATORY GATE (WP-Verify):** open each view on `:8080`, install a `fetch` counter in the console, confirm the list/detail/draft endpoints do **~0 background GETs over several seconds** (initial load + 20s liveness on the list only) — **NOT tens/sec.** Re-check on prod after flipping the flag.
+
+---
+
+## 11. Gotchas to carry (from shopping-list + chores + meal-plan)
+
+1. **Empty-body 4xx quirk** — `UseStatusCodePagesWithReExecute` re-executes empty-body 404s as empty **400s** (memory `fca-empty-404-surfaces-as-405-on-delete`; a bare `Results.NotFound()` on DELETE even surfaces as **405**). Every not-found returns a **non-empty body** (`Results.NotFound(new { message })`). Island treats any 4xx as a non-retryable rejection → reconcile + calm toast.
+2. **Casing** — `RecipeType` is a real enum on the DTO ⇒ **camelCase** via the global converter (`"main"`, `"side"`, …). `decimal? Quantity` ⇒ JSON number-or-null. Document at the top of `types.ts`.
+3. **Multi-tenant (M1)** — household/user always server-resolved via `UserContextResolver`; every query filters `HouseholdId`; cross-household integration tests mandatory; connected-household reads require a validated connection (403 otherwise).
+4. **Image upload is multipart, not JSON** — endpoint #11 binds `IFormFile`; the island sends `FormData` (no `Content-Type: application/json` — let the browser set the multipart boundary). Use the existing `SaveImageAsync(IFormFile,…)` overload (`ImageService.cs:47`), not the `IBrowserFile` one.
+5. **Drafts reuse the existing service records** — `DraftService` already serializes camelCase; the endpoints take/return `RecipeDraftData` **directly** (no new C# draft DTO, P1-3), and the island's `RecipeDraftData`/`IngredientDraftData` TS mirror must match those records field-for-field so a draft round-trips.
+6. **Soft delete + EF global query filter** — `DeleteRecipeAsync` sets `IsDeleted` (row persists; no hard delete). `Recipe` has an **EF global query filter** `HasQueryFilter(r => !r.IsDeleted)` (`RecipeConfiguration.cs:45`), so deleted recipes are auto-excluded from every list/detail query — endpoints need **no** explicit `!IsDeleted`. (A fresh-eyes pass flagged the service methods as unfiltered; the *global* filter covers them — verified.) `CreateRecipeAsync`'s next-id calc uses `IgnoreQueryFilters()` so ids still bump past deleted rows; the import dup-check's explicit `!IsDeleted` is belt-and-suspenders.
+7. **Import is slow + external** — ≤60s (Polly), SSRF-guarded server-side (`IUrlValidator`), YouTube branch uses yt-dlp. The island just shows a spinner and handles the result DTO; do **not** add a client fetch timeout shorter than 60s.
+8. **Island resilience** — reuse `main.ts`'s mount/heal/dark-mode self-heal verbatim (the `.NET 10` circuit-resume root-replacement fix). Load-bearing; don't reinvent. Extend only to handle the two root ids / `data-view` branch.
+9. **DbContextFactory** — services inject `IDbContextFactory<ApplicationDbContext>`, short-lived contexts (already true of every service the endpoints touch).
+10. **Servings scaler precision** — port the EXACT thresholds (§6 `quantity.ts`): the drawer's *scaled* formatter uses **ranges** (¼=`[0.2,0.3)`…¾=`[0.7,0.8)`, `Recipes.razor:897-905`); the edit list's formatter uses **exact-equality** (`IngredientList.razor:106-132`). They differ because scaled values are fuzzy and entered values are exact — keep both. Porting from intuition diverges.
+11. **`UpdateRecipeAsync` return is stale + drops `RecipeType`** (verified, `RecipeService.cs:94-132`) — the PUT endpoint must (a) add `existing.RecipeType = recipe.RecipeType;` (D12) and (b) project its response from a fresh `GetRecipeAsync(hh, recipeId)`, **not** the service return (whose `Ingredients` nav still holds the RemoveRange'd rows). Update/delete also **throw** `InvalidOperationException` on missing → catch → non-empty 404.
+
+---
+
+## 12. Build sequence (work packages)
+
+> **Format note:** this is a single consolidated spec (the project's precedent — cf. `.planning/meal-plan-island-spec.md`), not a multi-file workshop. The executor reads the **whole doc**, so each WP below is a build phase, not a standalone file; cross-references ("§3 #4", "D12") resolve within this document, and file ownership across WPs is disjoint (the §6 store split is the one place that mattered). The council's "split into `_orchestrator.md`/`wp-*.md`" note is a workshop-format preference that doesn't apply here.
+
+- **WP-1 — Backend DTOs + projection.** `Services/Dtos/RecipeDtos.cs` (§4), `IRecipeProjectionService`+impl (`ToListItem`/`ToFull`/`ToParsed`; `ToFull` uses `MarkdownHelper.ToSafeHtml` for `instructionsHtml`). No endpoints yet. Builds clean.
+- **WP-2 — Backend endpoints.** `Endpoints/RecipesEndpoints.cs` (all 20 routes, §3), request DTOs, M1 via `UserContextResolver`, multipart image upload, import dup-logic, connection validation on `/connected/*`, non-empty 404 bodies. `Program.cs` wiring (`MapRecipesEndpoints`, register `IRecipeProjectionService`). **Carry the fresh-eyes fixes:** import = `ImportFromUrlAsync`→`CreateRecipeAsync`→return the assigned id (the result's `Recipe` is unsaved, P1-2); `parse-ingredient` guards empty *before* calling (it throws, P2-2); drafts deserialize into / return `RecipeDraftData` directly — no new DTO (P1-3); connected detail = `GetRecipeAsync(chId,…)` + `ToFull(…, includeAuthor:false)` after the connection guard (P1-4). No explicit `!IsDeleted` needed (global query filter, §11.6). **Carry the council fixes:** this WP also edits **`Services/RecipeService.cs`** to add `existing.RecipeType = recipe.RecipeType;` in `UpdateRecipeAsync` (D12); the PUT endpoint projects from a **re-fetch** (`GetRecipeAsync`), not the `UpdateRecipeAsync` return (stale ingredients nav); update/delete **catch `InvalidOperationException`** → non-empty 404; favorite **pre-checks `GetRecipeAsync`** → 404 before toggling; connected list/copy **validate the connection** (`AreHouseholdsConnectedAsync`) → 403.
+- **WP-3 — Backend tests.** `RecipeListDtoContractTests` + `RecipeFullDtoContractTests` + fixtures; endpoint integration (real PG) incl. cross-household M1 + connected-household 403 + image-file-lands + draft round-trip (§9).
+- **WP-4 — Island scaffold.** `frontend/recipes/` config (`+svelte-dnd-action`), `types.ts`, `api.ts` (20 fns), `main.ts` (two-root `data-view` branch + self-heal), `liveness.ts`/`toasts*`/`styles` (copied + re-scoped from meal-plan), **`quantity.ts` (NEW — port the two formatters, §6)**, `ListApp.svelte`+`EditApp.svelte` skeletons. The two stores are created in WP-5/WP-6 (disjoint files: `recipeListStore.svelte.ts` / `recipeEditStore.svelte.ts`). `svelte-check` 0/0, `vite build` green.
+- **WP-5 — Island list view.** `RecipeListStore`, `ListApp` (the **`untrack` load**), `RecipeCard`, `ConnectedHouseholdSelector`, search + favorites, `RecipeDetailDrawer` (servings scaler), `ImportDialog`, `ConfirmDialog`, liveness. `svelte-check` 0/0, `vite build`.
+- **WP-6 — Island edit view.** `RecipeEditStore`, `EditApp` (the **`untrack` load**), `BasicInfoSection`/`ImageSection`, `IngredientEntry` (parse-on-blur), `IngredientList` (**dnd reorder**), `BulkPasteDialog`, `ImagePickerDialog`, instructions textarea, autosave drafts + `beforeunload` nav-lock, Save/Cancel/Delete. `svelte-check` 0/0, `vite build`.
+- **WP-7 — Host pages + build wiring.** `Recipes.razor` + `RecipeEdit.razor` flag + mount (keep Blazor fallback), `CopyRecipesIsland`, Dockerfile `recipes-node-build` stage, `docker-build.sh` entry, `RECIPES_USE_ISLAND` in compose + `.env`/`.env.local`.
+- **WP-8 — Verify.** Browser-verify on `:8080` (rebuild `familyapp:latest`, swap app container, DOM+psql — Chrome screenshots flake; memory `fca-local-browser-verify-recipe`); flip `RECIPES_USE_ISLAND=true`; exercise list/search/favorites/connected/detail+scaler/import + new/edit/ingredient-parse/drag/bulk-paste/image-upload+picker/autosave/delete; **the LOOP-CHECK gate** (§10) on both views.
+
+---
+
+## 13. Gates (chores/meal-plan precedent; worktree baseline = memory `fca-worktree-gate-baseline`)
+
+- `dotnet build` clean.
+- `dotnet test` full suite green incl. new contract + integration tests. *Worktree baseline:* 2 `ApiKeySecurityTests` fail (`.git` is a file) + 49 pre-existing `dotnet format` whitespace errors on master — "green" = **no NEW failures**.
+- `svelte-check` 0 errors / 0 warnings in `frontend/recipes/`.
+- `vite build` → `dist/index.js` + `dist/index.css`.
+- Real-Postgres integration for the new endpoints passes (incl. cross-household M1 + connected 403).
+- **Loop-check** (§10): both views ~0 background GETs/sec.
+- Browser-verify on `:8080` (both views, flag ON) confirms parity.
+
+---
+
+## 14. Provisional quests to harvest (don't build now — author in the Spine)
+
+- **Recipe edit optimistic concurrency (xmin).** Use the existing `Recipe.Version` to detect concurrent full-form edits (409 → "this recipe changed, reload"). Today (and this island, D5) is last-write-wins.
+- **Import scrape→preview-in-island.** Show the parsed result before creating, instead of create-then-edit (D7). New UX.
+- **Enhanced (no-reload) cross-view nav via `Blazor.navigateTo`.** Replace the full-document `window.location` transitions (D8) if the reload feel is poor.
+- **Inline ingredient edit.** Today edit = remove + re-add (`IngredientList.razor:451-456`); a proper inline editor is new UX.
+- **Delete the Blazor recipe pages + dialogs.** Cleanup once the island is prod-stable (mirrors the meal-plan fallback-removal follow-up).
+
+---
+
+## 15. Open items (non-blocking — resolve in-build)
+
+- **D8 reload feel** — confirm full-document nav between views is acceptable at WP-8; else harvest the `Blazor.navigateTo` quest.
+- **Exact Dockerfile stage placement / COPY line** — confirm against the real Dockerfile at WP-7 (the survey gives `Dockerfile:20-27,41`).
+- ~~`createdByAvatarColor`~~ **RESOLVED (fresh-eyes P2-1):** `User` has no color field (only `PictureUrl`/`Initials`, `User.cs`) → DTO carries `createdByPictureUrl` + `createdByName`; card renders pic-or-initials.
+- ~~Connected-household detail~~ **RESOLVED:** the island lazy-fetches detail for BOTH own (#2) and connected (#16) recipes (lean list + detail-on-open, D3 parity note); today's Blazor reuses the loaded object — benign divergence.

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,15 @@ RUN if [ -f package-lock.json ]; then npm ci; else npm install --no-audit --no-f
 COPY frontend/meal-plan/ ./
 RUN npm run build
 
+# Stage 1d: Build the Svelte recipes island (strangler; parallel to the others).
+# Emits ./dist/ which the .NET stage copies into wwwroot/islands/recipes/.
+FROM node:20-alpine AS recipes-node-build
+WORKDIR /frontend
+COPY frontend/recipes/package.json frontend/recipes/package-lock.json* ./
+RUN if [ -f package-lock.json ]; then npm ci; else npm install --no-audit --no-fund; fi
+COPY frontend/recipes/ ./
+RUN npm run build
+
 # Stage 2: Build the .NET app.
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
@@ -39,6 +48,7 @@ COPY src/FamilyCoordinationApp/ ./FamilyCoordinationApp/
 COPY --from=node-build /frontend/dist/ ./FamilyCoordinationApp/wwwroot/islands/shopping-list/
 COPY --from=chores-node-build /frontend/dist/ ./FamilyCoordinationApp/wwwroot/islands/chores/
 COPY --from=mealplan-node-build /frontend/dist/ ./FamilyCoordinationApp/wwwroot/islands/meal-plan/
+COPY --from=recipes-node-build /frontend/dist/ ./FamilyCoordinationApp/wwwroot/islands/recipes/
 
 # Explicitly set working directory to project folder before publish
 WORKDIR /src/FamilyCoordinationApp

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -61,6 +61,7 @@ build_island() {
 build_island "./frontend/shopping-list" "shopping-list"
 build_island "./frontend/chores" "chores"
 build_island "./frontend/meal-plan" "meal-plan"
+build_island "./frontend/recipes" "recipes"
 echo ""
 
 # Step 3: Publish locally

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       SHOPPING_LIST_USE_ISLAND: ${SHOPPING_LIST_USE_ISLAND:-false}
       CHORES_USE_ISLAND: ${CHORES_USE_ISLAND:-false}
       MEAL_PLAN_USE_ISLAND: ${MEAL_PLAN_USE_ISLAND:-false}
+      RECIPES_USE_ISLAND: ${RECIPES_USE_ISLAND:-false}
       # Chores v1.1 digest. The token gates POST /api/chores/digest/run (cron trigger); unset ⇒ endpoint
       # returns 503 (feature off). MUST be mapped here — .env is only used for ${VAR} substitution, not
       # auto-injected, so the documented go-live step (set CHORES_DIGEST_TRIGGER_TOKEN) is inert without this.

--- a/frontend/recipes/.gitignore
+++ b/frontend/recipes/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.log
+.DS_Store

--- a/frontend/recipes/index.html
+++ b/frontend/recipes/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Recipes (dev)</title>
+  </head>
+  <body>
+    <!--
+      Dev-only host. In production the Razor shells (Recipes.razor / RecipeEdit.razor)
+      provide these attrs. main.ts mounts whichever root id is present (spec D1):
+      #recipes-list-root (data-view="list") or #recipes-edit-root (data-view="edit").
+      Swap the block below to test the edit view standalone.
+    -->
+    <div
+      id="recipes-list-root"
+      data-household-id="1"
+      data-user-id="1"
+      data-user-name="Dev User"
+      data-view="list"
+    ></div>
+    <!--
+    <div
+      id="recipes-edit-root"
+      data-household-id="1"
+      data-user-id="1"
+      data-user-name="Dev User"
+      data-view="edit"
+      data-recipe-id=""
+    ></div>
+    -->
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/frontend/recipes/package-lock.json
+++ b/frontend/recipes/package-lock.json
@@ -1,0 +1,1533 @@
+{
+  "name": "recipes-island",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "recipes-island",
+      "version": "0.1.0",
+      "dependencies": {
+        "svelte-dnd-action": "^0.9.69"
+      },
+      "devDependencies": {
+        "@sveltejs/vite-plugin-svelte": "^5.0.3",
+        "@tsconfig/svelte": "^5.0.4",
+        "svelte": "^5.19.0",
+        "svelte-check": "^4.1.4",
+        "tslib": "^2.8.1",
+        "typescript": "~5.7.2",
+        "vite": "^6.0.7"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sveltejs/acorn-typescript": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.10.tgz",
+      "integrity": "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8.9.0"
+      }
+    },
+    "node_modules/@sveltejs/load-config": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@sveltejs/load-config/-/load-config-0.2.0.tgz",
+      "integrity": "sha512-1LgZ/qUqSoq+QorD83lk2hka79Px0wXNW2q5V1nZlxGhQgw1jrsIbVz5YiCeucVLo4XvFLjXukUaQjIiqowkcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-5.1.1.tgz",
+      "integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
+        "debug": "^4.4.1",
+        "deepmerge": "^4.3.1",
+        "kleur": "^4.1.5",
+        "magic-string": "^0.30.17",
+        "vitefu": "^1.0.6"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22"
+      },
+      "peerDependencies": {
+        "svelte": "^5.0.0",
+        "vite": "^6.0.0"
+      }
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte-inspector": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-4.0.1.tgz",
+      "integrity": "sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.7"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22"
+      },
+      "peerDependencies": {
+        "@sveltejs/vite-plugin-svelte": "^5.0.0",
+        "svelte": "^5.0.0",
+        "vite": "^6.0.0"
+      }
+    },
+    "node_modules/@tsconfig/svelte": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-5.0.8.tgz",
+      "integrity": "sha512-UkNnw1/oFEfecR8ypyHIQuWYdkPvHiwcQ78sh+ymIiYoF+uc5H1UBetbjyqT+vgGJ3qQN6nhucJviX6HesWtKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
+      "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/devalue": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "license": "MIT"
+    },
+    "node_modules/esrap": {
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.12.tgz",
+      "integrity": "sha512-On0QbLyaiAkVC4eXtgnXK9Kh2opit+3rcUSOc45DqJ2s/X2eXAHsGOKRSJ6IDagQEW5vPyivANfXUiqgXC67Rw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/types": "^8.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/is-reference": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.6"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/locate-character": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/svelte": {
+      "version": "5.56.4",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.4.tgz",
+      "integrity": "sha512-/d0QHehmRuJW8gVz395MTkPcPozxzdjBMBE8oEYGz8O3b9KTMzzQ9ZHJQLuFKOHOPQbU6kx/X4iid/EBBzH7iw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.4",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@sveltejs/acorn-typescript": "^1.0.10",
+        "@types/estree": "^1.0.5",
+        "@types/trusted-types": "^2.0.7",
+        "acorn": "^8.12.1",
+        "aria-query": "5.3.1",
+        "axobject-query": "^4.1.0",
+        "clsx": "^2.1.1",
+        "devalue": "^5.8.1",
+        "esm-env": "^1.2.1",
+        "esrap": "^2.2.12",
+        "is-reference": "^3.0.3",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.11",
+        "zimmerframe": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/svelte-check": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.7.1.tgz",
+      "integrity": "sha512-FGUOmAqxXdN/H9Zm8slrqO7SLtFisXRB7rfOsHNJ3MLTD2po/+Stg8XyErkpumPHbuUiYTcqrEIzxpVWKTLqtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "@sveltejs/load-config": "^0.2.0",
+        "chokidar": "^4.0.1",
+        "fdir": "^6.2.0",
+        "picocolors": "^1.0.0",
+        "sade": "^1.7.4"
+      },
+      "bin": {
+        "svelte-check": "bin/svelte-check"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "svelte": "^4.0.0 || ^5.0.0-next.0",
+        "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/svelte-dnd-action": {
+      "version": "0.9.70",
+      "resolved": "https://registry.npmjs.org/svelte-dnd-action/-/svelte-dnd-action-0.9.70.tgz",
+      "integrity": "sha512-iVqDAW1PtQArA96dHhM5Lwxj39iKNjIuYE+tqpq9DUaBWfv410SpGGFJ3NzPtvptx+YkXBzMYV3lpey8s07q+w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "svelte": ">=3.23.0 || ^5.0.0-next.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitefu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+      "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "tests/deps/*",
+        "tests/projects/*",
+        "tests/projects/workspace/packages/*"
+      ],
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zimmerframe": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
+      "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
+      "license": "MIT"
+    }
+  }
+}

--- a/frontend/recipes/package.json
+++ b/frontend/recipes/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "recipes-island",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "check": "svelte-check --tsconfig ./tsconfig.json"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^5.0.3",
+    "@tsconfig/svelte": "^5.0.4",
+    "svelte": "^5.19.0",
+    "svelte-check": "^4.1.4",
+    "tslib": "^2.8.1",
+    "typescript": "~5.7.2",
+    "vite": "^6.0.7"
+  },
+  "dependencies": {
+    "svelte-dnd-action": "^0.9.69"
+  }
+}

--- a/frontend/recipes/src/EditApp.svelte
+++ b/frontend/recipes/src/EditApp.svelte
@@ -1,0 +1,308 @@
+<script lang="ts">
+  // ───────────────────────────────────────────────────────────────────────
+  // Root of the recipes EDIT view (#recipes-edit-root, data-view="edit").
+  // ctx.recipeId is null for /recipes/new, set for /recipes/edit/{id}. Loads the
+  // recipe (or draft, or blank) into the edit store and renders the form
+  // sections, ingredient entry/list (dnd), instructions, autosave indicator, and
+  // Save/Cancel/Delete. Single-user form ⇒ NO liveness.
+  //
+  // ⚠ Loop safety (spec §10): the one-time setup $effect is wrapped ENTIRELY in
+  // untrack() — store.load() reads then writes store $state, so without untrack
+  // the effect would loop. untrack gives it zero reactive deps (runs once).
+  //
+  // Nav-lock: a `beforeunload` handler warns on unsaved changes (replaces the
+  // Blazor NavigationLock). Save/Cancel/Delete clear `dirty` before navigating,
+  // so only an unsaved manual nav-away prompts.
+  // ───────────────────────────────────────────────────────────────────────
+  import { untrack } from 'svelte';
+  import type { ShellContext } from './lib/types';
+  import { recipeEditStore } from './lib/recipeEditStore.svelte';
+  import BasicInfoSection from './lib/components/BasicInfoSection.svelte';
+  import ImageSection from './lib/components/ImageSection.svelte';
+  import IngredientEntry from './lib/components/IngredientEntry.svelte';
+  import IngredientList from './lib/components/IngredientList.svelte';
+  import BulkPasteDialog from './lib/components/BulkPasteDialog.svelte';
+  import ImagePickerDialog from './lib/components/ImagePickerDialog.svelte';
+  import ConfirmDialog from './lib/components/ConfirmDialog.svelte';
+  import Toasts from './lib/components/Toasts.svelte';
+
+  interface Props {
+    ctx: ShellContext;
+  }
+
+  let { ctx }: Props = $props();
+
+  const store = recipeEditStore;
+
+  let bulkOpen = $state(false);
+  let pickerOpen = $state(false);
+  let deleteOpen = $state(false);
+
+  function handleBeforeUnload(e: BeforeUnloadEvent): void {
+    if (store.dirty) {
+      e.preventDefault();
+      e.returnValue = '';
+    }
+  }
+
+  $effect(() => {
+    untrack(() => {
+      store.init(ctx);
+      store.load(ctx.recipeId); // reads then writes store $state — MUST be inside untrack
+      window.addEventListener('beforeunload', handleBeforeUnload);
+    });
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+      store.teardown();
+    };
+  });
+</script>
+
+<div class="rc-container">
+  <header class="rc-header">
+    <h1 class="rc-title">{store.isEdit ? 'Edit Recipe' : 'New Recipe'}</h1>
+    {#if store.isEdit}
+      <button type="button" class="rc-btn-danger-outline" onclick={() => (deleteOpen = true)}>Delete</button>
+    {/if}
+  </header>
+
+  {#if store.loading}
+    <div class="rc-loading-bar"><span></span></div>
+  {:else}
+    {#if store.error}
+      <div class="rc-inline-error" role="alert">{store.error}</div>
+    {/if}
+
+    <BasicInfoSection />
+
+    <ImageSection onChooseExisting={() => (pickerOpen = true)} />
+
+    <section class="rc-paper">
+      <h2 class="rc-section-title">Ingredients</h2>
+      <IngredientEntry
+        categories={store.categories}
+        onAdd={(i) => store.addIngredient(i)}
+        onBulkOpen={() => (bulkOpen = true)}
+      />
+      <IngredientList
+        ingredients={store.ingredients}
+        onReorder={(rows) => store.reorder(rows)}
+        onEdit={(id) => store.editIngredient(id)}
+        onRemove={(id) => store.removeIngredient(id)}
+      />
+    </section>
+
+    <section class="rc-paper">
+      <h2 class="rc-section-title">Instructions</h2>
+      <textarea
+        class="rc-input rc-instructions"
+        rows="10"
+        bind:value={store.form.instructions}
+        oninput={() => store.onEdit()}
+        placeholder="Supports Markdown formatting"
+      ></textarea>
+    </section>
+
+    <div class="rc-footer">
+      <div class="rc-autosave" aria-live="polite">
+        {#if store.autosaveStatus === 'saving'}
+          <span class="rc-spinner" aria-hidden="true"></span>
+          <span class="rc-autosave-text">Saving draft…</span>
+        {:else if store.autosaveStatus === 'saved'}
+          <span class="rc-autosave-saved">✓ Draft saved</span>
+        {/if}
+      </div>
+
+      <div class="rc-footer-actions">
+        <button type="button" class="rc-btn-ghost" onclick={() => store.cancel()}>Cancel</button>
+        <button type="button" class="rc-btn-solid" onclick={() => store.save()} disabled={store.saving}>
+          {store.saving ? 'Saving…' : store.isEdit ? 'Save Changes' : 'Create Recipe'}
+        </button>
+      </div>
+    </div>
+  {/if}
+</div>
+
+<BulkPasteDialog
+  open={bulkOpen}
+  categories={store.categories}
+  onClose={() => (bulkOpen = false)}
+  onImport={(rows) => store.addBulk(rows)}
+/>
+
+<ImagePickerDialog
+  open={pickerOpen}
+  currentImage={store.form.imagePath}
+  onClose={() => (pickerOpen = false)}
+  onSelect={(path) => store.setImage(path)}
+/>
+
+<ConfirmDialog
+  open={deleteOpen}
+  title="Delete Recipe"
+  message={`Are you sure you want to delete "${store.form.name}"? This action cannot be undone.`}
+  onCancel={() => (deleteOpen = false)}
+  onConfirm={() => {
+    deleteOpen = false;
+    store.delete();
+  }}
+/>
+
+<Toasts />
+
+<style>
+  .rc-container {
+    max-width: 880px;
+    margin: 0 auto;
+    padding: 24px 16px 96px;
+  }
+  .rc-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 16px;
+  }
+  .rc-title {
+    margin: 0;
+    font-size: 2.125rem;
+    font-weight: 400;
+    color: var(--color-text);
+  }
+  .rc-paper {
+    background: var(--color-surface);
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-1);
+    padding: 16px;
+    margin-bottom: 16px;
+  }
+  .rc-section-title {
+    margin: 0 0 12px;
+    font-size: 1.125rem;
+    font-weight: 500;
+  }
+  .rc-input {
+    font: inherit;
+    padding: 10px 12px;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text);
+    width: 100%;
+  }
+  .rc-input:focus {
+    outline: none;
+    border-color: var(--color-primary);
+  }
+  .rc-instructions {
+    resize: vertical;
+    min-height: 200px;
+  }
+  .rc-loading-bar {
+    height: 4px;
+    background: var(--color-action-hover);
+    border-radius: 2px;
+    overflow: hidden;
+    margin: 24px 0;
+  }
+  .rc-loading-bar span {
+    display: block;
+    height: 100%;
+    width: 40%;
+    background: var(--color-primary);
+    animation: rc-indeterminate 1.2s ease-in-out infinite;
+  }
+  @keyframes rc-indeterminate {
+    0% {
+      transform: translateX(-100%);
+    }
+    100% {
+      transform: translateX(350%);
+    }
+  }
+  .rc-inline-error {
+    padding: 10px 16px;
+    margin-bottom: 16px;
+    background: rgba(229, 57, 53, 0.08);
+    border-left: 4px solid var(--color-error);
+    border-radius: var(--radius-sm);
+    color: var(--color-error);
+    font-size: 0.875rem;
+  }
+  .rc-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+  .rc-autosave {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 24px;
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+  }
+  .rc-autosave-saved {
+    color: var(--color-success);
+  }
+  .rc-spinner {
+    width: 14px;
+    height: 14px;
+    border: 2px solid var(--color-line-strong);
+    border-top-color: var(--color-primary);
+    border-radius: 50%;
+    animation: rc-spin 0.8s linear infinite;
+  }
+  @keyframes rc-spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+  .rc-footer-actions {
+    display: flex;
+    gap: 8px;
+    margin-left: auto;
+  }
+  .rc-btn-ghost,
+  .rc-btn-solid,
+  .rc-btn-danger-outline {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    min-height: 40px;
+    font-weight: 500;
+  }
+  .rc-btn-ghost {
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
+  }
+  .rc-btn-ghost:hover {
+    background: var(--color-action-hover);
+  }
+  .rc-btn-solid {
+    border: none;
+    background: var(--color-primary);
+    color: #fff;
+  }
+  .rc-btn-solid:hover:not(:disabled) {
+    background: var(--color-primary-hover);
+  }
+  .rc-btn-solid:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+  .rc-btn-danger-outline {
+    border: 1px solid var(--color-error);
+    background: transparent;
+    color: var(--color-error);
+  }
+  .rc-btn-danger-outline:hover {
+    background: rgba(229, 57, 53, 0.08);
+  }
+</style>

--- a/frontend/recipes/src/ListApp.svelte
+++ b/frontend/recipes/src/ListApp.svelte
@@ -1,0 +1,424 @@
+<script lang="ts">
+  // ───────────────────────────────────────────────────────────────────────
+  // Root of the recipes LIST view (#recipes-list-root, data-view="list").
+  // Reads ShellContext from the root data-attrs, loads the grid into the shared
+  // list store, and renders the connected-household selector, search + favorites,
+  // the card grid, the detail drawer, the import + delete dialogs, and toasts.
+  // Liveness re-runs the current query while the tab is visible (collaboration).
+  //
+  // ⚠ Loop safety (spec §10): the one-time setup $effect is wrapped ENTIRELY in
+  // untrack() — load()/loadConnections() read then write store $state, so without
+  // untrack the effect would subscribe to the state it writes → an infinite
+  // fetch→write→re-run loop. untrack gives it zero reactive deps (runs once);
+  // liveness + user actions drive every later refresh.
+  // ───────────────────────────────────────────────────────────────────────
+  import { untrack } from 'svelte';
+  import type { RecipeListItemDto, ShellContext } from './lib/types';
+  import { recipeListStore } from './lib/recipeListStore.svelte';
+  import { copyConnectedRecipe } from './lib/api';
+  import { startLiveness, type LivenessHandle } from './lib/liveness';
+  import { showToast } from './lib/toasts.svelte';
+  import RecipeCard from './lib/components/RecipeCard.svelte';
+  import ConnectedHouseholdSelector from './lib/components/ConnectedHouseholdSelector.svelte';
+  import RecipeDetailDrawer from './lib/components/RecipeDetailDrawer.svelte';
+  import ImportDialog from './lib/components/ImportDialog.svelte';
+  import ConfirmDialog from './lib/components/ConfirmDialog.svelte';
+  import Toasts from './lib/components/Toasts.svelte';
+
+  interface Props {
+    ctx: ShellContext;
+  }
+
+  let { ctx }: Props = $props();
+
+  const store = recipeListStore;
+
+  let liveness: LivenessHandle | null = null;
+
+  // Search is debounced locally (300ms) before hitting the server (mirrors the
+  // Blazor MudTextField DebounceInterval). Kept separate from store.query so the
+  // input stays responsive between debounce ticks.
+  let searchValue = $state('');
+  let searchTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // Drawer / dialogs.
+  let drawerOpen = $state(false);
+  let drawerRecipe = $state<RecipeListItemDto | null>(null);
+  let importOpen = $state(false);
+  let deleteOpen = $state(false);
+  let deleteTarget = $state<RecipeListItemDto | null>(null);
+
+  async function load(): Promise<void> {
+    await store.load();
+  }
+
+  function onSearchInput(value: string): void {
+    searchValue = value;
+    if (searchTimer) clearTimeout(searchTimer);
+    searchTimer = setTimeout(() => void store.search(searchValue), 300);
+  }
+
+  async function onSelectHousehold(id: number | null): Promise<void> {
+    searchValue = '';
+    closeDrawer();
+    await store.setConnected(id);
+  }
+
+  function openDrawer(recipe: RecipeListItemDto): void {
+    drawerRecipe = recipe;
+    drawerOpen = true;
+  }
+
+  function closeDrawer(): void {
+    drawerOpen = false;
+    // Keep drawerRecipe so the panel content doesn't flash during the close slide.
+  }
+
+  function handleEdit(recipeId: number): void {
+    window.location.assign(`/recipes/edit/${recipeId}`);
+  }
+
+  function handleAddRecipe(): void {
+    window.location.assign('/recipes/new');
+  }
+
+  function handleAddToMealPlan(name: string): void {
+    showToast({ message: `Add '${name}' to meal plan — feature in development.`, kind: 'info' });
+  }
+
+  async function handleCopy(recipeId: number): Promise<void> {
+    if (store.selectedConnectedId == null) return;
+    try {
+      await copyConnectedRecipe(store.selectedConnectedId, recipeId);
+      showToast({ message: "Recipe copied! It's now in your collection.", kind: 'success' });
+    } catch {
+      showToast({ message: "Couldn't copy that recipe right now.", kind: 'error' });
+    }
+  }
+
+  function requestDelete(recipe: RecipeListItemDto): void {
+    deleteTarget = recipe;
+    deleteOpen = true;
+  }
+
+  async function confirmDelete(): Promise<void> {
+    const target = deleteTarget;
+    deleteOpen = false;
+    deleteTarget = null;
+    if (!target) return;
+    closeDrawer();
+    await store.deleteRecipe(target.recipeId);
+  }
+
+  function onImported(recipeId: number): void {
+    window.location.assign(`/recipes/edit/${recipeId}`);
+  }
+
+  // Empty-state copy mirrors Recipes.razor:120-195.
+  let emptyTitle = $derived(
+    store.isViewingConnected
+      ? 'No shared recipes'
+      : store.showFavoritesOnly
+        ? 'No favorites yet'
+        : 'No recipes yet',
+  );
+  let emptyHint = $derived(
+    store.isViewingConnected
+      ? store.query.trim()
+        ? `No recipes found matching "${store.query}"`
+        : "This family hasn't added any recipes yet"
+      : store.showFavoritesOnly
+        ? 'Tap the heart on a recipe to add it to your favorites'
+        : store.query.trim()
+          ? `No recipes found matching "${store.query}"`
+          : 'Start building your family recipe collection',
+  );
+
+  $effect(() => {
+    untrack(() => {
+      store.init(ctx);
+      store.setRefresh(load);
+      load(); // reads then writes store $state — MUST be inside untrack
+      store.loadConnections();
+      // Liveness: ~20s poll while visible + immediate refetch on refocus.
+      liveness = startLiveness(() => store.reconcile());
+    });
+
+    return () => {
+      liveness?.stop();
+      liveness = null;
+      if (searchTimer) clearTimeout(searchTimer);
+      searchTimer = null;
+    };
+  });
+</script>
+
+<div class="rc-container">
+  <header class="rc-header">
+    <h1 class="rc-title">Recipes</h1>
+    {#if !store.isViewingConnected}
+      <div class="rc-header-actions">
+        <button type="button" class="rc-btn-outline" onclick={() => (importOpen = true)}>
+          Import from URL
+        </button>
+        <button type="button" class="rc-btn-solid" onclick={handleAddRecipe}>Add Recipe</button>
+      </div>
+    {/if}
+  </header>
+
+  {#if store.connections.length > 0}
+    <ConnectedHouseholdSelector
+      connections={store.connections}
+      selectedId={store.selectedConnectedId}
+      onSelect={onSelectHousehold}
+    />
+  {/if}
+
+  <div class="rc-controls">
+    <input
+      type="search"
+      class="rc-search"
+      placeholder="Search by name, ingredients, or type"
+      value={searchValue}
+      oninput={(e) => onSearchInput(e.currentTarget.value)}
+    />
+    {#if !store.isViewingConnected}
+      <button
+        type="button"
+        class="rc-fav-chip"
+        class:rc-fav-chip-on={store.showFavoritesOnly}
+        aria-pressed={store.showFavoritesOnly}
+        onclick={() => store.toggleFavoritesFilter()}
+      >
+        {store.showFavoritesOnly ? '♥' : '♡'} Favorites
+      </button>
+    {/if}
+  </div>
+
+  {#if store.error}
+    <div class="rc-inline-error" role="alert">
+      <span>{store.error}</span>
+      <button type="button" class="rc-retry" onclick={load}>Retry</button>
+    </div>
+  {/if}
+
+  {#if store.loading}
+    <div class="rc-grid">
+      {#each Array(6) as _, i (i)}
+        <div class="rc-skeleton"></div>
+      {/each}
+    </div>
+  {:else if store.displayed.length === 0}
+    <div class="rc-empty">
+      <h2 class="rc-empty-title">{emptyTitle}</h2>
+      <p class="rc-empty-hint">{emptyHint}</p>
+      {#if !store.isViewingConnected && !store.showFavoritesOnly && !store.query.trim()}
+        <button type="button" class="rc-btn-solid" onclick={handleAddRecipe}>Add Your First Recipe</button>
+      {/if}
+    </div>
+  {:else}
+    <div class="rc-grid">
+      {#each store.displayed as recipe (recipe.recipeId)}
+        <RecipeCard
+          {recipe}
+          isFavorite={!store.isViewingConnected && store.favoriteIds.has(recipe.recipeId)}
+          isReadOnly={store.isViewingConnected}
+          sharedFromName={store.isViewingConnected ? store.selectedConnectedName : null}
+          onClick={openDrawer}
+          onToggleFavorite={(r) => store.toggleFavorite(r.recipeId)}
+        />
+      {/each}
+    </div>
+  {/if}
+</div>
+
+<RecipeDetailDrawer
+  open={drawerOpen}
+  summary={drawerRecipe}
+  connectedId={store.selectedConnectedId}
+  isReadOnly={store.isViewingConnected}
+  connectedName={store.selectedConnectedName}
+  onClose={closeDrawer}
+  onEdit={handleEdit}
+  onDelete={requestDelete}
+  onCopy={handleCopy}
+  onAddToMealPlan={handleAddToMealPlan}
+/>
+
+<ImportDialog open={importOpen} onClose={() => (importOpen = false)} {onImported} />
+
+<ConfirmDialog
+  open={deleteOpen}
+  title="Delete Recipe"
+  message={deleteTarget
+    ? `Are you sure you want to delete "${deleteTarget.name}"? This action cannot be undone.`
+    : ''}
+  onCancel={() => {
+    deleteOpen = false;
+    deleteTarget = null;
+  }}
+  onConfirm={confirmDelete}
+/>
+
+<Toasts />
+
+<style>
+  .rc-container {
+    max-width: 1280px;
+    margin: 0 auto;
+    padding: 24px 16px 96px;
+  }
+  .rc-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-bottom: 16px;
+  }
+  .rc-title {
+    margin: 0;
+    font-size: 2.125rem;
+    font-weight: 400;
+    color: var(--color-text);
+  }
+  .rc-header-actions {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .rc-controls {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    flex-wrap: wrap;
+    margin-bottom: 16px;
+  }
+  .rc-search {
+    flex: 1;
+    min-width: 200px;
+    font: inherit;
+    padding: 10px 14px;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text);
+  }
+  .rc-search:focus {
+    outline: none;
+    border-color: var(--color-primary);
+  }
+  .rc-fav-chip {
+    font: inherit;
+    font-size: 0.8125rem;
+    padding: 8px 16px;
+    border-radius: 18px;
+    border: 1px solid var(--color-line-strong);
+    background: transparent;
+    color: var(--color-text);
+    cursor: pointer;
+  }
+  .rc-fav-chip:hover {
+    background: var(--color-action-hover);
+  }
+  .rc-fav-chip-on {
+    background: var(--color-error);
+    border-color: var(--color-error);
+    color: #fff;
+  }
+  .rc-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 16px;
+    align-items: stretch;
+  }
+  .rc-skeleton {
+    height: 320px;
+    border-radius: var(--radius-md);
+    background: linear-gradient(
+      90deg,
+      var(--color-action-hover) 25%,
+      var(--color-divider) 37%,
+      var(--color-action-hover) 63%
+    );
+    background-size: 400% 100%;
+    animation: rc-shimmer 1.4s ease infinite;
+  }
+  @keyframes rc-shimmer {
+    0% {
+      background-position: 100% 50%;
+    }
+    100% {
+      background-position: 0 50%;
+    }
+  }
+  .rc-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    min-height: 360px;
+    gap: 8px;
+  }
+  .rc-empty-title {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 400;
+  }
+  .rc-empty-hint {
+    margin: 0 0 12px;
+    color: var(--color-text-muted);
+  }
+  .rc-inline-error {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 16px;
+    margin-bottom: 16px;
+    background: rgba(229, 57, 53, 0.08);
+    border-left: 4px solid var(--color-error);
+    border-radius: var(--radius-sm);
+    color: var(--color-error);
+    font-size: 0.875rem;
+  }
+  .rc-retry {
+    font: inherit;
+    border: none;
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+    padding: 4px 12px;
+    background: transparent;
+    color: var(--color-error);
+    font-weight: 500;
+  }
+  .rc-retry:hover {
+    background: rgba(229, 57, 53, 0.12);
+  }
+  .rc-btn-solid,
+  .rc-btn-outline {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    min-height: 40px;
+    font-weight: 500;
+  }
+  .rc-btn-solid {
+    border: none;
+    background: var(--color-primary);
+    color: #fff;
+  }
+  .rc-btn-solid:hover {
+    background: var(--color-primary-hover);
+  }
+  .rc-btn-outline {
+    border: 1px solid var(--color-secondary);
+    background: transparent;
+    color: var(--color-secondary);
+  }
+  .rc-btn-outline:hover {
+    background: var(--color-action-hover);
+  }
+</style>

--- a/frontend/recipes/src/lib/api.ts
+++ b/frontend/recipes/src/lib/api.ts
@@ -1,0 +1,187 @@
+import type {
+  RecipeListDto,
+  RecipeFullDto,
+  RecipeWriteRequest,
+  ParsedIngredientDto,
+  CategoryDto,
+  ConnectedHouseholdDto,
+  RecipeImportResultDto,
+  RecipeDraftData,
+  SaveDraftRequest,
+} from './types';
+
+const BASE = '/api/recipes';
+
+/**
+ * Thrown on any non-2xx response. `status` lets callers react to a rejection.
+ *
+ * ⚠ Carried from chores/shopping-list/meal-plan: the app re-executes empty-body
+ * API 404s through a Blazor `/not-found` page, so a server-side "not found" can
+ * arrive on the wire as an empty **400** (a bare DELETE 404 even surfaces as
+ * 405). Every recipes endpoint therefore returns a NON-EMPTY body on not-found,
+ * and the island treats ANY 4xx as a non-retryable client rejection → reconcile
+ * (refetch the list) + a calm toast. There is no retry branch (versionless).
+ */
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+
+  /** A non-retryable client rejection (validation / not found, incl. the empty-400 quirk). Any 4xx. */
+  get isClientRejection(): boolean {
+    return this.status >= 400 && this.status < 500;
+  }
+}
+
+async function request<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    // Same-origin cookie auth — the host page is already authenticated.
+    credentials: 'include',
+    headers: { Accept: 'application/json', ...(init?.headers ?? {}) },
+    ...init,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new ApiError(res.status, text || res.statusText);
+  }
+  // 204 No-Content (delete, save-draft, and the "no draft" GET) ⇒ undefined.
+  if (res.status === 204) return undefined as T;
+  return (await res.json()) as T;
+}
+
+function jsonBody(body: unknown): RequestInit {
+  return {
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  };
+}
+
+// ─── List + detail ────────────────────────────────────────────────────────
+
+/** #1 Own household's recipe grid + this user's favorite ids. Empty `q` ⇒ all. */
+export async function listRecipes(q: string): Promise<RecipeListDto> {
+  return request<RecipeListDto>(`${BASE}?q=${encodeURIComponent(q)}`);
+}
+
+/** #2 Full recipe (read drawer + edit load — superset). 404 → ApiError. */
+export async function getRecipe(recipeId: number): Promise<RecipeFullDto> {
+  return request<RecipeFullDto>(`${BASE}/${recipeId}`);
+}
+
+/** #3 Create → the saved recipe (201). */
+export async function createRecipe(body: RecipeWriteRequest): Promise<RecipeFullDto> {
+  return request<RecipeFullDto>(`${BASE}`, { method: 'POST', ...jsonBody(body) });
+}
+
+/** #4 Update (replaces ingredients wholesale) → the re-fetched recipe. */
+export async function updateRecipe(recipeId: number, body: RecipeWriteRequest): Promise<RecipeFullDto> {
+  return request<RecipeFullDto>(`${BASE}/${recipeId}`, { method: 'PUT', ...jsonBody(body) });
+}
+
+/** #5 Soft-delete → 204. A missing recipe → 404/empty-400. */
+export async function deleteRecipe(recipeId: number): Promise<void> {
+  await request<void>(`${BASE}/${recipeId}`, { method: 'DELETE' });
+}
+
+/** #6 Toggle favorite → the new state. */
+export async function toggleFavorite(recipeId: number): Promise<{ isFavorite: boolean }> {
+  return request<{ isFavorite: boolean }>(`${BASE}/${recipeId}/favorite`, { method: 'POST' });
+}
+
+// ─── Ingredient entry helpers ───────────────────────────────────────────────
+
+/** #7 Ingredient-name autocomplete. `<2` chars ⇒ [] (server guards). */
+export async function ingredientSuggestions(prefix: string): Promise<string[]> {
+  return request<string[]>(`${BASE}/ingredient-suggestions?prefix=${encodeURIComponent(prefix)}`);
+}
+
+/** #8 Server NL-parse one ingredient line (parse-on-blur). Empty text → 400. */
+export async function parseIngredient(text: string): Promise<ParsedIngredientDto> {
+  return request<ParsedIngredientDto>(`${BASE}/parse-ingredient`, { method: 'POST', ...jsonBody({ text }) });
+}
+
+/** #9 Bulk-paste preview — parse each non-blank line in one round-trip. */
+export async function parseIngredients(lines: string[]): Promise<ParsedIngredientDto[]> {
+  return request<ParsedIngredientDto[]>(`${BASE}/parse-ingredients`, { method: 'POST', ...jsonBody({ lines }) });
+}
+
+/** #10 Household categories for the entry category select. */
+export async function getCategories(): Promise<CategoryDto[]> {
+  return request<CategoryDto[]>(`${BASE}/categories`);
+}
+
+// ─── Images ─────────────────────────────────────────────────────────────────
+
+/**
+ * #11 Multipart upload → the stored path. NOT JSON — send FormData and let the
+ * browser set the multipart boundary (do not set Content-Type). 10 MB +
+ * jpg/png/gif/webp validated server-side (else 400).
+ */
+export async function uploadImage(file: File): Promise<{ imagePath: string }> {
+  const form = new FormData();
+  form.append('file', file);
+  return request<{ imagePath: string }>(`${BASE}/images`, { method: 'POST', body: form });
+}
+
+/** #12 Household image paths for the picker grid. */
+export async function listImages(): Promise<string[]> {
+  return request<string[]>(`${BASE}/images`);
+}
+
+// ─── Import ─────────────────────────────────────────────────────────────────
+
+/**
+ * #13 Scrape→create. On success returns the SAVED recipe id (then nav to edit).
+ * On a duplicate returns existingRecipeId/Name (unless `force`). On failure,
+ * errorType + partialData for the "Add Manually" fallback. May take ≤60s (Polly)
+ * — do NOT add a shorter client timeout.
+ */
+export async function importRecipe(url: string, force = false): Promise<RecipeImportResultDto> {
+  return request<RecipeImportResultDto>(`${BASE}/import`, { method: 'POST', ...jsonBody({ url, force }) });
+}
+
+// ─── Connected households ─────────────────────────────────────────────────────
+
+/** #14 Connected households for the selector. */
+export async function getConnections(): Promise<ConnectedHouseholdDto[]> {
+  return request<ConnectedHouseholdDto[]>(`${BASE}/connections`);
+}
+
+/** #15 A connected household's shared recipes (read-only; favoriteRecipeIds always []). 403 if not connected. */
+export async function listConnectedRecipes(chId: number, q: string): Promise<RecipeListDto> {
+  return request<RecipeListDto>(`${BASE}/connected/${chId}?q=${encodeURIComponent(q)}`);
+}
+
+/** #16 Read-only detail of a connected recipe (author stripped). 403 if not connected. */
+export async function getConnectedRecipe(chId: number, recipeId: number): Promise<RecipeFullDto> {
+  return request<RecipeFullDto>(`${BASE}/connected/${chId}/${recipeId}`);
+}
+
+/** #17 Copy a connected recipe into my household → the new recipe id (201). */
+export async function copyConnectedRecipe(chId: number, recipeId: number): Promise<{ recipeId: number }> {
+  return request<{ recipeId: number }>(`${BASE}/connected/${chId}/${recipeId}/copy`, { method: 'POST' });
+}
+
+// ─── Drafts (autosave) ────────────────────────────────────────────────────────
+
+/** #18 Load a draft. `recipeId` omitted ⇒ the new-recipe draft. 204 (no draft) ⇒ null. */
+export async function getDraft(recipeId?: number | null): Promise<RecipeDraftData | null> {
+  const qs = recipeId != null ? `?recipeId=${recipeId}` : '';
+  const draft = await request<RecipeDraftData | undefined>(`${BASE}/draft${qs}`);
+  return draft ?? null;
+}
+
+/** #19 Save a draft (flat body: recipeId + draft fields) → 204. */
+export async function saveDraft(body: SaveDraftRequest): Promise<void> {
+  await request<void>(`${BASE}/draft`, { method: 'PUT', ...jsonBody(body) });
+}
+
+/** #20 Delete a draft → 204 (idempotent). `recipeId` omitted ⇒ the new-recipe draft. */
+export async function deleteDraft(recipeId?: number | null): Promise<void> {
+  const qs = recipeId != null ? `?recipeId=${recipeId}` : '';
+  await request<void>(`${BASE}/draft${qs}`, { method: 'DELETE' });
+}

--- a/frontend/recipes/src/lib/avatar.ts
+++ b/frontend/recipes/src/lib/avatar.ts
@@ -1,0 +1,9 @@
+// Initials fallback for an author avatar when there's no picture URL. The server
+// sends only createdByName + createdByPictureUrl (User has no color field), so the
+// island derives initials client-side (mirrors User.Initials: first + last word).
+export function initials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return '?';
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}

--- a/frontend/recipes/src/lib/components/BasicInfoSection.svelte
+++ b/frontend/recipes/src/lib/components/BasicInfoSection.svelte
@@ -1,0 +1,191 @@
+<script lang="ts">
+  // Basic-info form section (mirrors RecipeEdit.razor:73-131): name (required),
+  // description, prep/cook/servings, source URL, and the recipe-type select.
+  // Also shows the "Imported from {domain}" notice for an edited imported recipe.
+  import { recipeEditStore } from '../recipeEditStore.svelte';
+  import { RECIPE_TYPES, recipeTypeLabel } from '../recipeType';
+
+  const store = recipeEditStore;
+
+  function domainOf(url: string): string {
+    try {
+      return new URL(url).host.replace(/^www\./, '');
+    } catch {
+      return url;
+    }
+  }
+
+  function isSafeUrl(url: string): boolean {
+    try {
+      const u = new URL(url);
+      return u.protocol === 'http:' || u.protocol === 'https:';
+    } catch {
+      return false;
+    }
+  }
+</script>
+
+<section class="rc-paper">
+  {#if store.isEdit && store.form.sourceUrl.trim()}
+    <div class="rc-import-note">
+      <span aria-hidden="true">☁</span>
+      <span>
+        Imported from
+        {#if isSafeUrl(store.form.sourceUrl)}
+          <a href={store.form.sourceUrl} target="_blank" rel="noopener noreferrer"
+            >{domainOf(store.form.sourceUrl)}</a
+          >
+        {:else}
+          {domainOf(store.form.sourceUrl)}
+        {/if}
+      </span>
+    </div>
+  {/if}
+
+  <h2 class="rc-section-title">Basic Info</h2>
+
+  <label class="rc-field">
+    <span class="rc-field-label">Recipe Name <span class="rc-req">*</span></span>
+    <input
+      type="text"
+      class="rc-input"
+      bind:value={store.form.name}
+      oninput={() => store.onEdit()}
+      required
+    />
+  </label>
+
+  <label class="rc-field">
+    <span class="rc-field-label">Description</span>
+    <textarea
+      class="rc-input rc-textarea"
+      rows="2"
+      bind:value={store.form.description}
+      oninput={() => store.onEdit()}
+      placeholder="Brief introduction to the recipe"
+    ></textarea>
+  </label>
+
+  <div class="rc-row3">
+    <label class="rc-field">
+      <span class="rc-field-label">Prep Time (min)</span>
+      <input
+        type="number"
+        class="rc-input"
+        min="0"
+        bind:value={store.form.prepTimeMinutes}
+        oninput={() => store.onEdit()}
+      />
+    </label>
+    <label class="rc-field">
+      <span class="rc-field-label">Cook Time (min)</span>
+      <input
+        type="number"
+        class="rc-input"
+        min="0"
+        bind:value={store.form.cookTimeMinutes}
+        oninput={() => store.onEdit()}
+      />
+    </label>
+    <label class="rc-field">
+      <span class="rc-field-label">Servings</span>
+      <input
+        type="number"
+        class="rc-input"
+        min="1"
+        bind:value={store.form.servings}
+        oninput={() => store.onEdit()}
+      />
+    </label>
+  </div>
+
+  <label class="rc-field">
+    <span class="rc-field-label">Source URL (optional)</span>
+    <input
+      type="url"
+      class="rc-input"
+      bind:value={store.form.sourceUrl}
+      oninput={() => store.onEdit()}
+      placeholder="Link to original recipe"
+    />
+  </label>
+
+  <label class="rc-field">
+    <span class="rc-field-label">Recipe Type</span>
+    <select class="rc-input" bind:value={store.form.recipeType} onchange={() => store.onEdit()}>
+      {#each RECIPE_TYPES as type (type)}
+        <option value={type}>{recipeTypeLabel(type)}</option>
+      {/each}
+    </select>
+  </label>
+</section>
+
+<style>
+  .rc-paper {
+    background: var(--color-surface);
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-1);
+    padding: 16px;
+    margin-bottom: 16px;
+  }
+  .rc-section-title {
+    margin: 0 0 12px;
+    font-size: 1.125rem;
+    font-weight: 500;
+  }
+  .rc-import-note {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 14px;
+    margin-bottom: 16px;
+    border-radius: var(--radius-sm);
+    background: rgba(30, 136, 229, 0.08);
+    border-left: 4px solid var(--color-info);
+    font-size: 0.875rem;
+  }
+  .rc-import-note a {
+    color: var(--color-info);
+  }
+  .rc-field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-bottom: 12px;
+  }
+  .rc-field-label {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .rc-req {
+    color: var(--color-error);
+  }
+  .rc-input {
+    font: inherit;
+    padding: 10px 12px;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text);
+    width: 100%;
+  }
+  .rc-input:focus {
+    outline: none;
+    border-color: var(--color-primary);
+  }
+  .rc-textarea {
+    resize: vertical;
+    min-height: 60px;
+  }
+  .rc-row3 {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 12px;
+  }
+  @media (max-width: 600px) {
+    .rc-row3 {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/frontend/recipes/src/lib/components/BulkPasteDialog.svelte
+++ b/frontend/recipes/src/lib/components/BulkPasteDialog.svelte
@@ -1,0 +1,309 @@
+<script lang="ts">
+  // Bulk-paste dialog (mirrors BulkPasteDialog.razor): a multi-line textarea →
+  // POST /parse-ingredients (one round-trip) → a preview list (qty/unit/name/notes
+  // + an incomplete-parse warning) → import all into the edit form.
+  import type { NewIngredientInput } from '../recipeEditStore.svelte';
+  import type { ParsedIngredientDto } from '../types';
+  import { parseIngredients } from '../api';
+
+  interface Props {
+    open: boolean;
+    categories: string[];
+    onClose: () => void;
+    onImport: (rows: NewIngredientInput[]) => void;
+  }
+
+  let { open, categories, onClose, onImport }: Props = $props();
+
+  let dialogEl: HTMLDialogElement | null = $state(null);
+  let pastedText = $state('');
+  let parsed = $state<ParsedIngredientDto[]>([]);
+  let parsing = $state(false);
+  let parseTimer: ReturnType<typeof setTimeout> | null = null;
+
+  $effect(() => {
+    if (!dialogEl) return;
+    if (open && !dialogEl.open) dialogEl.showModal();
+    else if (!open && dialogEl.open) dialogEl.close();
+  });
+
+  function findCategory(suggested: string): string {
+    const match = categories.find((c) => c.toLowerCase() === suggested.toLowerCase());
+    return match ?? categories[0] ?? 'Pantry';
+  }
+
+  function onText(value: string): void {
+    pastedText = value;
+    if (parseTimer) clearTimeout(parseTimer);
+    const lines = value
+      .split(/\r?\n/)
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0);
+    if (lines.length === 0) {
+      parsed = [];
+      return;
+    }
+    parseTimer = setTimeout(async () => {
+      parsing = true;
+      try {
+        parsed = await parseIngredients(lines);
+      } catch {
+        parsed = [];
+      } finally {
+        parsing = false;
+      }
+    }, 300);
+  }
+
+  function removeRow(index: number): void {
+    parsed = parsed.filter((_, i) => i !== index);
+  }
+
+  function reset(): void {
+    pastedText = '';
+    parsed = [];
+    parsing = false;
+  }
+
+  function handleClose(): void {
+    reset();
+    onClose();
+  }
+
+  function importAll(): void {
+    const rows: NewIngredientInput[] = parsed.map((p) => ({
+      name: p.name,
+      quantity: p.quantity,
+      unit: p.unit,
+      category: findCategory(p.suggestedCategory),
+      notes: p.notes,
+    }));
+    onImport(rows);
+    reset();
+    onClose();
+  }
+</script>
+
+<dialog bind:this={dialogEl} onclose={handleClose} class="rc-dialog">
+  {#if open}
+    <header class="rc-dialog-head">
+      <h2>Bulk Paste Ingredients</h2>
+      <button type="button" class="rc-dialog-x" aria-label="Close" onclick={handleClose}>×</button>
+    </header>
+
+    <div class="rc-dialog-body">
+      <p class="rc-bulk-intro">
+        Paste multiple ingredients (one per line). Each line is parsed into structured fields.
+      </p>
+      <textarea
+        class="rc-input rc-bulk-textarea"
+        rows="8"
+        placeholder="2 cups flour&#10;1/2 lb chicken, boneless&#10;3 cloves garlic, minced"
+        value={pastedText}
+        oninput={(e) => onText(e.currentTarget.value)}
+      ></textarea>
+
+      {#if parsing}
+        <p class="rc-bulk-status">Parsing…</p>
+      {:else if parsed.length > 0}
+        <p class="rc-bulk-status">Parsed Ingredients ({parsed.length})</p>
+        <div class="rc-bulk-list">
+          {#each parsed as p, i (i)}
+            <div class="rc-bulk-row">
+              <div class="rc-bulk-row-head">
+                <span class="rc-bulk-name">{p.name}</span>
+                <button type="button" class="rc-bulk-del" aria-label="Remove" onclick={() => removeRow(i)}
+                  >×</button
+                >
+              </div>
+              <div class="rc-bulk-fields">
+                <span><strong>Qty:</strong> {p.quantity ?? '—'}</span>
+                <span><strong>Unit:</strong> {p.unit ?? '—'}</span>
+              </div>
+              {#if p.notes}
+                <div class="rc-bulk-note"><strong>Notes:</strong> {p.notes}</div>
+              {/if}
+              {#if !p.isComplete}
+                <div class="rc-bulk-warn">Incomplete parse — review and edit after import.</div>
+              {/if}
+            </div>
+          {/each}
+        </div>
+      {/if}
+    </div>
+
+    <footer class="rc-dialog-actions">
+      <button type="button" class="rc-btn-ghost" onclick={handleClose}>Cancel</button>
+      <button type="button" class="rc-btn-solid" onclick={importAll} disabled={parsed.length === 0}>
+        Import {parsed.length} Ingredient{parsed.length !== 1 ? 's' : ''}
+      </button>
+    </footer>
+  {/if}
+</dialog>
+
+<style>
+  .rc-dialog[open] {
+    position: fixed;
+    inset: 0;
+    margin: auto;
+    border: none;
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text);
+    padding: 0;
+    width: min(600px, calc(100vw - 32px));
+    max-height: calc(100vh - 32px);
+    box-shadow: var(--shadow-4);
+    display: flex;
+    flex-direction: column;
+  }
+  .rc-dialog::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+  }
+  .rc-dialog-head {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 16px 16px 12px 24px;
+    border-bottom: 1px solid var(--color-line);
+  }
+  .rc-dialog-head h2 {
+    margin: 0;
+    flex: 1;
+    font-size: 1.25rem;
+    font-weight: 500;
+  }
+  .rc-dialog-x {
+    flex-shrink: 0;
+    width: 36px;
+    height: 36px;
+    display: grid;
+    place-items: center;
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
+    border-radius: var(--radius-sm);
+    font-size: 1.4rem;
+    line-height: 1;
+    cursor: pointer;
+  }
+  .rc-dialog-x:hover {
+    background: var(--color-action-hover);
+    color: var(--color-text);
+  }
+  .rc-dialog-body {
+    overflow-y: auto;
+    padding: 16px 24px;
+    flex: 1;
+  }
+  .rc-bulk-intro {
+    margin: 0 0 12px;
+    font-size: 0.9375rem;
+  }
+  .rc-input {
+    font: inherit;
+    padding: 10px 12px;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text);
+    width: 100%;
+  }
+  .rc-input:focus {
+    outline: none;
+    border-color: var(--color-primary);
+  }
+  .rc-bulk-textarea {
+    resize: vertical;
+    min-height: 140px;
+  }
+  .rc-bulk-status {
+    margin: 16px 0 8px;
+    font-size: 0.875rem;
+    font-weight: 500;
+  }
+  .rc-bulk-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    max-height: 360px;
+    overflow-y: auto;
+  }
+  .rc-bulk-row {
+    padding: 8px 12px;
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-sm);
+    background: var(--color-background);
+  }
+  .rc-bulk-row-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+  }
+  .rc-bulk-name {
+    font-weight: 500;
+  }
+  .rc-bulk-del {
+    border: none;
+    background: transparent;
+    color: var(--color-error);
+    font-size: 1.2rem;
+    line-height: 1;
+    cursor: pointer;
+  }
+  .rc-bulk-fields {
+    display: flex;
+    gap: 16px;
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+    margin-top: 4px;
+  }
+  .rc-bulk-note {
+    font-size: 0.8125rem;
+    margin-top: 4px;
+  }
+  .rc-bulk-warn {
+    margin-top: 6px;
+    padding: 6px 10px;
+    border-radius: var(--radius-sm);
+    background: rgba(251, 140, 0, 0.12);
+    color: var(--color-warning);
+    font-size: 0.8125rem;
+  }
+  .rc-dialog-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 12px 24px calc(16px + env(safe-area-inset-bottom, 0px));
+    border-top: 1px solid var(--color-line);
+  }
+  .rc-btn-ghost,
+  .rc-btn-solid {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    border: none;
+    cursor: pointer;
+    min-height: 44px;
+    font-weight: 500;
+  }
+  .rc-btn-ghost {
+    background: transparent;
+    color: var(--color-text-muted);
+  }
+  .rc-btn-ghost:hover {
+    background: var(--color-action-hover);
+  }
+  .rc-btn-solid {
+    background: var(--color-primary);
+    color: #fff;
+  }
+  .rc-btn-solid:hover:not(:disabled) {
+    background: var(--color-primary-hover);
+  }
+  .rc-btn-solid:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+</style>

--- a/frontend/recipes/src/lib/components/ConfirmDialog.svelte
+++ b/frontend/recipes/src/lib/components/ConfirmDialog.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+  // A tiny confirm dialog — replaces the Blazor delete-confirm MudDialog.
+  // Hosted in ListApp; opened with a message + a confirm callback.
+  interface Props {
+    open: boolean;
+    title: string;
+    message: string;
+    confirmLabel?: string;
+    cancelLabel?: string;
+    onCancel: () => void;
+    onConfirm: () => void;
+  }
+
+  let {
+    open,
+    title,
+    message,
+    confirmLabel = 'Delete',
+    cancelLabel = 'Cancel',
+    onCancel,
+    onConfirm,
+  }: Props = $props();
+
+  let dialogEl: HTMLDialogElement | null = $state(null);
+
+  $effect(() => {
+    if (!dialogEl) return;
+    if (open && !dialogEl.open) {
+      dialogEl.showModal();
+    } else if (!open && dialogEl.open) {
+      dialogEl.close();
+    }
+  });
+</script>
+
+<dialog bind:this={dialogEl} onclose={onCancel} class="rc-confirm">
+  {#if open}
+    <div class="rc-confirm-body">
+      <h2>{title}</h2>
+      <p class="rc-confirm-msg">{message}</p>
+      <div class="rc-confirm-actions">
+        <button type="button" class="rc-btn-ghost" onclick={onCancel}>{cancelLabel}</button>
+        <button type="button" class="rc-btn-danger" onclick={onConfirm}>{confirmLabel}</button>
+      </div>
+    </div>
+  {/if}
+</dialog>
+
+<style>
+  .rc-confirm[open] {
+    position: fixed;
+    inset: 0;
+    margin: auto;
+    border: none;
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text);
+    padding: 0;
+    width: min(400px, calc(100vw - 32px));
+    box-shadow: var(--shadow-4);
+  }
+  .rc-confirm::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+  }
+  .rc-confirm-body {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 24px;
+  }
+  .rc-confirm h2 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 500;
+  }
+  .rc-confirm-msg {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+  .rc-confirm-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 8px;
+  }
+  .rc-btn-ghost,
+  .rc-btn-danger {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    border: none;
+    cursor: pointer;
+    min-height: 40px;
+    font-weight: 500;
+  }
+  .rc-btn-ghost {
+    background: transparent;
+    color: var(--color-text-muted);
+  }
+  .rc-btn-ghost:hover {
+    background: var(--color-action-hover);
+  }
+  .rc-btn-danger {
+    background: var(--color-error);
+    color: #fff;
+  }
+  .rc-btn-danger:hover {
+    filter: brightness(0.95);
+  }
+</style>

--- a/frontend/recipes/src/lib/components/ConnectedHouseholdSelector.svelte
+++ b/frontend/recipes/src/lib/components/ConnectedHouseholdSelector.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+  // "My Recipes" + a chip per connected household + a "manage connections" link.
+  // Mirrors Recipes.razor:55-79. Shown only when connections exist.
+  import type { ConnectedHouseholdDto } from '../types';
+
+  interface Props {
+    connections: ConnectedHouseholdDto[];
+    selectedId: number | null;
+    onSelect: (id: number | null) => void;
+  }
+
+  let { connections, selectedId, onSelect }: Props = $props();
+</script>
+
+<div class="rc-selector">
+  <button
+    type="button"
+    class="rc-chip"
+    class:rc-chip-active={selectedId == null}
+    onclick={() => onSelect(null)}
+  >
+    My Recipes
+  </button>
+  {#each connections as hh (hh.householdId)}
+    <button
+      type="button"
+      class="rc-chip"
+      class:rc-chip-active={selectedId === hh.householdId}
+      onclick={() => onSelect(hh.householdId)}
+    >
+      {hh.householdName}
+    </button>
+  {/each}
+  <a
+    class="rc-manage"
+    href="/settings/connections"
+    title="Manage family connections"
+    aria-label="Manage family connections">＋</a
+  >
+</div>
+
+<style>
+  .rc-selector {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-bottom: 16px;
+  }
+  .rc-chip {
+    font: inherit;
+    font-size: 0.8125rem;
+    padding: 6px 14px;
+    border-radius: 16px;
+    border: 1px solid var(--color-line-strong);
+    background: transparent;
+    color: var(--color-text);
+    cursor: pointer;
+  }
+  .rc-chip:hover {
+    background: var(--color-action-hover);
+  }
+  .rc-chip-active {
+    background: var(--color-primary);
+    border-color: var(--color-primary);
+    color: #fff;
+  }
+  .rc-chip-active:hover {
+    background: var(--color-primary-hover);
+  }
+  .rc-manage {
+    display: grid;
+    place-items: center;
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    color: var(--color-primary);
+    text-decoration: none;
+    font-size: 1.1rem;
+    line-height: 1;
+  }
+  .rc-manage:hover {
+    background: var(--color-action-hover);
+  }
+</style>

--- a/frontend/recipes/src/lib/components/ImagePickerDialog.svelte
+++ b/frontend/recipes/src/lib/components/ImagePickerDialog.svelte
@@ -1,0 +1,248 @@
+<script lang="ts">
+  // Household image picker (mirrors ImagePickerDialog.razor): a grid of the
+  // household's uploaded images (GET /images), click to select, confirm to apply.
+  import { listImages, ApiError } from '../api';
+
+  interface Props {
+    open: boolean;
+    currentImage: string | null;
+    onClose: () => void;
+    onSelect: (path: string) => void;
+  }
+
+  let { open, currentImage, onClose, onSelect }: Props = $props();
+
+  let dialogEl: HTMLDialogElement | null = $state(null);
+  let images = $state<string[]>([]);
+  let loading = $state(false);
+  let error = $state<string | null>(null);
+  let selected = $state<string | null>(null);
+  // Re-fetch once per open (the grid can change between opens).
+  let loadedWhileOpen = false;
+
+  $effect(() => {
+    if (!dialogEl) return;
+    if (open && !dialogEl.open) {
+      dialogEl.showModal();
+      if (!loadedWhileOpen) {
+        loadedWhileOpen = true;
+        selected = currentImage;
+        void load();
+      }
+    } else if (!open && dialogEl.open) {
+      dialogEl.close();
+    }
+    if (!open) loadedWhileOpen = false;
+  });
+
+  async function load(): Promise<void> {
+    loading = true;
+    error = null;
+    try {
+      images = await listImages();
+    } catch (e) {
+      error = e instanceof ApiError ? `Couldn't load images (HTTP ${e.status}).` : "Couldn't load images.";
+    } finally {
+      loading = false;
+    }
+  }
+
+  function toggle(image: string): void {
+    selected = selected === image ? null : image;
+  }
+
+  function confirm(): void {
+    if (selected) {
+      onSelect(selected);
+      onClose();
+    }
+  }
+</script>
+
+<dialog bind:this={dialogEl} onclose={onClose} class="rc-dialog">
+  {#if open}
+    <header class="rc-dialog-head">
+      <h2>Select Image</h2>
+      <button type="button" class="rc-dialog-x" aria-label="Close" onclick={onClose}>×</button>
+    </header>
+
+    <div class="rc-dialog-body">
+      {#if loading}
+        <div class="rc-picker-status">Loading images…</div>
+      {:else if error}
+        <div class="rc-picker-error" role="alert">{error}</div>
+      {:else if images.length === 0}
+        <div class="rc-picker-status">No images found. Upload an image first using the file picker.</div>
+      {:else}
+        <p class="rc-picker-intro">Click an image to select it. These are all images uploaded for your household.</p>
+        <div class="rc-picker-grid">
+          {#each images as image (image)}
+            <button
+              type="button"
+              class="rc-picker-item"
+              class:rc-picker-selected={selected === image}
+              onclick={() => toggle(image)}
+              aria-pressed={selected === image}
+            >
+              <img src={image} alt="Recipe option" />
+              {#if selected === image}
+                <span class="rc-picker-check" aria-hidden="true">✓</span>
+              {/if}
+            </button>
+          {/each}
+        </div>
+      {/if}
+    </div>
+
+    <footer class="rc-dialog-actions">
+      <button type="button" class="rc-btn-ghost" onclick={onClose}>Cancel</button>
+      <button type="button" class="rc-btn-solid" onclick={confirm} disabled={!selected}>Select Image</button>
+    </footer>
+  {/if}
+</dialog>
+
+<style>
+  .rc-dialog[open] {
+    position: fixed;
+    inset: 0;
+    margin: auto;
+    border: none;
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text);
+    padding: 0;
+    width: min(640px, calc(100vw - 32px));
+    max-height: calc(100vh - 32px);
+    box-shadow: var(--shadow-4);
+    display: flex;
+    flex-direction: column;
+  }
+  .rc-dialog::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+  }
+  .rc-dialog-head {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 16px 16px 12px 24px;
+    border-bottom: 1px solid var(--color-line);
+  }
+  .rc-dialog-head h2 {
+    margin: 0;
+    flex: 1;
+    font-size: 1.25rem;
+    font-weight: 500;
+  }
+  .rc-dialog-x {
+    flex-shrink: 0;
+    width: 36px;
+    height: 36px;
+    display: grid;
+    place-items: center;
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
+    border-radius: var(--radius-sm);
+    font-size: 1.4rem;
+    line-height: 1;
+    cursor: pointer;
+  }
+  .rc-dialog-x:hover {
+    background: var(--color-action-hover);
+    color: var(--color-text);
+  }
+  .rc-dialog-body {
+    overflow-y: auto;
+    padding: 16px 24px;
+    flex: 1;
+  }
+  .rc-picker-intro {
+    margin: 0 0 12px;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+  .rc-picker-status {
+    padding: 24px 0;
+    text-align: center;
+    color: var(--color-text-muted);
+  }
+  .rc-picker-error {
+    padding: 12px 16px;
+    border-left: 4px solid var(--color-error);
+    background: rgba(229, 57, 53, 0.08);
+    color: var(--color-error);
+    border-radius: var(--radius-sm);
+    font-size: 0.875rem;
+  }
+  .rc-picker-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 12px;
+  }
+  .rc-picker-item {
+    position: relative;
+    padding: 0;
+    aspect-ratio: 1;
+    border-radius: 8px;
+    overflow: hidden;
+    cursor: pointer;
+    border: 3px solid transparent;
+    background: var(--color-action-hover);
+  }
+  .rc-picker-item:hover {
+    border-color: var(--color-primary);
+  }
+  .rc-picker-selected {
+    border-color: var(--color-success);
+  }
+  .rc-picker-item img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+  .rc-picker-check {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    background: rgba(0, 0, 0, 0.3);
+    color: var(--color-success);
+    font-size: 2rem;
+  }
+  .rc-dialog-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 12px 24px calc(16px + env(safe-area-inset-bottom, 0px));
+    border-top: 1px solid var(--color-line);
+  }
+  .rc-btn-ghost,
+  .rc-btn-solid {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    border: none;
+    cursor: pointer;
+    min-height: 44px;
+    font-weight: 500;
+  }
+  .rc-btn-ghost {
+    background: transparent;
+    color: var(--color-text-muted);
+  }
+  .rc-btn-ghost:hover {
+    background: var(--color-action-hover);
+  }
+  .rc-btn-solid {
+    background: var(--color-primary);
+    color: #fff;
+  }
+  .rc-btn-solid:hover:not(:disabled) {
+    background: var(--color-primary-hover);
+  }
+  .rc-btn-solid:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+</style>

--- a/frontend/recipes/src/lib/components/ImageSection.svelte
+++ b/frontend/recipes/src/lib/components/ImageSection.svelte
@@ -1,0 +1,133 @@
+<script lang="ts">
+  // Image form section (mirrors RecipeEdit.razor:133-177): preview + remove,
+  // file upload (multipart via the store), and "Choose Existing" (opens the
+  // household image picker, hosted by EditApp).
+  import { recipeEditStore } from '../recipeEditStore.svelte';
+
+  interface Props {
+    onChooseExisting: () => void;
+  }
+
+  let { onChooseExisting }: Props = $props();
+
+  const store = recipeEditStore;
+
+  let fileInput: HTMLInputElement | null = $state(null);
+
+  async function onFileChange(e: Event): Promise<void> {
+    const input = e.currentTarget as HTMLInputElement;
+    const file = input.files?.[0];
+    if (file) await store.uploadImage(file);
+    input.value = ''; // allow re-selecting the same file
+  }
+</script>
+
+<section class="rc-paper">
+  <h2 class="rc-section-title">Image</h2>
+
+  {#if store.form.imagePath}
+    <div class="rc-image-preview">
+      <img src={store.form.imagePath} alt="Recipe" />
+      <button type="button" class="rc-image-remove" aria-label="Remove image" onclick={() => store.removeImage()}
+        >×</button
+      >
+    </div>
+  {/if}
+
+  <div class="rc-image-actions">
+    <button type="button" class="rc-btn-outline" onclick={() => fileInput?.click()}>
+      {store.form.imagePath ? 'Change Image' : 'Upload Image'}
+    </button>
+    <button type="button" class="rc-btn-outline rc-secondary" onclick={onChooseExisting}>
+      Choose Existing
+    </button>
+    <input
+      bind:this={fileInput}
+      type="file"
+      accept="image/*"
+      class="rc-file-hidden"
+      onchange={onFileChange}
+    />
+  </div>
+  <p class="rc-image-hint">Max 10 MB. Supported: JPG, PNG, GIF, WebP</p>
+</section>
+
+<style>
+  .rc-paper {
+    background: var(--color-surface);
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-1);
+    padding: 16px;
+    margin-bottom: 16px;
+  }
+  .rc-section-title {
+    margin: 0 0 12px;
+    font-size: 1.125rem;
+    font-weight: 500;
+  }
+  .rc-image-preview {
+    position: relative;
+    display: inline-block;
+    margin-bottom: 12px;
+  }
+  .rc-image-preview img {
+    width: 300px;
+    max-width: 100%;
+    height: 200px;
+    object-fit: cover;
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-2);
+    display: block;
+  }
+  .rc-image-remove {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    width: 28px;
+    height: 28px;
+    display: grid;
+    place-items: center;
+    border: none;
+    border-radius: 50%;
+    background: rgba(0, 0, 0, 0.55);
+    color: #fff;
+    font-size: 1.2rem;
+    line-height: 1;
+    cursor: pointer;
+  }
+  .rc-image-remove:hover {
+    background: rgba(0, 0, 0, 0.75);
+  }
+  .rc-image-actions {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .rc-file-hidden {
+    display: none;
+  }
+  .rc-image-hint {
+    margin: 6px 0 0;
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .rc-btn-outline {
+    font: inherit;
+    padding: 10px 18px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--color-primary);
+    background: transparent;
+    color: var(--color-primary);
+    cursor: pointer;
+    min-height: 40px;
+    font-weight: 500;
+  }
+  .rc-btn-outline:hover {
+    background: var(--color-action-hover);
+  }
+  .rc-secondary {
+    border-color: var(--color-secondary);
+    color: var(--color-secondary);
+  }
+</style>

--- a/frontend/recipes/src/lib/components/ImportDialog.svelte
+++ b/frontend/recipes/src/lib/components/ImportDialog.svelte
@@ -1,0 +1,332 @@
+<script lang="ts">
+  // Import-from-URL dialog (mirrors ImportRecipeDialog.razor): URL field, a
+  // supported-sites note, a spinner (YouTube variant warns it's slower), duplicate
+  // detection ("View Existing" / "Import Anyway"=force), and an error → "Add
+  // Manually" fallback. On success the parent navigates to /recipes/edit/{id}.
+  import { importRecipe, ApiError } from '../api';
+
+  interface Props {
+    open: boolean;
+    onClose: () => void;
+    onImported: (recipeId: number) => void;
+  }
+
+  let { open, onClose, onImported }: Props = $props();
+
+  let dialogEl: HTMLDialogElement | null = $state(null);
+  let url = $state('');
+  let importing = $state(false);
+  let error = $state<string | null>(null);
+  let existingId = $state<number | null>(null);
+  let showManual = $state(false);
+
+  let isYouTube = $derived(/youtube\.com|youtu\.be/i.test(url));
+
+  $effect(() => {
+    if (!dialogEl) return;
+    if (open && !dialogEl.open) {
+      dialogEl.showModal();
+    } else if (!open && dialogEl.open) {
+      dialogEl.close();
+    }
+  });
+
+  function reset(): void {
+    url = '';
+    importing = false;
+    error = null;
+    existingId = null;
+    showManual = false;
+  }
+
+  function handleClose(): void {
+    reset();
+    onClose();
+  }
+
+  async function doImport(force = false): Promise<void> {
+    if (!url.trim() || importing) return;
+    importing = true;
+    error = null;
+    showManual = false;
+    existingId = null;
+    try {
+      const res = await importRecipe(url.trim(), force);
+      if (res.success && res.recipeId != null) {
+        onImported(res.recipeId);
+        return;
+      }
+      if (res.existingRecipeId != null) {
+        existingId = res.existingRecipeId;
+        error = res.errorMessage ?? 'This recipe has already been imported.';
+        return;
+      }
+      error = res.errorMessage ?? 'Import failed for unknown reason.';
+      // Offer manual entry unless the URL itself was invalid.
+      showManual = res.errorType !== 'InvalidUrl';
+    } catch (e) {
+      error =
+        e instanceof ApiError
+          ? `Import failed (HTTP ${e.status}).`
+          : 'An error occurred during import.';
+      showManual = true;
+    } finally {
+      importing = false;
+    }
+  }
+
+  function viewExisting(): void {
+    if (existingId != null) window.location.assign(`/recipes/edit/${existingId}`);
+  }
+
+  function importAnyway(): void {
+    void doImport(true);
+  }
+
+  function addManually(): void {
+    window.location.assign('/recipes/new');
+  }
+</script>
+
+<dialog bind:this={dialogEl} onclose={handleClose} class="rc-dialog">
+  {#if open}
+    <header class="rc-dialog-head">
+      <h2>Import Recipe</h2>
+      <button type="button" class="rc-dialog-x" aria-label="Close" onclick={handleClose}>×</button>
+    </header>
+
+    <div class="rc-dialog-body">
+      <p class="rc-import-intro">Paste a recipe URL to import. Tested and working with:</p>
+      <p class="rc-import-sites">✓ AllRecipes • BBC Good Food • NYT Cooking • Serious Eats • YouTube</p>
+
+      <label class="rc-field">
+        <span class="rc-field-label">Recipe URL</span>
+        <input
+          type="url"
+          class="rc-input"
+          placeholder="https://www.allrecipes.com/recipe/..."
+          bind:value={url}
+          disabled={importing}
+        />
+      </label>
+
+      {#if importing}
+        <div class="rc-import-progress">
+          <span class="rc-spinner" aria-hidden="true"></span>
+          <span>
+            {isYouTube
+              ? 'Extracting recipe from video… This may take a moment.'
+              : 'Importing recipe…'}
+          </span>
+        </div>
+      {/if}
+
+      {#if error}
+        <div class="rc-import-alert" class:rc-alert-info={existingId != null}>
+          <p class="rc-alert-msg">{error}</p>
+          {#if existingId != null}
+            <div class="rc-alert-actions">
+              <button type="button" class="rc-text-btn" onclick={viewExisting}>View Existing</button>
+              <button type="button" class="rc-text-btn" onclick={importAnyway}>Import Anyway</button>
+            </div>
+          {:else if showManual}
+            <button type="button" class="rc-text-btn" onclick={addManually}>Add Recipe Manually</button>
+          {/if}
+        </div>
+      {/if}
+    </div>
+
+    <footer class="rc-dialog-actions">
+      <button type="button" class="rc-btn-ghost" onclick={handleClose} disabled={importing}>Cancel</button>
+      <button
+        type="button"
+        class="rc-btn-solid"
+        onclick={() => doImport(false)}
+        disabled={importing || !url.trim()}
+      >
+        Import
+      </button>
+    </footer>
+  {/if}
+</dialog>
+
+<style>
+  .rc-dialog[open] {
+    position: fixed;
+    inset: 0;
+    margin: auto;
+    border: none;
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text);
+    padding: 0;
+    width: min(520px, calc(100vw - 32px));
+    max-height: calc(100vh - 32px);
+    box-shadow: var(--shadow-4);
+    display: flex;
+    flex-direction: column;
+  }
+  .rc-dialog::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+  }
+  .rc-dialog-head {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 16px 16px 12px 24px;
+    border-bottom: 1px solid var(--color-line);
+  }
+  .rc-dialog-head h2 {
+    margin: 0;
+    flex: 1;
+    font-size: 1.25rem;
+    font-weight: 500;
+  }
+  .rc-dialog-x {
+    flex-shrink: 0;
+    width: 36px;
+    height: 36px;
+    display: grid;
+    place-items: center;
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
+    border-radius: var(--radius-sm);
+    font-size: 1.4rem;
+    line-height: 1;
+    cursor: pointer;
+  }
+  .rc-dialog-x:hover {
+    background: var(--color-action-hover);
+    color: var(--color-text);
+  }
+  .rc-dialog-body {
+    overflow-y: auto;
+    padding: 16px 24px;
+    flex: 1;
+  }
+  .rc-import-intro {
+    margin: 0 0 8px;
+    font-size: 0.9375rem;
+  }
+  .rc-import-sites {
+    margin: 0 0 16px;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+  .rc-field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .rc-field-label {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .rc-input {
+    font: inherit;
+    padding: 10px 12px;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text);
+  }
+  .rc-input:focus {
+    outline: none;
+    border-color: var(--color-primary);
+  }
+  .rc-import-progress {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-top: 16px;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+  .rc-spinner {
+    width: 18px;
+    height: 18px;
+    border: 2px solid var(--color-line-strong);
+    border-top-color: var(--color-primary);
+    border-radius: 50%;
+    animation: rc-spin 0.8s linear infinite;
+  }
+  @keyframes rc-spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+  .rc-import-alert {
+    margin-top: 16px;
+    padding: 12px 16px;
+    border-radius: var(--radius-sm);
+    border-left: 4px solid var(--color-warning);
+    background: rgba(251, 140, 0, 0.08);
+  }
+  .rc-alert-info {
+    border-left-color: var(--color-info);
+    background: rgba(30, 136, 229, 0.08);
+  }
+  .rc-alert-msg {
+    margin: 0;
+    font-size: 0.875rem;
+  }
+  .rc-alert-actions {
+    display: flex;
+    gap: 12px;
+    margin-top: 8px;
+  }
+  .rc-text-btn {
+    font: inherit;
+    background: transparent;
+    border: none;
+    color: var(--color-primary);
+    cursor: pointer;
+    font-size: 0.875rem;
+    font-weight: 500;
+    margin-top: 8px;
+    padding: 0;
+  }
+  .rc-alert-actions .rc-text-btn {
+    margin-top: 0;
+  }
+  .rc-text-btn:hover {
+    text-decoration: underline;
+  }
+  .rc-dialog-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 12px 24px calc(16px + env(safe-area-inset-bottom, 0px));
+    border-top: 1px solid var(--color-line);
+  }
+  .rc-btn-ghost,
+  .rc-btn-solid {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    border: none;
+    cursor: pointer;
+    min-height: 44px;
+    font-weight: 500;
+  }
+  .rc-btn-ghost {
+    background: transparent;
+    color: var(--color-text-muted);
+  }
+  .rc-btn-ghost:hover:not(:disabled) {
+    background: var(--color-action-hover);
+  }
+  .rc-btn-solid {
+    background: var(--color-primary);
+    color: #fff;
+  }
+  .rc-btn-solid:hover:not(:disabled) {
+    background: var(--color-primary-hover);
+  }
+  .rc-btn-solid:disabled,
+  .rc-btn-ghost:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+</style>

--- a/frontend/recipes/src/lib/components/IngredientEntry.svelte
+++ b/frontend/recipes/src/lib/components/IngredientEntry.svelte
@@ -1,0 +1,309 @@
+<script lang="ts">
+  // Ingredient entry (mirrors IngredientEntry.razor): a raw NL input that parses
+  // on Enter/Tab/blur via POST /parse-ingredient, revealing editable qty / unit /
+  // name / category / notes fields. Unit autocomplete is a static list; the
+  // ingredient-name autocomplete pulls server suggestions (≥2 chars). A "Bulk
+  // Paste" button opens the bulk dialog (hosted by EditApp).
+  import type { NewIngredientInput } from '../recipeEditStore.svelte';
+  import { parseIngredient, ingredientSuggestions } from '../api';
+  import { showToast } from '../toasts.svelte';
+
+  interface Props {
+    categories: string[];
+    onAdd: (input: NewIngredientInput) => void;
+    onBulkOpen: () => void;
+  }
+
+  let { categories, onAdd, onBulkOpen }: Props = $props();
+
+  const UNITS = [
+    'cup', 'cups', 'tbsp', 'tsp', 'oz', 'lb', 'lbs', 'g', 'kg', 'ml', 'l',
+    'clove', 'cloves', 'can', 'cans', 'bunch', 'slice', 'slices', 'piece', 'pieces',
+  ];
+
+  let rawInput = $state('');
+  let showParsed = $state(false);
+  let quantity = $state('');
+  let unit = $state('');
+  let name = $state('');
+  let category = $state('Pantry');
+  let notes = $state('');
+  let parsing = $state(false);
+
+  let nameSuggestions = $state<string[]>([]);
+  let suggestTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function findCategory(suggested: string): string {
+    const match = categories.find((c) => c.toLowerCase() === suggested.toLowerCase());
+    return match ?? categories[0] ?? 'Pantry';
+  }
+
+  async function parseInput(): Promise<void> {
+    if (!rawInput.trim() || parsing) return;
+    parsing = true;
+    try {
+      const parsed = await parseIngredient(rawInput);
+      quantity = parsed.quantity != null ? String(parsed.quantity) : '';
+      unit = parsed.unit ?? '';
+      name = parsed.name;
+      notes = parsed.notes ?? '';
+      category = findCategory(parsed.suggestedCategory);
+      showParsed = true;
+    } catch {
+      showToast({ message: "Couldn't parse that ingredient.", kind: 'error' });
+    } finally {
+      parsing = false;
+    }
+  }
+
+  async function add(): Promise<void> {
+    if (!showParsed) {
+      await parseInput();
+      if (!showParsed) return;
+    }
+    if (!name.trim()) return;
+    const q = quantity.trim() === '' ? null : Number(quantity);
+    onAdd({
+      name: name.trim(),
+      quantity: q != null && !Number.isNaN(q) ? q : null,
+      unit: unit.trim() === '' ? null : unit.trim(),
+      category,
+      notes: notes.trim() === '' ? null : notes.trim(),
+    });
+    reset();
+  }
+
+  function reset(): void {
+    rawInput = '';
+    showParsed = false;
+    quantity = '';
+    unit = '';
+    name = '';
+    category = categories[0] ?? 'Pantry';
+    notes = '';
+    nameSuggestions = [];
+  }
+
+  function handleKeyDown(e: KeyboardEvent): void {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      if (showParsed) void add();
+      else if (rawInput.trim()) void parseInput();
+    } else if (e.key === 'Tab' && !showParsed && rawInput.trim()) {
+      void parseInput();
+    }
+  }
+
+  function handleRawBlur(): void {
+    if (!showParsed && rawInput.trim()) void parseInput();
+  }
+
+  function onNameInput(value: string): void {
+    name = value;
+    if (suggestTimer) clearTimeout(suggestTimer);
+    if (value.trim().length < 2) {
+      nameSuggestions = [];
+      return;
+    }
+    suggestTimer = setTimeout(async () => {
+      try {
+        nameSuggestions = await ingredientSuggestions(value.trim());
+      } catch {
+        nameSuggestions = [];
+      }
+    }, 300);
+  }
+</script>
+
+<section class="rc-paper">
+  <div class="rc-entry-head">
+    <h3 class="rc-entry-title">Add Ingredients</h3>
+    <button type="button" class="rc-text-btn" onclick={onBulkOpen}>⧉ Bulk Paste</button>
+  </div>
+
+  <div class="rc-raw-row">
+    <input
+      type="text"
+      class="rc-input"
+      placeholder="Add ingredient (e.g., '2 cups flour' or '1/2 lb chicken, boneless')"
+      bind:value={rawInput}
+      onkeydown={handleKeyDown}
+      onblur={handleRawBlur}
+    />
+    <button type="button" class="rc-icon-add" aria-label="Parse / add" onclick={add}>＋</button>
+  </div>
+
+  {#if showParsed}
+    <div class="rc-parsed-grid">
+      <label class="rc-field rc-col-qty">
+        <span class="rc-field-label">Quantity</span>
+        <input type="text" class="rc-input" bind:value={quantity} />
+      </label>
+      <label class="rc-field rc-col-unit">
+        <span class="rc-field-label">Unit</span>
+        <input type="text" class="rc-input" list="rc-unit-list" bind:value={unit} />
+        <datalist id="rc-unit-list">
+          {#each UNITS as u (u)}
+            <option value={u}></option>
+          {/each}
+        </datalist>
+      </label>
+      <label class="rc-field rc-col-name">
+        <span class="rc-field-label">Ingredient</span>
+        <input
+          type="text"
+          class="rc-input"
+          list="rc-name-list"
+          value={name}
+          oninput={(e) => onNameInput(e.currentTarget.value)}
+        />
+        <datalist id="rc-name-list">
+          {#each nameSuggestions as s (s)}
+            <option value={s}></option>
+          {/each}
+        </datalist>
+      </label>
+      <label class="rc-field rc-col-cat">
+        <span class="rc-field-label">Category</span>
+        <select class="rc-input" bind:value={category}>
+          {#each categories as cat (cat)}
+            <option value={cat}>{cat}</option>
+          {/each}
+        </select>
+      </label>
+      <div class="rc-col-add">
+        <button type="button" class="rc-btn-solid" onclick={add}>Add</button>
+      </div>
+      <label class="rc-field rc-col-notes">
+        <span class="rc-field-label">Notes (optional)</span>
+        <input type="text" class="rc-input" bind:value={notes} />
+      </label>
+    </div>
+  {/if}
+</section>
+
+<style>
+  .rc-paper {
+    background: var(--color-surface);
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-1);
+    padding: 16px;
+    margin-bottom: 16px;
+  }
+  .rc-entry-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 12px;
+  }
+  .rc-entry-title {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 500;
+  }
+  .rc-text-btn {
+    font: inherit;
+    background: transparent;
+    border: none;
+    color: var(--color-primary);
+    cursor: pointer;
+    font-size: 0.875rem;
+    font-weight: 500;
+  }
+  .rc-text-btn:hover {
+    text-decoration: underline;
+  }
+  .rc-raw-row {
+    display: flex;
+    gap: 8px;
+    align-items: stretch;
+  }
+  .rc-input {
+    font: inherit;
+    padding: 10px 12px;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text);
+    width: 100%;
+  }
+  .rc-input:focus {
+    outline: none;
+    border-color: var(--color-primary);
+  }
+  .rc-icon-add {
+    flex-shrink: 0;
+    width: 44px;
+    border: 1px solid var(--color-primary);
+    background: transparent;
+    color: var(--color-primary);
+    border-radius: var(--radius-sm);
+    font-size: 1.3rem;
+    line-height: 1;
+    cursor: pointer;
+  }
+  .rc-icon-add:hover {
+    background: var(--color-action-hover);
+  }
+  .rc-parsed-grid {
+    display: grid;
+    grid-template-columns: repeat(12, 1fr);
+    gap: 12px;
+    margin-top: 12px;
+  }
+  .rc-field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .rc-field-label {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .rc-col-qty {
+    grid-column: span 2;
+  }
+  .rc-col-unit {
+    grid-column: span 2;
+  }
+  .rc-col-name {
+    grid-column: span 4;
+  }
+  .rc-col-cat {
+    grid-column: span 2;
+  }
+  .rc-col-add {
+    grid-column: span 2;
+    display: flex;
+    align-items: flex-end;
+  }
+  .rc-col-notes {
+    grid-column: span 12;
+  }
+  @media (max-width: 700px) {
+    .rc-col-qty,
+    .rc-col-unit,
+    .rc-col-name,
+    .rc-col-cat,
+    .rc-col-add,
+    .rc-col-notes {
+      grid-column: span 12;
+    }
+  }
+  .rc-btn-solid {
+    font: inherit;
+    width: 100%;
+    padding: 10px 16px;
+    border: none;
+    border-radius: var(--radius-sm);
+    background: var(--color-primary);
+    color: #fff;
+    cursor: pointer;
+    min-height: 44px;
+    font-weight: 500;
+  }
+  .rc-btn-solid:hover {
+    background: var(--color-primary-hover);
+  }
+</style>

--- a/frontend/recipes/src/lib/components/IngredientList.svelte
+++ b/frontend/recipes/src/lib/components/IngredientList.svelte
@@ -1,0 +1,197 @@
+<script lang="ts">
+  // Ingredient list (mirrors IngredientList.razor): drag-reorder via
+  // svelte-dnd-action (the chores pattern), edit (remove + re-add), and
+  // delete-with-undo (the undo lives on the toast). Quantities use the EXACT
+  // formatter (formatExactQuantity — entered values are precise).
+  import type { IngredientRow } from '../recipeEditStore.svelte';
+  import { formatExactQuantity } from '../quantity';
+  import { dndzone, type DndEvent } from 'svelte-dnd-action';
+
+  interface Props {
+    ingredients: IngredientRow[];
+    onReorder: (rows: IngredientRow[]) => void;
+    onEdit: (id: number) => void;
+    onRemove: (id: number) => void;
+  }
+
+  let { ingredients, onReorder, onEdit, onRemove }: Props = $props();
+
+  // Local copy svelte-dnd-action mutates during a drag; resynced from the source
+  // whenever we're NOT dragging (chores pattern — avoids fighting the library).
+  let rows = $state<IngredientRow[]>([]);
+  let dragging = $state(false);
+  $effect(() => {
+    if (!dragging) rows = [...ingredients];
+  });
+
+  function handleConsider(e: CustomEvent<DndEvent<IngredientRow>>): void {
+    dragging = true;
+    rows = e.detail.items;
+  }
+  function handleFinalize(e: CustomEvent<DndEvent<IngredientRow>>): void {
+    rows = e.detail.items;
+    onReorder([...rows]);
+    dragging = false;
+  }
+
+  function formatLine(ing: IngredientRow): string {
+    const parts: string[] = [];
+    if (ing.quantity != null) parts.push(formatExactQuantity(ing.quantity));
+    if (ing.unit) parts.push(ing.unit);
+    parts.push(ing.name);
+    return parts.join(' ');
+  }
+
+  function categoryColor(category: string): string {
+    switch (category) {
+      case 'Meat':
+        return 'var(--color-error)';
+      case 'Produce':
+        return 'var(--color-success)';
+      case 'Dairy':
+        return 'var(--color-warning)';
+      case 'Spices':
+        return 'var(--color-secondary)';
+      case 'Frozen':
+        return 'var(--color-info)';
+      case 'Beverages':
+        return 'var(--color-primary)';
+      default:
+        return 'var(--color-text-muted)';
+    }
+  }
+</script>
+
+<h3 class="rc-list-title">Ingredients ({ingredients.length})</h3>
+
+{#if ingredients.length === 0}
+  <div class="rc-list-empty">No ingredients yet. Use the form above to add ingredients.</div>
+{:else}
+  <ul
+    class="rc-ing-list"
+    use:dndzone={{ items: rows, flipDurationMs: 150, dropTargetStyle: {}, delayTouchStart: 250 }}
+    onconsider={handleConsider}
+    onfinalize={handleFinalize}
+  >
+    {#each rows as ing (ing.id)}
+      <li class="rc-ing-item">
+        <div class="rc-ing-main">
+          <span class="rc-ing-grip" aria-hidden="true">⠿</span>
+          <div class="rc-ing-text">
+            <span class="rc-ing-line">{formatLine(ing)}</span>
+            {#if ing.notes}
+              <span class="rc-ing-notes">{ing.notes}</span>
+            {/if}
+          </div>
+        </div>
+        <div class="rc-ing-actions">
+          <span class="rc-cat-chip" style="--chip-color: {categoryColor(ing.category)}">{ing.category}</span>
+          <button type="button" class="rc-ing-btn" aria-label="Edit ingredient" onclick={() => onEdit(ing.id)}
+            >✎</button
+          >
+          <button
+            type="button"
+            class="rc-ing-btn rc-ing-del"
+            aria-label="Delete ingredient"
+            onclick={() => onRemove(ing.id)}>🗑</button
+          >
+        </div>
+      </li>
+    {/each}
+  </ul>
+{/if}
+
+<style>
+  .rc-list-title {
+    margin: 0 0 8px;
+    font-size: 1rem;
+    font-weight: 500;
+  }
+  .rc-list-empty {
+    padding: 12px 16px;
+    border-radius: var(--radius-sm);
+    background: rgba(30, 136, 229, 0.08);
+    border-left: 4px solid var(--color-info);
+    font-size: 0.875rem;
+    color: var(--color-text);
+  }
+  .rc-ing-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-height: 60px;
+  }
+  .rc-ing-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 12px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-1);
+    cursor: grab;
+  }
+  .rc-ing-item:active {
+    cursor: grabbing;
+  }
+  .rc-ing-main {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+  }
+  .rc-ing-grip {
+    color: var(--color-text-disabled);
+    cursor: grab;
+  }
+  .rc-ing-text {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+  .rc-ing-line {
+    overflow-wrap: anywhere;
+  }
+  .rc-ing-notes {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .rc-ing-actions {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+  }
+  .rc-cat-chip {
+    font-size: 0.6875rem;
+    font-weight: 500;
+    padding: 2px 10px;
+    border-radius: 12px;
+    border: 1px solid var(--chip-color);
+    color: var(--chip-color);
+    white-space: nowrap;
+  }
+  .rc-ing-btn {
+    width: 32px;
+    height: 32px;
+    display: grid;
+    place-items: center;
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    font-size: 0.95rem;
+  }
+  .rc-ing-btn:hover {
+    background: var(--color-action-hover);
+  }
+  .rc-ing-del:hover {
+    color: var(--color-error);
+  }
+</style>

--- a/frontend/recipes/src/lib/components/RecipeCard.svelte
+++ b/frontend/recipes/src/lib/components/RecipeCard.svelte
@@ -1,0 +1,253 @@
+<script lang="ts">
+  // One recipe card in the grid. Mirrors RecipeCard.razor: image/placeholder,
+  // type chip (hidden for `main`), "imported" cloud icon, favorite heart (hidden
+  // when read-only/connected), title, author (pic-or-initials, or "Deleted user"),
+  // optional connected-household attribution, and the first-3 ingredient preview.
+  import type { RecipeListItemDto } from '../types';
+  import { recipeTypeShort, recipeTypeColor } from '../recipeType';
+  import { initials } from '../avatar';
+
+  interface Props {
+    recipe: RecipeListItemDto;
+    isFavorite: boolean;
+    isReadOnly: boolean;
+    sharedFromName: string | null;
+    onClick: (recipe: RecipeListItemDto) => void;
+    onToggleFavorite: (recipe: RecipeListItemDto) => void;
+  }
+
+  let { recipe, isFavorite, isReadOnly, sharedFromName, onClick, onToggleFavorite }: Props = $props();
+
+  let preview = $derived(
+    recipe.ingredientCount === 0
+      ? null
+      : recipe.ingredientPreview.join(', ') +
+          (recipe.ingredientCount > 3 ? `, +${recipe.ingredientCount - 3} more` : ''),
+  );
+
+  function handleFavorite(e: MouseEvent): void {
+    e.stopPropagation(); // don't open the drawer when tapping the heart
+    onToggleFavorite(recipe);
+  }
+</script>
+
+<button type="button" class="rc-card" onclick={() => onClick(recipe)}>
+  <div class="rc-card-image">
+    <img
+      src={recipe.imagePath ?? '/images/recipe-placeholder.svg'}
+      alt={recipe.name}
+      loading="lazy"
+    />
+    {#if !isReadOnly}
+      <span
+        class="rc-fav"
+        class:rc-fav-on={isFavorite}
+        role="button"
+        tabindex="0"
+        aria-label={isFavorite ? 'Remove from favorites' : 'Add to favorites'}
+        aria-pressed={isFavorite}
+        onclick={handleFavorite}
+        onkeydown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleFavorite(e as unknown as MouseEvent);
+          }
+        }}
+      >
+        {isFavorite ? '♥' : '♡'}
+      </span>
+    {/if}
+  </div>
+
+  <div class="rc-card-body">
+    <div class="rc-card-title-row">
+      <span class="rc-card-title">{recipe.name}</span>
+      <span class="rc-card-badges">
+        {#if recipe.recipeType !== 'main'}
+          <span class="rc-type-chip" style="--chip-color: {recipeTypeColor(recipe.recipeType)}">
+            {recipeTypeShort(recipe.recipeType)}
+          </span>
+        {/if}
+        {#if recipe.hasSourceUrl}
+          <span class="rc-imported" title="Imported from web" aria-label="Imported from web">☁</span>
+        {/if}
+      </span>
+    </div>
+
+    <div class="rc-card-author">
+      {#if recipe.createdByName}
+        {#if recipe.createdByPictureUrl}
+          <img class="rc-avatar" src={recipe.createdByPictureUrl} alt={recipe.createdByName} />
+        {:else}
+          <span class="rc-avatar rc-avatar-initials">{initials(recipe.createdByName)}</span>
+        {/if}
+        <span class="rc-author-name">{recipe.createdByName}</span>
+      {:else}
+        <span class="rc-avatar rc-avatar-initials" aria-hidden="true">∅</span>
+        <span class="rc-author-name rc-author-deleted">Deleted user</span>
+      {/if}
+    </div>
+
+    {#if sharedFromName}
+      <div class="rc-attribution">From {sharedFromName}</div>
+    {/if}
+
+    <div class="rc-card-ingredients">
+      {#if preview}
+        {preview}
+      {:else}
+        <span class="rc-no-ingredients">No ingredients</span>
+      {/if}
+    </div>
+  </div>
+</button>
+
+<style>
+  .rc-card {
+    font: inherit;
+    text-align: left;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    background: var(--color-surface);
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-1);
+    cursor: pointer;
+    padding: 0;
+    overflow: hidden;
+    color: var(--color-text);
+    transition:
+      transform 0.2s ease,
+      box-shadow 0.2s ease;
+  }
+  .rc-card:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-4);
+  }
+  .rc-card-image {
+    position: relative;
+    flex-shrink: 0;
+    height: 200px;
+    background: var(--color-action-hover);
+  }
+  .rc-card-image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+  .rc-fav {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    display: grid;
+    place-items: center;
+    width: 34px;
+    height: 34px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.92);
+    color: var(--color-text-muted);
+    font-size: 1.1rem;
+    line-height: 1;
+    cursor: pointer;
+    backdrop-filter: blur(4px);
+  }
+  .rc-fav:hover {
+    background: #fff;
+  }
+  .rc-fav-on {
+    color: var(--color-error);
+  }
+  .rc-card-body {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 120px;
+    padding: 16px;
+  }
+  .rc-card-title-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    margin-bottom: 8px;
+    min-height: 48px;
+  }
+  .rc-card-title {
+    flex: 1;
+    font-size: 1.125rem;
+    font-weight: 500;
+    line-height: 1.3;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+  .rc-card-badges {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+  }
+  .rc-type-chip {
+    font-size: 0.6875rem;
+    font-weight: 500;
+    padding: 2px 8px;
+    border-radius: 12px;
+    border: 1px solid var(--chip-color);
+    color: var(--chip-color);
+    white-space: nowrap;
+  }
+  .rc-imported {
+    color: var(--color-secondary);
+    font-size: 0.9rem;
+  }
+  .rc-card-author {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+  }
+  .rc-avatar {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    object-fit: cover;
+    flex-shrink: 0;
+  }
+  .rc-avatar-initials {
+    display: grid;
+    place-items: center;
+    background: var(--color-primary-soft);
+    color: #fff;
+    font-size: 0.625rem;
+    font-weight: 600;
+  }
+  .rc-author-name {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .rc-author-deleted {
+    font-style: italic;
+  }
+  .rc-attribution {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    margin-bottom: 4px;
+  }
+  .rc-card-ingredients {
+    margin-top: auto;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+  .rc-no-ingredients {
+    font-style: italic;
+  }
+</style>

--- a/frontend/recipes/src/lib/components/RecipeDetailDrawer.svelte
+++ b/frontend/recipes/src/lib/components/RecipeDetailDrawer.svelte
@@ -89,6 +89,10 @@
   let hasTimeMeta = $derived(
     detail != null && (detail.prepTimeMinutes != null || detail.cookTimeMinutes != null),
   );
+  // Sort once when the detail changes (not on every render — e.g. each servings tick).
+  let sortedIngredients = $derived(
+    detail ? detail.ingredients.slice().sort((a, b) => a.sortOrder - b.sortOrder) : [],
+  );
 
   function ingredientLine(ing: RecipeIngredientFullDto): string {
     const parts: string[] = [];
@@ -214,7 +218,7 @@
       {#if detail.ingredients.length > 0}
         <h3 class="rc-detail-subhead">Ingredients</h3>
         <ul class="rc-detail-ingredients">
-          {#each [...detail.ingredients].sort((a, b) => a.sortOrder - b.sortOrder) as ing (ing.ingredientId)}
+          {#each sortedIngredients as ing (ing.ingredientId)}
             <li>{ingredientLine(ing)}</li>
           {/each}
         </ul>

--- a/frontend/recipes/src/lib/components/RecipeDetailDrawer.svelte
+++ b/frontend/recipes/src/lib/components/RecipeDetailDrawer.svelte
@@ -1,0 +1,568 @@
+<script lang="ts">
+  // Read-only detail slide-out (mirrors the Blazor MudDrawer at Recipes.razor:223-416).
+  // Lazy-fetches the full recipe on open — getRecipe (#2) for own recipes,
+  // getConnectedRecipe (#16) in connected mode. Hosts the live servings scaler
+  // (client-side rescale via quantity.ts), instructions via {@html} (server-
+  // sanitized), source link (safe-url guarded), and the action buttons.
+  import type { RecipeFullDto, RecipeIngredientFullDto, RecipeListItemDto } from '../types';
+  import { getRecipe, getConnectedRecipe, ApiError } from '../api';
+  import { initials } from '../avatar';
+  import {
+    formatScaledQuantity,
+    getScaledQuantity,
+    getScalingFactor,
+    getScalingLabel,
+  } from '../quantity';
+
+  interface Props {
+    open: boolean;
+    /** The card the drawer was opened from (fallback title + delete name). */
+    summary: RecipeListItemDto | null;
+    /** Connected household id when viewing a connected recipe (else null). */
+    connectedId: number | null;
+    isReadOnly: boolean;
+    connectedName: string | null;
+    onClose: () => void;
+    onEdit: (recipeId: number) => void;
+    onDelete: (summary: RecipeListItemDto) => void;
+    onCopy: (recipeId: number) => Promise<void>;
+    onAddToMealPlan: (name: string) => void;
+  }
+
+  let {
+    open,
+    summary,
+    connectedId,
+    isReadOnly,
+    connectedName,
+    onClose,
+    onEdit,
+    onDelete,
+    onCopy,
+    onAddToMealPlan,
+  }: Props = $props();
+
+  let detail = $state<RecipeFullDto | null>(null);
+  let loading = $state(false);
+  let error = $state<string | null>(null);
+  let scaledServings = $state(1);
+  let copying = $state(false);
+  // The `${connectedId}:${recipeId}` we last fetched — reopening the same recipe reuses it.
+  let loadedKey: string | null = null;
+
+  function keyFor(s: RecipeListItemDto): string {
+    return `${connectedId ?? ''}:${s.recipeId}`;
+  }
+
+  async function load(s: RecipeListItemDto): Promise<void> {
+    loading = true;
+    error = null;
+    try {
+      const full =
+        connectedId == null
+          ? await getRecipe(s.recipeId)
+          : await getConnectedRecipe(connectedId, s.recipeId);
+      detail = full;
+      scaledServings = full.servings ?? 1;
+      loadedKey = keyFor(s);
+    } catch (e) {
+      error =
+        e instanceof ApiError
+          ? `Couldn't load this recipe (HTTP ${e.status}).`
+          : "Couldn't load this recipe right now.";
+    } finally {
+      loading = false;
+    }
+  }
+
+  // Reactive lazy-load on open / recipe change (mirrors meal-plan RecipeDetailSheet).
+  // Guarded by the key so it settles after one load — NOT an unbounded loop.
+  $effect(() => {
+    if (open && summary && keyFor(summary) !== loadedKey) {
+      detail = null;
+      void load(summary);
+    }
+  });
+
+  let factor = $derived(detail ? getScalingFactor(detail.servings, scaledServings) : 1);
+  let title = $derived(detail?.name ?? summary?.name ?? '');
+  let hasTimeMeta = $derived(
+    detail != null && (detail.prepTimeMinutes != null || detail.cookTimeMinutes != null),
+  );
+
+  function ingredientLine(ing: RecipeIngredientFullDto): string {
+    const parts: string[] = [];
+    if (ing.quantity != null) {
+      parts.push(formatScaledQuantity(getScaledQuantity(ing.quantity, factor)));
+    }
+    if (ing.unit) parts.push(ing.unit);
+    parts.push(ing.name);
+    if (ing.notes) parts.push(`(${ing.notes})`);
+    return parts.join(' ');
+  }
+
+  function isSafeUrl(url: string | null): boolean {
+    if (!url) return false;
+    try {
+      const u = new URL(url);
+      return u.protocol === 'http:' || u.protocol === 'https:';
+    } catch {
+      return false;
+    }
+  }
+
+  function increaseServings(): void {
+    scaledServings++;
+  }
+  function decreaseServings(): void {
+    if (scaledServings > 1) scaledServings--;
+  }
+  function resetServings(): void {
+    scaledServings = detail?.servings ?? 1;
+  }
+
+  async function handleCopy(): Promise<void> {
+    if (!detail) return;
+    copying = true;
+    try {
+      await onCopy(detail.recipeId);
+    } finally {
+      copying = false;
+    }
+  }
+</script>
+
+{#if open}
+  <button type="button" class="rc-drawer-scrim" aria-label="Close panel" onclick={onClose}></button>
+{/if}
+
+<aside class="rc-drawer" class:rc-drawer-open={open} aria-hidden={!open}>
+  <header class="rc-drawer-head">
+    <h2 class="rc-drawer-title">{title}</h2>
+    <button type="button" class="rc-drawer-x" aria-label="Close panel" onclick={onClose}>×</button>
+  </header>
+
+  <div class="rc-drawer-body">
+    {#if loading}
+      <div class="rc-drawer-loading">Loading recipe…</div>
+    {:else if error}
+      <div class="rc-drawer-error" role="alert">
+        <span>{error}</span>
+        {#if summary}
+          <button type="button" class="rc-retry" onclick={() => summary && load(summary)}>Retry</button>
+        {/if}
+      </div>
+    {:else if detail}
+      {#if detail.imagePath}
+        <div class="rc-detail-image">
+          <img src={detail.imagePath} alt={detail.name} />
+        </div>
+      {/if}
+
+      <div class="rc-detail-author">
+        {#if detail.createdByName}
+          {#if detail.createdByPictureUrl}
+            <img class="rc-avatar" src={detail.createdByPictureUrl} alt={detail.createdByName} />
+          {:else}
+            <span class="rc-avatar rc-avatar-initials">{initials(detail.createdByName)}</span>
+          {/if}
+          <span class="rc-detail-author-name">Added by {detail.createdByName}</span>
+        {:else}
+          <span class="rc-avatar rc-avatar-initials" aria-hidden="true">∅</span>
+          <span class="rc-detail-author-name rc-italic">Added by deleted user</span>
+        {/if}
+      </div>
+
+      {#if isReadOnly && connectedName}
+        <p class="rc-detail-from">From {connectedName}</p>
+      {/if}
+
+      {#if hasTimeMeta}
+        <div class="rc-detail-chips">
+          {#if detail.prepTimeMinutes != null}
+            <span class="rc-detail-chip rc-chip-info">Prep: {detail.prepTimeMinutes} min</span>
+          {/if}
+          {#if detail.cookTimeMinutes != null}
+            <span class="rc-detail-chip rc-chip-warn">Cook: {detail.cookTimeMinutes} min</span>
+          {/if}
+        </div>
+      {/if}
+
+      {#if detail.servings != null}
+        <div class="rc-scaler">
+          <span class="rc-scaler-label">🍽 Servings:</span>
+          <button
+            type="button"
+            class="rc-step"
+            aria-label="Decrease servings"
+            onclick={decreaseServings}
+            disabled={scaledServings <= 1}>−</button
+          >
+          <strong class="rc-scaler-count">{scaledServings}</strong>
+          <button type="button" class="rc-step" aria-label="Increase servings" onclick={increaseServings}>+</button>
+          {#if scaledServings !== detail.servings}
+            <span class="rc-scaler-badge">{getScalingLabel(factor)}</span>
+            <button type="button" class="rc-text-btn" onclick={resetServings}>Reset</button>
+          {/if}
+        </div>
+      {/if}
+
+      {#if detail.description}
+        <p class="rc-detail-description">{detail.description}</p>
+      {/if}
+
+      {#if detail.ingredients.length > 0}
+        <h3 class="rc-detail-subhead">Ingredients</h3>
+        <ul class="rc-detail-ingredients">
+          {#each [...detail.ingredients].sort((a, b) => a.sortOrder - b.sortOrder) as ing (ing.ingredientId)}
+            <li>{ingredientLine(ing)}</li>
+          {/each}
+        </ul>
+      {/if}
+
+      {#if detail.instructionsHtml.trim()}
+        <h3 class="rc-detail-subhead">Instructions</h3>
+        <!-- Server-sanitized HTML (MarkdownHelper.ToSafeHtml). No client markdown lib. -->
+        <div class="rc-detail-instructions">{@html detail.instructionsHtml}</div>
+      {/if}
+
+      {#if isSafeUrl(detail.sourceUrl)}
+        <div class="rc-detail-source">
+          <span aria-hidden="true">🔗</span>
+          <a href={detail.sourceUrl} target="_blank" rel="noopener noreferrer">View Original Recipe</a>
+        </div>
+      {/if}
+    {/if}
+  </div>
+
+  {#if detail}
+    <footer class="rc-drawer-actions">
+      {#if isReadOnly}
+        <button type="button" class="rc-btn-solid rc-full" onclick={handleCopy} disabled={copying}>
+          {copying ? 'Copying…' : 'Copy to My Recipes'}
+        </button>
+      {:else}
+        <button type="button" class="rc-btn-solid rc-full" onclick={() => detail && onEdit(detail.recipeId)}>
+          Edit Recipe
+        </button>
+        <button type="button" class="rc-btn-outline rc-full" onclick={() => detail && onAddToMealPlan(detail.name)}>
+          Add to Meal Plan
+        </button>
+        <button type="button" class="rc-btn-text-danger rc-full" onclick={() => summary && onDelete(summary)}>
+          Delete Recipe
+        </button>
+      {/if}
+    </footer>
+  {/if}
+</aside>
+
+<style>
+  .rc-drawer-scrim {
+    position: fixed;
+    inset: 0;
+    border: none;
+    padding: 0;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 1299;
+    cursor: default;
+  }
+  .rc-drawer {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: min(800px, 90vw);
+    background: var(--color-surface);
+    color: var(--color-text);
+    box-shadow: var(--shadow-4);
+    z-index: 1300;
+    display: flex;
+    flex-direction: column;
+    transform: translateX(100%);
+    transition: transform 0.25s ease;
+    visibility: hidden;
+  }
+  .rc-drawer-open {
+    transform: translateX(0);
+    visibility: visible;
+  }
+  .rc-drawer-head {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 16px 16px 12px 24px;
+    border-bottom: 1px solid var(--color-line);
+  }
+  .rc-drawer-title {
+    flex: 1;
+    min-width: 0;
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 400;
+    overflow-wrap: anywhere;
+  }
+  .rc-drawer-x {
+    flex-shrink: 0;
+    width: 40px;
+    height: 40px;
+    display: grid;
+    place-items: center;
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
+    border-radius: var(--radius-sm);
+    font-size: 1.5rem;
+    line-height: 1;
+    cursor: pointer;
+  }
+  .rc-drawer-x:hover {
+    background: var(--color-action-hover);
+    color: var(--color-text);
+  }
+  .rc-drawer-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 16px 24px;
+  }
+  .rc-detail-image {
+    width: 100%;
+    height: 250px;
+    margin-bottom: 16px;
+    border-radius: 8px;
+    overflow: hidden;
+  }
+  .rc-detail-image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+  .rc-detail-author {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 12px;
+  }
+  .rc-avatar {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    object-fit: cover;
+    flex-shrink: 0;
+  }
+  .rc-avatar-initials {
+    display: grid;
+    place-items: center;
+    background: var(--color-primary-soft);
+    color: #fff;
+    font-size: 0.6875rem;
+    font-weight: 600;
+  }
+  .rc-detail-author-name {
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+  .rc-italic {
+    font-style: italic;
+  }
+  .rc-detail-from {
+    margin: 0 0 12px;
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .rc-detail-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 16px;
+  }
+  .rc-detail-chip {
+    font-size: 0.8125rem;
+    padding: 4px 12px;
+    border-radius: 14px;
+    background: var(--color-action-hover);
+    color: var(--color-text);
+  }
+  .rc-chip-info {
+    color: var(--color-info);
+    border: 1px solid var(--color-info);
+    background: transparent;
+  }
+  .rc-chip-warn {
+    color: var(--color-warning);
+    border: 1px solid var(--color-warning);
+    background: transparent;
+  }
+  .rc-scaler {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 16px;
+    flex-wrap: wrap;
+  }
+  .rc-scaler-label {
+    font-size: 0.875rem;
+    color: var(--color-success);
+  }
+  .rc-step {
+    width: 28px;
+    height: 28px;
+    display: grid;
+    place-items: center;
+    border: 1px solid var(--color-line-strong);
+    background: transparent;
+    color: var(--color-text);
+    border-radius: 50%;
+    cursor: pointer;
+    font-size: 1.1rem;
+    line-height: 1;
+  }
+  .rc-step:hover:not(:disabled) {
+    background: var(--color-action-hover);
+  }
+  .rc-step:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+  .rc-scaler-count {
+    min-width: 24px;
+    text-align: center;
+  }
+  .rc-scaler-badge {
+    font-size: 0.75rem;
+    padding: 2px 10px;
+    border-radius: 12px;
+    border: 1px solid var(--color-info);
+    color: var(--color-info);
+  }
+  .rc-text-btn {
+    font: inherit;
+    background: transparent;
+    border: none;
+    color: var(--color-primary);
+    cursor: pointer;
+    font-size: 0.8125rem;
+  }
+  .rc-text-btn:hover {
+    text-decoration: underline;
+  }
+  .rc-detail-description {
+    margin: 0 0 16px;
+    line-height: 1.5;
+  }
+  .rc-detail-subhead {
+    margin: 16px 0 8px;
+    font-size: 1.125rem;
+    font-weight: 500;
+  }
+  .rc-detail-ingredients {
+    margin: 0 0 16px;
+    padding-left: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 0.9375rem;
+  }
+  .rc-detail-instructions {
+    line-height: 1.6;
+    margin-bottom: 16px;
+  }
+  .rc-detail-instructions :global(ol),
+  .rc-detail-instructions :global(ul) {
+    margin-left: 1.5rem;
+    margin-bottom: 1rem;
+  }
+  .rc-detail-instructions :global(li) {
+    margin-bottom: 0.5rem;
+  }
+  .rc-detail-instructions :global(p) {
+    margin: 0 0 0.75rem;
+  }
+  .rc-detail-source {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 16px;
+    font-size: 0.875rem;
+  }
+  .rc-detail-source a {
+    color: var(--color-secondary);
+  }
+  .rc-drawer-loading {
+    padding: 48px 0;
+    text-align: center;
+    color: var(--color-text-muted);
+  }
+  .rc-drawer-error {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 12px 16px;
+    background: rgba(229, 57, 53, 0.08);
+    border-left: 4px solid var(--color-error);
+    border-radius: var(--radius-sm);
+    color: var(--color-error);
+    font-size: 0.875rem;
+  }
+  .rc-retry {
+    font: inherit;
+    border: none;
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+    padding: 4px 12px;
+    background: transparent;
+    color: var(--color-error);
+    font-weight: 500;
+  }
+  .rc-drawer-actions {
+    flex-shrink: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 16px 24px calc(16px + env(safe-area-inset-bottom, 0px));
+    border-top: 1px solid var(--color-line);
+    background: var(--color-surface);
+  }
+  .rc-full {
+    width: 100%;
+  }
+  .rc-btn-solid,
+  .rc-btn-outline,
+  .rc-btn-text-danger {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    min-height: 44px;
+    font-weight: 500;
+  }
+  .rc-btn-solid {
+    border: none;
+    background: var(--color-primary);
+    color: #fff;
+  }
+  .rc-btn-solid:hover:not(:disabled) {
+    background: var(--color-primary-hover);
+  }
+  .rc-btn-solid:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+  .rc-btn-outline {
+    border: 1px solid var(--color-secondary);
+    background: transparent;
+    color: var(--color-secondary);
+  }
+  .rc-btn-outline:hover {
+    background: var(--color-action-hover);
+  }
+  .rc-btn-text-danger {
+    border: none;
+    background: transparent;
+    color: var(--color-error);
+  }
+  .rc-btn-text-danger:hover {
+    background: rgba(229, 57, 53, 0.08);
+  }
+</style>

--- a/frontend/recipes/src/lib/components/Toasts.svelte
+++ b/frontend/recipes/src/lib/components/Toasts.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+  // The toast region. Mirrors the meal-plan island's Toasts component, re-scoped
+  // to `rc-`. Mounted once at each App root (ListApp / EditApp).
+  import { toasts, dismissToast } from '../toasts.svelte';
+</script>
+
+<div class="rc-toast-region" role="status" aria-live="polite">
+  {#each toasts() as toast (toast.id)}
+    <div class="rc-toast rc-toast-{toast.kind}">
+      <span class="rc-toast-msg">{toast.message}</span>
+      {#if toast.action}
+        <button
+          type="button"
+          class="rc-toast-action"
+          onclick={() => {
+            toast.action?.onClick();
+            dismissToast(toast.id);
+          }}
+        >
+          {toast.action.label}
+        </button>
+      {/if}
+      <button
+        type="button"
+        class="rc-toast-close"
+        aria-label="Dismiss"
+        onclick={() => dismissToast(toast.id)}
+      >
+        ×
+      </button>
+    </div>
+  {/each}
+</div>
+
+<style>
+  .rc-toast-region {
+    position: fixed;
+    left: 50%;
+    bottom: 24px;
+    transform: translateX(-50%);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    z-index: 1100;
+    pointer-events: none;
+    max-width: min(560px, calc(100vw - 32px));
+  }
+  /* Mobile: clear the MainLayout bottom nav so toasts aren't hidden behind it. */
+  @media (max-width: 960px) {
+    .rc-toast-region {
+      bottom: calc(80px + env(safe-area-inset-bottom, 0px));
+    }
+  }
+  .rc-toast {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 12px 10px 16px;
+    border-radius: var(--radius-sm);
+    color: #fff;
+    background: #323232;
+    box-shadow: var(--shadow-4);
+    font-size: 0.875rem;
+    pointer-events: auto;
+    animation: rc-toast-in 0.2s ease-out;
+  }
+  .rc-toast-success {
+    background: var(--color-success);
+  }
+  .rc-toast-error {
+    background: var(--color-error);
+  }
+  .rc-toast-msg {
+    flex: 1;
+    min-width: 0;
+  }
+  .rc-toast-action {
+    background: transparent;
+    border: none;
+    color: #fff;
+    font: inherit;
+    font-weight: 600;
+    text-transform: uppercase;
+    font-size: 0.8125rem;
+    cursor: pointer;
+    padding: 0 4px;
+    flex-shrink: 0;
+  }
+  .rc-toast-action:hover {
+    text-decoration: underline;
+  }
+  .rc-toast-close {
+    background: transparent;
+    border: none;
+    color: rgba(255, 255, 255, 0.8);
+    font-size: 1.25rem;
+    line-height: 1;
+    padding: 0 4px;
+    cursor: pointer;
+  }
+  .rc-toast-close:hover {
+    color: #fff;
+  }
+  @keyframes rc-toast-in {
+    from {
+      opacity: 0;
+      transform: translateY(8px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+</style>

--- a/frontend/recipes/src/lib/liveness.ts
+++ b/frontend/recipes/src/lib/liveness.ts
@@ -1,0 +1,77 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Liveness — lightweight collaboration refresh for the recipes LIST view.
+//
+// A recipe added/edited/deleted by another household member should appear
+// within ~20s while the tab is VISIBLE, and immediately when the tab regains
+// focus. We do this with a plain interval + `visibilitychange`, NOT Blazor's
+// DataNotifier / PresenceService / PollingService (those are SignalR-circuit-
+// bound — the exact failure mode the strangler removes).
+//
+// The poll PAUSES while the tab is hidden: no interval ticks fire when
+// `document.hidden` is true, and on re-show we refetch once immediately, then
+// resume the interval. This keeps background tabs quiet.
+//
+// Wired ONLY in ListApp — the edit form is single-user (autosave-drafts is its
+// persistence path); a poll there would clobber in-progress edits.
+// ─────────────────────────────────────────────────────────────────────────
+
+const POLL_INTERVAL_MS = 20_000;
+
+export interface LivenessHandle {
+  /** Tear down the interval + visibility listener. Call on unmount. */
+  stop(): void;
+}
+
+/**
+ * Start polling. `refresh` is the list reload (ListApp's reconcile). It is only
+ * invoked while the document is visible. Returns a handle whose `stop()` removes
+ * the interval + listener.
+ */
+export function startLiveness(refresh: () => void): LivenessHandle {
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  function tick() {
+    // Guard: never poll while hidden (the interval is cleared on hide, but this
+    // is belt-and-suspenders in case a tick is queued at the moment of hiding).
+    if (document.visibilityState === 'visible') {
+      refresh();
+    }
+  }
+
+  function startInterval() {
+    if (timer != null) return;
+    timer = setInterval(tick, POLL_INTERVAL_MS);
+  }
+
+  function stopInterval() {
+    if (timer != null) {
+      clearInterval(timer);
+      timer = null;
+    }
+  }
+
+  function handleVisibility() {
+    if (document.visibilityState === 'visible') {
+      // Re-show: refetch immediately, then resume the interval.
+      refresh();
+      startInterval();
+    } else {
+      // Hidden: pause polling entirely.
+      stopInterval();
+    }
+  }
+
+  document.addEventListener('visibilitychange', handleVisibility);
+
+  // Begin polling only if we start visible.
+  if (document.visibilityState === 'visible') {
+    startInterval();
+  }
+
+  return {
+    stop() {
+      stopInterval();
+      document.removeEventListener('visibilitychange', handleVisibility);
+    },
+  };
+}

--- a/frontend/recipes/src/lib/quantity.ts
+++ b/frontend/recipes/src/lib/quantity.ts
@@ -1,0 +1,102 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Quantity formatting + servings-scaling math. Client-only (no endpoint).
+//
+// ⚠ TWO DISTINCT FORMATTERS — do NOT merge them (spec §6 / §11.10):
+//   • formatScaledQuantity — the DRAWER's *scaled* values. Uses RANGE
+//     thresholds (Recipes.razor FormatQuantity, :897-905) because a scaled
+//     value is fuzzy (e.g. 0.333… → "⅓"). Unicode-fraction glyphs.
+//   • formatExactQuantity — the ingredient-LIST display. Uses EXACT-equality
+//     checks (IngredientList.razor FormatQuantity, :106-132) because entered
+//     values are precise. ASCII "1/2"-style fractions + mixed numbers.
+// They differ on purpose; porting from intuition diverges.
+// ─────────────────────────────────────────────────────────────────────────
+
+// Unicode fraction glyphs used by the scaled formatter.
+const QUARTER = '¼'; // ¼
+const THIRD = '⅓'; // ⅓
+const HALF = '½'; // ½
+const TWO_THIRDS = '⅔'; // ⅔
+const THREE_QUARTERS = '¾'; // ¾
+const TIMES = '×'; // ×
+
+/** Mirror C# "0.##": round to ≤2 decimals, trim trailing zeros. */
+function formatDecimal(n: number): string {
+  const rounded = Math.round(n * 100) / 100;
+  return String(rounded);
+}
+
+/**
+ * Format a SCALED quantity for the detail drawer (range thresholds — the value
+ * is the product of user scaling, so it's approximate). Ports
+ * Recipes.razor:887-912 exactly.
+ */
+export function formatScaledQuantity(qty: number): string {
+  if (qty === Math.floor(qty)) {
+    return String(Math.trunc(qty));
+  }
+
+  const fractionalPart = qty - Math.floor(qty);
+  const wholePart = Math.floor(qty);
+
+  let fraction: string | null = null;
+  if (fractionalPart >= 0.2 && fractionalPart < 0.3) fraction = QUARTER;
+  else if (fractionalPart >= 0.3 && fractionalPart < 0.4) fraction = THIRD;
+  else if (fractionalPart >= 0.45 && fractionalPart < 0.55) fraction = HALF;
+  else if (fractionalPart >= 0.6 && fractionalPart < 0.7) fraction = TWO_THIRDS;
+  else if (fractionalPart >= 0.7 && fractionalPart < 0.8) fraction = THREE_QUARTERS;
+
+  if (fraction != null) {
+    return wholePart > 0 ? `${wholePart} ${fraction}` : fraction;
+  }
+
+  return formatDecimal(qty);
+}
+
+/**
+ * Format an EXACT entered quantity for the ingredient list (exact-equality
+ * fractions + mixed numbers). Ports IngredientList.razor:106-132 exactly.
+ */
+export function formatExactQuantity(qty: number): string {
+  // Common fractions (exact).
+  if (qty === 0.25) return '1/4';
+  if (qty === 0.5) return '1/2';
+  if (qty === 0.75) return '3/4';
+  if (qty === 0.33 || qty === 1 / 3) return '1/3';
+  if (qty === 0.67 || qty === 2 / 3) return '2/3';
+
+  // Mixed fractions.
+  const whole = Math.trunc(qty);
+  const frac = qty - whole;
+
+  if (frac === 0) return formatDecimal(whole);
+
+  if (whole > 0) {
+    if (frac === 0.25) return `${whole} 1/4`;
+    if (frac === 0.5) return `${whole} 1/2`;
+    if (frac === 0.75) return `${whole} 3/4`;
+    if (frac === 0.33 || Math.abs(frac - 1 / 3) < 0.01) return `${whole} 1/3`;
+    if (frac === 0.67 || Math.abs(frac - 2 / 3) < 0.01) return `${whole} 2/3`;
+  }
+
+  // Decimal fallback.
+  return formatDecimal(qty);
+}
+
+/** Scaling factor = scaledServings / baseServings (1 when base is null/0). */
+export function getScalingFactor(baseServings: number | null, scaledServings: number): number {
+  if (baseServings == null || baseServings === 0) return 1;
+  return scaledServings / baseServings;
+}
+
+/** Apply a scaling factor to one quantity. */
+export function getScaledQuantity(original: number, factor: number): number {
+  return original * factor;
+}
+
+/** The "×2" / "½×" / "1.5×" badge for the drawer. Ports Recipes.razor:930-937. */
+export function getScalingLabel(factor: number): string {
+  if (factor === 2) return `2${TIMES}`;
+  if (factor === 0.5) return `${HALF}${TIMES}`;
+  if (factor === 1.5) return `1.5${TIMES}`;
+  return `${formatDecimal(factor)}${TIMES}`;
+}

--- a/frontend/recipes/src/lib/recipeEditStore.svelte.ts
+++ b/frontend/recipes/src/lib/recipeEditStore.svelte.ts
@@ -110,6 +110,9 @@ class RecipeEditStore {
   private uidSeq = 1;
   private autosaveTimer: ReturnType<typeof setTimeout> | null = null;
   private savedClearTimer: ReturnType<typeof setTimeout> | null = null;
+  /** The in-flight draft-save (if any) — save()/delete() await it before deleteDraft so a late
+   *  autosave can't re-create the draft we just cleared (council race fix). */
+  private autosaveInFlight: Promise<void> | null = null;
 
   init(ctx: ShellContext): void {
     this.currentUserId = ctx.userId;
@@ -238,22 +241,46 @@ class RecipeEditStore {
   }
 
   private async runAutosave(): Promise<void> {
-    // The draft endpoint requires a non-blank name — skip until the recipe is named.
-    if (!this.form.name.trim()) {
+    // Skip if: the draft endpoint requires a non-blank name, OR a save/delete is underway (that path
+    // owns the draft lifecycle and will deleteDraft — autosaving now would resurrect it).
+    if (!this.form.name.trim() || this.saving || this.deleting) {
       this.autosaveStatus = 'none';
       return;
     }
     this.autosaveStatus = 'saving';
-    try {
-      await saveDraft(this.buildDraftBody());
-      this.autosaveStatus = 'saved';
-      if (this.savedClearTimer) clearTimeout(this.savedClearTimer);
-      this.savedClearTimer = setTimeout(() => {
-        if (this.autosaveStatus === 'saved') this.autosaveStatus = 'none';
-      }, SAVED_CLEAR_MS);
-    } catch {
-      this.autosaveStatus = 'none';
-      showToast({ message: "Couldn't save draft.", kind: 'info' });
+    const inFlight = (async () => {
+      try {
+        await saveDraft(this.buildDraftBody());
+        this.autosaveStatus = 'saved';
+        if (this.savedClearTimer) clearTimeout(this.savedClearTimer);
+        this.savedClearTimer = setTimeout(() => {
+          if (this.autosaveStatus === 'saved') this.autosaveStatus = 'none';
+        }, SAVED_CLEAR_MS);
+      } catch {
+        this.autosaveStatus = 'none';
+        showToast({ message: "Couldn't save draft.", kind: 'info' });
+      }
+    })();
+    this.autosaveInFlight = inFlight;
+    await inFlight;
+    if (this.autosaveInFlight === inFlight) this.autosaveInFlight = null;
+  }
+
+  /**
+   * Cancel a pending autosave timer and wait out any in-flight draft save. save()/delete() call this
+   * before deleteDraft so a late autosave PUT can't land after the delete and re-create the draft.
+   */
+  private async flushAutosave(): Promise<void> {
+    if (this.autosaveTimer) {
+      clearTimeout(this.autosaveTimer);
+      this.autosaveTimer = null;
+    }
+    if (this.autosaveInFlight) {
+      try {
+        await this.autosaveInFlight;
+      } catch {
+        /* the autosave handles its own errors */
+      }
     }
   }
 
@@ -367,7 +394,8 @@ class RecipeEditStore {
       showToast({ message: 'Recipe name is required.', kind: 'error' });
       return;
     }
-    this.saving = true;
+    this.saving = true; // set first: a timer-fired autosave now bails on the saving guard
+    await this.flushAutosave(); // wait out any in-flight draft save before we deleteDraft
     this.error = null;
     try {
       const body = this.buildWriteRequest();
@@ -396,7 +424,8 @@ class RecipeEditStore {
 
   async delete(): Promise<void> {
     if (this.recipeId == null) return;
-    this.deleting = true;
+    this.deleting = true; // set first: a timer-fired autosave now bails on the deleting guard
+    await this.flushAutosave(); // wait out any in-flight draft save before we deleteDraft
     try {
       await deleteRecipe(this.recipeId);
       await this.safeDeleteDraft();

--- a/frontend/recipes/src/lib/recipeEditStore.svelte.ts
+++ b/frontend/recipes/src/lib/recipeEditStore.svelte.ts
@@ -1,0 +1,503 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Edit-view store — the source of truth for the recipe edit form
+// (#recipes-edit-root). Owns ONLY edit-view files (spec §6 store split) so
+// WP-5 / WP-6 never collide.
+//
+// ⚠ Svelte 5 rune rule: export the class INSTANCE, not reassigned $state.
+//
+// Mirrors RecipeEdit.razor: draft-first load (restore + toast, else recipe-or-
+// blank), 2s-debounce autosave drafts, ingredient add/bulk/remove(undo)/reorder,
+// image upload/remove/pick, and Save/Cancel/Delete. Versionless / last-write-wins
+// (D5): on any 4xx during save/delete we surface a calm "this recipe changed"
+// and return to the list (§8). Single-user form ⇒ NO liveness (autosave is the
+// persistence path).
+// ─────────────────────────────────────────────────────────────────────────
+
+import type {
+  RecipeDraftData,
+  RecipeFullDto,
+  RecipeType,
+  RecipeWriteRequest,
+  SaveDraftRequest,
+  ShellContext,
+} from './types';
+import {
+  ApiError,
+  getRecipe,
+  getDraft,
+  saveDraft,
+  deleteDraft,
+  createRecipe,
+  updateRecipe,
+  deleteRecipe,
+  uploadImage,
+  getCategories,
+} from './api';
+import { showToast } from './toasts.svelte';
+
+/** The bound form model (text fields are strings; trimmed/null-on-save). */
+export interface RecipeEditModel {
+  name: string;
+  description: string;
+  instructions: string;
+  sourceUrl: string;
+  prepTimeMinutes: number | null;
+  cookTimeMinutes: number | null;
+  servings: number | null;
+  recipeType: RecipeType;
+  imagePath: string | null;
+}
+
+/** One ingredient row. `id` is a stable client uid for keying + svelte-dnd-action. */
+export interface IngredientRow {
+  id: number;
+  ingredientId: number;
+  quantity: number | null;
+  unit: string | null;
+  name: string;
+  category: string;
+  notes: string | null;
+  groupName: string | null;
+  sortOrder: number;
+}
+
+/** A structured ingredient produced by the entry / bulk-paste (pre-row). */
+export interface NewIngredientInput {
+  name: string;
+  quantity: number | null;
+  unit: string | null;
+  category: string;
+  notes: string | null;
+  groupName?: string | null;
+}
+
+type AutosaveStatus = 'none' | 'saving' | 'saved';
+
+const AUTOSAVE_DELAY_MS = 2000;
+const SAVED_CLEAR_MS = 3000;
+
+function blankForm(): RecipeEditModel {
+  return {
+    name: '',
+    description: '',
+    instructions: '',
+    sourceUrl: '',
+    prepTimeMinutes: null,
+    cookTimeMinutes: null,
+    servings: null,
+    recipeType: 'main',
+    imagePath: null,
+  };
+}
+
+class RecipeEditStore {
+  form = $state<RecipeEditModel>(blankForm());
+  ingredients = $state<IngredientRow[]>([]);
+  categories = $state<string[]>([]);
+  loading = $state(true);
+  saving = $state(false);
+  deleting = $state(false);
+  dirty = $state(false);
+  autosaveStatus = $state<AutosaveStatus>('none');
+  error = $state<string | null>(null);
+
+  /** The recipe id (null = new). Set from the shell context. */
+  recipeId = $state<number | null>(null);
+  currentUserId = $state(0);
+
+  isEdit = $derived(this.recipeId != null);
+
+  private uidSeq = 1;
+  private autosaveTimer: ReturnType<typeof setTimeout> | null = null;
+  private savedClearTimer: ReturnType<typeof setTimeout> | null = null;
+
+  init(ctx: ShellContext): void {
+    this.currentUserId = ctx.userId;
+    this.recipeId = ctx.recipeId;
+  }
+
+  /**
+   * Load draft-first (restore + toast), else the existing recipe (edit) or blank
+   * defaults (new). Mirrors RecipeEdit.razor LoadRecipeOrDraft. Also loads the
+   * household categories for the entry select.
+   */
+  async load(recipeId: number | null): Promise<void> {
+    this.recipeId = recipeId;
+    this.loading = true;
+    this.error = null;
+    try {
+      const draft = await getDraft(recipeId);
+      if (draft) {
+        this.applyDraft(draft);
+        showToast({ message: 'Restored from draft', kind: 'info' });
+      } else if (recipeId != null) {
+        const full = await getRecipe(recipeId);
+        this.applyFull(full);
+      } else {
+        // New recipe defaults (RecipeEdit.razor:352-357).
+        this.form = { ...blankForm(), recipeType: 'main', servings: 4 };
+        this.ingredients = [];
+      }
+      this.dirty = false;
+    } catch (e) {
+      if (recipeId != null && e instanceof ApiError) {
+        // Missing / cross-household recipe → calm message + back to the list.
+        showToast({ message: 'Recipe not found.', kind: 'error' });
+        this.navigateToList();
+        return;
+      }
+      this.error = e instanceof Error ? e.message : String(e);
+    } finally {
+      this.loading = false;
+    }
+    // Categories are non-critical — load after the form is up.
+    void this.loadCategories();
+  }
+
+  private async loadCategories(): Promise<void> {
+    try {
+      const cats = await getCategories();
+      this.categories = cats.map((c) => c.name);
+    } catch {
+      this.categories = [];
+    }
+  }
+
+  private applyDraft(d: RecipeDraftData): void {
+    this.form = {
+      name: d.name,
+      description: d.description ?? '',
+      instructions: d.instructions ?? '',
+      sourceUrl: d.sourceUrl ?? '',
+      prepTimeMinutes: d.prepTimeMinutes,
+      cookTimeMinutes: d.cookTimeMinutes,
+      servings: d.servings,
+      // Drafts don't persist recipeType (DraftService.RecipeDraftData has no type) —
+      // mirrors Blazor restoring a draft into a default-Main recipe.
+      recipeType: 'main',
+      imagePath: d.imagePath,
+    };
+    this.ingredients = d.ingredients.map((i) => this.toRow(i, 0));
+  }
+
+  private applyFull(f: RecipeFullDto): void {
+    this.form = {
+      name: f.name,
+      description: f.description ?? '',
+      instructions: f.instructions ?? '',
+      sourceUrl: f.sourceUrl ?? '',
+      prepTimeMinutes: f.prepTimeMinutes,
+      cookTimeMinutes: f.cookTimeMinutes,
+      servings: f.servings,
+      recipeType: f.recipeType,
+      imagePath: f.imagePath,
+    };
+    this.ingredients = f.ingredients
+      .slice()
+      .sort((a, b) => a.sortOrder - b.sortOrder)
+      .map((i) => this.toRow(i, i.ingredientId));
+  }
+
+  private toRow(
+    i: {
+      quantity: number | null;
+      unit: string | null;
+      name: string;
+      category: string;
+      notes: string | null;
+      groupName: string | null;
+      sortOrder: number;
+    },
+    ingredientId: number,
+  ): IngredientRow {
+    return {
+      id: this.uidSeq++,
+      ingredientId,
+      quantity: i.quantity,
+      unit: i.unit,
+      name: i.name,
+      category: i.category,
+      notes: i.notes,
+      groupName: i.groupName,
+      sortOrder: i.sortOrder,
+    };
+  }
+
+  // ── Field edits → dirty + autosave ─────────────────────────────────────────
+
+  /** Call on any form-field edit: marks dirty + (re)schedules the draft autosave. */
+  onEdit(): void {
+    this.dirty = true;
+    this.autosaveStatus = 'none';
+    this.scheduleAutosave();
+  }
+
+  private scheduleAutosave(): void {
+    if (this.autosaveTimer) clearTimeout(this.autosaveTimer);
+    this.autosaveTimer = setTimeout(() => void this.runAutosave(), AUTOSAVE_DELAY_MS);
+  }
+
+  private async runAutosave(): Promise<void> {
+    // The draft endpoint requires a non-blank name — skip until the recipe is named.
+    if (!this.form.name.trim()) {
+      this.autosaveStatus = 'none';
+      return;
+    }
+    this.autosaveStatus = 'saving';
+    try {
+      await saveDraft(this.buildDraftBody());
+      this.autosaveStatus = 'saved';
+      if (this.savedClearTimer) clearTimeout(this.savedClearTimer);
+      this.savedClearTimer = setTimeout(() => {
+        if (this.autosaveStatus === 'saved') this.autosaveStatus = 'none';
+      }, SAVED_CLEAR_MS);
+    } catch {
+      this.autosaveStatus = 'none';
+      showToast({ message: "Couldn't save draft.", kind: 'info' });
+    }
+  }
+
+  // ── Ingredients ────────────────────────────────────────────────────────────
+
+  addIngredient(input: NewIngredientInput): void {
+    this.ingredients = [...this.ingredients, this.newRow(input, this.ingredients.length)];
+    this.onEdit();
+  }
+
+  addBulk(inputs: NewIngredientInput[]): void {
+    let order = this.ingredients.length;
+    const rows = inputs.map((i) => this.newRow(i, order++));
+    this.ingredients = [...this.ingredients, ...rows];
+    this.onEdit();
+  }
+
+  private newRow(input: NewIngredientInput, sortOrder: number): IngredientRow {
+    return {
+      id: this.uidSeq++,
+      ingredientId: 0,
+      quantity: input.quantity,
+      unit: input.unit,
+      name: input.name,
+      category: input.category,
+      notes: input.notes,
+      groupName: input.groupName ?? null,
+      sortOrder,
+    };
+  }
+
+  /** Remove an ingredient with a 5s "Undo" toast (mirrors IngredientList delete-with-undo). */
+  removeIngredient(id: number): void {
+    const index = this.ingredients.findIndex((r) => r.id === id);
+    if (index < 0) return;
+    const removed = this.ingredients[index];
+    this.ingredients = this.resequence(this.ingredients.filter((r) => r.id !== id));
+    this.onEdit();
+    showToast({
+      message: 'Ingredient deleted',
+      kind: 'info',
+      durationMs: 5000,
+      action: {
+        label: 'Undo',
+        onClick: () => this.restoreIngredient(removed, index),
+      },
+    });
+  }
+
+  private restoreIngredient(row: IngredientRow, index: number): void {
+    const next = this.ingredients.slice();
+    next.splice(Math.min(index, next.length), 0, row);
+    this.ingredients = this.resequence(next);
+    this.onEdit();
+    showToast({ message: 'Ingredient restored', kind: 'success' });
+  }
+
+  /**
+   * "Edit" an ingredient — parity with Blazor's remove-and-re-add flow
+   * (IngredientList.razor:451-456). Inline editing is a harvested follow-up quest.
+   */
+  editIngredient(id: number): void {
+    this.ingredients = this.resequence(this.ingredients.filter((r) => r.id !== id));
+    this.onEdit();
+    showToast({ message: 'Re-add the ingredient with your changes.', kind: 'info' });
+  }
+
+  /** Apply a drag-reorder (svelte-dnd-action finalize gives the new row order). */
+  reorder(rows: IngredientRow[]): void {
+    this.ingredients = this.resequence(rows);
+    this.onEdit();
+  }
+
+  /** Recompute sortOrder 0..n in list order. */
+  private resequence(rows: IngredientRow[]): IngredientRow[] {
+    return rows.map((r, i) => ({ ...r, sortOrder: i }));
+  }
+
+  // ── Image ──────────────────────────────────────────────────────────────────
+
+  async uploadImage(file: File): Promise<void> {
+    try {
+      const { imagePath } = await uploadImage(file);
+      this.form.imagePath = imagePath;
+      this.onEdit();
+      showToast({ message: 'Image uploaded', kind: 'success' });
+    } catch (e) {
+      const msg =
+        e instanceof ApiError && e.status === 400
+          ? 'That image was rejected (max 10 MB; JPG/PNG/GIF/WebP).'
+          : "Couldn't upload that image.";
+      showToast({ message: msg, kind: 'error' });
+    }
+  }
+
+  removeImage(): void {
+    this.form.imagePath = null;
+    this.onEdit();
+  }
+
+  setImage(path: string): void {
+    this.form.imagePath = path;
+    this.onEdit();
+  }
+
+  // ── Save / Delete / Cancel ───────────────────────────────────────────────────
+
+  async save(): Promise<void> {
+    const name = this.form.name.trim();
+    if (!name) {
+      showToast({ message: 'Recipe name is required.', kind: 'error' });
+      return;
+    }
+    this.saving = true;
+    this.error = null;
+    try {
+      const body = this.buildWriteRequest();
+      if (this.recipeId != null) {
+        await updateRecipe(this.recipeId, body);
+      } else {
+        await createRecipe(body);
+      }
+      await this.safeDeleteDraft();
+      this.dirty = false; // suppress the beforeunload nav-lock before navigating
+      this.navigateToList();
+    } catch (e) {
+      if (e instanceof ApiError) {
+        // 4xx incl. the empty-400-from-404 quirk → concurrent delete / last-write-wins.
+        this.error = 'This recipe changed since you opened it.';
+        this.dirty = false;
+        showToast({ message: 'This recipe changed — returning to the list.', kind: 'info' });
+        this.navigateToList();
+      } else {
+        showToast({ message: 'Something went wrong saving. Please try again.', kind: 'error' });
+      }
+    } finally {
+      this.saving = false;
+    }
+  }
+
+  async delete(): Promise<void> {
+    if (this.recipeId == null) return;
+    this.deleting = true;
+    try {
+      await deleteRecipe(this.recipeId);
+      await this.safeDeleteDraft();
+      this.dirty = false;
+      showToast({ message: 'Recipe deleted', kind: 'success' });
+      this.navigateToList();
+    } catch (e) {
+      if (e instanceof ApiError) {
+        // Already gone — just return to the list.
+        this.dirty = false;
+        showToast({ message: 'That recipe was already removed.', kind: 'info' });
+        this.navigateToList();
+      } else {
+        showToast({ message: "Couldn't delete that recipe right now.", kind: 'error' });
+      }
+    } finally {
+      this.deleting = false;
+    }
+  }
+
+  cancel(): void {
+    this.dirty = false; // explicit discard — no nav-lock prompt
+    this.navigateToList();
+  }
+
+  private async safeDeleteDraft(): Promise<void> {
+    try {
+      await deleteDraft(this.recipeId);
+    } catch {
+      /* draft cleanup is best-effort */
+    }
+  }
+
+  private navigateToList(): void {
+    window.location.assign('/recipes');
+  }
+
+  /** Clear timers on unmount (EditApp's effect cleanup). */
+  teardown(): void {
+    if (this.autosaveTimer) clearTimeout(this.autosaveTimer);
+    if (this.savedClearTimer) clearTimeout(this.savedClearTimer);
+    this.autosaveTimer = null;
+    this.savedClearTimer = null;
+  }
+
+  // ── Mappers (form → wire) ────────────────────────────────────────────────────
+
+  private buildWriteRequest(): RecipeWriteRequest {
+    return {
+      name: this.form.name.trim(),
+      description: nullIfBlank(this.form.description),
+      instructions: nullIfBlank(this.form.instructions),
+      sourceUrl: nullIfBlank(this.form.sourceUrl),
+      servings: this.form.servings,
+      prepTimeMinutes: this.form.prepTimeMinutes,
+      cookTimeMinutes: this.form.cookTimeMinutes,
+      recipeType: this.form.recipeType,
+      imagePath: this.form.imagePath,
+      ingredients: this.ingredients.map((r, i) => ({
+        name: r.name.trim(),
+        quantity: r.quantity,
+        unit: nullIfBlank(r.unit),
+        category: r.category?.trim() || this.fallbackCategory(),
+        notes: nullIfBlank(r.notes),
+        groupName: nullIfBlank(r.groupName),
+        sortOrder: i,
+      })),
+    };
+  }
+
+  private buildDraftBody(): SaveDraftRequest {
+    return {
+      recipeId: this.recipeId,
+      name: this.form.name.trim(),
+      description: nullIfBlank(this.form.description),
+      instructions: nullIfBlank(this.form.instructions),
+      imagePath: this.form.imagePath,
+      sourceUrl: nullIfBlank(this.form.sourceUrl),
+      servings: this.form.servings,
+      prepTimeMinutes: this.form.prepTimeMinutes,
+      cookTimeMinutes: this.form.cookTimeMinutes,
+      ingredients: this.ingredients.map((r, i) => ({
+        name: r.name.trim(),
+        quantity: r.quantity,
+        unit: nullIfBlank(r.unit),
+        category: r.category?.trim() || this.fallbackCategory(),
+        notes: nullIfBlank(r.notes),
+        groupName: nullIfBlank(r.groupName),
+        sortOrder: i,
+      })),
+    };
+  }
+
+  private fallbackCategory(): string {
+    return this.categories[0] ?? 'Pantry';
+  }
+}
+
+function nullIfBlank(s: string | null | undefined): string | null {
+  return s == null || s.trim() === '' ? null : s.trim();
+}
+
+/** The single shared edit-view store instance (export the instance, not the runes). */
+export const recipeEditStore = new RecipeEditStore();

--- a/frontend/recipes/src/lib/recipeListStore.svelte.ts
+++ b/frontend/recipes/src/lib/recipeListStore.svelte.ts
@@ -49,6 +49,9 @@ class RecipeListStore {
 
   /** True once the first load has resolved — gates the skeleton so search/liveness don't reflash it. */
   private hasLoaded = false;
+  /** Monotonic load id — search / connected-switch / liveness / reconcile all call load(); a slower
+   *  older response must NOT overwrite a newer one, so each load only applies if it's still the latest. */
+  private loadSeq = 0;
   /** The list refetch hook (ListApp's loader), shared by liveness + error reconcile. */
   private refresh: (() => Promise<void>) | null = null;
 
@@ -89,20 +92,24 @@ class RecipeListStore {
    * refresh in place (no skeleton reflash).
    */
   async load(): Promise<void> {
+    const seq = ++this.loadSeq;
     try {
       if (!this.hasLoaded) this.loading = true;
       this.error = null;
       if (this.selectedConnectedId == null) {
         const dto = await listRecipes(this.query);
+        if (seq !== this.loadSeq) return; // a newer load superseded this one
         this.recipes = dto.recipes;
         this.favoriteIds = new Set(dto.favoriteRecipeIds);
       } else {
         const dto = await listConnectedRecipes(this.selectedConnectedId, this.query);
+        if (seq !== this.loadSeq) return;
         this.recipes = dto.recipes;
         this.favoriteIds = new Set();
       }
       this.hasLoaded = true;
     } catch (e) {
+      if (seq !== this.loadSeq) return; // don't surface an error from a superseded load
       this.error =
         e instanceof ApiError
           ? `Failed to load recipes (HTTP ${e.status}).`
@@ -110,7 +117,7 @@ class RecipeListStore {
             ? e.message
             : String(e);
     } finally {
-      this.loading = false;
+      if (seq === this.loadSeq) this.loading = false;
     }
   }
 

--- a/frontend/recipes/src/lib/recipeListStore.svelte.ts
+++ b/frontend/recipes/src/lib/recipeListStore.svelte.ts
@@ -1,0 +1,202 @@
+// ─────────────────────────────────────────────────────────────────────────
+// List-view store — the source of truth for the recipes grid (#recipes-list-root).
+//
+// ⚠ Svelte 5 rune rule (global CORRECTION): never `export` a reassigned
+// `$state`/`$derived` from a module. We wrap the mutable state in a class
+// instance and export the instance — the runes live as fields on the object.
+//
+// Parity-first ⇒ versionless / last-write-wins. Search is SERVER-side + debounced
+// (D9); the favorites filter is CLIENT-side over the loaded set; favoriteRecipeIds
+// arrive with the same payload (one round-trip). On any 4xx/network error we
+// reconcile (re-run the current query) + a calm toast. Liveness re-runs the
+// current query while the tab is visible.
+//
+// Owns ONLY list-view files (spec §6 store split) — the edit view has its own
+// store (recipeEditStore.svelte.ts), so WP-5 / WP-6 never collide.
+// ─────────────────────────────────────────────────────────────────────────
+
+import type {
+  ConnectedHouseholdDto,
+  RecipeListItemDto,
+  ShellContext,
+} from './types';
+import {
+  ApiError,
+  listRecipes,
+  listConnectedRecipes,
+  toggleFavorite as apiToggleFavorite,
+  deleteRecipe as apiDeleteRecipe,
+  getConnections,
+} from './api';
+import { showToast } from './toasts.svelte';
+
+class RecipeListStore {
+  /** The active search term (server-filtered, debounced by the view). */
+  query = $state('');
+  /** The loaded card set (own household OR a connected household). */
+  recipes = $state<RecipeListItemDto[]>([]);
+  /** This user's favorite recipe ids (own household only — empty for connected). */
+  favoriteIds = $state<Set<number>>(new Set());
+  /** Client-side "favorites only" filter chip (own household only). */
+  showFavoritesOnly = $state(false);
+  /** null = my recipes; a household id = viewing that connected household (read-only). */
+  selectedConnectedId = $state<number | null>(null);
+  /** Connected households for the selector (empty ⇒ no selector shown). */
+  connections = $state<ConnectedHouseholdDto[]>([]);
+  loading = $state(true);
+  error = $state<string | null>(null);
+  currentUserId = $state(0);
+
+  /** True once the first load has resolved — gates the skeleton so search/liveness don't reflash it. */
+  private hasLoaded = false;
+  /** The list refetch hook (ListApp's loader), shared by liveness + error reconcile. */
+  private refresh: (() => Promise<void>) | null = null;
+
+  /** Viewing a connected household? (favorites + per-card heart hide when true.) */
+  isViewingConnected = $derived(this.selectedConnectedId != null);
+
+  /** The connected household's name (attribution) — null when viewing my recipes. */
+  selectedConnectedName = $derived(
+    this.selectedConnectedId == null
+      ? null
+      : (this.connections.find((c) => c.householdId === this.selectedConnectedId)?.householdName ?? null),
+  );
+
+  /** The cards actually rendered — applies the client-side favorites filter (own household only). */
+  displayed = $derived.by(() =>
+    this.showFavoritesOnly && this.selectedConnectedId == null
+      ? this.recipes.filter((r) => this.favoriteIds.has(r.recipeId))
+      : this.recipes,
+  );
+
+  init(ctx: ShellContext): void {
+    this.currentUserId = ctx.userId;
+  }
+
+  setRefresh(refresh: () => Promise<void>): void {
+    this.refresh = refresh;
+  }
+
+  /** Re-run the current query. Shared by liveness + error reconcile. */
+  async reconcile(): Promise<void> {
+    if (this.refresh) await this.refresh();
+  }
+
+  /**
+   * Load the current view: own recipes (#1) when no connected household is
+   * selected, else the connected household's shared recipes (#15, same shape,
+   * favorites always empty). Spinner only on the FIRST load — search + liveness
+   * refresh in place (no skeleton reflash).
+   */
+  async load(): Promise<void> {
+    try {
+      if (!this.hasLoaded) this.loading = true;
+      this.error = null;
+      if (this.selectedConnectedId == null) {
+        const dto = await listRecipes(this.query);
+        this.recipes = dto.recipes;
+        this.favoriteIds = new Set(dto.favoriteRecipeIds);
+      } else {
+        const dto = await listConnectedRecipes(this.selectedConnectedId, this.query);
+        this.recipes = dto.recipes;
+        this.favoriteIds = new Set();
+      }
+      this.hasLoaded = true;
+    } catch (e) {
+      this.error =
+        e instanceof ApiError
+          ? `Failed to load recipes (HTTP ${e.status}).`
+          : e instanceof Error
+            ? e.message
+            : String(e);
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  /** Load the connected-household selector chips (non-critical: failure ⇒ no selector). */
+  async loadConnections(): Promise<void> {
+    try {
+      this.connections = await getConnections();
+    } catch {
+      this.connections = [];
+    }
+  }
+
+  /** Set the new search term and reload (the view debounces before calling this). */
+  async search(q: string): Promise<void> {
+    this.query = q;
+    await this.load();
+  }
+
+  /**
+   * Switch between "My Recipes" (null) and a connected household. Resets the
+   * search + favorites filter (mirrors the Blazor OnHouseholdSelectionChanged),
+   * then reloads.
+   */
+  async setConnected(id: number | null): Promise<void> {
+    this.selectedConnectedId = id;
+    this.query = '';
+    this.showFavoritesOnly = false;
+    await this.load();
+  }
+
+  toggleFavoritesFilter(): void {
+    this.showFavoritesOnly = !this.showFavoritesOnly;
+  }
+
+  /**
+   * Toggle a favorite (own household only). Optimistic Set toggle, then POST and
+   * reconcile to the server's authoritative state; on error revert + (4xx) refetch.
+   */
+  async toggleFavorite(id: number): Promise<void> {
+    if (this.selectedConnectedId != null) return;
+    const had = this.favoriteIds.has(id);
+    this.favoriteIds = toggled(this.favoriteIds, id, !had);
+    try {
+      const res = await apiToggleFavorite(id);
+      this.favoriteIds = toggled(this.favoriteIds, id, res.isFavorite);
+    } catch (e) {
+      this.favoriteIds = toggled(this.favoriteIds, id, had); // revert
+      if (e instanceof ApiError) {
+        await this.reconcile();
+        showToast({ message: 'That recipe changed — the list was refreshed.', kind: 'info' });
+      } else {
+        showToast({ message: "Couldn't update that favorite right now.", kind: 'error' });
+      }
+    }
+  }
+
+  /**
+   * Delete a recipe (own household only). Optimistic removal from the grid, then
+   * DELETE; on a 4xx (incl. the empty-400-from-404 quirk) reconcile to truth, on
+   * network/5xx restore the card.
+   */
+  async deleteRecipe(id: number): Promise<void> {
+    const prev = this.recipes;
+    this.recipes = this.recipes.filter((r) => r.recipeId !== id);
+    try {
+      await apiDeleteRecipe(id);
+      showToast({ message: 'Recipe deleted.', kind: 'success' });
+    } catch (e) {
+      if (e instanceof ApiError) {
+        await this.reconcile();
+        showToast({ message: 'That recipe changed — the list was refreshed.', kind: 'info' });
+      } else {
+        this.recipes = prev;
+        showToast({ message: "Couldn't delete that recipe right now.", kind: 'error' });
+      }
+    }
+  }
+}
+
+/** Return a NEW Set with `id` present (`on`) or absent — keeps the $state reassignment reactive. */
+function toggled(set: ReadonlySet<number>, id: number, on: boolean): Set<number> {
+  const next = new Set(set);
+  if (on) next.add(id);
+  else next.delete(id);
+  return next;
+}
+
+/** The single shared list-view store instance (export the instance, not the runes). */
+export const recipeListStore = new RecipeListStore();

--- a/frontend/recipes/src/lib/recipeType.ts
+++ b/frontend/recipes/src/lib/recipeType.ts
@@ -1,0 +1,65 @@
+// Display labels for the RecipeType union (mirrors the Blazor GetRecipeTypeLabel
+// in RecipeEdit / RecipeCard) + the type-select option order (the C# enum order).
+import type { RecipeType } from './types';
+
+export const RECIPE_TYPE_LABELS: Record<RecipeType, string> = {
+  main: 'Main Dish',
+  side: 'Side Dish',
+  appetizer: 'Appetizer',
+  dessert: 'Dessert',
+  beverage: 'Beverage',
+  sauce: 'Sauce/Condiment',
+  breakfast: 'Breakfast',
+  snack: 'Snack',
+  other: 'Other',
+};
+
+/** The select option order — matches the C# enum declaration order. */
+export const RECIPE_TYPES: RecipeType[] = [
+  'main',
+  'side',
+  'appetizer',
+  'dessert',
+  'beverage',
+  'sauce',
+  'breakfast',
+  'snack',
+  'other',
+];
+
+export function recipeTypeLabel(type: RecipeType): string {
+  return RECIPE_TYPE_LABELS[type] ?? type;
+}
+
+/** Short chip labels for the card (mirrors RecipeCard.razor GetTypeLabel; `main` chip is hidden). */
+const RECIPE_TYPE_SHORT: Record<RecipeType, string> = {
+  main: 'Main',
+  side: 'Side',
+  appetizer: 'Appetizer',
+  dessert: 'Dessert',
+  beverage: 'Beverage',
+  sauce: 'Sauce',
+  breakfast: 'Breakfast',
+  snack: 'Snack',
+  other: 'Other',
+};
+
+export function recipeTypeShort(type: RecipeType): string {
+  return RECIPE_TYPE_SHORT[type] ?? type;
+}
+
+/** Chip accent color per type (mirrors RecipeCard.razor GetTypeColor). */
+export function recipeTypeColor(type: RecipeType): string {
+  switch (type) {
+    case 'dessert':
+      return 'var(--color-secondary)';
+    case 'beverage':
+      return 'var(--color-info)';
+    case 'breakfast':
+      return 'var(--color-warning)';
+    case 'appetizer':
+      return 'var(--color-primary-soft)';
+    default:
+      return 'var(--color-text-muted)';
+  }
+}

--- a/frontend/recipes/src/lib/toasts.svelte.ts
+++ b/frontend/recipes/src/lib/toasts.svelte.ts
@@ -1,0 +1,60 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Transient toast notices for the recipes island (mirrors the meal-plan/chores
+// toast store). Used for non-alarming 4xx/network surfacing, the "someone
+// changed this — refreshed" reconcile notice, and edit-form save outcomes. Kept
+// deliberately small: a module-level `$state` list + helpers.
+//
+// ⚠ Svelte 5 rune rule: we never export a reassigned `$state` rune directly.
+// The list lives inside a module-private `$state` object; callers read it via
+// the `toasts()` accessor and mutate it only through the exported functions.
+// ─────────────────────────────────────────────────────────────────────────
+
+export type ToastKind = 'info' | 'success' | 'error';
+
+/** Optional inline action (e.g. the ingredient delete-with-undo). */
+export interface ToastAction {
+  label: string;
+  onClick: () => void;
+}
+
+export interface Toast {
+  id: number;
+  message: string;
+  kind: ToastKind;
+  durationMs: number;
+  action?: ToastAction;
+}
+
+let nextId = 1;
+const store = $state<{ items: Toast[] }>({ items: [] });
+
+/** The live toast list (reactive — read inside markup). */
+export function toasts(): readonly Toast[] {
+  return store.items;
+}
+
+/** Push a toast. Auto-dismisses after `durationMs` (default 3.5s). */
+export function showToast(toast: {
+  message: string;
+  kind: ToastKind;
+  durationMs?: number;
+  action?: ToastAction;
+}): number {
+  const id = nextId++;
+  const full: Toast = {
+    id,
+    message: toast.message,
+    kind: toast.kind,
+    durationMs: toast.durationMs ?? 3500,
+    action: toast.action,
+  };
+  store.items = [...store.items, full];
+  if (full.durationMs > 0) {
+    setTimeout(() => dismissToast(id), full.durationMs);
+  }
+  return id;
+}
+
+export function dismissToast(id: number): void {
+  store.items = store.items.filter((t) => t.id !== id);
+}

--- a/frontend/recipes/src/lib/types.ts
+++ b/frontend/recipes/src/lib/types.ts
@@ -1,0 +1,203 @@
+// ─────────────────────────────────────────────────────────────────────────
+// TS mirror of the /api/recipes contract (M9 lockstep). Source of truth:
+//   - Services/Dtos/RecipeDtos.cs (the C# records)
+//   - tests/.../Fixtures/RecipeList/list.json + Fixtures/RecipeFull/recipe.json
+//     (the contract-test tripwires — these keys/casing are byte-locked)
+//   - Endpoints/RecipesEndpoints.cs (request DTOs)
+//   - Services/DraftService.cs (RecipeDraftData / IngredientDraftData)
+//
+// ⚠ CASING: all keys are camelCase. `RecipeType` is a real C# enum on the DTO →
+//   it serializes as a camelCase STRING via JsonStringEnumConverter(CamelCase)
+//   ("main", "side", …). `decimal?`/`int?` serialize as number-or-null.
+// ─────────────────────────────────────────────────────────────────────────
+
+export type RecipeType =
+  | 'main'
+  | 'side'
+  | 'appetizer'
+  | 'dessert'
+  | 'beverage'
+  | 'sauce'
+  | 'breakfast'
+  | 'snack'
+  | 'other';
+
+// ── List (Fixtures/RecipeList/list.json) ───────────────────────────────────
+
+export interface RecipeListItemDto {
+  recipeId: number;
+  name: string;
+  recipeType: RecipeType;
+  imagePath: string | null;
+  /** bool, NOT the url — the card only shows the "imported" cloud icon. */
+  hasSourceUrl: boolean;
+  /** null when connected (privacy) or the author was deleted. */
+  createdByName: string | null;
+  /** User has PictureUrl + Initials, NO color → card renders pic-or-initials. */
+  createdByPictureUrl: string | null;
+  /** First 3 ingredient names (ordered by sort order). */
+  ingredientPreview: string[];
+  /** Total count — for the "+N more" suffix. */
+  ingredientCount: number;
+}
+
+export interface RecipeListDto {
+  recipes: RecipeListItemDto[];
+  /** Own-household only; always [] for a connected household. */
+  favoriteRecipeIds: number[];
+}
+
+// ── Full (read drawer + edit form superset, D3) (Fixtures/RecipeFull/recipe.json) ──
+
+export interface RecipeIngredientFullDto {
+  ingredientId: number;
+  quantity: number | null;
+  unit: string | null;
+  name: string;
+  category: string;
+  notes: string | null;
+  groupName: string | null;
+  sortOrder: number;
+}
+
+export interface RecipeFullDto {
+  recipeId: number;
+  name: string;
+  recipeType: RecipeType;
+  description: string | null;
+  /** RAW markdown — for the edit textarea. */
+  instructions: string | null;
+  /** Server-sanitized HTML — for the read drawer's {@html}. */
+  instructionsHtml: string;
+  imagePath: string | null;
+  sourceUrl: string | null;
+  prepTimeMinutes: number | null;
+  cookTimeMinutes: number | null;
+  servings: number | null;
+  /** Both null when connected (includeAuthor:false) / deleted user. */
+  createdByName: string | null;
+  createdByPictureUrl: string | null;
+  /** Attribution for copied recipes. */
+  sharedFromHouseholdName: string | null;
+  ingredients: RecipeIngredientFullDto[];
+}
+
+// ── Parse / categories / connections / import ──────────────────────────────
+
+export interface ParsedIngredientDto {
+  quantity: number | null;
+  unit: string | null;
+  name: string;
+  notes: string | null;
+  isComplete: boolean;
+  suggestedCategory: string;
+}
+
+export interface CategoryDto {
+  name: string;
+}
+
+export interface ConnectedHouseholdDto {
+  householdId: number;
+  householdName: string;
+}
+
+export interface PartialRecipeDataDto {
+  name: string | null;
+  description: string | null;
+  instructions: string | null;
+  ingredientStrings: string[] | null;
+  imageUrl: string | null;
+  prepTimeMinutes: number | null;
+  cookTimeMinutes: number | null;
+  servings: number | null;
+}
+
+export interface RecipeImportResultDto {
+  success: boolean;
+  /** The SAVED recipe id on success. */
+  recipeId: number | null;
+  errorMessage: string | null;
+  /** The RecipeImportErrorType name (e.g. "NetworkError"). */
+  errorType: string | null;
+  existingRecipeId: number | null;
+  existingRecipeName: string | null;
+  partialData: PartialRecipeDataDto | null;
+}
+
+// ── Drafts (mirror DraftService.RecipeDraftData / IngredientDraftData) ──────
+// Reused as BOTH the GET /draft response AND (flattened with recipeId) the PUT body.
+
+export interface IngredientDraftData {
+  name: string;
+  quantity: number | null;
+  unit: string | null;
+  category: string;
+  notes: string | null;
+  groupName: string | null;
+  sortOrder: number;
+}
+
+export interface RecipeDraftData {
+  name: string;
+  description: string | null;
+  instructions: string | null;
+  imagePath: string | null;
+  sourceUrl: string | null;
+  servings: number | null;
+  prepTimeMinutes: number | null;
+  cookTimeMinutes: number | null;
+  ingredients: IngredientDraftData[];
+}
+
+// ── Write request (POST/PUT body — Endpoints RecipeWriteRequest) ────────────
+
+export interface RecipeIngredientWrite {
+  name: string;
+  quantity: number | null;
+  unit: string | null;
+  category: string;
+  notes: string | null;
+  groupName: string | null;
+  sortOrder: number;
+}
+
+export interface RecipeWriteRequest {
+  name: string;
+  description: string | null;
+  instructions: string | null;
+  sourceUrl: string | null;
+  servings: number | null;
+  prepTimeMinutes: number | null;
+  cookTimeMinutes: number | null;
+  recipeType: RecipeType;
+  imagePath: string | null;
+  ingredients: RecipeIngredientWrite[];
+}
+
+/** PUT /draft body — FLAT (recipeId + the draft fields). recipeId omitted ⇒ new-recipe draft. */
+export interface SaveDraftRequest {
+  recipeId: number | null;
+  name: string;
+  description: string | null;
+  instructions: string | null;
+  imagePath: string | null;
+  sourceUrl: string | null;
+  servings: number | null;
+  prepTimeMinutes: number | null;
+  cookTimeMinutes: number | null;
+  ingredients: IngredientDraftData[];
+}
+
+// ── Shell context (read from the root data-attrs) ──────────────────────────
+
+export type IslandView = 'list' | 'edit';
+
+export interface ShellContext {
+  householdId: number;
+  userId: number;
+  userName: string;
+  view: IslandView;
+  /** Set only for editing an existing recipe (null for /recipes/new). */
+  recipeId: number | null;
+}

--- a/frontend/recipes/src/main.ts
+++ b/frontend/recipes/src/main.ts
@@ -1,0 +1,221 @@
+import { mount as svelteMount, unmount } from 'svelte';
+import type { Component } from 'svelte';
+import ListApp from './ListApp.svelte';
+import EditApp from './EditApp.svelte';
+import './styles/app.css';
+import type { ShellContext } from './lib/types';
+
+type MountedApp = ReturnType<typeof svelteMount>;
+
+interface Instance {
+  app: MountedApp;
+  /** The exact node we mounted into — lets us detect a Blazor resume that
+   *  replaced or emptied the root out from under us. */
+  el: HTMLElement;
+}
+
+// Blazor Server inserts component output via DOM diff, and inline <script>
+// tags in that output are NOT executed by the browser. The Razor shells
+// (Recipes.razor / RecipeEdit.razor) use IJSRuntime.InvokeAsync("import", ...)
+// to load this module, then call the global mounter below. Exposing a named
+// entry on window is the simplest way to survive enhanced-nav round-trips.
+declare global {
+  interface Window {
+    RecipesIsland?: {
+      mount(rootId: string): void;
+      destroy(rootId: string): void;
+    };
+  }
+}
+
+// One bundle serves BOTH recipe routes (spec D1): the list page mounts the list
+// root, the new/edit page mounts the edit root. The root's `data-view` attr picks
+// the component; only one root is present per page (the other id never resolves).
+const LIST_ROOT_ID = 'recipes-list-root';
+const EDIT_ROOT_ID = 'recipes-edit-root';
+const ALL_ROOT_IDS = [LIST_ROOT_ID, EDIT_ROOT_ID];
+
+const instances = new Map<string, Instance>();
+
+// Roots the Razor shell has asked us to mount. We re-assert these when the page
+// is restored so a Blazor circuit resume / enhanced-nav merge that wiped our
+// content can't leave the island permanently blank (see reassertMounts below).
+const desiredRoots = new Set<string>();
+
+function readContext(el: HTMLElement): ShellContext {
+  const householdId = Number(el.dataset.householdId ?? '0');
+  const userId = Number(el.dataset.userId ?? '0');
+  const userName = el.dataset.userName ?? '';
+  const view = el.dataset.view === 'edit' ? 'edit' : 'list';
+  // data-recipe-id is set only when editing an existing recipe ("" / absent ⇒ new).
+  const raw = el.dataset.recipeId;
+  const recipeId = raw != null && raw.trim() !== '' ? Number(raw) : null;
+  if (!householdId || !userId) {
+    throw new Error('recipes: missing data-household-id / data-user-id');
+  }
+  return { householdId, userId, userName, view, recipeId };
+}
+
+function componentForView(view: ShellContext['view']): Component<{ ctx: ShellContext }> {
+  return (view === 'edit' ? EditApp : ListApp) as Component<{ ctx: ShellContext }>;
+}
+
+// Track dark-mode state and mirror it as a class on the island root so the
+// CSS override wins even when MudBlazor's runtime toggle doesn't propagate
+// the class down to us (we've seen it stay on <html> at load but go missing
+// after runtime toggles, leaving the island stuck in light mode).
+const darkObservers = new Map<string, () => void>();
+
+function isDarkActive(): boolean {
+  if (document.documentElement.classList.contains('mud-theme-dark')) return true;
+  if (document.body?.classList.contains('mud-theme-dark')) return true;
+  try {
+    if (localStorage.getItem('darkMode') === 'true') return true;
+  } catch { /* storage blocked */ }
+  return false;
+}
+
+function syncDarkClass(el: HTMLElement) {
+  el.classList.toggle('rc-dark-mode', isDarkActive());
+}
+
+function installDarkObserver(rootId: string, el: HTMLElement) {
+  syncDarkClass(el);
+  const htmlObs = new MutationObserver(() => syncDarkClass(el));
+  htmlObs.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
+  const bodyObs = new MutationObserver(() => syncDarkClass(el));
+  if (document.body) bodyObs.observe(document.body, { attributes: true, attributeFilter: ['class'] });
+  const storageHandler = (e: StorageEvent) => {
+    if (e.key === 'darkMode') syncDarkClass(el);
+  };
+  window.addEventListener('storage', storageHandler);
+  darkObservers.set(rootId, () => {
+    htmlObs.disconnect();
+    bodyObs.disconnect();
+    window.removeEventListener('storage', storageHandler);
+  });
+}
+
+/**
+ * A mount is healthy only if the CURRENT root element is the exact node we
+ * mounted into, it's still in the document, and it still holds our rendered
+ * children. Blazor's .NET 10 circuit resume (the path that fires on a mobile
+ * background→return) REPLACES the root node and re-runs the host component's
+ * lifecycle — a fresh firstRender re-calls mount(). The old mount-once guard
+ * (`instances.has`) refused to re-mount into that new node, leaving the page
+ * blank until a full reload. Comparing the live node to the one we mounted into
+ * lets the re-invoked mount() rebuild instead of no-op.
+ */
+function isHealthy(rootId: string): boolean {
+  const inst = instances.get(rootId);
+  if (!inst) return false;
+  const el = document.getElementById(rootId);
+  return el != null && el === inst.el && el.isConnected && el.childElementCount > 0;
+}
+
+function mountRoot(rootId: string) {
+  desiredRoots.add(rootId);
+  // Already mounted AND still intact — nothing to do.
+  if (isHealthy(rootId)) return;
+  // A stale prior mount (root emptied / replaced / detached): tear it down first
+  // so we don't leak the Svelte instance or its observers before remounting.
+  if (instances.has(rootId)) destroyRoot(rootId, /* internal */ true);
+  const el = document.getElementById(rootId) as HTMLElement | null;
+  if (!el) {
+    console.warn('[recipes-island] root element not found:', rootId);
+    return;
+  }
+  installDarkObserver(rootId, el);
+  const ctx = readContext(el);
+  const app = svelteMount(componentForView(ctx.view), { target: el, props: { ctx } });
+  instances.set(rootId, { app, el });
+  ensureHealObserver();
+}
+
+function destroyRoot(rootId: string, internal = false) {
+  const inst = instances.get(rootId);
+  if (!inst) {
+    if (!internal) desiredRoots.delete(rootId);
+    return;
+  }
+  // Blazor's circuit resume disposes the OLD page component AFTER it has already
+  // re-initialised the new one — whose firstRender re-calls mount(), which we use
+  // to rebuild into the freshly-replaced root. That trailing destroy() targets a
+  // SUPERSEDED component and would otherwise tear our live island back down.
+  // Ignore an external destroy while the current mount is healthy; a genuine
+  // navigation-away leaves no healthy root (the page is gone), so real teardown
+  // still runs then. `internal` is our own self-heal replacing a stale mount — it
+  // must always proceed.
+  if (!internal && isHealthy(rootId)) return;
+  if (!internal) desiredRoots.delete(rootId);
+  unmount(inst.app);
+  instances.delete(rootId);
+  const disposer = darkObservers.get(rootId);
+  if (disposer) {
+    disposer();
+    darkObservers.delete(rootId);
+  }
+}
+
+window.RecipesIsland = { mount: mountRoot, destroy: destroyRoot };
+
+// ── Resilience: self-heal after a Blazor circuit resume ────────────────────
+// Mobile browsers background the tab on an app/tab switch; Blazor Server's .NET
+// 10 circuit pause/resume then reconciles the DOM on return and can REPLACE the
+// island root — sometimes re-invoking our mount() (handled in mountRoot), and
+// sometimes NOT (observed: nondeterministic). Either way the swap is a DOM
+// mutation, so we watch a STABLE anchor (document.body — Blazor replaces a chunk
+// of the island's ancestors, so observing the root or its parent misses it) and
+// rebuild any desired root that has gone unhealthy.
+//
+// The heal runs SYNCHRONOUSLY in the observer microtask — NOT via
+// requestAnimationFrame, which is paused while the tab is hidden (the wipe can
+// land a beat after the tab is technically still settling). `healing` guards
+// re-entrancy (mountRoot mutates the DOM, which re-queues this callback); once
+// the root is healthy again the next pass no-ops, so it can't loop. The cost on
+// every unrelated DOM change is one getElementById + isHealthy per desired root
+// (normally one), which is negligible.
+let healObserver: MutationObserver | null = null;
+let healing = false;
+function runHeal() {
+  if (healing) return;
+  healing = true;
+  try {
+    for (const rootId of desiredRoots) {
+      // Only rebuild when the root EXISTS but is stale/empty. A missing root is
+      // a navigation-away (or mid-reconcile) — not ours to remount; the next
+      // mutation re-checks once the fresh root lands.
+      if (document.getElementById(rootId) && !isHealthy(rootId)) mountRoot(rootId);
+    }
+  } finally {
+    healing = false;
+  }
+}
+function ensureHealObserver() {
+  if (healObserver || !document.body) return;
+  healObserver = new MutationObserver(runHeal);
+  healObserver.observe(document.body, { childList: true, subtree: true });
+}
+
+// bfcache restore re-attaches the frozen DOM without any mutation, so the body
+// observer won't fire — re-assert directly on pageshow as a cheap belt.
+window.addEventListener('pageshow', () => {
+  ensureHealObserver();
+  for (const rootId of desiredRoots) {
+    if (document.getElementById(rootId) && !isHealthy(rootId)) mountRoot(rootId);
+  }
+});
+
+// Standalone dev auto-mount: if a known root is already on the page when the
+// module loads (Vite's index.html), mount it immediately. In production the
+// Razor shell calls window.RecipesIsland.mount() explicitly via JS interop.
+function autoMountIfReady() {
+  for (const rootId of ALL_ROOT_IDS) {
+    if (document.getElementById(rootId)) mountRoot(rootId);
+  }
+}
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', autoMountIfReady);
+} else {
+  autoMountIfReady();
+}

--- a/frontend/recipes/src/styles/app.css
+++ b/frontend/recipes/src/styles/app.css
@@ -1,0 +1,38 @@
+@import './tokens.css';
+
+/*
+ * The island renders inside the host page, which also loads Bootstrap + MudBlazor.
+ * Bootstrap defines .row / .container globally, and those names collide with
+ * ambient island styles. We avoid the collision by prefixing all island class
+ * names with `rc-` (recipes) rather than overriding globals here.
+ */
+
+#recipes-list-root,
+#recipes-edit-root {
+  font-family: var(--font-family);
+  color: var(--color-text);
+  background: var(--color-background);
+  min-height: 100%;
+}
+
+#recipes-list-root,
+#recipes-list-root *,
+#recipes-list-root *::before,
+#recipes-list-root *::after,
+#recipes-edit-root,
+#recipes-edit-root *,
+#recipes-edit-root *::before,
+#recipes-edit-root *::after {
+  box-sizing: border-box;
+}
+
+/*
+ * Suppress the outer Blazor ReconnectModal while the island is on the page.
+ * It's a showModal() <dialog>, which blocks all interaction behind it —
+ * including our HTTP-driven island that doesn't need the circuit to work.
+ * This CSS only ships on the recipes pages (via <HeadContent>), so other
+ * pages still get the normal reconnect UX.
+ */
+#components-reconnect-modal {
+  display: none !important;
+}

--- a/frontend/recipes/src/styles/tokens.css
+++ b/frontend/recipes/src/styles/tokens.css
@@ -1,0 +1,97 @@
+/*
+ * Design tokens mirrored from the MudBlazor theme used elsewhere in the app
+ * (kept in sync with frontend/meal-plan/src/styles/tokens.css).
+ * Light mode = :root. Dark mode = html.mud-theme-dark (set by App.razor)
+ * plus #recipes-list-root.rc-dark-mode / #recipes-edit-root.rc-dark-mode
+ * (mirrored by main.ts's dark observer).
+ */
+
+:root {
+  /* brand */
+  --color-primary: rgb(46, 125, 50);
+  --color-primary-hover: rgb(36, 97, 39);
+  --color-primary-soft: rgb(58, 156, 63);
+  --color-secondary: rgb(255, 111, 0);
+
+  /* surfaces */
+  --color-surface: rgb(255, 255, 255);
+  --color-background: rgb(250, 250, 250);
+  --color-appbar: rgb(46, 125, 50);
+  --color-drawer: rgb(245, 245, 245);
+
+  /* text */
+  --color-text: rgb(66, 66, 66);
+  --color-text-muted: rgba(0, 0, 0, 0.54);
+  --color-text-disabled: rgba(0, 0, 0, 0.38);
+
+  /* structure */
+  --color-line: rgba(0, 0, 0, 0.12);
+  --color-line-strong: rgb(189, 189, 189);
+  --color-divider: rgb(224, 224, 224);
+  --color-action-hover: rgba(0, 0, 0, 0.06);
+  --color-action-disabled: rgba(0, 0, 0, 0.26);
+
+  /* semantic */
+  --color-success: rgb(67, 160, 71);
+  --color-error: rgb(229, 57, 53);
+  --color-warning: rgb(251, 140, 0);
+  --color-info: rgb(30, 136, 229);
+
+  /* typography */
+  --font-family: Roboto, Helvetica, Arial, sans-serif;
+
+  /* shape */
+  --radius-sm: 4px;
+  --radius-md: 4px;
+
+  /* elevation (MudBlazor 1, 2, 4) */
+  --shadow-1:
+    0 2px 1px -1px rgba(0, 0, 0, 0.2),
+    0 1px 1px 0 rgba(0, 0, 0, 0.14),
+    0 1px 3px 0 rgba(0, 0, 0, 0.12);
+  --shadow-2:
+    0 3px 1px -2px rgba(0, 0, 0, 0.2),
+    0 2px 2px 0 rgba(0, 0, 0, 0.14),
+    0 1px 5px 0 rgba(0, 0, 0, 0.12);
+  --shadow-4:
+    0 2px 4px -1px rgba(0, 0, 0, 0.2),
+    0 4px 5px 0 rgba(0, 0, 0, 0.14),
+    0 1px 10px 0 rgba(0, 0, 0, 0.12);
+}
+
+/*
+ * Dark-mode override. MudBlazor v8 + the App.razor bootstrap script both
+ * toggle `mud-theme-dark` on <html>, but runtime theme toggles sometimes
+ * land on <body> or deeper. Matching the bare class is a superset that
+ * works regardless of where the ancestor lives.
+ */
+.mud-theme-dark,
+html.mud-theme-dark,
+body.mud-theme-dark,
+#recipes-list-root.rc-dark-mode,
+#recipes-edit-root.rc-dark-mode {
+  --color-primary: rgb(102, 187, 106);
+  --color-primary-hover: rgb(77, 172, 82);
+  --color-primary-soft: rgb(128, 198, 132);
+  --color-secondary: rgb(255, 183, 77);
+
+  --color-surface: rgb(30, 30, 30);
+  --color-background: rgb(18, 18, 18);
+  --color-appbar: rgb(26, 26, 26);
+  --color-drawer: rgb(26, 26, 26);
+
+  --color-text: rgba(255, 255, 255, 0.87);
+  --color-text-muted: rgba(255, 255, 255, 0.6);
+  --color-text-disabled: rgba(255, 255, 255, 0.2);
+
+  --color-line: rgba(255, 255, 255, 0.12);
+  --color-line-strong: rgba(255, 255, 255, 0.3);
+  --color-divider: rgba(255, 255, 255, 0.12);
+  --color-action-hover: rgba(173, 173, 177, 0.06);
+  --color-action-disabled: rgba(255, 255, 255, 0.26);
+
+  --color-success: rgb(102, 187, 106);
+  --color-error: rgb(239, 83, 80);
+  --color-warning: rgb(255, 167, 38);
+  --color-info: rgb(66, 165, 245);
+}

--- a/frontend/recipes/src/vite-env.d.ts
+++ b/frontend/recipes/src/vite-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="svelte" />
+/// <reference types="vite/client" />

--- a/frontend/recipes/svelte.config.js
+++ b/frontend/recipes/svelte.config.js
@@ -1,0 +1,8 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+export default {
+  preprocess: vitePreprocess(),
+  compilerOptions: {
+    runes: true,
+  },
+};

--- a/frontend/recipes/tsconfig.json
+++ b/frontend/recipes/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "@tsconfig/svelte/tsconfig.json",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowJs": false,
+    "checkJs": false,
+    "isolatedModules": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitAny": true,
+    "skipLibCheck": true,
+    "types": ["svelte", "vite/client"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.svelte", "src/vite-env.d.ts"]
+}

--- a/frontend/recipes/vite.config.ts
+++ b/frontend/recipes/vite.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+
+// The recipes island is embedded into two Razor shells (Recipes.razor at /recipes
+// and RecipeEdit.razor at /recipes/new + /recipes/edit/{id}). Both host pages load
+// this single bundle and mount the matching root by a data-view attr (spec D1).
+// Build output goes to ./dist/ — the CopyRecipesIsland MSBuild target in
+// FamilyCoordinationApp.csproj copies this into wwwroot/islands/recipes/.
+// Keeping the output local here makes the Docker build cleaner
+// (the recipes-node-build stage emits dist/, the .NET stage reads it via COPY --from).
+// Mirrors frontend/meal-plan/vite.config.ts (output index.js + index.css).
+export default defineConfig({
+  plugins: [svelte()],
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    rollupOptions: {
+      input: 'src/main.ts',
+      output: {
+        entryFileNames: 'index.js',
+        chunkFileNames: 'chunks/[name]-[hash].js',
+        assetFileNames: (info) =>
+          info.name?.endsWith('.css') ? 'index.css' : 'assets/[name]-[hash][extname]',
+      },
+    },
+    sourcemap: true,
+  },
+  server: {
+    port: 5176,
+    // Dev server proxies /api to the running .NET app so `npm run dev` works
+    // standalone against a locally-running Blazor host on :5000.
+    proxy: {
+      '/api': {
+        target: 'http://localhost:5000',
+        changeOrigin: false,
+      },
+    },
+  },
+});

--- a/src/FamilyCoordinationApp/Components/Pages/RecipeEdit.razor
+++ b/src/FamilyCoordinationApp/Components/Pages/RecipeEdit.razor
@@ -1,619 +1,129 @@
 @page "/recipes/new"
 @page "/recipes/edit/{RecipeId:int}"
-@attribute [Authorize]
-
 @using FamilyCoordinationApp.Data
-@using FamilyCoordinationApp.Data.Entities
-@using FamilyCoordinationApp.Services
 @using FamilyCoordinationApp.Components.Recipe
+@using Microsoft.AspNetCore.Components.Web
 @using Microsoft.EntityFrameworkCore
+@using Microsoft.JSInterop
 @using System.Security.Claims
+@attribute [Authorize]
+@implements IAsyncDisposable
 
-@implements IDisposable
-
-@inject IRecipeService RecipeService
-@inject IImageService ImageService
-@inject IDraftService DraftService
+@inject IConfiguration Config
+@inject AuthenticationStateProvider AuthStateProvider
 @inject IDbContextFactory<ApplicationDbContext> DbFactory
-@inject NavigationManager Navigation
-@inject ISnackbar Snackbar
-@inject IDialogService DialogService
+@inject IJSRuntime JS
+@inject IWebHostEnvironment HostEnv
 
-<PageTitle>@(IsEdit ? "Edit Recipe" : "New Recipe") - Family Kitchen</PageTitle>
+@*
+    Thin island host (strangler) for /recipes/new + /recipes/edit/{id}. Flag ON (RECIPES_USE_ISLAND=true) →
+    mount the Svelte island (edit view, one bundle shared with the list host via data-view); flag OFF → the
+    existing Blazor UI (<RecipeEditBlazor/>) as the zero-regression fallback. Mirrors MealPlan.razor.
+*@
 
-<MudContainer MaxWidth="MaxWidth.Medium" Class="mt-4 mb-8">
-    <div class="d-flex justify-space-between align-center mb-4">
-        <MudText Typo="Typo.h4">@(IsEdit ? "Edit Recipe" : "New Recipe")</MudText>
-        @if (IsEdit)
-        {
-            <MudButton Variant="Variant.Outlined"
-                       Color="Color.Error"
-                       StartIcon="@Icons.Material.Filled.Delete"
-                       OnClick="DeleteRecipe">
-                Delete
-            </MudButton>
-        }
-    </div>
+@if (_useIsland && _shell is not null)
+{
+    <PageTitle>@(RecipeId.HasValue ? "Edit Recipe" : "New Recipe") - Family Kitchen</PageTitle>
 
-    @if (_loading)
-    {
-        <MudProgressLinear Indeterminate="true" />
-    }
-    else
-    {
-        <EditForm EditContext="_editContext" OnValidSubmit="SaveRecipe">
-            <DataAnnotationsValidator />
-            <NavigationLock ConfirmExternalNavigation="_hasUnsavedChanges" />
+    <HeadContent>
+        <link rel="stylesheet" href="/islands/recipes/index.css?v=@IslandVersion" />
+    </HeadContent>
 
-            @if (!string.IsNullOrWhiteSpace(_recipe.SourceUrl) && IsEdit)
-            {
-                <MudAlert Severity="Severity.Info" Class="mb-4" Dense="true">
-                    <div class="d-flex align-center">
-                        <MudIcon Icon="@Icons.Material.Filled.CloudDownload" Size="Size.Small" Class="mr-2" />
-                        <MudText Typo="Typo.body2">
-                            Imported from
-                            @if (IsSafeUrl(_recipe.SourceUrl))
-                            {
-                                <a href="@_recipe.SourceUrl"
-                                   target="_blank"
-                                   rel="noopener noreferrer"
-                                   class="mud-link">
-                                    @GetDomainFromUrl(_recipe.SourceUrl)
-                                </a>
-                            }
-                            else
-                            {
-                                <span>@GetDomainFromUrl(_recipe.SourceUrl)</span>
-                            }
-                        </MudText>
-                    </div>
-                </MudAlert>
-            }
-
-            <MudPaper Class="pa-4 mb-4" Elevation="1">
-                <MudText Typo="Typo.h6" Class="mb-3">Basic Info</MudText>
-
-                <MudTextField @bind-Value="_recipe.Name"
-                              Label="Recipe Name"
-                              Required="true"
-                              Variant="Variant.Outlined"
-                              @oninput="ScheduleAutoSave"
-                              Class="mb-3" />
-
-                <MudTextField @bind-Value="_recipe.Description"
-                              Label="Description"
-                              Lines="2"
-                              Variant="Variant.Outlined"
-                              @oninput="ScheduleAutoSave"
-                              Class="mb-3"
-                              HelperText="Brief introduction to the recipe" />
-
-                <MudGrid>
-                    <MudItem xs="12" sm="4">
-                        <MudNumericField @bind-Value="_recipe.PrepTimeMinutes"
-                                         Label="Prep Time (min)"
-                                         Variant="Variant.Outlined"
-                                         Min="0"
-                                         @oninput="ScheduleAutoSave" />
-                    </MudItem>
-                    <MudItem xs="12" sm="4">
-                        <MudNumericField @bind-Value="_recipe.CookTimeMinutes"
-                                         Label="Cook Time (min)"
-                                         Variant="Variant.Outlined"
-                                         Min="0"
-                                         @oninput="ScheduleAutoSave" />
-                    </MudItem>
-                    <MudItem xs="12" sm="4">
-                        <MudNumericField @bind-Value="_recipe.Servings"
-                                         Label="Servings"
-                                         Variant="Variant.Outlined"
-                                         Min="1"
-                                         @oninput="ScheduleAutoSave" />
-                    </MudItem>
-                </MudGrid>
-
-                <MudTextField @bind-Value="_recipe.SourceUrl"
-                              Label="Source URL (optional)"
-                              Variant="Variant.Outlined"
-                              @oninput="ScheduleAutoSave"
-                              Class="mt-3"
-                              HelperText="Link to original recipe" />
-
-                <MudSelect @bind-Value="_recipe.RecipeType"
-                           Label="Recipe Type"
-                           Variant="Variant.Outlined"
-                           Class="mt-3">
-                    @foreach (var type in Enum.GetValues<RecipeType>())
-                    {
-                        <MudSelectItem Value="@type">@GetRecipeTypeLabel(type)</MudSelectItem>
-                    }
-                </MudSelect>
-            </MudPaper>
-
-            <MudPaper Class="pa-4 mb-4" Elevation="1">
-                <MudText Typo="Typo.h6" Class="mb-3">Image</MudText>
-
-                @if (!string.IsNullOrWhiteSpace(_recipe.ImagePath))
-                {
-                    <div class="mb-3" style="position: relative; display: inline-block;">
-                        <MudImage Src="@_recipe.ImagePath"
-                                  Alt="Recipe image"
-                                  ObjectFit="ObjectFit.Cover"
-                                  Width="300"
-                                  Height="200"
-                                  Elevation="2"
-                                  Class="rounded" />
-                        <MudIconButton Icon="@Icons.Material.Filled.Close"
-                                       Color="Color.Error"
-                                       Size="Size.Small"
-                                       OnClick="RemoveImage"
-                                       Style="position: absolute; top: 4px; right: 4px; background: rgba(0,0,0,0.5);" />
-                    </div>
-                }
-
-                <div class="d-flex gap-2 flex-wrap">
-                    <MudFileUpload T="IBrowserFile"
-                                   FilesChanged="UploadImage"
-                                   Accept="image/*"
-                                   MaximumFileCount="1">
-                        <ActivatorContent>
-                            <MudButton Variant="Variant.Outlined"
-                                       Color="Color.Primary"
-                                       StartIcon="@Icons.Material.Filled.CloudUpload">
-                                @(string.IsNullOrWhiteSpace(_recipe.ImagePath) ? "Upload Image" : "Change Image")
-                            </MudButton>
-                        </ActivatorContent>
-                    </MudFileUpload>
-                    <MudButton Variant="Variant.Outlined"
-                               Color="Color.Secondary"
-                               StartIcon="@Icons.Material.Filled.PhotoLibrary"
-                               OnClick="OpenImagePicker">
-                        Choose Existing
-                    </MudButton>
-                </div>
-                <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mt-1">
-                    Max 10 MB. Supported: JPG, PNG, GIF, WebP
-                </MudText>
-            </MudPaper>
-
-            <MudPaper Class="pa-4 mb-4" Elevation="1">
-                <MudText Typo="Typo.h6" Class="mb-3">Ingredients</MudText>
-
-                <IngredientEntry HouseholdId="_householdId"
-                                 OnIngredientAdded="AddIngredient"
-                                 OnBulkIngredientsAdded="AddBulkIngredients" />
-
-                <IngredientList Ingredients="_ingredients"
-                                IngredientsChanged="OnIngredientsChanged"
-                                OnEditIngredient="EditIngredient" />
-            </MudPaper>
-
-            <MudPaper Class="pa-4 mb-4" Elevation="1">
-                <MudText Typo="Typo.h6" Class="mb-3">Instructions</MudText>
-
-                <MudTextField @bind-Value="_recipe.Instructions"
-                              Label="Instructions"
-                              Lines="10"
-                              Variant="Variant.Outlined"
-                              @oninput="ScheduleAutoSave"
-                              HelperText="Supports Markdown formatting" />
-            </MudPaper>
-
-            <div class="d-flex justify-space-between align-center">
-                <div>
-                    @if (_autoSaveStatus == AutoSaveStatus.Saving)
-                    {
-                        <div class="d-flex align-center">
-                            <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
-                            <MudText Typo="Typo.caption" Color="Color.Secondary">Saving draft...</MudText>
-                        </div>
-                    }
-                    else if (_autoSaveStatus == AutoSaveStatus.Saved)
-                    {
-                        <MudText Typo="Typo.caption" Color="Color.Success">
-                            <MudIcon Icon="@Icons.Material.Filled.Check" Size="Size.Small" Class="mr-1" />
-                            Draft saved
-                        </MudText>
-                    }
-                </div>
-
-                <div>
-                    <MudButton Variant="Variant.Text"
-                               Color="Color.Default"
-                               OnClick="Cancel"
-                               Class="mr-2">
-                        Cancel
-                    </MudButton>
-                    <MudButton Variant="Variant.Filled"
-                               Color="Color.Primary"
-                               ButtonType="ButtonType.Submit"
-                               Disabled="_saving">
-                        @if (_saving)
-                        {
-                            <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
-                        }
-                        @(IsEdit ? "Save Changes" : "Create Recipe")
-                    </MudButton>
-                </div>
-            </div>
-        </EditForm>
-    }
-</MudContainer>
+    <div id="recipes-edit-root"
+         data-household-id="@_shell.HouseholdId"
+         data-user-id="@_shell.UserId"
+         data-user-name="@_shell.UserName"
+         data-view="edit"
+         data-recipe-id="@(RecipeId?.ToString() ?? "")"></div>
+}
+else
+{
+    <RecipeEditBlazor RecipeId="RecipeId" />
+}
 
 @code {
     [Parameter] public int? RecipeId { get; set; }
-    [CascadingParameter] private Task<AuthenticationState>? AuthState { get; set; }
 
-    private bool IsEdit => RecipeId.HasValue;
-
-    private Recipe _recipe = new();
-    private List<RecipeIngredient> _ingredients = new();
-    private EditContext _editContext = default!;
-
-    private bool _loading = true;
-    private bool _saving = false;
-    private bool _hasUnsavedChanges = false;
-
-    private int _householdId;
-    private int _userId;
-
-    private System.Threading.Timer? _autoSaveTimer;
-    private const int AutoSaveDelayMs = 2000;
-
-    private enum AutoSaveStatus { None, Saving, Saved }
-    private AutoSaveStatus _autoSaveStatus = AutoSaveStatus.None;
+    private bool _useIsland;
+    private ShellData? _shell;
+    private IJSObjectReference? _islandModule;
 
     protected override async Task OnInitializedAsync()
     {
-        await LoadUserContext();
-        await LoadRecipeOrDraft();
+        _useIsland = IsIslandEnabled();
+        if (!_useIsland) return;
 
-        _editContext = new EditContext(_recipe);
-        _editContext.OnFieldChanged += OnFieldChanged;
-
-        _loading = false;
-    }
-
-    private async Task LoadUserContext()
-    {
-        if (AuthState == null) return;
-
-        var authState = await AuthState;
-        var email = authState.User.FindFirstValue(ClaimTypes.Email);
-
-        if (string.IsNullOrEmpty(email)) return;
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        var email = authState.User.FindFirst(ClaimTypes.Email)?.Value;
+        var userName = authState.User.FindFirst(ClaimTypes.Name)?.Value ?? string.Empty;
 
         await using var context = await DbFactory.CreateDbContextAsync();
-        var user = await context.Users
-            .FirstOrDefaultAsync(u => u.Email == email);
-
-        if (user != null)
+        var user = await context.Users.FirstOrDefaultAsync(u => u.Email == email);
+        if (user is null)
         {
-            _householdId = user.HouseholdId;
-            _userId = user.Id;
-        }
-    }
-
-    private async Task LoadRecipeOrDraft()
-    {
-        // Check for existing draft first
-        var draft = await DraftService.GetDraftAsync(_householdId, _userId, RecipeId);
-
-        if (draft != null)
-        {
-            // Restore from draft
-            _recipe = new Recipe
-            {
-                HouseholdId = _householdId,
-                RecipeId = RecipeId ?? 0,
-                Name = draft.Name,
-                Description = draft.Description,
-                Instructions = draft.Instructions,
-                ImagePath = draft.ImagePath,
-                SourceUrl = draft.SourceUrl,
-                Servings = draft.Servings,
-                PrepTimeMinutes = draft.PrepTimeMinutes,
-                CookTimeMinutes = draft.CookTimeMinutes,
-                CreatedByUserId = _userId
-            };
-
-            _ingredients = draft.Ingredients.Select(i => new RecipeIngredient
-            {
-                Name = i.Name,
-                Quantity = i.Quantity,
-                Unit = i.Unit,
-                Category = i.Category,
-                Notes = i.Notes,
-                GroupName = i.GroupName,
-                SortOrder = i.SortOrder
-            }).ToList();
-
-            Snackbar.Add("Restored from draft", Severity.Info);
-            return;
+            throw new InvalidOperationException("User not found. Please log in again.");
         }
 
-        if (IsEdit)
-        {
-            // Load existing recipe
-            var recipe = await RecipeService.GetRecipeAsync(_householdId, RecipeId!.Value);
-            if (recipe == null)
-            {
-                Snackbar.Add("Recipe not found", Severity.Error);
-                Navigation.NavigateTo("/recipes");
-                return;
-            }
-
-            _recipe = recipe;
-            _ingredients = recipe.Ingredients.ToList();
-        }
-        else
-        {
-            // New recipe
-            _recipe = new Recipe
-            {
-                HouseholdId = _householdId,
-                CreatedByUserId = _userId,
-                Servings = 4 // Default
-            };
-            _ingredients = new();
-        }
+        _shell = new ShellData(user.HouseholdId, user.Id, userName);
     }
 
-    private void OnFieldChanged(object? sender, FieldChangedEventArgs e)
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        _hasUnsavedChanges = true;
-        _autoSaveStatus = AutoSaveStatus.None;
+        if (!firstRender || !_useIsland || _shell is null) return;
+
+        // Blazor enhanced navigation does not apply this page's <HeadContent>, so (re)inject the island
+        // stylesheet here (idempotent) — OnAfterRender runs for both full loads and enhanced nav.
+        await JS.InvokeVoidAsync("ensureIslandStylesheet", $"/islands/recipes/index.css?v={IslandVersion}");
+
+        // Load the Svelte bundle as an ES module, then mount the EDIT root (data-view="edit"). mountRoot is
+        // idempotent and re-mounts against the fresh <div id="recipes-edit-root">.
+        _islandModule = await JS.InvokeAsync<IJSObjectReference>(
+            "import", $"/islands/recipes/index.js?v={IslandVersion}");
+        await JS.InvokeVoidAsync("RecipesIsland.mount", "recipes-edit-root");
     }
 
-    private void ScheduleAutoSave()
-    {
-        _hasUnsavedChanges = true;
-        _autoSaveTimer?.Dispose();
-        _autoSaveTimer = new System.Threading.Timer(async _ =>
-        {
-            await InvokeAsync(async () =>
-            {
-                _autoSaveStatus = AutoSaveStatus.Saving;
-                StateHasChanged();
+    // Cache-bust the island URLs per deploy via the published bundle's mtime (mirrors MealPlan.razor).
+    private static string? _islandVersion;
+    private string IslandVersion => _islandVersion ??= ComputeIslandVersion();
 
-                try
-                {
-                    var draftData = CreateDraftData();
-                    await DraftService.SaveDraftAsync(_householdId, _userId, RecipeId, draftData);
-
-                    _autoSaveStatus = AutoSaveStatus.Saved;
-                    StateHasChanged();
-
-                    // Clear "Saved" status after a few seconds
-                    await Task.Delay(3000);
-                    if (_autoSaveStatus == AutoSaveStatus.Saved)
-                    {
-                        _autoSaveStatus = AutoSaveStatus.None;
-                        StateHasChanged();
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Snackbar.Add($"Failed to save draft: {ex.Message}", Severity.Warning);
-                    _autoSaveStatus = AutoSaveStatus.None;
-                    StateHasChanged();
-                }
-            });
-        }, null, AutoSaveDelayMs, Timeout.Infinite);
-    }
-
-    private RecipeDraftData CreateDraftData()
-    {
-        return new RecipeDraftData(
-            _recipe.Name,
-            _recipe.Description,
-            _recipe.Instructions,
-            _recipe.ImagePath,
-            _recipe.SourceUrl,
-            _recipe.Servings,
-            _recipe.PrepTimeMinutes,
-            _recipe.CookTimeMinutes,
-            _ingredients.Select(i => new IngredientDraftData(
-                i.Name,
-                i.Quantity,
-                i.Unit,
-                i.Category,
-                i.Notes,
-                i.GroupName,
-                i.SortOrder
-            )).ToList()
-        );
-    }
-
-    private void OnIngredientsChanged(List<RecipeIngredient> ingredients)
-    {
-        _ingredients = ingredients;
-        ScheduleAutoSave();
-    }
-
-    private void AddIngredient(RecipeIngredient ingredient)
-    {
-        ingredient.SortOrder = _ingredients.Count;
-        _ingredients.Add(ingredient);
-        ScheduleAutoSave();
-    }
-
-    private void AddBulkIngredients(List<RecipeIngredient> ingredients)
-    {
-        foreach (var ingredient in ingredients)
-        {
-            ingredient.SortOrder = _ingredients.Count;
-            _ingredients.Add(ingredient);
-        }
-        ScheduleAutoSave();
-    }
-
-    private void EditIngredient(RecipeIngredient ingredient)
-    {
-        // Simple edit flow: remove and re-add. Inline editing planned for future release.
-        _ingredients.Remove(ingredient);
-        Snackbar.Add("Re-add ingredient with changes", Severity.Info);
-    }
-
-    private async Task UploadImage(IBrowserFile file)
+    private string ComputeIslandVersion()
     {
         try
         {
-            var path = await ImageService.SaveImageAsync(file, _householdId);
-            _recipe.ImagePath = path;
-            ScheduleAutoSave();
-            Snackbar.Add("Image uploaded", Severity.Success);
-        }
-        catch (Exception ex)
-        {
-            Snackbar.Add($"Failed to upload image: {ex.Message}", Severity.Error);
-        }
-    }
-
-    private void RemoveImage()
-    {
-        // Note: Don't delete the file yet - it might be the original recipe's image
-        _recipe.ImagePath = null;
-        ScheduleAutoSave();
-    }
-
-    private async Task OpenImagePicker()
-    {
-        var parameters = new DialogParameters<ImagePickerDialog>
-        {
-            { x => x.HouseholdId, _householdId },
-            { x => x.CurrentImage, _recipe.ImagePath }
-        };
-
-        var options = new DialogOptions
-        {
-            MaxWidth = MaxWidth.Medium,
-            FullWidth = true
-        };
-
-        var dialog = await DialogService.ShowAsync<ImagePickerDialog>("Select Image", parameters, options);
-        var result = await dialog.Result;
-
-        if (result is { Canceled: false, Data: string selectedImage })
-        {
-            _recipe.ImagePath = selectedImage;
-            ScheduleAutoSave();
-        }
-    }
-
-    private async Task SaveRecipe()
-    {
-        if (string.IsNullOrWhiteSpace(_recipe.Name))
-        {
-            Snackbar.Add("Recipe name is required", Severity.Warning);
-            return;
-        }
-
-        _saving = true;
-        StateHasChanged();
-
-        try
-        {
-            // Update ingredients on recipe
-            _recipe.Ingredients = _ingredients;
-
-            if (IsEdit)
-            {
-                _recipe.UpdatedByUserId = _userId;
-                _recipe.UpdatedAt = DateTime.UtcNow;
-                await RecipeService.UpdateRecipeAsync(_recipe);
-                Snackbar.Add("Recipe updated", Severity.Success);
-            }
-            else
-            {
-                await RecipeService.CreateRecipeAsync(_recipe);
-                Snackbar.Add("Recipe created", Severity.Success);
-            }
-
-            // Delete draft after successful save
-            await DraftService.DeleteDraftAsync(_householdId, _userId, RecipeId);
-
-            _hasUnsavedChanges = false;
-            Navigation.NavigateTo("/recipes");
-        }
-        catch (Exception ex)
-        {
-            Snackbar.Add($"Failed to save recipe: {ex.Message}", Severity.Error);
-        }
-        finally
-        {
-            _saving = false;
-        }
-    }
-
-    private async Task DeleteRecipe()
-    {
-        var result = await DialogService.ShowMessageBox(
-            "Delete Recipe",
-            $"Are you sure you want to delete \"{_recipe.Name}\"? This action cannot be undone.",
-            yesText: "Delete",
-            cancelText: "Cancel");
-
-        if (result == true)
-        {
-            try
-            {
-                await RecipeService.DeleteRecipeAsync(_householdId, _recipe.RecipeId);
-                await DraftService.DeleteDraftAsync(_householdId, _userId, RecipeId);
-                _hasUnsavedChanges = false;
-                Snackbar.Add("Recipe deleted", Severity.Success);
-                Navigation.NavigateTo("/recipes");
-            }
-            catch (Exception ex)
-            {
-                Snackbar.Add($"Failed to delete recipe: {ex.Message}", Severity.Error);
-            }
-        }
-    }
-
-    private void Cancel()
-    {
-        Navigation.NavigateTo("/recipes");
-    }
-
-    private static string GetDomainFromUrl(string url)
-    {
-        try
-        {
-            var uri = new Uri(url);
-            return uri.Host.Replace("www.", "");
+            var path = Path.Combine(HostEnv.WebRootPath, "islands", "recipes", "index.js");
+            return new DateTimeOffset(File.GetLastWriteTimeUtc(path)).ToUnixTimeSeconds().ToString();
         }
         catch
         {
-            return url;
+            return "0";
         }
     }
 
-    private static bool IsSafeUrl(string? url) =>
-        !string.IsNullOrEmpty(url) &&
-        Uri.TryCreate(url, UriKind.Absolute, out var uri) &&
-        (uri.Scheme == "http" || uri.Scheme == "https");
-
-    private static string GetRecipeTypeLabel(RecipeType type) => type switch
+    private bool IsIslandEnabled()
     {
-        RecipeType.Main => "Main Dish",
-        RecipeType.Side => "Side Dish",
-        RecipeType.Appetizer => "Appetizer",
-        RecipeType.Dessert => "Dessert",
-        RecipeType.Beverage => "Beverage",
-        RecipeType.Sauce => "Sauce/Condiment",
-        RecipeType.Breakfast => "Breakfast",
-        RecipeType.Snack => "Snack",
-        RecipeType.Other => "Other",
-        _ => type.ToString()
-    };
-
-    public void Dispose()
-    {
-        _autoSaveTimer?.Dispose();
-        if (_editContext != null)
+        var configValue = Config["RECIPES_USE_ISLAND"];
+        if (!string.IsNullOrEmpty(configValue))
         {
-            _editContext.OnFieldChanged -= OnFieldChanged;
+            return configValue.Equals("true", StringComparison.OrdinalIgnoreCase);
+        }
+
+        var envValue = Environment.GetEnvironmentVariable("RECIPES_USE_ISLAND");
+        return string.Equals(envValue, "true", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_islandModule is null) return;
+        try
+        {
+            await JS.InvokeVoidAsync("RecipesIsland.destroy", "recipes-edit-root");
+            await _islandModule.DisposeAsync();
+        }
+        catch (JSDisconnectedException)
+        {
+            // Circuit already gone (user navigated away after disconnect) — nothing to clean up.
         }
     }
+
+    private sealed record ShellData(int HouseholdId, int UserId, string UserName);
 }

--- a/src/FamilyCoordinationApp/Components/Pages/Recipes.razor
+++ b/src/FamilyCoordinationApp/Components/Pages/Recipes.razor
@@ -1,961 +1,126 @@
 @page "/recipes"
-@rendermode InteractiveServer
-@attribute [Authorize]
-@implements IDisposable
-@using System.Security.Claims
 @using FamilyCoordinationApp.Data
-@using FamilyCoordinationApp.Data.Entities
-@using FamilyCoordinationApp.Services
-@using FamilyCoordinationApp.Services.Interfaces
 @using FamilyCoordinationApp.Components.Recipe
-@using FamilyCoordinationApp.Components.Shared
+@using Microsoft.AspNetCore.Components.Web
 @using Microsoft.EntityFrameworkCore
-@inject IRecipeService RecipeService
-@inject IHouseholdConnectionService ConnectionService
+@using Microsoft.JSInterop
+@using System.Security.Claims
+@attribute [Authorize]
+@implements IAsyncDisposable
+
+@inject IConfiguration Config
+@inject AuthenticationStateProvider AuthStateProvider
 @inject IDbContextFactory<ApplicationDbContext> DbFactory
-@inject ISnackbar Snackbar
-@inject NavigationManager NavigationManager
-@inject DataNotifier Notifier
-@inject IDialogService DialogService
+@inject IJSRuntime JS
+@inject IWebHostEnvironment HostEnv
 
-<PageTitle>Recipes - Family Kitchen</PageTitle>
+@*
+    Thin island host (strangler). Flag ON (RECIPES_USE_ISLAND=true) → mount the Svelte island (list view);
+    flag OFF → the existing Blazor UI (<RecipesBlazor/>) as the zero-regression fallback. Mirrors MealPlan.razor.
+    Flip the flag to switch; delete RecipesBlazor once the island is the only path.
+*@
 
-<MudContainer MaxWidth="MaxWidth.ExtraLarge" Class="py-4">
-    <div class="d-flex justify-space-between align-center flex-wrap mb-4 gap-3">
-        <MudText Typo="Typo.h4">Recipes</MudText>
-        @if (!_isViewingConnectedHousehold)
-        {
-            <div class="d-flex gap-2 flex-wrap">
-                <MudHidden Breakpoint="Breakpoint.Xs">
-                    <MudButton StartIcon="@Icons.Material.Filled.CloudDownload"
-                               Color="Color.Secondary"
-                               Variant="Variant.Outlined"
-                               OnClick="OpenImportDialog">
-                        Import from URL
-                    </MudButton>
-                </MudHidden>
-                <MudHidden Breakpoint="Breakpoint.SmAndUp" Invert="true">
-                    <MudIconButton Icon="@Icons.Material.Filled.CloudDownload"
-                                   Color="Color.Secondary"
-                                   OnClick="OpenImportDialog"
-                                   aria-label="Import from URL" />
-                </MudHidden>
-                <MudButton StartIcon="@Icons.Material.Filled.Add"
-                           Color="Color.Primary"
-                           Variant="Variant.Filled"
-                           OnClick="HandleAddRecipe">
-                    <MudHidden Breakpoint="Breakpoint.Xs">Add Recipe</MudHidden>
-                    <MudHidden Breakpoint="Breakpoint.SmAndUp" Invert="true">Add</MudHidden>
-                </MudButton>
-            </div>
-        }
-    </div>
-
-    @* Household selector — only when connections exist *@
-    @if (_connectedHouseholds.Count > 0)
-    {
-        <div class="d-flex align-center gap-2 mb-4 flex-wrap">
-            <MudChipSet T="int?" SelectedValue="_selectedHouseholdId" SelectedValueChanged="OnHouseholdChipChanged" SelectionMode="SelectionMode.SingleSelection" CheckMark="false">
-                <MudChip T="int?" Value="@((int?)null)"
-                         Color="@(_selectedHouseholdId == null ? Color.Primary : Color.Default)"
-                         Variant="@(_selectedHouseholdId == null ? Variant.Filled : Variant.Outlined)">
-                    My Recipes
-                </MudChip>
-                @foreach (var household in _connectedHouseholds)
-                {
-                    <MudChip T="int?" Value="@((int?)household.HouseholdId)"
-                             Color="@(_selectedHouseholdId == household.HouseholdId ? Color.Primary : Color.Default)"
-                             Variant="@(_selectedHouseholdId == household.HouseholdId ? Variant.Filled : Variant.Outlined)">
-                        @household.HouseholdName
-                    </MudChip>
-                }
-            </MudChipSet>
-            <MudIconButton Icon="@Icons.Material.Filled.GroupAdd"
-                           Size="Size.Small"
-                           Color="Color.Primary"
-                           Href="/settings/connections"
-                           Title="Manage family connections" />
-        </div>
-    }
-
-    <div class="d-flex gap-3 align-center mb-4 flex-wrap">
-        <MudTextField @bind-Value="_searchTerm"
-                      Label="Search by name, ingredients, or type"
-                      Variant="Variant.Outlined"
-                      Adornment="Adornment.Start"
-                      AdornmentIcon="@Icons.Material.Filled.Search"
-                      DebounceInterval="300"
-                      OnDebounceIntervalElapsed="OnSearchChanged"
-                      Style="flex: 1; min-width: 200px;" />
-        @if (!_isViewingConnectedHousehold)
-        {
-            <MudChip T="bool"
-                     Icon="@Icons.Material.Filled.Favorite"
-                     Color="@(_showFavoritesOnly ? Color.Error : Color.Default)"
-                     Variant="@(_showFavoritesOnly ? Variant.Filled : Variant.Outlined)"
-                     OnClick="ToggleFavoritesFilter">
-                Favorites
-            </MudChip>
-        }
-    </div>
-
-    @if (_loading)
-    {
-        <!-- Loading skeleton -->
-        <MudGrid>
-            @for (int i = 0; i < 6; i++)
-            {
-                <MudItem xs="12" sm="6" md="4">
-                    <MudCard>
-                        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="200px" />
-                        <MudCardContent>
-                            <MudSkeleton SkeletonType="SkeletonType.Text" />
-                            <MudSkeleton SkeletonType="SkeletonType.Text" />
-                        </MudCardContent>
-                    </MudCard>
-                </MudItem>
-            }
-        </MudGrid>
-    }
-    else if (!DisplayedRecipes.Any())
-    {
-        <!-- Empty state -->
-        <div class="d-flex flex-column align-center justify-center" style="min-height: 400px;">
-            <MudIcon Icon="@(_isViewingConnectedHousehold ? Icons.Material.Filled.PeopleOutline : (_showFavoritesOnly ? Icons.Material.Filled.FavoriteBorder : Icons.Material.Filled.MenuBook))"
-                     Size="Size.Large"
-                     Color="Color.Secondary"
-                     Style="font-size: 6rem; margin-bottom: 1rem;" />
-            <MudText Typo="Typo.h5" Class="mb-2">
-                @if (_isViewingConnectedHousehold)
-                {
-                    <text>No shared recipes</text>
-                }
-                else if (_showFavoritesOnly)
-                {
-                    <text>No favorites yet</text>
-                }
-                else
-                {
-                    <text>No recipes yet</text>
-                }
-            </MudText>
-            <MudText Typo="Typo.body1" Color="Color.Secondary" Class="mb-4">
-                @if (_isViewingConnectedHousehold)
-                {
-                    if (string.IsNullOrWhiteSpace(_searchTerm))
-                    {
-                        <text>This family hasn't added any recipes yet</text>
-                    }
-                    else
-                    {
-                        <text>No recipes found matching "@_searchTerm"</text>
-                    }
-                }
-                else if (_showFavoritesOnly)
-                {
-                    <text>Click the heart icon on recipes to add them to your favorites</text>
-                }
-                else if (string.IsNullOrWhiteSpace(_searchTerm))
-                {
-                    <text>Start building your family recipe collection</text>
-                }
-                else
-                {
-                    <text>No recipes found matching "@_searchTerm"</text>
-                }
-            </MudText>
-            @if (_showFavoritesOnly && !_isViewingConnectedHousehold)
-            {
-                <MudButton StartIcon="@Icons.Material.Filled.Clear"
-                           Color="Color.Primary"
-                           Variant="Variant.Text"
-                           OnClick="ToggleFavoritesFilter">
-                    Show All Recipes
-                </MudButton>
-            }
-            else if (!_isViewingConnectedHousehold && string.IsNullOrWhiteSpace(_searchTerm))
-            {
-                <MudButton StartIcon="@Icons.Material.Filled.Add"
-                           Color="Color.Primary"
-                           Variant="Variant.Filled"
-                           Size="Size.Large"
-                           OnClick="HandleAddRecipe">
-                    Add Your First Recipe
-                </MudButton>
-            }
-            else if (!string.IsNullOrWhiteSpace(_searchTerm))
-            {
-                <MudButton StartIcon="@Icons.Material.Filled.Clear"
-                           Color="Color.Primary"
-                           Variant="Variant.Text"
-                           OnClick="ClearSearch">
-                    Clear Search
-                </MudButton>
-            }
-        </div>
-    }
-    else
-    {
-        <!-- Recipe grid -->
-        <MudGrid Class="recipe-grid">
-            @foreach (var recipe in DisplayedRecipes)
-            {
-                <MudItem xs="12" sm="6" md="4" Class="recipe-grid-item">
-                    <RecipeCard Recipe="recipe"
-                                IsSelected="@(_selectedRecipe?.RecipeId == recipe.RecipeId && _selectedRecipe?.HouseholdId == recipe.HouseholdId)"
-                                IsFavorite="@(!_isViewingConnectedHousehold && FavoriteRecipeIds.Contains(recipe.RecipeId))"
-                                IsReadOnly="_isViewingConnectedHousehold"
-                                SharedFromHouseholdName="@(_isViewingConnectedHousehold ? _selectedConnectedHouseholdName : null)"
-                                OnClick="HandleCardClick"
-                                OnToggleFavorite="HandleToggleFavorite" />
-                </MudItem>
-            }
-        </MudGrid>
-    }
-</MudContainer>
-
-<!-- Overlay for dimming when drawer is open -->
-@if (_drawerOpen)
+@if (_useIsland && _shell is not null)
 {
-    <div class="recipe-drawer-overlay" @onclick="CloseDrawer"></div>
+    <PageTitle>Recipes - Family Kitchen</PageTitle>
+
+    <HeadContent>
+        <link rel="stylesheet" href="/islands/recipes/index.css?v=@IslandVersion" />
+    </HeadContent>
+
+    <div id="recipes-list-root"
+         data-household-id="@_shell.HouseholdId"
+         data-user-id="@_shell.UserId"
+         data-user-name="@_shell.UserName"
+         data-view="list"></div>
+}
+else
+{
+    <RecipesBlazor />
 }
 
-<!-- Recipe detail slide-out panel -->
-<MudDrawer @bind-Open="_drawerOpen"
-           Anchor="Anchor.End"
-           Elevation="4"
-           Variant="DrawerVariant.Temporary"
-           Width="min(800px, 90vw)"
-           Class="recipe-detail-drawer">
-    @if (_selectedRecipe != null)
-    {
-        <MudDrawerHeader Class="recipe-drawer-header">
-            <div class="d-flex justify-space-between align-center" style="width: 100%;">
-                <MudText Typo="Typo.h5" Class="text-truncate" Style="max-width: calc(100% - 48px);">
-                    @_selectedRecipe.Name
-                </MudText>
-                <MudIconButton Icon="@Icons.Material.Filled.Close"
-                               OnClick="CloseDrawer"
-                               aria-label="Close panel" />
-            </div>
-        </MudDrawerHeader>
-
-        <div class="recipe-drawer-content">
-            <!-- Recipe Image -->
-            @if (!string.IsNullOrWhiteSpace(_selectedRecipe.ImagePath))
-            {
-                <div class="recipe-detail-image">
-                    <img src="@_selectedRecipe.ImagePath" alt="@_selectedRecipe.Name" />
-                </div>
-            }
-
-            <!-- Author info -->
-            <div class="d-flex align-center gap-2 mb-3">
-                @if (_selectedRecipe.CreatedBy != null)
-                {
-                    <UserAvatar User="@_selectedRecipe.CreatedBy" Size="Size.Small" />
-                    <MudText Typo="Typo.body2" Color="Color.Secondary">
-                        Added by @_selectedRecipe.CreatedBy.DisplayName
-                    </MudText>
-                }
-                else
-                {
-                    <MudAvatar Size="Size.Small" Color="Color.Default">
-                        <MudIcon Icon="@Icons.Material.Filled.PersonOff" Size="Size.Small" />
-                    </MudAvatar>
-                    <MudText Typo="Typo.body2" Color="Color.Secondary" Class="font-italic">
-                        Added by deleted user
-                    </MudText>
-                }
-            </div>
-
-            @* Connected household attribution in drawer *@
-            @if (_isViewingConnectedHousehold && !string.IsNullOrWhiteSpace(_selectedConnectedHouseholdName))
-            {
-                <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-3">
-                    From @_selectedConnectedHouseholdName
-                </MudText>
-            }
-
-            <!-- Meta chips -->
-            @if (_selectedRecipe.PrepTimeMinutes.HasValue || _selectedRecipe.CookTimeMinutes.HasValue || _selectedRecipe.Servings.HasValue)
-            {
-                <div class="recipe-meta-chips mb-4">
-                    @if (_selectedRecipe.PrepTimeMinutes.HasValue)
-                    {
-                        <MudChip T="string" Icon="@Icons.Material.Filled.Schedule" Size="Size.Small" Color="Color.Info">
-                            Prep: @_selectedRecipe.PrepTimeMinutes min
-                        </MudChip>
-                    }
-                    @if (_selectedRecipe.CookTimeMinutes.HasValue)
-                    {
-                        <MudChip T="string" Icon="@Icons.Material.Filled.Whatshot" Size="Size.Small" Color="Color.Warning">
-                            Cook: @_selectedRecipe.CookTimeMinutes min
-                        </MudChip>
-                    }
-                </div>
-            }
-
-            <!-- Servings scaler -->
-            @if (_selectedRecipe.Servings.HasValue)
-            {
-                <div class="d-flex align-center gap-2 mb-4">
-                    <MudIcon Icon="@Icons.Material.Filled.Restaurant" Color="Color.Success" />
-                    <MudText Typo="Typo.body2">Servings:</MudText>
-                    <MudIconButton Icon="@Icons.Material.Filled.Remove"
-                                   Size="Size.Small"
-                                   OnClick="DecreaseServings"
-                                   Disabled="@(_scaledServings <= 1)" />
-                    <MudText Typo="Typo.body1" Class="mx-1" Style="min-width: 24px; text-align: center;">
-                        <strong>@_scaledServings</strong>
-                    </MudText>
-                    <MudIconButton Icon="@Icons.Material.Filled.Add"
-                                   Size="Size.Small"
-                                   OnClick="IncreaseServings" />
-                    @if (_scaledServings != _selectedRecipe.Servings)
-                    {
-                        <MudChip T="string" Size="Size.Small" Color="Color.Info" Variant="Variant.Outlined">
-                            @GetScalingLabel()
-                        </MudChip>
-                        <MudButton Size="Size.Small" Variant="Variant.Text" OnClick="ResetServings">
-                            Reset
-                        </MudButton>
-                    }
-                </div>
-            }
-
-            <!-- Description -->
-            @if (!string.IsNullOrWhiteSpace(_selectedRecipe.Description))
-            {
-                <MudText Typo="Typo.body1" Class="mb-4">@_selectedRecipe.Description</MudText>
-            }
-
-            <!-- Ingredients -->
-            @if (_selectedRecipe.Ingredients.Any())
-            {
-                <MudText Typo="Typo.h6" Class="mb-2">Ingredients</MudText>
-                <MudList T="string" Dense="true" Class="mb-4">
-                    @foreach (var ingredient in _selectedRecipe.Ingredients.OrderBy(i => i.SortOrder))
-                    {
-                        <MudListItem T="string" Icon="@Icons.Material.Filled.Circle" IconSize="Size.Small">
-                            @GetIngredientDisplay(ingredient)
-                        </MudListItem>
-                    }
-                </MudList>
-            }
-
-            <!-- Instructions -->
-            @if (!string.IsNullOrWhiteSpace(_selectedRecipe.Instructions))
-            {
-                <MudText Typo="Typo.h6" Class="mb-2">Instructions</MudText>
-                <div class="recipe-instructions mb-4">
-                    @((MarkupString)MarkdownHelper.ToSafeHtml(_selectedRecipe.Instructions))
-                </div>
-            }
-
-            <!-- Source URL -->
-            @if (!string.IsNullOrWhiteSpace(_selectedRecipe.SourceUrl) && IsSafeUrl(_selectedRecipe.SourceUrl))
-            {
-                <div class="d-flex align-center mb-4">
-                    <MudIcon Icon="@Icons.Material.Filled.Link" Size="Size.Small" Class="mr-2" />
-                    <a href="@_selectedRecipe.SourceUrl"
-                       target="_blank"
-                       rel="noopener noreferrer"
-                       class="mud-typography mud-link mud-secondary-text mud-typography-body2">
-                        View Original Recipe
-                    </a>
-                </div>
-            }
-        </div>
-
-        <!-- Action buttons -->
-        <div class="recipe-drawer-actions">
-            @if (_isViewingConnectedHousehold)
-            {
-                <MudButton StartIcon="@Icons.Material.Filled.ContentCopy"
-                           Color="Color.Primary"
-                           Variant="Variant.Filled"
-                           OnClick="@(() => HandleCopyRecipe(_selectedRecipe))"
-                           FullWidth="true"
-                           Disabled="_copyingRecipe">
-                    @if (_copyingRecipe)
-                    {
-                        <MudProgressCircular Indeterminate="true" Size="Size.Small" Class="mr-2" />
-                    }
-                    Copy to My Recipes
-                </MudButton>
-            }
-            else
-            {
-                <MudButton StartIcon="@Icons.Material.Filled.Edit"
-                           Color="Color.Primary"
-                           Variant="Variant.Filled"
-                           OnClick="@(() => HandleEdit(_selectedRecipe))"
-                           FullWidth="true"
-                           Class="mb-2">
-                    Edit Recipe
-                </MudButton>
-                <MudButton StartIcon="@Icons.Material.Filled.CalendarMonth"
-                           Color="Color.Secondary"
-                           Variant="Variant.Outlined"
-                           OnClick="@(() => HandleAddToMealPlan(_selectedRecipe))"
-                           FullWidth="true"
-                           Class="mb-2">
-                    Add to Meal Plan
-                </MudButton>
-                <MudButton StartIcon="@Icons.Material.Filled.Delete"
-                           Color="Color.Error"
-                           Variant="Variant.Text"
-                           OnClick="@(() => HandleDeleteConfirm(_selectedRecipe))"
-                           FullWidth="true">
-                    Delete Recipe
-                </MudButton>
-            }
-        </div>
-    }
-</MudDrawer>
-
-<!-- Delete confirmation dialog -->
-<MudDialog @bind-Visible="_showDeleteDialog" Options="_dialogOptions">
-    <TitleContent>
-        <MudText Typo="Typo.h6">Delete Recipe</MudText>
-    </TitleContent>
-    <DialogContent>
-        <MudText>
-            Are you sure you want to delete "<strong>@_recipeToDelete?.Name</strong>"?
-            This action cannot be undone.
-        </MudText>
-    </DialogContent>
-    <DialogActions>
-        <MudButton OnClick="CancelDelete" Color="Color.Default">Cancel</MudButton>
-        <MudButton OnClick="ConfirmDelete" Color="Color.Error" Variant="Variant.Filled">Delete</MudButton>
-    </DialogActions>
-</MudDialog>
-
-<style>
-    /* Recipe grid - equal height cards */
-    .recipe-grid {
-        align-items: stretch;
-    }
-
-    .recipe-grid-item {
-        display: flex;
-    }
-
-    .recipe-grid-item > * {
-        width: 100%;
-    }
-
-    .recipe-drawer-overlay {
-        position: fixed;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: rgba(0, 0, 0, 0.5);
-        z-index: 1299; /* Just below MudDrawer's z-index */
-    }
-
-    .recipe-detail-drawer {
-        display: flex;
-        flex-direction: column;
-        height: 100%;
-    }
-
-    .recipe-drawer-header {
-        flex-shrink: 0;
-        border-bottom: 1px solid var(--mud-palette-lines-default);
-    }
-
-    .recipe-drawer-content {
-        flex: 1;
-        overflow-y: auto;
-        padding: 16px 24px;
-    }
-
-    .recipe-detail-image {
-        width: 100%;
-        height: 250px;
-        margin-bottom: 16px;
-        border-radius: 8px;
-        overflow: hidden;
-    }
-
-    .recipe-detail-image img {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-    }
-
-    .recipe-meta-chips {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.5rem;
-    }
-
-    .recipe-instructions {
-        line-height: 1.6;
-    }
-
-    .recipe-instructions ol,
-    .recipe-instructions ul {
-        margin-left: 1.5rem;
-        margin-bottom: 1rem;
-    }
-
-    .recipe-instructions li {
-        margin-bottom: 0.5rem;
-    }
-
-    .recipe-drawer-actions {
-        flex-shrink: 0;
-        padding: 16px 24px;
-        border-top: 1px solid var(--mud-palette-lines-default);
-        background: var(--mud-palette-background);
-    }
-</style>
-
 @code {
-    [CascadingParameter] private Task<AuthenticationState>? AuthState { get; set; }
-
-    // Persisted state to prevent prerender flash
-    [PersistentState(AllowUpdates = true)]
-    public List<Recipe> RecipeList { get; set; } = new();
-
-    [PersistentState(AllowUpdates = true)]
-    public HashSet<int> FavoriteRecipeIds { get; set; } = new();
-
-    [PersistentState(AllowUpdates = true)]
-    public int HouseholdId { get; set; }
-
-    [PersistentState(AllowUpdates = true)]
-    public int UserId { get; set; }
-
-    // Non-persisted state
-    private bool _loading = true;
-    private string _searchTerm = string.Empty;
-    private bool _showFavoritesOnly;
-
-    private Recipe? _selectedRecipe;
-    private bool _drawerOpen;
-    private int _scaledServings;
-
-    private bool _showDeleteDialog;
-    private Recipe? _recipeToDelete;
-
-    // Connected household state
-    private List<ConnectedHouseholdInfo> _connectedHouseholds = new();
-    private int? _selectedHouseholdId;
-    private bool _isViewingConnectedHousehold => _selectedHouseholdId != null;
-    private List<Recipe> _connectedRecipes = new();
-    private string? _selectedConnectedHouseholdName;
-    private bool _copyingRecipe;
-
-    private DialogOptions _dialogOptions = new()
-    {
-        CloseOnEscapeKey = true,
-        MaxWidth = MaxWidth.Small
-    };
-
-    private IEnumerable<Recipe> DisplayedRecipes =>
-        _isViewingConnectedHousehold
-            ? _connectedRecipes
-            : FilteredRecipes;
+    private bool _useIsland;
+    private ShellData? _shell;
+    private IJSObjectReference? _islandModule;
 
     protected override async Task OnInitializedAsync()
     {
-        Notifier.OnRecipesChanged += OnDataChanged;
+        _useIsland = IsIslandEnabled();
+        if (!_useIsland) return;
 
-        // Skip loading if already persisted from prerender
-        if (HouseholdId > 0 && RecipeList.Any())
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        var email = authState.User.FindFirst(ClaimTypes.Email)?.Value;
+        var userName = authState.User.FindFirst(ClaimTypes.Name)?.Value ?? string.Empty;
+
+        await using var context = await DbFactory.CreateDbContextAsync();
+        var user = await context.Users.FirstOrDefaultAsync(u => u.Email == email);
+        if (user is null)
         {
-            _loading = false;
-            // Still load connected households for the selector
-            await LoadConnectedHouseholds();
-            return;
+            throw new InvalidOperationException("User not found. Please log in again.");
         }
 
-        await LoadUserContext();
-        if (HouseholdId > 0)
-        {
-            await LoadRecipes();
-            await LoadConnectedHouseholds();
-        }
-        else
-        {
-            Snackbar.Add("Unable to load household information", Severity.Error);
-            _loading = false;
-        }
+        _shell = new ShellData(user.HouseholdId, user.Id, userName);
     }
 
-    private async Task OnHouseholdChipChanged(int? value)
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        _selectedHouseholdId = value;
-        await OnHouseholdSelectionChanged();
+        if (!firstRender || !_useIsland || _shell is null) return;
+
+        // Blazor enhanced navigation does not apply this page's <HeadContent>, so the island stylesheet is
+        // missing on in-app navigation. (Re)inject it here (idempotent) — OnAfterRender runs for both full
+        // loads and enhanced nav, so the island is styled either way.
+        await JS.InvokeVoidAsync("ensureIslandStylesheet", $"/islands/recipes/index.css?v={IslandVersion}");
+
+        // Load the Svelte bundle as an ES module, then call its exposed mounter. mountRoot is idempotent and
+        // re-mounts against the fresh <div id="recipes-list-root"> (data-view="list").
+        _islandModule = await JS.InvokeAsync<IJSObjectReference>(
+            "import", $"/islands/recipes/index.js?v={IslandVersion}");
+        await JS.InvokeVoidAsync("RecipesIsland.mount", "recipes-list-root");
     }
 
-    private async Task OnHouseholdSelectionChanged()
-    {
-        _searchTerm = string.Empty;
-        _showFavoritesOnly = false;
-        CloseDrawer();
+    // Cache-bust the island URLs per deploy via the published bundle's mtime (mirrors MealPlan.razor).
+    private static string? _islandVersion;
+    private string IslandVersion => _islandVersion ??= ComputeIslandVersion();
 
-        if (_isViewingConnectedHousehold)
-        {
-            _selectedConnectedHouseholdName = _connectedHouseholds
-                .FirstOrDefault(h => h.HouseholdId == _selectedHouseholdId)?.HouseholdName;
-            await LoadConnectedRecipes();
-        }
-        else
-        {
-            _selectedConnectedHouseholdName = null;
-            _connectedRecipes.Clear();
-        }
-    }
-
-    private async Task LoadConnectedHouseholds()
+    private string ComputeIslandVersion()
     {
         try
         {
-            _connectedHouseholds = await ConnectionService.GetConnectedHouseholdsAsync(HouseholdId);
+            var path = Path.Combine(HostEnv.WebRootPath, "islands", "recipes", "index.js");
+            return new DateTimeOffset(File.GetLastWriteTimeUtc(path)).ToUnixTimeSeconds().ToString();
         }
         catch
         {
-            // Non-critical — selector just won't show
-            _connectedHouseholds = new();
+            return "0";
         }
     }
 
-    private async Task LoadConnectedRecipes()
+    private bool IsIslandEnabled()
     {
-        if (_selectedHouseholdId == null) return;
+        var configValue = Config["RECIPES_USE_ISLAND"];
+        if (!string.IsNullOrEmpty(configValue))
+        {
+            return configValue.Equals("true", StringComparison.OrdinalIgnoreCase);
+        }
 
+        var envValue = Environment.GetEnvironmentVariable("RECIPES_USE_ISLAND");
+        return string.Equals(envValue, "true", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_islandModule is null) return;
         try
         {
-            _loading = true;
-            _connectedRecipes = await RecipeService.GetRecipesFromConnectedHouseholdAsync(
-                HouseholdId, _selectedHouseholdId.Value, _searchTerm);
+            await JS.InvokeVoidAsync("RecipesIsland.destroy", "recipes-list-root");
+            await _islandModule.DisposeAsync();
         }
-        catch (Exception ex)
+        catch (JSDisconnectedException)
         {
-            Snackbar.Add($"Error loading shared recipes: {ex.Message}", Severity.Error);
-            _connectedRecipes = new();
-        }
-        finally
-        {
-            _loading = false;
+            // Circuit already gone (user navigated away after disconnect) — nothing to clean up.
         }
     }
 
-    private async Task OnSearchChanged()
-    {
-        if (_isViewingConnectedHousehold)
-        {
-            await LoadConnectedRecipes();
-        }
-        else
-        {
-            await LoadRecipes();
-        }
-    }
-
-    private async Task LoadUserContext()
-    {
-        if (AuthState == null) return;
-
-        var authState = await AuthState;
-        var email = authState.User.FindFirstValue(ClaimTypes.Email);
-
-        if (string.IsNullOrEmpty(email)) return;
-
-        await using var context = await DbFactory.CreateDbContextAsync();
-        var user = await context.Users
-            .FirstOrDefaultAsync(u => u.Email == email);
-
-        if (user != null)
-        {
-            HouseholdId = user.HouseholdId;
-            UserId = user.Id;
-        }
-    }
-
-    private async Task LoadRecipes()
-    {
-        try
-        {
-            _loading = true;
-            RecipeList = await RecipeService.GetRecipesAsync(HouseholdId, _searchTerm);
-            FavoriteRecipeIds = await RecipeService.GetFavoriteRecipeIdsAsync(UserId, HouseholdId);
-        }
-        catch (Exception ex)
-        {
-            Snackbar.Add($"Error loading recipes: {ex.Message}", Severity.Error);
-        }
-        finally
-        {
-            _loading = false;
-        }
-    }
-
-    private async Task HandleToggleFavorite(Recipe recipe)
-    {
-        if (_isViewingConnectedHousehold) return;
-
-        await RecipeService.ToggleFavoriteAsync(UserId, HouseholdId, recipe.RecipeId);
-        // Toggle local state immediately for responsive UI
-        if (FavoriteRecipeIds.Contains(recipe.RecipeId))
-            FavoriteRecipeIds.Remove(recipe.RecipeId);
-        else
-            FavoriteRecipeIds.Add(recipe.RecipeId);
-    }
-
-    private void ToggleFavoritesFilter()
-    {
-        _showFavoritesOnly = !_showFavoritesOnly;
-    }
-
-    private IEnumerable<Recipe> FilteredRecipes =>
-        _showFavoritesOnly
-            ? RecipeList.Where(r => FavoriteRecipeIds.Contains(r.RecipeId))
-            : RecipeList;
-
-    private void HandleCardClick(Recipe recipe)
-    {
-        _selectedRecipe = recipe;
-        _scaledServings = recipe.Servings ?? 1;
-        _drawerOpen = true;
-    }
-
-    private void CloseDrawer()
-    {
-        _drawerOpen = false;
-        // Keep _selectedRecipe so the drawer content doesn't flash during close animation
-    }
-
-    private void HandleAddRecipe()
-    {
-        NavigationManager.NavigateTo("/recipes/new");
-    }
-
-    private async Task OpenImportDialog()
-    {
-        var options = new DialogOptions
-        {
-            MaxWidth = MaxWidth.Small,
-            FullWidth = true,
-            CloseButton = true
-        };
-
-        var dialog = await DialogService.ShowAsync<ImportRecipeDialog>("Import Recipe", options);
-        var result = await dialog.Result;
-
-        if (result != null && !result.Canceled)
-        {
-            // Refresh recipe list after successful import
-            await LoadRecipes();
-        }
-    }
-
-    private void HandleEdit(Recipe recipe)
-    {
-        NavigationManager.NavigateTo($"/recipes/edit/{recipe.RecipeId}");
-    }
-
-    private async Task HandleCopyRecipe(Recipe recipe)
-    {
-        if (_selectedHouseholdId == null) return;
-
-        _copyingRecipe = true;
-
-        try
-        {
-            await RecipeService.CopyRecipeFromConnectedHouseholdAsync(
-                _selectedHouseholdId.Value, recipe.RecipeId, HouseholdId, UserId);
-
-            Snackbar.Add("Recipe copied! It's now in your collection.", Severity.Success);
-            // Stay on connected view per spec
-        }
-        catch (Exception ex)
-        {
-            Snackbar.Add($"Error copying recipe: {ex.Message}", Severity.Error);
-        }
-        finally
-        {
-            _copyingRecipe = false;
-        }
-    }
-
-    private void HandleDeleteConfirm(Recipe recipe)
-    {
-        _recipeToDelete = recipe;
-        _showDeleteDialog = true;
-    }
-
-    private void CancelDelete()
-    {
-        _showDeleteDialog = false;
-        _recipeToDelete = null;
-    }
-
-    private async Task ConfirmDelete()
-    {
-        if (_recipeToDelete == null) return;
-
-        try
-        {
-            await RecipeService.DeleteRecipeAsync(HouseholdId, _recipeToDelete.RecipeId);
-            Snackbar.Add($"Recipe '{_recipeToDelete.Name}' deleted", Severity.Success);
-
-            // Close drawer if this was the selected recipe
-            if (_selectedRecipe?.RecipeId == _recipeToDelete.RecipeId)
-            {
-                _drawerOpen = false;
-                _selectedRecipe = null;
-            }
-
-            // Reload recipes
-            await LoadRecipes();
-        }
-        catch (Exception ex)
-        {
-            Snackbar.Add($"Error deleting recipe: {ex.Message}", Severity.Error);
-        }
-        finally
-        {
-            _showDeleteDialog = false;
-            _recipeToDelete = null;
-        }
-    }
-
-    private void HandleAddToMealPlan(Recipe recipe)
-    {
-        // Meal planning integration planned for future release
-        Snackbar.Add($"Add '{recipe.Name}' to meal plan - feature in development", Severity.Info);
-    }
-
-    private async Task ClearSearch()
-    {
-        _searchTerm = string.Empty;
-        if (_isViewingConnectedHousehold)
-        {
-            await LoadConnectedRecipes();
-        }
-        else
-        {
-            await LoadRecipes();
-        }
-    }
-
-    private string GetIngredientDisplay(RecipeIngredient ingredient)
-    {
-        var parts = new List<string>();
-
-        if (ingredient.Quantity.HasValue)
-        {
-            var scaledQty = GetScaledQuantity(ingredient.Quantity.Value);
-            parts.Add(FormatQuantity(scaledQty));
-        }
-
-        if (!string.IsNullOrWhiteSpace(ingredient.Unit))
-        {
-            parts.Add(ingredient.Unit);
-        }
-
-        parts.Add(ingredient.Name);
-
-        if (!string.IsNullOrWhiteSpace(ingredient.Notes))
-        {
-            parts.Add($"({ingredient.Notes})");
-        }
-
-        return string.Join(" ", parts);
-    }
-
-    // Servings scaling methods
-    private decimal GetScalingFactor()
-    {
-        if (_selectedRecipe?.Servings == null || _selectedRecipe.Servings == 0)
-            return 1m;
-        return (decimal)_scaledServings / _selectedRecipe.Servings.Value;
-    }
-
-    private decimal GetScaledQuantity(decimal original)
-    {
-        return original * GetScalingFactor();
-    }
-
-    private string FormatQuantity(decimal qty)
-    {
-        // Round to sensible fractions
-        if (qty == Math.Floor(qty))
-            return ((int)qty).ToString();
-
-        // Common fractions
-        var fractionalPart = qty - Math.Floor(qty);
-        var wholePart = (int)Math.Floor(qty);
-
-        string fraction = fractionalPart switch
-        {
-            >= 0.2m and < 0.3m => "\u00bc",
-            >= 0.3m and < 0.4m => "\u2153",
-            >= 0.45m and < 0.55m => "\u00bd",
-            >= 0.6m and < 0.7m => "\u2154",
-            >= 0.7m and < 0.8m => "\u00be",
-            _ => null
-        };
-
-        if (fraction != null)
-            return wholePart > 0 ? $"{wholePart} {fraction}" : fraction;
-
-        // Default to decimal
-        return qty.ToString("0.##");
-    }
-
-    private void IncreaseServings()
-    {
-        _scaledServings++;
-    }
-
-    private void DecreaseServings()
-    {
-        if (_scaledServings > 1)
-            _scaledServings--;
-    }
-
-    private void ResetServings()
-    {
-        _scaledServings = _selectedRecipe?.Servings ?? 1;
-    }
-
-    private string GetScalingLabel()
-    {
-        var factor = GetScalingFactor();
-        if (factor == 2) return "2\u00d7";
-        if (factor == 0.5m) return "\u00bd\u00d7";
-        if (factor == 1.5m) return "1.5\u00d7";
-        return $"{factor:0.##}\u00d7";
-    }
-
-    private void OnDataChanged(int householdId)
-    {
-        // Security: Only respond to changes for our household
-        if (householdId != HouseholdId)
-            return;
-
-        InvokeAsync(async () =>
-        {
-            await LoadRecipes();
-            StateHasChanged();
-        });
-    }
-
-    private static bool IsSafeUrl(string? url) =>
-        !string.IsNullOrEmpty(url) &&
-        Uri.TryCreate(url, UriKind.Absolute, out var uri) &&
-        (uri.Scheme == "http" || uri.Scheme == "https");
-
-    public void Dispose()
-    {
-        Notifier.OnRecipesChanged -= OnDataChanged;
-    }
+    private sealed record ShellData(int HouseholdId, int UserId, string UserName);
 }

--- a/src/FamilyCoordinationApp/Components/Recipe/RecipeEditBlazor.razor
+++ b/src/FamilyCoordinationApp/Components/Recipe/RecipeEditBlazor.razor
@@ -1,0 +1,622 @@
+@*
+    The original Blazor recipe edit/new UI, extracted verbatim from RecipeEdit.razor so the page can become a
+    thin island host (mirrors MealPlan.razor → MealPlanBlazor). This is the flag-OFF fallback during the
+    recipes strangler migration; delete it once RECIPES_USE_ISLAND is the only path. RecipeId is supplied by
+    the host page; render mode + [Authorize] come from the host + the global Routes @rendermode.
+*@
+
+@using FamilyCoordinationApp.Data
+@using FamilyCoordinationApp.Data.Entities
+@using FamilyCoordinationApp.Services
+@using FamilyCoordinationApp.Components.Recipe
+@using Microsoft.EntityFrameworkCore
+@using System.Security.Claims
+
+@implements IDisposable
+
+@inject IRecipeService RecipeService
+@inject IImageService ImageService
+@inject IDraftService DraftService
+@inject IDbContextFactory<ApplicationDbContext> DbFactory
+@inject NavigationManager Navigation
+@inject ISnackbar Snackbar
+@inject IDialogService DialogService
+
+<PageTitle>@(IsEdit ? "Edit Recipe" : "New Recipe") - Family Kitchen</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Medium" Class="mt-4 mb-8">
+    <div class="d-flex justify-space-between align-center mb-4">
+        <MudText Typo="Typo.h4">@(IsEdit ? "Edit Recipe" : "New Recipe")</MudText>
+        @if (IsEdit)
+        {
+            <MudButton Variant="Variant.Outlined"
+                       Color="Color.Error"
+                       StartIcon="@Icons.Material.Filled.Delete"
+                       OnClick="DeleteRecipe">
+                Delete
+            </MudButton>
+        }
+    </div>
+
+    @if (_loading)
+    {
+        <MudProgressLinear Indeterminate="true" />
+    }
+    else
+    {
+        <EditForm EditContext="_editContext" OnValidSubmit="SaveRecipe">
+            <DataAnnotationsValidator />
+            <NavigationLock ConfirmExternalNavigation="_hasUnsavedChanges" />
+
+            @if (!string.IsNullOrWhiteSpace(_recipe.SourceUrl) && IsEdit)
+            {
+                <MudAlert Severity="Severity.Info" Class="mb-4" Dense="true">
+                    <div class="d-flex align-center">
+                        <MudIcon Icon="@Icons.Material.Filled.CloudDownload" Size="Size.Small" Class="mr-2" />
+                        <MudText Typo="Typo.body2">
+                            Imported from
+                            @if (IsSafeUrl(_recipe.SourceUrl))
+                            {
+                                <a href="@_recipe.SourceUrl"
+                                   target="_blank"
+                                   rel="noopener noreferrer"
+                                   class="mud-link">
+                                    @GetDomainFromUrl(_recipe.SourceUrl)
+                                </a>
+                            }
+                            else
+                            {
+                                <span>@GetDomainFromUrl(_recipe.SourceUrl)</span>
+                            }
+                        </MudText>
+                    </div>
+                </MudAlert>
+            }
+
+            <MudPaper Class="pa-4 mb-4" Elevation="1">
+                <MudText Typo="Typo.h6" Class="mb-3">Basic Info</MudText>
+
+                <MudTextField @bind-Value="_recipe.Name"
+                              Label="Recipe Name"
+                              Required="true"
+                              Variant="Variant.Outlined"
+                              @oninput="ScheduleAutoSave"
+                              Class="mb-3" />
+
+                <MudTextField @bind-Value="_recipe.Description"
+                              Label="Description"
+                              Lines="2"
+                              Variant="Variant.Outlined"
+                              @oninput="ScheduleAutoSave"
+                              Class="mb-3"
+                              HelperText="Brief introduction to the recipe" />
+
+                <MudGrid>
+                    <MudItem xs="12" sm="4">
+                        <MudNumericField @bind-Value="_recipe.PrepTimeMinutes"
+                                         Label="Prep Time (min)"
+                                         Variant="Variant.Outlined"
+                                         Min="0"
+                                         @oninput="ScheduleAutoSave" />
+                    </MudItem>
+                    <MudItem xs="12" sm="4">
+                        <MudNumericField @bind-Value="_recipe.CookTimeMinutes"
+                                         Label="Cook Time (min)"
+                                         Variant="Variant.Outlined"
+                                         Min="0"
+                                         @oninput="ScheduleAutoSave" />
+                    </MudItem>
+                    <MudItem xs="12" sm="4">
+                        <MudNumericField @bind-Value="_recipe.Servings"
+                                         Label="Servings"
+                                         Variant="Variant.Outlined"
+                                         Min="1"
+                                         @oninput="ScheduleAutoSave" />
+                    </MudItem>
+                </MudGrid>
+
+                <MudTextField @bind-Value="_recipe.SourceUrl"
+                              Label="Source URL (optional)"
+                              Variant="Variant.Outlined"
+                              @oninput="ScheduleAutoSave"
+                              Class="mt-3"
+                              HelperText="Link to original recipe" />
+
+                <MudSelect @bind-Value="_recipe.RecipeType"
+                           Label="Recipe Type"
+                           Variant="Variant.Outlined"
+                           Class="mt-3">
+                    @foreach (var type in Enum.GetValues<RecipeType>())
+                    {
+                        <MudSelectItem Value="@type">@GetRecipeTypeLabel(type)</MudSelectItem>
+                    }
+                </MudSelect>
+            </MudPaper>
+
+            <MudPaper Class="pa-4 mb-4" Elevation="1">
+                <MudText Typo="Typo.h6" Class="mb-3">Image</MudText>
+
+                @if (!string.IsNullOrWhiteSpace(_recipe.ImagePath))
+                {
+                    <div class="mb-3" style="position: relative; display: inline-block;">
+                        <MudImage Src="@_recipe.ImagePath"
+                                  Alt="Recipe image"
+                                  ObjectFit="ObjectFit.Cover"
+                                  Width="300"
+                                  Height="200"
+                                  Elevation="2"
+                                  Class="rounded" />
+                        <MudIconButton Icon="@Icons.Material.Filled.Close"
+                                       Color="Color.Error"
+                                       Size="Size.Small"
+                                       OnClick="RemoveImage"
+                                       Style="position: absolute; top: 4px; right: 4px; background: rgba(0,0,0,0.5);" />
+                    </div>
+                }
+
+                <div class="d-flex gap-2 flex-wrap">
+                    <MudFileUpload T="IBrowserFile"
+                                   FilesChanged="UploadImage"
+                                   Accept="image/*"
+                                   MaximumFileCount="1">
+                        <ActivatorContent>
+                            <MudButton Variant="Variant.Outlined"
+                                       Color="Color.Primary"
+                                       StartIcon="@Icons.Material.Filled.CloudUpload">
+                                @(string.IsNullOrWhiteSpace(_recipe.ImagePath) ? "Upload Image" : "Change Image")
+                            </MudButton>
+                        </ActivatorContent>
+                    </MudFileUpload>
+                    <MudButton Variant="Variant.Outlined"
+                               Color="Color.Secondary"
+                               StartIcon="@Icons.Material.Filled.PhotoLibrary"
+                               OnClick="OpenImagePicker">
+                        Choose Existing
+                    </MudButton>
+                </div>
+                <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mt-1">
+                    Max 10 MB. Supported: JPG, PNG, GIF, WebP
+                </MudText>
+            </MudPaper>
+
+            <MudPaper Class="pa-4 mb-4" Elevation="1">
+                <MudText Typo="Typo.h6" Class="mb-3">Ingredients</MudText>
+
+                <IngredientEntry HouseholdId="_householdId"
+                                 OnIngredientAdded="AddIngredient"
+                                 OnBulkIngredientsAdded="AddBulkIngredients" />
+
+                <IngredientList Ingredients="_ingredients"
+                                IngredientsChanged="OnIngredientsChanged"
+                                OnEditIngredient="EditIngredient" />
+            </MudPaper>
+
+            <MudPaper Class="pa-4 mb-4" Elevation="1">
+                <MudText Typo="Typo.h6" Class="mb-3">Instructions</MudText>
+
+                <MudTextField @bind-Value="_recipe.Instructions"
+                              Label="Instructions"
+                              Lines="10"
+                              Variant="Variant.Outlined"
+                              @oninput="ScheduleAutoSave"
+                              HelperText="Supports Markdown formatting" />
+            </MudPaper>
+
+            <div class="d-flex justify-space-between align-center">
+                <div>
+                    @if (_autoSaveStatus == AutoSaveStatus.Saving)
+                    {
+                        <div class="d-flex align-center">
+                            <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">Saving draft...</MudText>
+                        </div>
+                    }
+                    else if (_autoSaveStatus == AutoSaveStatus.Saved)
+                    {
+                        <MudText Typo="Typo.caption" Color="Color.Success">
+                            <MudIcon Icon="@Icons.Material.Filled.Check" Size="Size.Small" Class="mr-1" />
+                            Draft saved
+                        </MudText>
+                    }
+                </div>
+
+                <div>
+                    <MudButton Variant="Variant.Text"
+                               Color="Color.Default"
+                               OnClick="Cancel"
+                               Class="mr-2">
+                        Cancel
+                    </MudButton>
+                    <MudButton Variant="Variant.Filled"
+                               Color="Color.Primary"
+                               ButtonType="ButtonType.Submit"
+                               Disabled="_saving">
+                        @if (_saving)
+                        {
+                            <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
+                        }
+                        @(IsEdit ? "Save Changes" : "Create Recipe")
+                    </MudButton>
+                </div>
+            </div>
+        </EditForm>
+    }
+</MudContainer>
+
+@code {
+    [Parameter] public int? RecipeId { get; set; }
+    [CascadingParameter] private Task<AuthenticationState>? AuthState { get; set; }
+
+    private bool IsEdit => RecipeId.HasValue;
+
+    private Recipe _recipe = new();
+    private List<RecipeIngredient> _ingredients = new();
+    private EditContext _editContext = default!;
+
+    private bool _loading = true;
+    private bool _saving = false;
+    private bool _hasUnsavedChanges = false;
+
+    private int _householdId;
+    private int _userId;
+
+    private System.Threading.Timer? _autoSaveTimer;
+    private const int AutoSaveDelayMs = 2000;
+
+    private enum AutoSaveStatus { None, Saving, Saved }
+    private AutoSaveStatus _autoSaveStatus = AutoSaveStatus.None;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadUserContext();
+        await LoadRecipeOrDraft();
+
+        _editContext = new EditContext(_recipe);
+        _editContext.OnFieldChanged += OnFieldChanged;
+
+        _loading = false;
+    }
+
+    private async Task LoadUserContext()
+    {
+        if (AuthState == null) return;
+
+        var authState = await AuthState;
+        var email = authState.User.FindFirstValue(ClaimTypes.Email);
+
+        if (string.IsNullOrEmpty(email)) return;
+
+        await using var context = await DbFactory.CreateDbContextAsync();
+        var user = await context.Users
+            .FirstOrDefaultAsync(u => u.Email == email);
+
+        if (user != null)
+        {
+            _householdId = user.HouseholdId;
+            _userId = user.Id;
+        }
+    }
+
+    private async Task LoadRecipeOrDraft()
+    {
+        // Check for existing draft first
+        var draft = await DraftService.GetDraftAsync(_householdId, _userId, RecipeId);
+
+        if (draft != null)
+        {
+            // Restore from draft
+            _recipe = new Recipe
+            {
+                HouseholdId = _householdId,
+                RecipeId = RecipeId ?? 0,
+                Name = draft.Name,
+                Description = draft.Description,
+                Instructions = draft.Instructions,
+                ImagePath = draft.ImagePath,
+                SourceUrl = draft.SourceUrl,
+                Servings = draft.Servings,
+                PrepTimeMinutes = draft.PrepTimeMinutes,
+                CookTimeMinutes = draft.CookTimeMinutes,
+                CreatedByUserId = _userId
+            };
+
+            _ingredients = draft.Ingredients.Select(i => new RecipeIngredient
+            {
+                Name = i.Name,
+                Quantity = i.Quantity,
+                Unit = i.Unit,
+                Category = i.Category,
+                Notes = i.Notes,
+                GroupName = i.GroupName,
+                SortOrder = i.SortOrder
+            }).ToList();
+
+            Snackbar.Add("Restored from draft", Severity.Info);
+            return;
+        }
+
+        if (IsEdit)
+        {
+            // Load existing recipe
+            var recipe = await RecipeService.GetRecipeAsync(_householdId, RecipeId!.Value);
+            if (recipe == null)
+            {
+                Snackbar.Add("Recipe not found", Severity.Error);
+                Navigation.NavigateTo("/recipes");
+                return;
+            }
+
+            _recipe = recipe;
+            _ingredients = recipe.Ingredients.ToList();
+        }
+        else
+        {
+            // New recipe
+            _recipe = new Recipe
+            {
+                HouseholdId = _householdId,
+                CreatedByUserId = _userId,
+                Servings = 4 // Default
+            };
+            _ingredients = new();
+        }
+    }
+
+    private void OnFieldChanged(object? sender, FieldChangedEventArgs e)
+    {
+        _hasUnsavedChanges = true;
+        _autoSaveStatus = AutoSaveStatus.None;
+    }
+
+    private void ScheduleAutoSave()
+    {
+        _hasUnsavedChanges = true;
+        _autoSaveTimer?.Dispose();
+        _autoSaveTimer = new System.Threading.Timer(async _ =>
+        {
+            await InvokeAsync(async () =>
+            {
+                _autoSaveStatus = AutoSaveStatus.Saving;
+                StateHasChanged();
+
+                try
+                {
+                    var draftData = CreateDraftData();
+                    await DraftService.SaveDraftAsync(_householdId, _userId, RecipeId, draftData);
+
+                    _autoSaveStatus = AutoSaveStatus.Saved;
+                    StateHasChanged();
+
+                    // Clear "Saved" status after a few seconds
+                    await Task.Delay(3000);
+                    if (_autoSaveStatus == AutoSaveStatus.Saved)
+                    {
+                        _autoSaveStatus = AutoSaveStatus.None;
+                        StateHasChanged();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Snackbar.Add($"Failed to save draft: {ex.Message}", Severity.Warning);
+                    _autoSaveStatus = AutoSaveStatus.None;
+                    StateHasChanged();
+                }
+            });
+        }, null, AutoSaveDelayMs, Timeout.Infinite);
+    }
+
+    private RecipeDraftData CreateDraftData()
+    {
+        return new RecipeDraftData(
+            _recipe.Name,
+            _recipe.Description,
+            _recipe.Instructions,
+            _recipe.ImagePath,
+            _recipe.SourceUrl,
+            _recipe.Servings,
+            _recipe.PrepTimeMinutes,
+            _recipe.CookTimeMinutes,
+            _ingredients.Select(i => new IngredientDraftData(
+                i.Name,
+                i.Quantity,
+                i.Unit,
+                i.Category,
+                i.Notes,
+                i.GroupName,
+                i.SortOrder
+            )).ToList()
+        );
+    }
+
+    private void OnIngredientsChanged(List<RecipeIngredient> ingredients)
+    {
+        _ingredients = ingredients;
+        ScheduleAutoSave();
+    }
+
+    private void AddIngredient(RecipeIngredient ingredient)
+    {
+        ingredient.SortOrder = _ingredients.Count;
+        _ingredients.Add(ingredient);
+        ScheduleAutoSave();
+    }
+
+    private void AddBulkIngredients(List<RecipeIngredient> ingredients)
+    {
+        foreach (var ingredient in ingredients)
+        {
+            ingredient.SortOrder = _ingredients.Count;
+            _ingredients.Add(ingredient);
+        }
+        ScheduleAutoSave();
+    }
+
+    private void EditIngredient(RecipeIngredient ingredient)
+    {
+        // Simple edit flow: remove and re-add. Inline editing planned for future release.
+        _ingredients.Remove(ingredient);
+        Snackbar.Add("Re-add ingredient with changes", Severity.Info);
+    }
+
+    private async Task UploadImage(IBrowserFile file)
+    {
+        try
+        {
+            var path = await ImageService.SaveImageAsync(file, _householdId);
+            _recipe.ImagePath = path;
+            ScheduleAutoSave();
+            Snackbar.Add("Image uploaded", Severity.Success);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Failed to upload image: {ex.Message}", Severity.Error);
+        }
+    }
+
+    private void RemoveImage()
+    {
+        // Note: Don't delete the file yet - it might be the original recipe's image
+        _recipe.ImagePath = null;
+        ScheduleAutoSave();
+    }
+
+    private async Task OpenImagePicker()
+    {
+        var parameters = new DialogParameters<ImagePickerDialog>
+        {
+            { x => x.HouseholdId, _householdId },
+            { x => x.CurrentImage, _recipe.ImagePath }
+        };
+
+        var options = new DialogOptions
+        {
+            MaxWidth = MaxWidth.Medium,
+            FullWidth = true
+        };
+
+        var dialog = await DialogService.ShowAsync<ImagePickerDialog>("Select Image", parameters, options);
+        var result = await dialog.Result;
+
+        if (result is { Canceled: false, Data: string selectedImage })
+        {
+            _recipe.ImagePath = selectedImage;
+            ScheduleAutoSave();
+        }
+    }
+
+    private async Task SaveRecipe()
+    {
+        if (string.IsNullOrWhiteSpace(_recipe.Name))
+        {
+            Snackbar.Add("Recipe name is required", Severity.Warning);
+            return;
+        }
+
+        _saving = true;
+        StateHasChanged();
+
+        try
+        {
+            // Update ingredients on recipe
+            _recipe.Ingredients = _ingredients;
+
+            if (IsEdit)
+            {
+                _recipe.UpdatedByUserId = _userId;
+                _recipe.UpdatedAt = DateTime.UtcNow;
+                await RecipeService.UpdateRecipeAsync(_recipe);
+                Snackbar.Add("Recipe updated", Severity.Success);
+            }
+            else
+            {
+                await RecipeService.CreateRecipeAsync(_recipe);
+                Snackbar.Add("Recipe created", Severity.Success);
+            }
+
+            // Delete draft after successful save
+            await DraftService.DeleteDraftAsync(_householdId, _userId, RecipeId);
+
+            _hasUnsavedChanges = false;
+            Navigation.NavigateTo("/recipes");
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Failed to save recipe: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+
+    private async Task DeleteRecipe()
+    {
+        var result = await DialogService.ShowMessageBox(
+            "Delete Recipe",
+            $"Are you sure you want to delete \"{_recipe.Name}\"? This action cannot be undone.",
+            yesText: "Delete",
+            cancelText: "Cancel");
+
+        if (result == true)
+        {
+            try
+            {
+                await RecipeService.DeleteRecipeAsync(_householdId, _recipe.RecipeId);
+                await DraftService.DeleteDraftAsync(_householdId, _userId, RecipeId);
+                _hasUnsavedChanges = false;
+                Snackbar.Add("Recipe deleted", Severity.Success);
+                Navigation.NavigateTo("/recipes");
+            }
+            catch (Exception ex)
+            {
+                Snackbar.Add($"Failed to delete recipe: {ex.Message}", Severity.Error);
+            }
+        }
+    }
+
+    private void Cancel()
+    {
+        Navigation.NavigateTo("/recipes");
+    }
+
+    private static string GetDomainFromUrl(string url)
+    {
+        try
+        {
+            var uri = new Uri(url);
+            return uri.Host.Replace("www.", "");
+        }
+        catch
+        {
+            return url;
+        }
+    }
+
+    private static bool IsSafeUrl(string? url) =>
+        !string.IsNullOrEmpty(url) &&
+        Uri.TryCreate(url, UriKind.Absolute, out var uri) &&
+        (uri.Scheme == "http" || uri.Scheme == "https");
+
+    private static string GetRecipeTypeLabel(RecipeType type) => type switch
+    {
+        RecipeType.Main => "Main Dish",
+        RecipeType.Side => "Side Dish",
+        RecipeType.Appetizer => "Appetizer",
+        RecipeType.Dessert => "Dessert",
+        RecipeType.Beverage => "Beverage",
+        RecipeType.Sauce => "Sauce/Condiment",
+        RecipeType.Breakfast => "Breakfast",
+        RecipeType.Snack => "Snack",
+        RecipeType.Other => "Other",
+        _ => type.ToString()
+    };
+
+    public void Dispose()
+    {
+        _autoSaveTimer?.Dispose();
+        if (_editContext != null)
+        {
+            _editContext.OnFieldChanged -= OnFieldChanged;
+        }
+    }
+}

--- a/src/FamilyCoordinationApp/Components/Recipe/RecipesBlazor.razor
+++ b/src/FamilyCoordinationApp/Components/Recipe/RecipesBlazor.razor
@@ -1,0 +1,964 @@
+@implements IDisposable
+@*
+    The original Blazor recipes list UI, extracted verbatim from Recipes.razor so the page can become a thin
+    island host (mirrors MealPlan.razor → MealPlanBlazor). This is the flag-OFF fallback during the recipes
+    strangler migration; delete it once RECIPES_USE_ISLAND is the only path. Render mode + [Authorize] come
+    from the host page (Recipes.razor) + the global Routes @rendermode="InteractiveServer".
+*@
+@using System.Security.Claims
+@using FamilyCoordinationApp.Data
+@using FamilyCoordinationApp.Data.Entities
+@using FamilyCoordinationApp.Services
+@using FamilyCoordinationApp.Services.Interfaces
+@using FamilyCoordinationApp.Components.Recipe
+@using FamilyCoordinationApp.Components.Shared
+@using Microsoft.EntityFrameworkCore
+@inject IRecipeService RecipeService
+@inject IHouseholdConnectionService ConnectionService
+@inject IDbContextFactory<ApplicationDbContext> DbFactory
+@inject ISnackbar Snackbar
+@inject NavigationManager NavigationManager
+@inject DataNotifier Notifier
+@inject IDialogService DialogService
+
+<PageTitle>Recipes - Family Kitchen</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.ExtraLarge" Class="py-4">
+    <div class="d-flex justify-space-between align-center flex-wrap mb-4 gap-3">
+        <MudText Typo="Typo.h4">Recipes</MudText>
+        @if (!_isViewingConnectedHousehold)
+        {
+            <div class="d-flex gap-2 flex-wrap">
+                <MudHidden Breakpoint="Breakpoint.Xs">
+                    <MudButton StartIcon="@Icons.Material.Filled.CloudDownload"
+                               Color="Color.Secondary"
+                               Variant="Variant.Outlined"
+                               OnClick="OpenImportDialog">
+                        Import from URL
+                    </MudButton>
+                </MudHidden>
+                <MudHidden Breakpoint="Breakpoint.SmAndUp" Invert="true">
+                    <MudIconButton Icon="@Icons.Material.Filled.CloudDownload"
+                                   Color="Color.Secondary"
+                                   OnClick="OpenImportDialog"
+                                   aria-label="Import from URL" />
+                </MudHidden>
+                <MudButton StartIcon="@Icons.Material.Filled.Add"
+                           Color="Color.Primary"
+                           Variant="Variant.Filled"
+                           OnClick="HandleAddRecipe">
+                    <MudHidden Breakpoint="Breakpoint.Xs">Add Recipe</MudHidden>
+                    <MudHidden Breakpoint="Breakpoint.SmAndUp" Invert="true">Add</MudHidden>
+                </MudButton>
+            </div>
+        }
+    </div>
+
+    @* Household selector — only when connections exist *@
+    @if (_connectedHouseholds.Count > 0)
+    {
+        <div class="d-flex align-center gap-2 mb-4 flex-wrap">
+            <MudChipSet T="int?" SelectedValue="_selectedHouseholdId" SelectedValueChanged="OnHouseholdChipChanged" SelectionMode="SelectionMode.SingleSelection" CheckMark="false">
+                <MudChip T="int?" Value="@((int?)null)"
+                         Color="@(_selectedHouseholdId == null ? Color.Primary : Color.Default)"
+                         Variant="@(_selectedHouseholdId == null ? Variant.Filled : Variant.Outlined)">
+                    My Recipes
+                </MudChip>
+                @foreach (var household in _connectedHouseholds)
+                {
+                    <MudChip T="int?" Value="@((int?)household.HouseholdId)"
+                             Color="@(_selectedHouseholdId == household.HouseholdId ? Color.Primary : Color.Default)"
+                             Variant="@(_selectedHouseholdId == household.HouseholdId ? Variant.Filled : Variant.Outlined)">
+                        @household.HouseholdName
+                    </MudChip>
+                }
+            </MudChipSet>
+            <MudIconButton Icon="@Icons.Material.Filled.GroupAdd"
+                           Size="Size.Small"
+                           Color="Color.Primary"
+                           Href="/settings/connections"
+                           Title="Manage family connections" />
+        </div>
+    }
+
+    <div class="d-flex gap-3 align-center mb-4 flex-wrap">
+        <MudTextField @bind-Value="_searchTerm"
+                      Label="Search by name, ingredients, or type"
+                      Variant="Variant.Outlined"
+                      Adornment="Adornment.Start"
+                      AdornmentIcon="@Icons.Material.Filled.Search"
+                      DebounceInterval="300"
+                      OnDebounceIntervalElapsed="OnSearchChanged"
+                      Style="flex: 1; min-width: 200px;" />
+        @if (!_isViewingConnectedHousehold)
+        {
+            <MudChip T="bool"
+                     Icon="@Icons.Material.Filled.Favorite"
+                     Color="@(_showFavoritesOnly ? Color.Error : Color.Default)"
+                     Variant="@(_showFavoritesOnly ? Variant.Filled : Variant.Outlined)"
+                     OnClick="ToggleFavoritesFilter">
+                Favorites
+            </MudChip>
+        }
+    </div>
+
+    @if (_loading)
+    {
+        <!-- Loading skeleton -->
+        <MudGrid>
+            @for (int i = 0; i < 6; i++)
+            {
+                <MudItem xs="12" sm="6" md="4">
+                    <MudCard>
+                        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="200px" />
+                        <MudCardContent>
+                            <MudSkeleton SkeletonType="SkeletonType.Text" />
+                            <MudSkeleton SkeletonType="SkeletonType.Text" />
+                        </MudCardContent>
+                    </MudCard>
+                </MudItem>
+            }
+        </MudGrid>
+    }
+    else if (!DisplayedRecipes.Any())
+    {
+        <!-- Empty state -->
+        <div class="d-flex flex-column align-center justify-center" style="min-height: 400px;">
+            <MudIcon Icon="@(_isViewingConnectedHousehold ? Icons.Material.Filled.PeopleOutline : (_showFavoritesOnly ? Icons.Material.Filled.FavoriteBorder : Icons.Material.Filled.MenuBook))"
+                     Size="Size.Large"
+                     Color="Color.Secondary"
+                     Style="font-size: 6rem; margin-bottom: 1rem;" />
+            <MudText Typo="Typo.h5" Class="mb-2">
+                @if (_isViewingConnectedHousehold)
+                {
+                    <text>No shared recipes</text>
+                }
+                else if (_showFavoritesOnly)
+                {
+                    <text>No favorites yet</text>
+                }
+                else
+                {
+                    <text>No recipes yet</text>
+                }
+            </MudText>
+            <MudText Typo="Typo.body1" Color="Color.Secondary" Class="mb-4">
+                @if (_isViewingConnectedHousehold)
+                {
+                    if (string.IsNullOrWhiteSpace(_searchTerm))
+                    {
+                        <text>This family hasn't added any recipes yet</text>
+                    }
+                    else
+                    {
+                        <text>No recipes found matching "@_searchTerm"</text>
+                    }
+                }
+                else if (_showFavoritesOnly)
+                {
+                    <text>Click the heart icon on recipes to add them to your favorites</text>
+                }
+                else if (string.IsNullOrWhiteSpace(_searchTerm))
+                {
+                    <text>Start building your family recipe collection</text>
+                }
+                else
+                {
+                    <text>No recipes found matching "@_searchTerm"</text>
+                }
+            </MudText>
+            @if (_showFavoritesOnly && !_isViewingConnectedHousehold)
+            {
+                <MudButton StartIcon="@Icons.Material.Filled.Clear"
+                           Color="Color.Primary"
+                           Variant="Variant.Text"
+                           OnClick="ToggleFavoritesFilter">
+                    Show All Recipes
+                </MudButton>
+            }
+            else if (!_isViewingConnectedHousehold && string.IsNullOrWhiteSpace(_searchTerm))
+            {
+                <MudButton StartIcon="@Icons.Material.Filled.Add"
+                           Color="Color.Primary"
+                           Variant="Variant.Filled"
+                           Size="Size.Large"
+                           OnClick="HandleAddRecipe">
+                    Add Your First Recipe
+                </MudButton>
+            }
+            else if (!string.IsNullOrWhiteSpace(_searchTerm))
+            {
+                <MudButton StartIcon="@Icons.Material.Filled.Clear"
+                           Color="Color.Primary"
+                           Variant="Variant.Text"
+                           OnClick="ClearSearch">
+                    Clear Search
+                </MudButton>
+            }
+        </div>
+    }
+    else
+    {
+        <!-- Recipe grid -->
+        <MudGrid Class="recipe-grid">
+            @foreach (var recipe in DisplayedRecipes)
+            {
+                <MudItem xs="12" sm="6" md="4" Class="recipe-grid-item">
+                    <RecipeCard Recipe="recipe"
+                                IsSelected="@(_selectedRecipe?.RecipeId == recipe.RecipeId && _selectedRecipe?.HouseholdId == recipe.HouseholdId)"
+                                IsFavorite="@(!_isViewingConnectedHousehold && FavoriteRecipeIds.Contains(recipe.RecipeId))"
+                                IsReadOnly="_isViewingConnectedHousehold"
+                                SharedFromHouseholdName="@(_isViewingConnectedHousehold ? _selectedConnectedHouseholdName : null)"
+                                OnClick="HandleCardClick"
+                                OnToggleFavorite="HandleToggleFavorite" />
+                </MudItem>
+            }
+        </MudGrid>
+    }
+</MudContainer>
+
+<!-- Overlay for dimming when drawer is open -->
+@if (_drawerOpen)
+{
+    <div class="recipe-drawer-overlay" @onclick="CloseDrawer"></div>
+}
+
+<!-- Recipe detail slide-out panel -->
+<MudDrawer @bind-Open="_drawerOpen"
+           Anchor="Anchor.End"
+           Elevation="4"
+           Variant="DrawerVariant.Temporary"
+           Width="min(800px, 90vw)"
+           Class="recipe-detail-drawer">
+    @if (_selectedRecipe != null)
+    {
+        <MudDrawerHeader Class="recipe-drawer-header">
+            <div class="d-flex justify-space-between align-center" style="width: 100%;">
+                <MudText Typo="Typo.h5" Class="text-truncate" Style="max-width: calc(100% - 48px);">
+                    @_selectedRecipe.Name
+                </MudText>
+                <MudIconButton Icon="@Icons.Material.Filled.Close"
+                               OnClick="CloseDrawer"
+                               aria-label="Close panel" />
+            </div>
+        </MudDrawerHeader>
+
+        <div class="recipe-drawer-content">
+            <!-- Recipe Image -->
+            @if (!string.IsNullOrWhiteSpace(_selectedRecipe.ImagePath))
+            {
+                <div class="recipe-detail-image">
+                    <img src="@_selectedRecipe.ImagePath" alt="@_selectedRecipe.Name" />
+                </div>
+            }
+
+            <!-- Author info -->
+            <div class="d-flex align-center gap-2 mb-3">
+                @if (_selectedRecipe.CreatedBy != null)
+                {
+                    <UserAvatar User="@_selectedRecipe.CreatedBy" Size="Size.Small" />
+                    <MudText Typo="Typo.body2" Color="Color.Secondary">
+                        Added by @_selectedRecipe.CreatedBy.DisplayName
+                    </MudText>
+                }
+                else
+                {
+                    <MudAvatar Size="Size.Small" Color="Color.Default">
+                        <MudIcon Icon="@Icons.Material.Filled.PersonOff" Size="Size.Small" />
+                    </MudAvatar>
+                    <MudText Typo="Typo.body2" Color="Color.Secondary" Class="font-italic">
+                        Added by deleted user
+                    </MudText>
+                }
+            </div>
+
+            @* Connected household attribution in drawer *@
+            @if (_isViewingConnectedHousehold && !string.IsNullOrWhiteSpace(_selectedConnectedHouseholdName))
+            {
+                <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-3">
+                    From @_selectedConnectedHouseholdName
+                </MudText>
+            }
+
+            <!-- Meta chips -->
+            @if (_selectedRecipe.PrepTimeMinutes.HasValue || _selectedRecipe.CookTimeMinutes.HasValue || _selectedRecipe.Servings.HasValue)
+            {
+                <div class="recipe-meta-chips mb-4">
+                    @if (_selectedRecipe.PrepTimeMinutes.HasValue)
+                    {
+                        <MudChip T="string" Icon="@Icons.Material.Filled.Schedule" Size="Size.Small" Color="Color.Info">
+                            Prep: @_selectedRecipe.PrepTimeMinutes min
+                        </MudChip>
+                    }
+                    @if (_selectedRecipe.CookTimeMinutes.HasValue)
+                    {
+                        <MudChip T="string" Icon="@Icons.Material.Filled.Whatshot" Size="Size.Small" Color="Color.Warning">
+                            Cook: @_selectedRecipe.CookTimeMinutes min
+                        </MudChip>
+                    }
+                </div>
+            }
+
+            <!-- Servings scaler -->
+            @if (_selectedRecipe.Servings.HasValue)
+            {
+                <div class="d-flex align-center gap-2 mb-4">
+                    <MudIcon Icon="@Icons.Material.Filled.Restaurant" Color="Color.Success" />
+                    <MudText Typo="Typo.body2">Servings:</MudText>
+                    <MudIconButton Icon="@Icons.Material.Filled.Remove"
+                                   Size="Size.Small"
+                                   OnClick="DecreaseServings"
+                                   Disabled="@(_scaledServings <= 1)" />
+                    <MudText Typo="Typo.body1" Class="mx-1" Style="min-width: 24px; text-align: center;">
+                        <strong>@_scaledServings</strong>
+                    </MudText>
+                    <MudIconButton Icon="@Icons.Material.Filled.Add"
+                                   Size="Size.Small"
+                                   OnClick="IncreaseServings" />
+                    @if (_scaledServings != _selectedRecipe.Servings)
+                    {
+                        <MudChip T="string" Size="Size.Small" Color="Color.Info" Variant="Variant.Outlined">
+                            @GetScalingLabel()
+                        </MudChip>
+                        <MudButton Size="Size.Small" Variant="Variant.Text" OnClick="ResetServings">
+                            Reset
+                        </MudButton>
+                    }
+                </div>
+            }
+
+            <!-- Description -->
+            @if (!string.IsNullOrWhiteSpace(_selectedRecipe.Description))
+            {
+                <MudText Typo="Typo.body1" Class="mb-4">@_selectedRecipe.Description</MudText>
+            }
+
+            <!-- Ingredients -->
+            @if (_selectedRecipe.Ingredients.Any())
+            {
+                <MudText Typo="Typo.h6" Class="mb-2">Ingredients</MudText>
+                <MudList T="string" Dense="true" Class="mb-4">
+                    @foreach (var ingredient in _selectedRecipe.Ingredients.OrderBy(i => i.SortOrder))
+                    {
+                        <MudListItem T="string" Icon="@Icons.Material.Filled.Circle" IconSize="Size.Small">
+                            @GetIngredientDisplay(ingredient)
+                        </MudListItem>
+                    }
+                </MudList>
+            }
+
+            <!-- Instructions -->
+            @if (!string.IsNullOrWhiteSpace(_selectedRecipe.Instructions))
+            {
+                <MudText Typo="Typo.h6" Class="mb-2">Instructions</MudText>
+                <div class="recipe-instructions mb-4">
+                    @((MarkupString)MarkdownHelper.ToSafeHtml(_selectedRecipe.Instructions))
+                </div>
+            }
+
+            <!-- Source URL -->
+            @if (!string.IsNullOrWhiteSpace(_selectedRecipe.SourceUrl) && IsSafeUrl(_selectedRecipe.SourceUrl))
+            {
+                <div class="d-flex align-center mb-4">
+                    <MudIcon Icon="@Icons.Material.Filled.Link" Size="Size.Small" Class="mr-2" />
+                    <a href="@_selectedRecipe.SourceUrl"
+                       target="_blank"
+                       rel="noopener noreferrer"
+                       class="mud-typography mud-link mud-secondary-text mud-typography-body2">
+                        View Original Recipe
+                    </a>
+                </div>
+            }
+        </div>
+
+        <!-- Action buttons -->
+        <div class="recipe-drawer-actions">
+            @if (_isViewingConnectedHousehold)
+            {
+                <MudButton StartIcon="@Icons.Material.Filled.ContentCopy"
+                           Color="Color.Primary"
+                           Variant="Variant.Filled"
+                           OnClick="@(() => HandleCopyRecipe(_selectedRecipe))"
+                           FullWidth="true"
+                           Disabled="_copyingRecipe">
+                    @if (_copyingRecipe)
+                    {
+                        <MudProgressCircular Indeterminate="true" Size="Size.Small" Class="mr-2" />
+                    }
+                    Copy to My Recipes
+                </MudButton>
+            }
+            else
+            {
+                <MudButton StartIcon="@Icons.Material.Filled.Edit"
+                           Color="Color.Primary"
+                           Variant="Variant.Filled"
+                           OnClick="@(() => HandleEdit(_selectedRecipe))"
+                           FullWidth="true"
+                           Class="mb-2">
+                    Edit Recipe
+                </MudButton>
+                <MudButton StartIcon="@Icons.Material.Filled.CalendarMonth"
+                           Color="Color.Secondary"
+                           Variant="Variant.Outlined"
+                           OnClick="@(() => HandleAddToMealPlan(_selectedRecipe))"
+                           FullWidth="true"
+                           Class="mb-2">
+                    Add to Meal Plan
+                </MudButton>
+                <MudButton StartIcon="@Icons.Material.Filled.Delete"
+                           Color="Color.Error"
+                           Variant="Variant.Text"
+                           OnClick="@(() => HandleDeleteConfirm(_selectedRecipe))"
+                           FullWidth="true">
+                    Delete Recipe
+                </MudButton>
+            }
+        </div>
+    }
+</MudDrawer>
+
+<!-- Delete confirmation dialog -->
+<MudDialog @bind-Visible="_showDeleteDialog" Options="_dialogOptions">
+    <TitleContent>
+        <MudText Typo="Typo.h6">Delete Recipe</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudText>
+            Are you sure you want to delete "<strong>@_recipeToDelete?.Name</strong>"?
+            This action cannot be undone.
+        </MudText>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="CancelDelete" Color="Color.Default">Cancel</MudButton>
+        <MudButton OnClick="ConfirmDelete" Color="Color.Error" Variant="Variant.Filled">Delete</MudButton>
+    </DialogActions>
+</MudDialog>
+
+<style>
+    /* Recipe grid - equal height cards */
+    .recipe-grid {
+        align-items: stretch;
+    }
+
+    .recipe-grid-item {
+        display: flex;
+    }
+
+    .recipe-grid-item > * {
+        width: 100%;
+    }
+
+    .recipe-drawer-overlay {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: rgba(0, 0, 0, 0.5);
+        z-index: 1299; /* Just below MudDrawer's z-index */
+    }
+
+    .recipe-detail-drawer {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+    }
+
+    .recipe-drawer-header {
+        flex-shrink: 0;
+        border-bottom: 1px solid var(--mud-palette-lines-default);
+    }
+
+    .recipe-drawer-content {
+        flex: 1;
+        overflow-y: auto;
+        padding: 16px 24px;
+    }
+
+    .recipe-detail-image {
+        width: 100%;
+        height: 250px;
+        margin-bottom: 16px;
+        border-radius: 8px;
+        overflow: hidden;
+    }
+
+    .recipe-detail-image img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+    }
+
+    .recipe-meta-chips {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
+
+    .recipe-instructions {
+        line-height: 1.6;
+    }
+
+    .recipe-instructions ol,
+    .recipe-instructions ul {
+        margin-left: 1.5rem;
+        margin-bottom: 1rem;
+    }
+
+    .recipe-instructions li {
+        margin-bottom: 0.5rem;
+    }
+
+    .recipe-drawer-actions {
+        flex-shrink: 0;
+        padding: 16px 24px;
+        border-top: 1px solid var(--mud-palette-lines-default);
+        background: var(--mud-palette-background);
+    }
+</style>
+
+@code {
+    [CascadingParameter] private Task<AuthenticationState>? AuthState { get; set; }
+
+    // Persisted state to prevent prerender flash
+    [PersistentState(AllowUpdates = true)]
+    public List<Recipe> RecipeList { get; set; } = new();
+
+    [PersistentState(AllowUpdates = true)]
+    public HashSet<int> FavoriteRecipeIds { get; set; } = new();
+
+    [PersistentState(AllowUpdates = true)]
+    public int HouseholdId { get; set; }
+
+    [PersistentState(AllowUpdates = true)]
+    public int UserId { get; set; }
+
+    // Non-persisted state
+    private bool _loading = true;
+    private string _searchTerm = string.Empty;
+    private bool _showFavoritesOnly;
+
+    private Recipe? _selectedRecipe;
+    private bool _drawerOpen;
+    private int _scaledServings;
+
+    private bool _showDeleteDialog;
+    private Recipe? _recipeToDelete;
+
+    // Connected household state
+    private List<ConnectedHouseholdInfo> _connectedHouseholds = new();
+    private int? _selectedHouseholdId;
+    private bool _isViewingConnectedHousehold => _selectedHouseholdId != null;
+    private List<Recipe> _connectedRecipes = new();
+    private string? _selectedConnectedHouseholdName;
+    private bool _copyingRecipe;
+
+    private DialogOptions _dialogOptions = new()
+    {
+        CloseOnEscapeKey = true,
+        MaxWidth = MaxWidth.Small
+    };
+
+    private IEnumerable<Recipe> DisplayedRecipes =>
+        _isViewingConnectedHousehold
+            ? _connectedRecipes
+            : FilteredRecipes;
+
+    protected override async Task OnInitializedAsync()
+    {
+        Notifier.OnRecipesChanged += OnDataChanged;
+
+        // Skip loading if already persisted from prerender
+        if (HouseholdId > 0 && RecipeList.Any())
+        {
+            _loading = false;
+            // Still load connected households for the selector
+            await LoadConnectedHouseholds();
+            return;
+        }
+
+        await LoadUserContext();
+        if (HouseholdId > 0)
+        {
+            await LoadRecipes();
+            await LoadConnectedHouseholds();
+        }
+        else
+        {
+            Snackbar.Add("Unable to load household information", Severity.Error);
+            _loading = false;
+        }
+    }
+
+    private async Task OnHouseholdChipChanged(int? value)
+    {
+        _selectedHouseholdId = value;
+        await OnHouseholdSelectionChanged();
+    }
+
+    private async Task OnHouseholdSelectionChanged()
+    {
+        _searchTerm = string.Empty;
+        _showFavoritesOnly = false;
+        CloseDrawer();
+
+        if (_isViewingConnectedHousehold)
+        {
+            _selectedConnectedHouseholdName = _connectedHouseholds
+                .FirstOrDefault(h => h.HouseholdId == _selectedHouseholdId)?.HouseholdName;
+            await LoadConnectedRecipes();
+        }
+        else
+        {
+            _selectedConnectedHouseholdName = null;
+            _connectedRecipes.Clear();
+        }
+    }
+
+    private async Task LoadConnectedHouseholds()
+    {
+        try
+        {
+            _connectedHouseholds = await ConnectionService.GetConnectedHouseholdsAsync(HouseholdId);
+        }
+        catch
+        {
+            // Non-critical — selector just won't show
+            _connectedHouseholds = new();
+        }
+    }
+
+    private async Task LoadConnectedRecipes()
+    {
+        if (_selectedHouseholdId == null) return;
+
+        try
+        {
+            _loading = true;
+            _connectedRecipes = await RecipeService.GetRecipesFromConnectedHouseholdAsync(
+                HouseholdId, _selectedHouseholdId.Value, _searchTerm);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Error loading shared recipes: {ex.Message}", Severity.Error);
+            _connectedRecipes = new();
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private async Task OnSearchChanged()
+    {
+        if (_isViewingConnectedHousehold)
+        {
+            await LoadConnectedRecipes();
+        }
+        else
+        {
+            await LoadRecipes();
+        }
+    }
+
+    private async Task LoadUserContext()
+    {
+        if (AuthState == null) return;
+
+        var authState = await AuthState;
+        var email = authState.User.FindFirstValue(ClaimTypes.Email);
+
+        if (string.IsNullOrEmpty(email)) return;
+
+        await using var context = await DbFactory.CreateDbContextAsync();
+        var user = await context.Users
+            .FirstOrDefaultAsync(u => u.Email == email);
+
+        if (user != null)
+        {
+            HouseholdId = user.HouseholdId;
+            UserId = user.Id;
+        }
+    }
+
+    private async Task LoadRecipes()
+    {
+        try
+        {
+            _loading = true;
+            RecipeList = await RecipeService.GetRecipesAsync(HouseholdId, _searchTerm);
+            FavoriteRecipeIds = await RecipeService.GetFavoriteRecipeIdsAsync(UserId, HouseholdId);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Error loading recipes: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private async Task HandleToggleFavorite(Recipe recipe)
+    {
+        if (_isViewingConnectedHousehold) return;
+
+        await RecipeService.ToggleFavoriteAsync(UserId, HouseholdId, recipe.RecipeId);
+        // Toggle local state immediately for responsive UI
+        if (FavoriteRecipeIds.Contains(recipe.RecipeId))
+            FavoriteRecipeIds.Remove(recipe.RecipeId);
+        else
+            FavoriteRecipeIds.Add(recipe.RecipeId);
+    }
+
+    private void ToggleFavoritesFilter()
+    {
+        _showFavoritesOnly = !_showFavoritesOnly;
+    }
+
+    private IEnumerable<Recipe> FilteredRecipes =>
+        _showFavoritesOnly
+            ? RecipeList.Where(r => FavoriteRecipeIds.Contains(r.RecipeId))
+            : RecipeList;
+
+    private void HandleCardClick(Recipe recipe)
+    {
+        _selectedRecipe = recipe;
+        _scaledServings = recipe.Servings ?? 1;
+        _drawerOpen = true;
+    }
+
+    private void CloseDrawer()
+    {
+        _drawerOpen = false;
+        // Keep _selectedRecipe so the drawer content doesn't flash during close animation
+    }
+
+    private void HandleAddRecipe()
+    {
+        NavigationManager.NavigateTo("/recipes/new");
+    }
+
+    private async Task OpenImportDialog()
+    {
+        var options = new DialogOptions
+        {
+            MaxWidth = MaxWidth.Small,
+            FullWidth = true,
+            CloseButton = true
+        };
+
+        var dialog = await DialogService.ShowAsync<ImportRecipeDialog>("Import Recipe", options);
+        var result = await dialog.Result;
+
+        if (result != null && !result.Canceled)
+        {
+            // Refresh recipe list after successful import
+            await LoadRecipes();
+        }
+    }
+
+    private void HandleEdit(Recipe recipe)
+    {
+        NavigationManager.NavigateTo($"/recipes/edit/{recipe.RecipeId}");
+    }
+
+    private async Task HandleCopyRecipe(Recipe recipe)
+    {
+        if (_selectedHouseholdId == null) return;
+
+        _copyingRecipe = true;
+
+        try
+        {
+            await RecipeService.CopyRecipeFromConnectedHouseholdAsync(
+                _selectedHouseholdId.Value, recipe.RecipeId, HouseholdId, UserId);
+
+            Snackbar.Add("Recipe copied! It's now in your collection.", Severity.Success);
+            // Stay on connected view per spec
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Error copying recipe: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _copyingRecipe = false;
+        }
+    }
+
+    private void HandleDeleteConfirm(Recipe recipe)
+    {
+        _recipeToDelete = recipe;
+        _showDeleteDialog = true;
+    }
+
+    private void CancelDelete()
+    {
+        _showDeleteDialog = false;
+        _recipeToDelete = null;
+    }
+
+    private async Task ConfirmDelete()
+    {
+        if (_recipeToDelete == null) return;
+
+        try
+        {
+            await RecipeService.DeleteRecipeAsync(HouseholdId, _recipeToDelete.RecipeId);
+            Snackbar.Add($"Recipe '{_recipeToDelete.Name}' deleted", Severity.Success);
+
+            // Close drawer if this was the selected recipe
+            if (_selectedRecipe?.RecipeId == _recipeToDelete.RecipeId)
+            {
+                _drawerOpen = false;
+                _selectedRecipe = null;
+            }
+
+            // Reload recipes
+            await LoadRecipes();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Error deleting recipe: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _showDeleteDialog = false;
+            _recipeToDelete = null;
+        }
+    }
+
+    private void HandleAddToMealPlan(Recipe recipe)
+    {
+        // Meal planning integration planned for future release
+        Snackbar.Add($"Add '{recipe.Name}' to meal plan - feature in development", Severity.Info);
+    }
+
+    private async Task ClearSearch()
+    {
+        _searchTerm = string.Empty;
+        if (_isViewingConnectedHousehold)
+        {
+            await LoadConnectedRecipes();
+        }
+        else
+        {
+            await LoadRecipes();
+        }
+    }
+
+    private string GetIngredientDisplay(RecipeIngredient ingredient)
+    {
+        var parts = new List<string>();
+
+        if (ingredient.Quantity.HasValue)
+        {
+            var scaledQty = GetScaledQuantity(ingredient.Quantity.Value);
+            parts.Add(FormatQuantity(scaledQty));
+        }
+
+        if (!string.IsNullOrWhiteSpace(ingredient.Unit))
+        {
+            parts.Add(ingredient.Unit);
+        }
+
+        parts.Add(ingredient.Name);
+
+        if (!string.IsNullOrWhiteSpace(ingredient.Notes))
+        {
+            parts.Add($"({ingredient.Notes})");
+        }
+
+        return string.Join(" ", parts);
+    }
+
+    // Servings scaling methods
+    private decimal GetScalingFactor()
+    {
+        if (_selectedRecipe?.Servings == null || _selectedRecipe.Servings == 0)
+            return 1m;
+        return (decimal)_scaledServings / _selectedRecipe.Servings.Value;
+    }
+
+    private decimal GetScaledQuantity(decimal original)
+    {
+        return original * GetScalingFactor();
+    }
+
+    private string FormatQuantity(decimal qty)
+    {
+        // Round to sensible fractions
+        if (qty == Math.Floor(qty))
+            return ((int)qty).ToString();
+
+        // Common fractions
+        var fractionalPart = qty - Math.Floor(qty);
+        var wholePart = (int)Math.Floor(qty);
+
+        string fraction = fractionalPart switch
+        {
+            >= 0.2m and < 0.3m => "\u00bc",
+            >= 0.3m and < 0.4m => "\u2153",
+            >= 0.45m and < 0.55m => "\u00bd",
+            >= 0.6m and < 0.7m => "\u2154",
+            >= 0.7m and < 0.8m => "\u00be",
+            _ => null
+        };
+
+        if (fraction != null)
+            return wholePart > 0 ? $"{wholePart} {fraction}" : fraction;
+
+        // Default to decimal
+        return qty.ToString("0.##");
+    }
+
+    private void IncreaseServings()
+    {
+        _scaledServings++;
+    }
+
+    private void DecreaseServings()
+    {
+        if (_scaledServings > 1)
+            _scaledServings--;
+    }
+
+    private void ResetServings()
+    {
+        _scaledServings = _selectedRecipe?.Servings ?? 1;
+    }
+
+    private string GetScalingLabel()
+    {
+        var factor = GetScalingFactor();
+        if (factor == 2) return "2\u00d7";
+        if (factor == 0.5m) return "\u00bd\u00d7";
+        if (factor == 1.5m) return "1.5\u00d7";
+        return $"{factor:0.##}\u00d7";
+    }
+
+    private void OnDataChanged(int householdId)
+    {
+        // Security: Only respond to changes for our household
+        if (householdId != HouseholdId)
+            return;
+
+        InvokeAsync(async () =>
+        {
+            await LoadRecipes();
+            StateHasChanged();
+        });
+    }
+
+    private static bool IsSafeUrl(string? url) =>
+        !string.IsNullOrEmpty(url) &&
+        Uri.TryCreate(url, UriKind.Absolute, out var uri) &&
+        (uri.Scheme == "http" || uri.Scheme == "https");
+
+    public void Dispose()
+    {
+        Notifier.OnRecipesChanged -= OnDataChanged;
+    }
+}

--- a/src/FamilyCoordinationApp/Endpoints/RecipesEndpoints.cs
+++ b/src/FamilyCoordinationApp/Endpoints/RecipesEndpoints.cs
@@ -1,0 +1,646 @@
+using System.Security.Claims;
+using FamilyCoordinationApp.Data;
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Services;
+using FamilyCoordinationApp.Services.Dtos;
+using FamilyCoordinationApp.Services.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace FamilyCoordinationApp.Endpoints;
+
+/// <summary>
+/// Minimal-API surface for the recipes island (strangler — mirrors <see cref="MealPlanEndpoints"/>): a
+/// <c>/api/recipes</c> group behind <c>.RequireAuthorization().DisableAntiforgery()</c>, every handler resolving
+/// the HouseholdId/UserId from the authenticated caller (M1, never client-supplied) via
+/// <see cref="UserContextResolver"/>. Writes delegate to <see cref="IRecipeService"/> / <see cref="IImageService"/>
+/// / <see cref="IDraftService"/> / <see cref="IRecipeImportService"/>; recipe→DTO shaping goes through the ONE
+/// <see cref="IRecipeProjectionService"/> (no card/detail drift, M9). Kept SEPARATE from the meal-plan picker's
+/// <c>/api/meal-plan/recipes/*</c> (spec D11).
+///
+/// <para>Parity-first ⇒ versionless / last-write-wins (no xmin token on the wire). Not-found responses carry a
+/// NON-EMPTY body so the app-global <c>UseStatusCodePagesWithReExecute</c> leaves them as clean 404s (an empty
+/// 404 surfaces as an empty 400/405). <c>Recipe</c> has an EF global query filter on <c>IsDeleted</c>
+/// (<c>RecipeConfiguration</c>), so soft-deleted recipes are auto-excluded — no explicit filter here.</para>
+/// </summary>
+public static class RecipesEndpoints
+{
+    public static IEndpointRouteBuilder MapRecipesEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/recipes")
+            .RequireAuthorization()
+            // Same rationale as the other island groups: same-origin credentialed fetch + JSON/multipart bodies,
+            // SameSite auth cookie — the antiforgery token the SPA can't readily supply is not the CSRF control.
+            .DisableAntiforgery();
+
+        // ⚠ Register all LITERAL-segment routes BEFORE the parameterized /{recipeId:int} routes. A non-GET
+        // literal (PUT/DELETE /draft) that shares the root level with PUT/DELETE /{recipeId:int} was being
+        // shadowed by the parameterized route at match time (→ 404 → re-executed to 405); registering literals
+        // first makes the matcher prefer them deterministically. (GET literals happened to resolve regardless.)
+
+        // List (root)
+        group.MapGet("/", ListRecipes);
+        group.MapPost("/", CreateRecipe);
+
+        // Ingredient entry helpers (literal)
+        group.MapGet("/ingredient-suggestions", IngredientSuggestions);
+        group.MapPost("/parse-ingredient", ParseIngredient);
+        group.MapPost("/parse-ingredients", ParseIngredients);
+        group.MapGet("/categories", GetCategories);
+
+        // Images (literal)
+        group.MapPost("/images", UploadImage);
+        group.MapGet("/images", ListImages);
+
+        // Import (literal)
+        group.MapPost("/import", ImportRecipe);
+
+        // Connected households (literal prefix)
+        group.MapGet("/connections", GetConnections);
+        group.MapGet("/connected/{chId:int}", ListConnectedRecipes);
+        group.MapGet("/connected/{chId:int}/{recipeId:int}", GetConnectedRecipe);
+        group.MapPost("/connected/{chId:int}/{recipeId:int}/copy", CopyConnectedRecipe);
+
+        // Drafts (autosave). recipeId omitted ⇒ a "new recipe" draft (the endpoints use a 0 sentinel — the
+        // RecipeDraft composite PK includes RecipeId, which can't be null; there's no FK on it, so 0 is safe).
+        group.MapGet("/draft", GetDraft);
+        group.MapPut("/draft", SaveDraft);
+        group.MapDelete("/draft", DeleteDraft);
+
+        // Single-recipe by id (parameterized — registered last)
+        group.MapGet("/{recipeId:int}", GetRecipe);
+        group.MapPut("/{recipeId:int}", UpdateRecipe);
+        group.MapDelete("/{recipeId:int}", DeleteRecipe);
+        group.MapPost("/{recipeId:int}/favorite", ToggleFavorite);
+
+        return app;
+    }
+
+    // ─── List + detail ───────────────────────────────────────────────────────────
+
+    private static async Task<IResult> ListRecipes(
+        [FromQuery] string? q,
+        ClaimsPrincipal principal,
+        IRecipeService recipeService,
+        IRecipeProjectionService projection,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        var recipes = await recipeService.GetRecipesAsync(user.HouseholdId, q, ct);
+        var favorites = await recipeService.GetFavoriteRecipeIdsAsync(user.UserId, user.HouseholdId, ct);
+
+        var items = recipes.Select(projection.ToListItem).ToList();
+        return Results.Ok(new RecipeListDto(items, favorites.ToList()));
+    }
+
+    private static async Task<IResult> GetRecipe(
+        int recipeId,
+        ClaimsPrincipal principal,
+        IRecipeService recipeService,
+        IRecipeProjectionService projection,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        var recipe = await recipeService.GetRecipeAsync(user.HouseholdId, recipeId, ct);
+        if (recipe is null) return Results.NotFound(new { message = "Recipe not found." });
+
+        return Results.Ok(projection.ToFull(recipe));
+    }
+
+    private static async Task<IResult> CreateRecipe(
+        RecipeWriteRequest req,
+        ClaimsPrincipal principal,
+        IRecipeService recipeService,
+        IRecipeProjectionService projection,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        if (string.IsNullOrWhiteSpace(req.Name))
+        {
+            return Results.BadRequest(new { message = "Recipe name is required." });
+        }
+
+        var recipe = MapToRecipe(req, user.HouseholdId, recipeId: 0);
+        recipe.CreatedByUserId = user.UserId;
+        recipe.CreatedAt = DateTime.UtcNow;
+
+        var created = await recipeService.CreateRecipeAsync(recipe, ct);
+
+        // Re-fetch so the response projection has the CreatedBy nav (CreateRecipeAsync doesn't load it).
+        var full = await recipeService.GetRecipeAsync(user.HouseholdId, created.RecipeId, ct);
+        return Results.Created($"/api/recipes/{created.RecipeId}", projection.ToFull(full!));
+    }
+
+    private static async Task<IResult> UpdateRecipe(
+        int recipeId,
+        RecipeWriteRequest req,
+        ClaimsPrincipal principal,
+        IRecipeService recipeService,
+        IRecipeProjectionService projection,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        if (string.IsNullOrWhiteSpace(req.Name))
+        {
+            return Results.BadRequest(new { message = "Recipe name is required." });
+        }
+
+        var recipe = MapToRecipe(req, user.HouseholdId, recipeId);
+        recipe.UpdatedByUserId = user.UserId;
+
+        try
+        {
+            await recipeService.UpdateRecipeAsync(recipe, ct);
+        }
+        catch (InvalidOperationException)
+        {
+            // Household-scoped load missed (missing / cross-household id) → clean 404 (non-empty body, M1).
+            return Results.NotFound(new { message = "Recipe not found." });
+        }
+
+        // Project from a FRESH load, NOT the UpdateRecipeAsync return — its Ingredients nav is stale after the
+        // RemoveRange/Add (spec §11.11 / council).
+        var full = await recipeService.GetRecipeAsync(user.HouseholdId, recipeId, ct);
+        return Results.Ok(projection.ToFull(full!));
+    }
+
+    private static async Task<IResult> DeleteRecipe(
+        int recipeId,
+        ClaimsPrincipal principal,
+        IRecipeService recipeService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        try
+        {
+            await recipeService.DeleteRecipeAsync(user.HouseholdId, recipeId, ct);
+            return Results.NoContent();
+        }
+        catch (InvalidOperationException)
+        {
+            return Results.NotFound(new { message = "Recipe not found." });
+        }
+    }
+
+    private static async Task<IResult> ToggleFavorite(
+        int recipeId,
+        ClaimsPrincipal principal,
+        IRecipeService recipeService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        // Existence pre-check FIRST — a bare ToggleFavorite inserts a UserFavorite directly, so a missing or
+        // cross-household recipe id would FK-violation/500. The household-scoped lookup makes it a clean 404 (M1).
+        var recipe = await recipeService.GetRecipeAsync(user.HouseholdId, recipeId, ct);
+        if (recipe is null) return Results.NotFound(new { message = "Recipe not found." });
+
+        await recipeService.ToggleFavoriteAsync(user.UserId, user.HouseholdId, recipeId, ct);
+        var isFavorite = await recipeService.IsFavoriteAsync(user.UserId, user.HouseholdId, recipeId, ct);
+        return Results.Ok(new { isFavorite });
+    }
+
+    // ─── Ingredient entry helpers ──────────────────────────────────────────────────
+
+    private static async Task<IResult> IngredientSuggestions(
+        [FromQuery] string? prefix,
+        ClaimsPrincipal principal,
+        IRecipeService recipeService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        // The service guards <2 chars ⇒ []; pass through.
+        var suggestions = await recipeService.GetIngredientSuggestionsAsync(user.HouseholdId, prefix ?? string.Empty, ct);
+        return Results.Ok(suggestions);
+    }
+
+    private static async Task<IResult> ParseIngredient(
+        ParseIngredientRequest req,
+        ClaimsPrincipal principal,
+        IIngredientParser parser,
+        ICategoryInferenceService categoryInference,
+        IRecipeProjectionService projection,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        // ParseIngredient THROWS on empty input — guard BEFORE calling (a 400, not a 500).
+        if (string.IsNullOrWhiteSpace(req.Text))
+        {
+            return Results.BadRequest(new { message = "Ingredient text is required." });
+        }
+
+        var parsed = parser.ParseIngredient(req.Text);
+        var category = categoryInference.InferCategory(parsed.Name);
+        return Results.Ok(projection.ToParsed(parsed, category));
+    }
+
+    private static async Task<IResult> ParseIngredients(
+        ParseIngredientsRequest req,
+        ClaimsPrincipal principal,
+        IIngredientParser parser,
+        ICategoryInferenceService categoryInference,
+        IRecipeProjectionService projection,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        var parsed = (req.Lines ?? new List<string>())
+            .Where(l => !string.IsNullOrWhiteSpace(l))
+            .Select(l =>
+            {
+                var p = parser.ParseIngredient(l);
+                return projection.ToParsed(p, categoryInference.InferCategory(p.Name));
+            })
+            .ToList();
+        return Results.Ok(parsed);
+    }
+
+    private static async Task<IResult> GetCategories(
+        ClaimsPrincipal principal,
+        ICategoryService categoryService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        var categories = await categoryService.GetCategoriesAsync(user.HouseholdId, cancellationToken: ct);
+        return Results.Ok(categories.Select(c => new CategoryDto(c.Name)).ToList());
+    }
+
+    // ─── Images ────────────────────────────────────────────────────────────────────
+
+    private static async Task<IResult> UploadImage(
+        IFormFile? file,
+        ClaimsPrincipal principal,
+        IImageService imageService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        if (file is null || file.Length == 0)
+        {
+            return Results.BadRequest(new { message = "No file uploaded." });
+        }
+
+        try
+        {
+            var path = await imageService.SaveImageAsync(file, user.HouseholdId, ct);
+            return Results.Created(path, new { imagePath = path });
+        }
+        catch (InvalidOperationException ex)
+        {
+            // Size / extension / content-type validation failures throw InvalidOperationException → 400.
+            return Results.BadRequest(new { message = ex.Message });
+        }
+    }
+
+    private static async Task<IResult> ListImages(
+        ClaimsPrincipal principal,
+        IImageService imageService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        var images = await imageService.ListImagesAsync(user.HouseholdId, ct);
+        return Results.Ok(images.ToArray());
+    }
+
+    // ─── Import ──────────────────────────────────────────────────────────────────
+
+    private static async Task<IResult> ImportRecipe(
+        ImportRequest req,
+        ClaimsPrincipal principal,
+        IRecipeImportService importService,
+        IRecipeService recipeService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        if (string.IsNullOrWhiteSpace(req.Url))
+        {
+            return Results.BadRequest(new { message = "A recipe URL is required." });
+        }
+
+        // Endpoint-level duplicate detection (exact SourceUrl match; the global filter excludes deleted). `force`
+        // bypasses ONLY this check (ImportFromUrlAsync has no force param) — mirrors ImportRecipeDialog.
+        if (!req.Force)
+        {
+            await using var ctx = await dbFactory.CreateDbContextAsync(ct);
+            var existing = await ctx.Recipes
+                .Where(r => r.HouseholdId == user.HouseholdId && r.SourceUrl == req.Url)
+                .Select(r => new { r.RecipeId, r.Name })
+                .FirstOrDefaultAsync(ct);
+
+            if (existing is not null)
+            {
+                return Results.Ok(new RecipeImportResultDto(
+                    Success: false,
+                    RecipeId: null,
+                    ErrorMessage: $"This recipe has already been imported as \"{existing.Name}\".",
+                    ErrorType: null,
+                    ExistingRecipeId: existing.RecipeId,
+                    ExistingRecipeName: existing.Name,
+                    PartialData: null));
+            }
+        }
+
+        var result = await importService.ImportFromUrlAsync(req.Url, user.HouseholdId, user.UserId, ct);
+
+        if (result.Success && result.Recipe is not null)
+        {
+            // ImportFromUrlAsync returns an UNSAVED entity — persist it, then return the assigned id.
+            var created = await recipeService.CreateRecipeAsync(result.Recipe, ct);
+            return Results.Ok(new RecipeImportResultDto(
+                Success: true, RecipeId: created.RecipeId, ErrorMessage: null, ErrorType: null,
+                ExistingRecipeId: null, ExistingRecipeName: null, PartialData: null));
+        }
+
+        return Results.Ok(new RecipeImportResultDto(
+            Success: false,
+            RecipeId: null,
+            ErrorMessage: result.ErrorMessage,
+            ErrorType: result.ErrorType.ToString(),
+            ExistingRecipeId: null,
+            ExistingRecipeName: null,
+            PartialData: MapPartial(result.PartialData)));
+    }
+
+    // ─── Connected households ──────────────────────────────────────────────────────
+
+    private static async Task<IResult> GetConnections(
+        ClaimsPrincipal principal,
+        IHouseholdConnectionService connectionService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        var connections = await connectionService.GetConnectedHouseholdsAsync(user.HouseholdId, ct);
+        return Results.Ok(connections.Select(c => new ConnectedHouseholdDto(c.HouseholdId, c.HouseholdName)).ToList());
+    }
+
+    private static async Task<IResult> ListConnectedRecipes(
+        int chId,
+        [FromQuery] string? q,
+        ClaimsPrincipal principal,
+        IRecipeService recipeService,
+        IRecipeProjectionService projection,
+        IHouseholdConnectionService connectionService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        if (!await connectionService.AreHouseholdsConnectedAsync(user.HouseholdId, chId, ct))
+        {
+            return Forbidden();
+        }
+
+        var recipes = await recipeService.GetRecipesFromConnectedHouseholdAsync(user.HouseholdId, chId, q, ct);
+        var items = recipes.Select(projection.ToListItem).ToList();
+        // Same shape as the own list (favorites always empty for a connected household).
+        return Results.Ok(new RecipeListDto(items, Array.Empty<int>()));
+    }
+
+    private static async Task<IResult> GetConnectedRecipe(
+        int chId,
+        int recipeId,
+        ClaimsPrincipal principal,
+        IRecipeService recipeService,
+        IRecipeProjectionService projection,
+        IHouseholdConnectionService connectionService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        if (!await connectionService.AreHouseholdsConnectedAsync(user.HouseholdId, chId, ct))
+        {
+            return Forbidden();
+        }
+
+        // Reuse the household-scoped fetch with the CONNECTED id (connection-gated above) — the only single-fetch.
+        var recipe = await recipeService.GetRecipeAsync(chId, recipeId, ct);
+        if (recipe is null) return Results.NotFound(new { message = "Recipe not found." });
+
+        // Strip author for connected reads (privacy — mirrors GetRecipesFromConnectedHouseholdAsync excluding CreatedBy).
+        return Results.Ok(projection.ToFull(recipe, includeAuthor: false));
+    }
+
+    private static async Task<IResult> CopyConnectedRecipe(
+        int chId,
+        int recipeId,
+        ClaimsPrincipal principal,
+        IRecipeService recipeService,
+        IHouseholdConnectionService connectionService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        if (!await connectionService.AreHouseholdsConnectedAsync(user.HouseholdId, chId, ct))
+        {
+            return Forbidden();
+        }
+
+        // Validate the source exists in the connected household before copying (clean 404, no NRE in the service).
+        var source = await recipeService.GetRecipeAsync(chId, recipeId, ct);
+        if (source is null) return Results.NotFound(new { message = "Recipe not found." });
+
+        var copy = await recipeService.CopyRecipeFromConnectedHouseholdAsync(chId, recipeId, user.HouseholdId, user.UserId, ct);
+        return Results.Created($"/api/recipes/{copy.RecipeId}", new { recipeId = copy.RecipeId });
+    }
+
+    // ─── Drafts ────────────────────────────────────────────────────────────────────
+
+    private static async Task<IResult> GetDraft(
+        [FromQuery] int? recipeId,
+        ClaimsPrincipal principal,
+        IDraftService draftService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        // recipeId omitted ⇒ "new recipe" draft ⇒ 0 sentinel (matches SaveDraft).
+        var draft = await draftService.GetDraftAsync(user.HouseholdId, user.UserId, recipeId ?? 0, ct);
+        // 204 when there's no draft (the island's request<T> treats No-Content as null); 200 + body otherwise.
+        return draft is null ? Results.NoContent() : Results.Ok(draft);
+    }
+
+    private static async Task<IResult> SaveDraft(
+        SaveDraftRequest req,
+        ClaimsPrincipal principal,
+        IDraftService draftService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        if (string.IsNullOrWhiteSpace(req.Name))
+        {
+            return Results.BadRequest(new { message = "Draft name is required." });
+        }
+
+        // Map the flat request to DraftService's RecipeDraftData (which it serializes to the draft row).
+        var draft = new RecipeDraftData(
+            req.Name, req.Description, req.Instructions, req.ImagePath, req.SourceUrl,
+            req.Servings, req.PrepTimeMinutes, req.CookTimeMinutes,
+            (req.Ingredients ?? new List<DraftIngredientBody>())
+                .Select(i => new IngredientDraftData(i.Name, i.Quantity, i.Unit, i.Category, i.Notes, i.GroupName, i.SortOrder))
+                .ToList());
+
+        // recipeId null ⇒ "new recipe" draft ⇒ 0 sentinel (RecipeDraft's composite PK can't take null).
+        await draftService.SaveDraftAsync(user.HouseholdId, user.UserId, req.RecipeId ?? 0, draft, ct);
+        return Results.NoContent();
+    }
+
+    private static async Task<IResult> DeleteDraft(
+        [FromQuery] int? recipeId,
+        ClaimsPrincipal principal,
+        IDraftService draftService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        await draftService.DeleteDraftAsync(user.HouseholdId, user.UserId, recipeId ?? 0, ct);
+        return Results.NoContent();
+    }
+
+    // ─── Helpers ───────────────────────────────────────────────────────────────────
+
+    /// <summary>A 403 with a non-empty body (so the status-code re-execute leaves it as a clean 403).</summary>
+    private static IResult Forbidden() =>
+        Results.Json(new { message = "Households are not connected." }, statusCode: StatusCodes.Status403Forbidden);
+
+    /// <summary>Map a write request to a <see cref="Recipe"/>. RecipeId 0 ⇒ create (service assigns the id).</summary>
+    private static Recipe MapToRecipe(RecipeWriteRequest req, int householdId, int recipeId) => new()
+    {
+        HouseholdId = householdId,
+        RecipeId = recipeId,
+        Name = req.Name.Trim(),
+        Description = NullIfBlank(req.Description),
+        Instructions = NullIfBlank(req.Instructions),
+        SourceUrl = NullIfBlank(req.SourceUrl),
+        Servings = req.Servings,
+        PrepTimeMinutes = req.PrepTimeMinutes,
+        CookTimeMinutes = req.CookTimeMinutes,
+        RecipeType = req.RecipeType,
+        ImagePath = NullIfBlank(req.ImagePath),
+        Ingredients = (req.Ingredients ?? new List<RecipeIngredientWrite>())
+            .Select((ing, i) => new RecipeIngredient
+            {
+                Name = ing.Name.Trim(),
+                Quantity = ing.Quantity,
+                Unit = NullIfBlank(ing.Unit),
+                Category = string.IsNullOrWhiteSpace(ing.Category) ? "Pantry" : ing.Category.Trim(),
+                Notes = NullIfBlank(ing.Notes),
+                GroupName = NullIfBlank(ing.GroupName),
+                SortOrder = i, // recompute 0..n in list order
+            })
+            .ToList(),
+    };
+
+    private static PartialRecipeDataDto? MapPartial(PartialRecipeData? p) => p is null ? null : new(
+        p.Name, p.Description, p.Instructions, p.IngredientStrings, p.ImageUrl,
+        p.PrepTimeMinutes, p.CookTimeMinutes, p.Servings);
+
+    private static string? NullIfBlank(string? s) => string.IsNullOrWhiteSpace(s) ? null : s.Trim();
+
+    // ─── Request DTOs ─────────────────────────────────────────────────────────────
+
+    /// <summary>Create/update body. <see cref="ImagePath"/> is a path already returned by POST /images.</summary>
+    public sealed record RecipeWriteRequest(
+        string Name,
+        string? Description,
+        string? Instructions,
+        string? SourceUrl,
+        int? Servings,
+        int? PrepTimeMinutes,
+        int? CookTimeMinutes,
+        RecipeType RecipeType,
+        string? ImagePath,
+        IReadOnlyList<RecipeIngredientWrite> Ingredients);
+
+    public sealed record RecipeIngredientWrite(
+        string Name,
+        decimal? Quantity,
+        string? Unit,
+        string Category,
+        string? Notes,
+        string? GroupName,
+        int SortOrder);
+
+    public sealed record ParseIngredientRequest(string Text);
+
+    public sealed record ParseIngredientsRequest(IReadOnlyList<string> Lines);
+
+    public sealed record ImportRequest(string Url, bool Force = false);
+
+    /// <summary>
+    /// Draft autosave body — FLAT (recipeId + the draft fields), mapped to DraftService's
+    /// <see cref="RecipeDraftData"/> in the handler. The island sends <c>{ recipeId, ...draftFields }</c>
+    /// (recipeId omitted/null for a new-recipe draft → 0 sentinel server-side); GET /draft returns the draft
+    /// fields (RecipeDraftData).
+    /// </summary>
+    public sealed record SaveDraftRequest(
+        int? RecipeId,
+        string Name,
+        string? Description,
+        string? Instructions,
+        string? ImagePath,
+        string? SourceUrl,
+        int? Servings,
+        int? PrepTimeMinutes,
+        int? CookTimeMinutes,
+        IReadOnlyList<DraftIngredientBody> Ingredients);
+
+    public sealed record DraftIngredientBody(
+        string Name,
+        decimal? Quantity,
+        string? Unit,
+        string Category,
+        string? Notes,
+        string? GroupName,
+        int SortOrder);
+}

--- a/src/FamilyCoordinationApp/FamilyCoordinationApp.csproj
+++ b/src/FamilyCoordinationApp/FamilyCoordinationApp.csproj
@@ -70,6 +70,24 @@
           SkipUnchangedFiles="true" />
   </Target>
 
+  <!--
+    Copy the built recipes island into wwwroot before build (strangler). Run `npm run build` in
+    frontend/recipes/ first (or let the Docker build do it via the recipes-node-build stage). If dist/
+    doesn't exist, the target is skipped silently and the island endpoint 404s — Recipes.razor /
+    RecipeEdit.razor render the Blazor fallback via the RECIPES_USE_ISLAND toggle. Parallel to
+    CopyMealPlanIsland (one bundle serves both the list and edit host pages).
+  -->
+  <Target Name="CopyRecipesIsland"
+          BeforeTargets="AssignTargetPaths"
+          Condition="Exists('$(MSBuildThisFileDirectory)..\..\frontend\recipes\dist')">
+    <ItemGroup>
+      <_RecipesIslandFiles Include="$(MSBuildThisFileDirectory)..\..\frontend\recipes\dist\**\*.*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_RecipesIslandFiles)"
+          DestinationFiles="@(_RecipesIslandFiles->'$(MSBuildThisFileDirectory)wwwroot\islands\recipes\%(RecursiveDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true" />
+  </Target>
+
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.4.0" />
     <PackageReference Include="blazor-dragdrop" Version="2.6.1" />

--- a/src/FamilyCoordinationApp/Program.cs
+++ b/src/FamilyCoordinationApp/Program.cs
@@ -89,6 +89,8 @@ builder.Services.AddScoped<IDraftService, DraftService>();
 builder.Services.AddScoped<IMealPlanService, MealPlanService>();
 // Meal-plan island (strangler): read-only board + entry/recipe projection (mirrors IChoreBoardService).
 builder.Services.AddScoped<IMealPlanBoardService, MealPlanBoardService>();
+// Recipes island (strangler): the single recipe→DTO projection (list card / full detail / parsed ingredient).
+builder.Services.AddScoped<IRecipeProjectionService, RecipeProjectionService>();
 builder.Services.AddScoped<IShoppingListService, ShoppingListService>();
 builder.Services.AddScoped<UnitConverter>();
 builder.Services.AddScoped<IShoppingListGenerator, ShoppingListGenerator>();
@@ -399,6 +401,7 @@ app.MapShoppingListEndpoints();
 app.MapChoresEndpoints();
 app.MapRoomsEndpoints();
 app.MapMealPlanEndpoints();
+app.MapRecipesEndpoints();
 
 // Health check endpoint for Docker
 app.MapGet("/health", () => Results.Ok("healthy"));

--- a/src/FamilyCoordinationApp/Services/Dtos/RecipeDtos.cs
+++ b/src/FamilyCoordinationApp/Services/Dtos/RecipeDtos.cs
@@ -1,0 +1,122 @@
+using FamilyCoordinationApp.Data.Entities;
+
+namespace FamilyCoordinationApp.Services.Dtos;
+
+// ─────────────────────────────────────────────────────────────────────────
+// Recipes island DTOs (strangler — mirrors the meal-plan M9 lockstep).
+// Source of truth for the island TS contract: tests/FamilyCoordinationApp.Tests/
+// Fixtures/RecipeList/list.json + Fixtures/RecipeFull/recipe.json +
+// frontend/recipes/src/lib/types.ts. A shape/casing change updates THIS file,
+// those fixtures, and types.ts in lockstep (RecipeListDtoContractTests +
+// RecipeFullDtoContractTests are the tripwires).
+//
+// ⚠ CASING: RecipeType is a real enum TYPE on the DTO → it serializes as a
+//   camelCase string via the globally-registered JsonStringEnumConverter(CamelCase)
+//   (Program.cs ConfigureHttpJsonOptions). decimal?/int? serialize as number-or-null.
+//
+// Kept SEPARATE from MealPlanDtos.cs (D11): the meal-plan RecipeDetailDto is a lean
+// board-card view; the recipes RecipeFullDto is a read-drawer + edit-form superset
+// (raw markdown + sanitized HTML + per-ingredient Category/GroupName/IngredientId).
+//
+// Drafts reuse DraftService's existing RecipeDraftData / IngredientDraftData records
+// directly (no draft DTO here) — they already serialize camelCase via the web defaults.
+//
+// Parity-first ⇒ versionless / last-write-wins: NO xmin token on the wire. Recipe.Version
+// exists on the entity but is unused here (a future quest may add 409 concurrency).
+// ─────────────────────────────────────────────────────────────────────────
+
+// ── List ──────────────────────────────────────────────────────────────────
+
+/// <summary>The recipe grid payload: the cards + this user's favorite ids (empty for connected households).</summary>
+public sealed record RecipeListDto(
+    IReadOnlyList<RecipeListItemDto> Recipes,
+    IReadOnlyList<int> FavoriteRecipeIds);
+
+/// <summary>One card. <see cref="HasSourceUrl"/> is a bool (the card shows only the "imported" icon, not the url).</summary>
+public sealed record RecipeListItemDto(
+    int RecipeId,
+    string Name,
+    RecipeType RecipeType,
+    string? ImagePath,
+    bool HasSourceUrl,
+    string? CreatedByName,            // null when connected (privacy) or deleted user
+    string? CreatedByPictureUrl,      // User has PictureUrl + Initials, NO color field → card renders pic-or-initials
+    IReadOnlyList<string> IngredientPreview,   // first 3 ingredient names (ordered by sort order)
+    int IngredientCount);             // for the "+N more" suffix
+
+// ── Full (read drawer + edit form — superset, D3) ──────────────────────────
+
+/// <summary>
+/// Read-drawer + edit-form detail. <see cref="InstructionsHtml"/> is server-sanitized
+/// (<see cref="MarkdownHelper.ToSafeHtml"/>) for the drawer's {@html}; <see cref="Instructions"/> is the raw
+/// markdown for the edit textarea. Author fields are null when projected with includeAuthor:false (connected).
+/// </summary>
+public sealed record RecipeFullDto(
+    int RecipeId,
+    string Name,
+    RecipeType RecipeType,
+    string? Description,
+    string? Instructions,             // RAW markdown — for the edit textarea
+    string InstructionsHtml,          // server-sanitized — for the read drawer ({@html})
+    string? ImagePath,
+    string? SourceUrl,
+    int? PrepTimeMinutes,
+    int? CookTimeMinutes,
+    int? Servings,
+    string? CreatedByName,            // both null when connected (includeAuthor:false) / deleted user
+    string? CreatedByPictureUrl,
+    string? SharedFromHouseholdName,  // attribution for copied recipes
+    IReadOnlyList<RecipeIngredientFullDto> Ingredients);
+
+/// <summary>One ingredient line for the edit form / detail (full shape incl. category/group/id).</summary>
+public sealed record RecipeIngredientFullDto(
+    int IngredientId,
+    decimal? Quantity,
+    string? Unit,
+    string Name,
+    string Category,
+    string? Notes,
+    string? GroupName,
+    int SortOrder);
+
+// ── Parse / categories / connections / import ──────────────────────────────
+
+/// <summary>A natural-language-parsed ingredient + the inferred category (the entry form's parse-on-blur result).</summary>
+public sealed record ParsedIngredientDto(
+    decimal? Quantity,
+    string? Unit,
+    string Name,
+    string? Notes,
+    bool IsComplete,
+    string SuggestedCategory);
+
+/// <summary>A household category name (for the ingredient-entry category select).</summary>
+public sealed record CategoryDto(string Name);
+
+/// <summary>A connected household for the selector. Intentionally drops ConnectedHouseholdInfo.ConnectedAt.</summary>
+public sealed record ConnectedHouseholdDto(int HouseholdId, string HouseholdName);
+
+/// <summary>
+/// Result of a URL import. On success, <see cref="RecipeId"/> is the SAVED recipe's id (the endpoint persists
+/// the unsaved entity via CreateRecipeAsync). On a duplicate, <see cref="ExistingRecipeId"/> / Name are set. On
+/// failure, <see cref="ErrorType"/> (the RecipeImportErrorType name) + optional <see cref="PartialData"/>.
+/// </summary>
+public sealed record RecipeImportResultDto(
+    bool Success,
+    int? RecipeId,
+    string? ErrorMessage,
+    string? ErrorType,
+    int? ExistingRecipeId,
+    string? ExistingRecipeName,
+    PartialRecipeDataDto? PartialData);
+
+/// <summary>Partially-extracted import data for manual completion when full extraction fails.</summary>
+public sealed record PartialRecipeDataDto(
+    string? Name,
+    string? Description,
+    string? Instructions,
+    IReadOnlyList<string>? IngredientStrings,
+    string? ImageUrl,
+    int? PrepTimeMinutes,
+    int? CookTimeMinutes,
+    int? Servings);

--- a/src/FamilyCoordinationApp/Services/Interfaces/IRecipeProjectionService.cs
+++ b/src/FamilyCoordinationApp/Services/Interfaces/IRecipeProjectionService.cs
@@ -1,0 +1,25 @@
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Services.Dtos;
+
+namespace FamilyCoordinationApp.Services.Interfaces;
+
+/// <summary>
+/// The ONE projection from <see cref="Recipe"/> (+ a parsed ingredient) to the recipes-island DTOs — so the
+/// list cards, the read drawer, and the edit form can't drift (M9, mirrors <see cref="IMealPlanBoardService"/>'s
+/// single-projection rule). Pure mapping; callers load the entity (with the navs the projection reads) and
+/// filter by HouseholdId (M1).
+/// </summary>
+public interface IRecipeProjectionService
+{
+    /// <summary>A grid card. Reads <c>Ingredients</c> (for the preview/count) and <c>CreatedBy</c> (author).</summary>
+    RecipeListItemDto ToListItem(Recipe recipe);
+
+    /// <summary>
+    /// The read-drawer + edit-form superset. Reads <c>Ingredients</c> + <c>CreatedBy</c>.
+    /// <paramref name="includeAuthor"/> = false strips the author fields (connected-household reads — privacy).
+    /// </summary>
+    RecipeFullDto ToFull(Recipe recipe, bool includeAuthor = true);
+
+    /// <summary>A natural-language-parsed ingredient + the inferred category (the entry form's parse result).</summary>
+    ParsedIngredientDto ToParsed(ParsedIngredient parsed, string suggestedCategory);
+}

--- a/src/FamilyCoordinationApp/Services/RecipeProjectionService.cs
+++ b/src/FamilyCoordinationApp/Services/RecipeProjectionService.cs
@@ -1,0 +1,54 @@
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Services.Dtos;
+using FamilyCoordinationApp.Services.Interfaces;
+
+namespace FamilyCoordinationApp.Services;
+
+/// <summary>
+/// The single recipe→DTO projection for the recipes island (mirrors <see cref="MealPlanBoardService"/>'s
+/// projection pattern). Stateless — no DB access; callers pass already-loaded entities. <see cref="ToFull"/>
+/// server-sanitizes the markdown instructions via <see cref="MarkdownHelper.ToSafeHtml"/> so the island ships
+/// no Markdown library (render via {@html}); it ALSO returns the raw markdown for the edit textarea.
+/// </summary>
+public class RecipeProjectionService : IRecipeProjectionService
+{
+    public RecipeListItemDto ToListItem(Recipe recipe) => new(
+        recipe.RecipeId,
+        recipe.Name,
+        recipe.RecipeType,
+        recipe.ImagePath,
+        !string.IsNullOrWhiteSpace(recipe.SourceUrl),
+        recipe.CreatedBy?.DisplayName,
+        recipe.CreatedBy?.PictureUrl,
+        recipe.Ingredients.OrderBy(i => i.SortOrder).Take(3).Select(i => i.Name).ToList(),
+        recipe.Ingredients.Count);
+
+    public RecipeFullDto ToFull(Recipe recipe, bool includeAuthor = true) => new(
+        recipe.RecipeId,
+        recipe.Name,
+        recipe.RecipeType,
+        recipe.Description,
+        recipe.Instructions,
+        MarkdownHelper.ToSafeHtml(recipe.Instructions),
+        recipe.ImagePath,
+        recipe.SourceUrl,
+        recipe.PrepTimeMinutes,
+        recipe.CookTimeMinutes,
+        recipe.Servings,
+        includeAuthor ? recipe.CreatedBy?.DisplayName : null,
+        includeAuthor ? recipe.CreatedBy?.PictureUrl : null,
+        recipe.SharedFromHouseholdName,
+        recipe.Ingredients
+            .OrderBy(i => i.SortOrder)
+            .Select(i => new RecipeIngredientFullDto(
+                i.IngredientId, i.Quantity, i.Unit, i.Name, i.Category, i.Notes, i.GroupName, i.SortOrder))
+            .ToList());
+
+    public ParsedIngredientDto ToParsed(ParsedIngredient parsed, string suggestedCategory) => new(
+        parsed.Quantity,
+        parsed.Unit,
+        parsed.Name,
+        parsed.Notes,
+        parsed.IsComplete,
+        suggestedCategory);
+}

--- a/src/FamilyCoordinationApp/Services/RecipeService.cs
+++ b/src/FamilyCoordinationApp/Services/RecipeService.cs
@@ -100,6 +100,7 @@ public class RecipeService(
         existing.Servings = recipe.Servings;
         existing.PrepTimeMinutes = recipe.PrepTimeMinutes;
         existing.CookTimeMinutes = recipe.CookTimeMinutes;
+        existing.RecipeType = recipe.RecipeType; // was silently dropped — fixed for the recipes island (spec D12)
         existing.UpdatedAt = DateTime.UtcNow;
         existing.UpdatedByUserId = recipe.UpdatedByUserId;
 

--- a/tests/FamilyCoordinationApp.Tests/Fixtures/RecipeFull/recipe.json
+++ b/tests/FamilyCoordinationApp.Tests/Fixtures/RecipeFull/recipe.json
@@ -1,0 +1,48 @@
+{
+  "recipeId": 10,
+  "name": "Overnight Oats",
+  "recipeType": "breakfast",
+  "description": "Creamy make-ahead oats.",
+  "instructions": "1. Combine oats and milk.\n2. Chill overnight.",
+  "instructionsHtml": "<ol><li>Combine oats and milk.</li><li>Chill overnight.</li></ol>",
+  "imagePath": "/uploads/1/oats.jpg",
+  "sourceUrl": "https://example.test/oats",
+  "prepTimeMinutes": 10,
+  "cookTimeMinutes": null,
+  "servings": 4,
+  "createdByName": "Alice A",
+  "createdByPictureUrl": "https://pic.test/alice.jpg",
+  "sharedFromHouseholdName": null,
+  "ingredients": [
+    {
+      "ingredientId": 1,
+      "quantity": 0.5,
+      "unit": "cup",
+      "name": "Rolled oats",
+      "category": "Pantry",
+      "notes": null,
+      "groupName": null,
+      "sortOrder": 0
+    },
+    {
+      "ingredientId": 2,
+      "quantity": 1,
+      "unit": "cup",
+      "name": "Milk",
+      "category": "Dairy",
+      "notes": "any kind",
+      "groupName": "For the base",
+      "sortOrder": 1
+    },
+    {
+      "ingredientId": 3,
+      "quantity": null,
+      "unit": null,
+      "name": "Pinch of salt",
+      "category": "Pantry",
+      "notes": null,
+      "groupName": null,
+      "sortOrder": 2
+    }
+  ]
+}

--- a/tests/FamilyCoordinationApp.Tests/Fixtures/RecipeList/list.json
+++ b/tests/FamilyCoordinationApp.Tests/Fixtures/RecipeList/list.json
@@ -1,0 +1,38 @@
+{
+  "recipes": [
+    {
+      "recipeId": 10,
+      "name": "Overnight Oats",
+      "recipeType": "breakfast",
+      "imagePath": "/uploads/1/oats.jpg",
+      "hasSourceUrl": true,
+      "createdByName": "Alice A",
+      "createdByPictureUrl": "https://pic.test/alice.jpg",
+      "ingredientPreview": ["Rolled oats", "Milk", "Honey"],
+      "ingredientCount": 5
+    },
+    {
+      "recipeId": 11,
+      "name": "Spaghetti Bolognese",
+      "recipeType": "main",
+      "imagePath": null,
+      "hasSourceUrl": false,
+      "createdByName": null,
+      "createdByPictureUrl": null,
+      "ingredientPreview": ["Spaghetti", "Beef", "Tomato"],
+      "ingredientCount": 8
+    },
+    {
+      "recipeId": 12,
+      "name": "Lemon Tart",
+      "recipeType": "dessert",
+      "imagePath": "/uploads/1/tart.jpg",
+      "hasSourceUrl": true,
+      "createdByName": "Amy A",
+      "createdByPictureUrl": null,
+      "ingredientPreview": [],
+      "ingredientCount": 0
+    }
+  ],
+  "favoriteRecipeIds": [10, 12]
+}

--- a/tests/FamilyCoordinationApp.Tests/Integration/RecipesEndpointTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Integration/RecipesEndpointTests.cs
@@ -1,0 +1,463 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using FamilyCoordinationApp.Services.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FamilyCoordinationApp.Tests.Integration;
+
+/// <summary>
+/// End-to-end coverage of the recipes-island endpoints through the real HTTP pipeline against real Postgres
+/// (reuses <see cref="ChoresWebAppFactory"/>'s two-household seed). Proves: list/search, create→list→detail
+/// round-trip, update (RecipeType change [D12] + wholesale ingredient replace, response projected from a fresh
+/// load), soft delete, favorite toggle + the 404-not-500 guards, ingredient suggestions + parse + bulk-parse,
+/// categories, image-upload validation, import duplicate detection, connected-household 403 + the connected
+/// list/detail/copy happy path, draft round-trip, the 401 gate, and the M1 cross-household no-leak invariant.
+/// Versionless — no token on the wire. Tests use DISTINCT recipe names + scoped searches so the class's shared
+/// database can't let them interfere; all 403 assertions use a never-connected household id.
+/// </summary>
+[Collection(IntegrationCollection.Name)]
+[Trait("kind", "integration")]
+public sealed class RecipesEndpointTests(PostgresContainerFixture postgres) : IAsyncLifetime
+{
+    private readonly ChoresWebAppFactory _factory = new(postgres);
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    public async Task InitializeAsync() => await _factory.EnsureSeededAsync();
+
+    public async Task DisposeAsync() => await _factory.DisposeAsync();
+
+    // ── Wire shapes (camelCase via JsonSerializerDefaults.Web) ──────────────────────
+    private sealed record ListItem(
+        int recipeId, string name, string recipeType, string? imagePath, bool hasSourceUrl,
+        string? createdByName, string? createdByPictureUrl, List<string> ingredientPreview, int ingredientCount);
+    private sealed record RecipeList(List<ListItem> recipes, List<int> favoriteRecipeIds);
+    private sealed record IngredientFull(
+        int ingredientId, decimal? quantity, string? unit, string name, string category,
+        string? notes, string? groupName, int sortOrder);
+    private sealed record RecipeFull(
+        int recipeId, string name, string recipeType, string? description, string? instructions,
+        string instructionsHtml, string? imagePath, string? sourceUrl, int? prepTimeMinutes,
+        int? cookTimeMinutes, int? servings, string? createdByName, string? createdByPictureUrl,
+        string? sharedFromHouseholdName, List<IngredientFull> ingredients);
+    private sealed record Parsed(
+        decimal? quantity, string? unit, string name, string? notes, bool isComplete, string suggestedCategory);
+    private sealed record ImportResult(
+        bool success, int? recipeId, string? errorMessage, string? errorType,
+        int? existingRecipeId, string? existingRecipeName);
+    private sealed record Connected(int householdId, string householdName);
+    private sealed record FavoriteResult(bool isFavorite);
+    private sealed record ImagePathResult(string imagePath);
+    private sealed record DraftIngredient(
+        string name, decimal? quantity, string? unit, string category, string? notes, string? groupName, int sortOrder);
+    private sealed record DraftWire(
+        string name, string? description, string? instructions, string? imagePath, string? sourceUrl,
+        int? servings, int? prepTimeMinutes, int? cookTimeMinutes, List<DraftIngredient> ingredients);
+
+    private HttpClient ClientA => _factory.CreateClientAs(ChoresWebAppFactory.UserAEmail);
+    private HttpClient ClientB => _factory.CreateClientAs(ChoresWebAppFactory.UserBEmail);
+
+    private static object WriteBody(
+        string name, string type = "main", string? sourceUrl = null,
+        IEnumerable<object>? ingredients = null, int? servings = 4, string? instructions = null) => new
+    {
+        name,
+        description = (string?)null,
+        instructions,
+        sourceUrl,
+        servings,
+        prepTimeMinutes = (int?)null,
+        cookTimeMinutes = (int?)null,
+        recipeType = type,
+        imagePath = (string?)null,
+        ingredients = ingredients ?? Array.Empty<object>()
+    };
+
+    private static object Ing(string name, double? qty = null, string? unit = null, string category = "Pantry",
+        string? notes = null, string? groupName = null, int sortOrder = 0) => new
+    {
+        name,
+        quantity = qty,
+        unit,
+        category,
+        notes,
+        groupName,
+        sortOrder
+    };
+
+    private async Task<RecipeFull> CreateAsync(HttpClient client, object body)
+    {
+        var resp = await client.PostAsJsonAsync("/api/recipes", body, Json);
+        resp.StatusCode.Should().Be(HttpStatusCode.Created);
+        var full = await resp.Content.ReadFromJsonAsync<RecipeFull>(Json);
+        full.Should().NotBeNull();
+        return full!;
+    }
+
+    // ── List + detail ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task List_SearchForNonexistent_ReturnsEmpty()
+    {
+        var list = await ClientA.GetFromJsonAsync<RecipeList>(
+            "/api/recipes?q=zzz-definitely-no-such-recipe-zzz", Json);
+
+        list.Should().NotBeNull();
+        list!.recipes.Should().BeEmpty();
+        list.favoriteRecipeIds.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Create_AppearsInList_AndDetailRoundTrips()
+    {
+        var created = await CreateAsync(ClientA, WriteBody(
+            "RT Banana Bread", "dessert",
+            ingredients: new[] { Ing("Bananas", 3, null, "Produce"), Ing("Flour", 2, "cup", "Pantry") },
+            instructions: "Mash, mix, bake."));
+
+        created.recipeId.Should().BeGreaterThan(0);
+        created.recipeType.Should().Be("dessert");
+        created.ingredients.Should().HaveCount(2);
+        created.ingredients[0].name.Should().Be("Bananas");
+        created.createdByName.Should().Be("Alice A"); // re-fetch loaded the author
+
+        var list = await ClientA.GetFromJsonAsync<RecipeList>("/api/recipes?q=RT Banana", Json);
+        list!.recipes.Should().Contain(r =>
+            r.recipeId == created.recipeId && r.ingredientCount == 2 && r.ingredientPreview.Contains("Bananas"));
+
+        var detail = await ClientA.GetFromJsonAsync<RecipeFull>($"/api/recipes/{created.recipeId}", Json);
+        detail!.name.Should().Be("RT Banana Bread");
+        detail.instructionsHtml.Should().Contain("Mash"); // markdown sanitized server-side
+        detail.ingredients.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task Search_MatchesIngredientName()
+    {
+        var created = await CreateAsync(ClientA, WriteBody(
+            "Search By Ingredient Dish", "main",
+            ingredients: new[] { Ing("Tarragon", 1, "tbsp", "Spices") }));
+
+        // The server search matches ingredient names, not just the recipe name.
+        var list = await ClientA.GetFromJsonAsync<RecipeList>("/api/recipes?q=Tarragon", Json);
+        list!.recipes.Should().Contain(r => r.recipeId == created.recipeId);
+    }
+
+    [Fact]
+    public async Task GetRecipe_Missing_Returns404()
+    {
+        var resp = await ClientA.GetAsync("/api/recipes/999999");
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Update_ChangesRecipeType_AndReplacesIngredients_ResponseReflectsThem()
+    {
+        var created = await CreateAsync(ClientA, WriteBody(
+            "Update Target Dish", "main",
+            ingredients: new[] { Ing("Old A", 1, "cup"), Ing("Old B", 2, "cup") }));
+
+        var putBody = WriteBody(
+            "Update Target Dish (edited)", "dessert",
+            ingredients: new[] { Ing("New X", 3, "tbsp", "Spices"), Ing("New Y"), Ing("New Z", 1, "pinch") });
+
+        var resp = await ClientA.PutAsJsonAsync($"/api/recipes/{created.recipeId}", putBody, Json);
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var updated = await resp.Content.ReadFromJsonAsync<RecipeFull>(Json);
+
+        // D12: RecipeType actually persists now (was silently dropped).
+        updated!.recipeType.Should().Be("dessert");
+        updated.name.Should().Be("Update Target Dish (edited)");
+        // Council: the response is projected from a fresh load, so it shows the NEW ingredients, not the stale
+        // pre-RemoveRange nav.
+        updated.ingredients.Should().HaveCount(3);
+        updated.ingredients.Select(i => i.name).Should().Equal("New X", "New Y", "New Z");
+        updated.ingredients.Select(i => i.sortOrder).Should().Equal(0, 1, 2);
+
+        // Persisted on a subsequent GET too.
+        var detail = await ClientA.GetFromJsonAsync<RecipeFull>($"/api/recipes/{created.recipeId}", Json);
+        detail!.recipeType.Should().Be("dessert");
+        detail.ingredients.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task Update_Missing_Returns404()
+    {
+        var resp = await ClientA.PutAsJsonAsync("/api/recipes/999999", WriteBody("Nope"), Json);
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Delete_SoftDeletes_GoneFromList()
+    {
+        var created = await CreateAsync(ClientA, WriteBody("Delete Me Dish"));
+
+        var del = await ClientA.DeleteAsync($"/api/recipes/{created.recipeId}");
+        del.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var list = await ClientA.GetFromJsonAsync<RecipeList>("/api/recipes?q=Delete Me Dish", Json);
+        list!.recipes.Should().NotContain(r => r.recipeId == created.recipeId);
+
+        // Soft-deleted ⇒ the global query filter hides it from detail too.
+        var detail = await ClientA.GetAsync($"/api/recipes/{created.recipeId}");
+        detail.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Delete_Missing_Returns404()
+    {
+        var resp = await ClientA.DeleteAsync("/api/recipes/999999");
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // ── Favorites ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Favorite_TogglesBothWays()
+    {
+        var created = await CreateAsync(ClientA, WriteBody("Favorite Toggle Dish"));
+
+        var on = await ClientA.PostAsync($"/api/recipes/{created.recipeId}/favorite", null);
+        on.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await on.Content.ReadFromJsonAsync<FavoriteResult>(Json))!.isFavorite.Should().BeTrue();
+
+        var listOn = await ClientA.GetFromJsonAsync<RecipeList>("/api/recipes?q=Favorite Toggle", Json);
+        listOn!.favoriteRecipeIds.Should().Contain(created.recipeId);
+
+        var off = await ClientA.PostAsync($"/api/recipes/{created.recipeId}/favorite", null);
+        (await off.Content.ReadFromJsonAsync<FavoriteResult>(Json))!.isFavorite.Should().BeFalse();
+
+        var listOff = await ClientA.GetFromJsonAsync<RecipeList>("/api/recipes?q=Favorite Toggle", Json);
+        listOff!.favoriteRecipeIds.Should().NotContain(created.recipeId);
+    }
+
+    [Fact]
+    public async Task Favorite_Missing_Returns404_NotServerError()
+    {
+        // A bare ToggleFavorite would FK-violation/500 on a missing id; the existence pre-check makes it a 404.
+        var resp = await ClientA.PostAsync("/api/recipes/999999/favorite", null);
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // ── Ingredient entry helpers ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task IngredientSuggestions_ShortPrefix_ReturnsEmpty()
+    {
+        var results = await ClientA.GetFromJsonAsync<List<string>>("/api/recipes/ingredient-suggestions?prefix=a", Json);
+        results.Should().NotBeNull().And.BeEmpty(); // service guards <2 chars
+    }
+
+    [Fact]
+    public async Task IngredientSuggestions_FindsCreatedIngredient()
+    {
+        await CreateAsync(ClientA, WriteBody(
+            "Suggestion Source Dish", ingredients: new[] { Ing("Cardamom", 1, "tsp", "Spices") }));
+
+        var results = await ClientA.GetFromJsonAsync<List<string>>(
+            "/api/recipes/ingredient-suggestions?prefix=Cardam", Json);
+        results.Should().Contain("Cardamom");
+    }
+
+    [Fact]
+    public async Task ParseIngredient_ParsesQuantityUnitName_AndInfersCategory()
+    {
+        var resp = await ClientA.PostAsJsonAsync("/api/recipes/parse-ingredient", new { text = "2 cups flour" }, Json);
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var parsed = await resp.Content.ReadFromJsonAsync<Parsed>(Json);
+
+        parsed!.quantity.Should().Be(2m);
+        parsed.unit.Should().NotBeNullOrEmpty();
+        parsed.name.ToLowerInvariant().Should().Contain("flour");
+        parsed.isComplete.Should().BeTrue();
+        parsed.suggestedCategory.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task ParseIngredient_Empty_Returns400()
+    {
+        var resp = await ClientA.PostAsJsonAsync("/api/recipes/parse-ingredient", new { text = "   " }, Json);
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task ParseIngredients_Bulk_ParsesEachNonBlankLine()
+    {
+        var resp = await ClientA.PostAsJsonAsync("/api/recipes/parse-ingredients",
+            new { lines = new[] { "1 cup sugar", "", "  ", "2 eggs" } }, Json);
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var parsed = await resp.Content.ReadFromJsonAsync<List<Parsed>>(Json);
+
+        parsed.Should().HaveCount(2); // blanks skipped
+        parsed!.Select(p => p.name.ToLowerInvariant()).Should().Contain(n => n.Contains("sugar"));
+    }
+
+    [Fact]
+    public async Task Categories_ReturnsAList()
+    {
+        var resp = await ClientA.GetAsync("/api/recipes/categories");
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var categories = await resp.Content.ReadFromJsonAsync<List<CategoryWire>>(Json);
+        categories.Should().NotBeNull(); // possibly empty (no category seed) — proves the endpoint + auth
+    }
+
+    private sealed record CategoryWire(string name);
+
+    // ── Images ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ImageUpload_NonImage_Returns400()
+    {
+        using var content = new MultipartFormDataContent();
+        var fileContent = new ByteArrayContent("not an image"u8.ToArray());
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
+        content.Add(fileContent, "file", "notanimage.txt");
+
+        var resp = await ClientA.PostAsync("/api/recipes/images", content);
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task ImageUpload_NoFile_Returns400()
+    {
+        using var content = new MultipartFormDataContent();
+        var resp = await ClientA.PostAsync("/api/recipes/images", content);
+        resp.StatusCode.Should().BeOneOf(HttpStatusCode.BadRequest, HttpStatusCode.UnsupportedMediaType);
+    }
+
+    [Fact]
+    public async Task ListImages_Returns200()
+    {
+        var resp = await ClientA.GetAsync("/api/recipes/images");
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var images = await resp.Content.ReadFromJsonAsync<List<string>>(Json);
+        images.Should().NotBeNull();
+    }
+
+    // ── Import (duplicate detection — no network) ──────────────────────────────────
+
+    [Fact]
+    public async Task Import_DuplicateUrl_ReturnsExisting()
+    {
+        const string url = "https://dup.test/recipe-already-here";
+        var created = await CreateAsync(ClientA, WriteBody("Import Dup Source", sourceUrl: url));
+
+        var resp = await ClientA.PostAsJsonAsync("/api/recipes/import", new { url, force = false }, Json);
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await resp.Content.ReadFromJsonAsync<ImportResult>(Json);
+
+        result!.success.Should().BeFalse();
+        result.existingRecipeId.Should().Be(created.recipeId);
+        result.existingRecipeName.Should().Be("Import Dup Source");
+    }
+
+    // ── Connected households ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ConnectedList_Unconnected_Returns403()
+    {
+        // Household 999 is never connected to A.
+        var resp = await ClientA.GetAsync("/api/recipes/connected/999");
+        resp.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Connected_ListDetailCopy_HappyPath()
+    {
+        await ConnectHouseholdsAsync();
+
+        // B owns a recipe; A (connected) can list it (author stripped), read detail, and copy it.
+        var bRecipe = await CreateAsync(ClientB, WriteBody(
+            "Shared Casserole", "main", ingredients: new[] { Ing("Potatoes", 4, null, "Produce") }));
+
+        var connectedList = await ClientA.GetFromJsonAsync<RecipeList>(
+            $"/api/recipes/connected/{ChoresWebAppFactory.HouseholdBId}?q=Shared Casserole", Json);
+        connectedList!.recipes.Should().Contain(r => r.recipeId == bRecipe.recipeId && r.createdByName == null);
+        connectedList.favoriteRecipeIds.Should().BeEmpty();
+
+        var detail = await ClientA.GetFromJsonAsync<RecipeFull>(
+            $"/api/recipes/connected/{ChoresWebAppFactory.HouseholdBId}/{bRecipe.recipeId}", Json);
+        detail!.name.Should().Be("Shared Casserole");
+        detail.createdByName.Should().BeNull(); // privacy on connected reads
+
+        var copyResp = await ClientA.PostAsync(
+            $"/api/recipes/connected/{ChoresWebAppFactory.HouseholdBId}/{bRecipe.recipeId}/copy", null);
+        copyResp.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var myList = await ClientA.GetFromJsonAsync<RecipeList>("/api/recipes?q=Shared Casserole", Json);
+        myList!.recipes.Should().Contain(r => r.name == "Shared Casserole"); // now in A's own collection
+    }
+
+    // ── Drafts ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Draft_RoundTrip_SaveGetDelete()
+    {
+        // New-recipe draft (recipeId null). The body is FLAT: recipeId + the draft fields.
+        var put = await ClientA.PutAsJsonAsync("/api/recipes/draft", new
+        {
+            recipeId = (int?)null,
+            name = "Work In Progress",
+            description = (string?)"a draft",
+            instructions = (string?)null,
+            imagePath = (string?)null,
+            sourceUrl = (string?)null,
+            servings = (int?)6,
+            prepTimeMinutes = (int?)null,
+            cookTimeMinutes = (int?)null,
+            ingredients = new[] { new { name = "Eggs", quantity = (decimal?)2m, unit = (string?)null, category = "Dairy", notes = (string?)null, groupName = (string?)null, sortOrder = 0 } }
+        }, Json);
+        put.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var got = await ClientA.GetFromJsonAsync<DraftWire>("/api/recipes/draft", Json);
+        got.Should().NotBeNull();
+        got!.name.Should().Be("Work In Progress");
+        got.servings.Should().Be(6);
+        got.ingredients.Should().ContainSingle(i => i.name == "Eggs");
+
+        var del = await ClientA.DeleteAsync("/api/recipes/draft");
+        del.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var afterDelete = await ClientA.GetAsync("/api/recipes/draft");
+        afterDelete.StatusCode.Should().Be(HttpStatusCode.NoContent); // no draft ⇒ 204
+    }
+
+    // ── Auth + M1 ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task List_Unauthenticated_Returns401()
+    {
+        var client = _factory.CreateAnonymousClient();
+        var resp = await client.GetAsync("/api/recipes");
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task CrossHousehold_BsRecipe_DoesNotLeakIntoAsList()
+    {
+        // B creates a uniquely-named recipe; it must NEVER appear in A's OWN list (M1) — regardless of any
+        // connection (a connection only enables /connected/* reads, not leakage into the own-household list).
+        var bRecipe = await CreateAsync(ClientB, WriteBody("B Private Secret Dish 4173"));
+
+        var aList = await ClientA.GetFromJsonAsync<RecipeList>("/api/recipes?q=B Private Secret Dish 4173", Json);
+        aList!.recipes.Should().NotContain(r => r.name == "B Private Secret Dish 4173");
+        aList.recipes.Should().NotContain(r => r.recipeId == bRecipe.recipeId && r.name == "B Private Secret Dish 4173");
+    }
+
+    private async Task ConnectHouseholdsAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var connections = scope.ServiceProvider.GetRequiredService<IHouseholdConnectionService>();
+        if (await connections.AreHouseholdsConnectedAsync(ChoresWebAppFactory.HouseholdAId, ChoresWebAppFactory.HouseholdBId))
+        {
+            return;
+        }
+
+        var invite = await connections.GenerateInviteAsync(ChoresWebAppFactory.HouseholdBId, ChoresWebAppFactory.UserBId);
+        var (success, _, error) = await connections.AcceptInviteAsync(
+            invite.InviteCode, ChoresWebAppFactory.HouseholdAId, ChoresWebAppFactory.UserAId);
+        success.Should().BeTrue($"the test households must connect (error: {error})");
+    }
+}

--- a/tests/FamilyCoordinationApp.Tests/Services/RecipeFullDtoContractTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/RecipeFullDtoContractTests.cs
@@ -1,0 +1,111 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Services.Dtos;
+
+namespace FamilyCoordinationApp.Tests.Services;
+
+/// <summary>
+/// Contract / consumer-audit tests for the recipes-island FULL DTO (read drawer + edit form superset, M9).
+/// Serializes a representative <see cref="RecipeFullDto"/> with the global camelCase + enum-string options and
+/// asserts it matches the checked-in <c>Fixtures/RecipeFull/recipe.json</c>. Locks the edit/drawer superset
+/// shape — both raw <c>instructions</c> (markdown for the textarea) AND <c>instructionsHtml</c> (sanitized for
+/// the drawer), plus per-ingredient <c>category</c>/<c>groupName</c>/<c>ingredientId</c>.
+/// </summary>
+public class RecipeFullDtoContractTests
+{
+    private static readonly JsonSerializerOptions RecipeJsonOptions = RecipeListDtoContractTests.RecipeJsonOptions;
+
+    private static readonly string FixturePath =
+        Path.Combine(AppContext.BaseDirectory, "Fixtures", "RecipeFull", "recipe.json");
+
+    /// <summary>
+    /// A representative full recipe: raw + sanitized instructions, a null cook time, an author with a picture,
+    /// and three ingredients exercising decimal quantity (0.5), whole quantity (1), null quantity/unit, a
+    /// non-default category, and an optional notes + groupName. Static values only.
+    /// </summary>
+    public static RecipeFullDto BuildRepresentativeFull()
+    {
+        var ingredients = new List<RecipeIngredientFullDto>
+        {
+            new(IngredientId: 1, Quantity: 0.5m, Unit: "cup", Name: "Rolled oats",
+                Category: "Pantry", Notes: null, GroupName: null, SortOrder: 0),
+            new(IngredientId: 2, Quantity: 1m, Unit: "cup", Name: "Milk",
+                Category: "Dairy", Notes: "any kind", GroupName: "For the base", SortOrder: 1),
+            new(IngredientId: 3, Quantity: null, Unit: null, Name: "Pinch of salt",
+                Category: "Pantry", Notes: null, GroupName: null, SortOrder: 2),
+        };
+
+        return new RecipeFullDto(
+            RecipeId: 10,
+            Name: "Overnight Oats",
+            RecipeType: RecipeType.Breakfast,
+            Description: "Creamy make-ahead oats.",
+            Instructions: "1. Combine oats and milk.\n2. Chill overnight.",
+            InstructionsHtml: "<ol><li>Combine oats and milk.</li><li>Chill overnight.</li></ol>",
+            ImagePath: "/uploads/1/oats.jpg",
+            SourceUrl: "https://example.test/oats",
+            PrepTimeMinutes: 10,
+            CookTimeMinutes: null,
+            Servings: 4,
+            CreatedByName: "Alice A",
+            CreatedByPictureUrl: "https://pic.test/alice.jpg",
+            SharedFromHouseholdName: null,
+            Ingredients: ingredients);
+    }
+
+    [Fact]
+    public void SerializedFull_MatchesContractFixture()
+    {
+        var dto = BuildRepresentativeFull();
+        var actualJson = JsonSerializer.Serialize(dto, RecipeJsonOptions);
+
+        File.Exists(FixturePath).Should().BeTrue(
+            $"the recipe.json contract fixture must be checked in at {FixturePath}");
+        var expectedJson = File.ReadAllText(FixturePath);
+
+        Normalize(actualJson).Should().Be(Normalize(expectedJson),
+            "the serialized RecipeFullDto must match the checked-in contract fixture; if this fails after a "
+            + "deliberate DTO change, update recipe.json AND the island types.ts in lockstep (M9)");
+    }
+
+    [Fact]
+    public void SerializedFull_HasBothRawAndSanitizedInstructions_AndCamelCaseEnums()
+    {
+        var json = JsonSerializer.Serialize(BuildRepresentativeFull(), RecipeJsonOptions);
+        var root = JsonNode.Parse(json)!.AsObject();
+
+        root.Select(kvp => kvp.Key).Should().BeEquivalentTo(
+            "recipeId", "name", "recipeType", "description", "instructions", "instructionsHtml",
+            "imagePath", "sourceUrl", "prepTimeMinutes", "cookTimeMinutes", "servings",
+            "createdByName", "createdByPictureUrl", "sharedFromHouseholdName", "ingredients");
+
+        root["recipeType"]!.GetValue<string>().Should().Be("breakfast");
+        root["instructions"]!.GetValue<string>().Should().Contain("Combine oats");   // raw markdown
+        root["instructionsHtml"]!.GetValue<string>().Should().StartWith("<ol>");      // sanitized html
+        root["cookTimeMinutes"].Should().BeNull();
+
+        var ing = root["ingredients"]!.AsArray()[0]!.AsObject();
+        ing.Select(kvp => kvp.Key).Should().BeEquivalentTo(
+            "ingredientId", "quantity", "unit", "name", "category", "notes", "groupName", "sortOrder");
+        ing["quantity"]!.GetValue<decimal>().Should().Be(0.5m);
+
+        // A null-quantity ingredient serializes quantity:null (not 0).
+        root["ingredients"]!.AsArray()[2]!.AsObject()["quantity"].Should().BeNull();
+    }
+
+    [Fact]
+    public void RenamingAField_BreaksTheFixture()
+    {
+        var json = JsonSerializer.Serialize(BuildRepresentativeFull(), RecipeJsonOptions);
+        var drifted = json.Replace("\"instructionsHtml\"", "\"html\"");
+        var expectedJson = File.ReadAllText(FixturePath);
+
+        Normalize(drifted).Should().NotBe(Normalize(expectedJson));
+    }
+
+    private static string Normalize(string json) =>
+        JsonNode.Parse(json)!.ToJsonString(new JsonSerializerOptions { WriteIndented = false });
+}

--- a/tests/FamilyCoordinationApp.Tests/Services/RecipeListDtoContractTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/RecipeListDtoContractTests.cs
@@ -1,0 +1,131 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Services.Dtos;
+
+namespace FamilyCoordinationApp.Tests.Services;
+
+/// <summary>
+/// Contract / consumer-audit tests for the recipes-island LIST DTO (M9 — mirrors
+/// <see cref="MealPlanBoardDtoContractTests"/>). Serializes a representative <see cref="RecipeListDto"/> with the
+/// SAME <see cref="JsonSerializerOptions"/> the app registers globally (camelCase properties +
+/// <see cref="JsonStringEnumConverter"/> camelCase) and asserts it matches the checked-in
+/// <c>Fixtures/RecipeList/list.json</c>. The island's <c>types.ts</c> mirrors this fixture; any DTO shape/casing
+/// drift (rename, enum casing, added/removed field) breaks this test → forcing the island contract to update in
+/// lockstep.
+/// </summary>
+public class RecipeListDtoContractTests
+{
+    public static readonly JsonSerializerOptions RecipeJsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+    };
+
+    private static readonly string FixturePath =
+        Path.Combine(AppContext.BaseDirectory, "Fixtures", "RecipeList", "list.json");
+
+    /// <summary>
+    /// A representative grid payload covering: a card WITH image + source url + author + picture + ingredient
+    /// preview; a card with NO image / NO source url / a DELETED author (null name+picture) but with a preview;
+    /// a card with an author that has NO picture and NO ingredients (empty preview, count 0); plus a non-empty
+    /// favoriteRecipeIds. Static values only — byte-deterministic.
+    /// </summary>
+    public static RecipeListDto BuildRepresentativeList()
+    {
+        var recipes = new List<RecipeListItemDto>
+        {
+            new(
+                RecipeId: 10,
+                Name: "Overnight Oats",
+                RecipeType: RecipeType.Breakfast,
+                ImagePath: "/uploads/1/oats.jpg",
+                HasSourceUrl: true,
+                CreatedByName: "Alice A",
+                CreatedByPictureUrl: "https://pic.test/alice.jpg",
+                IngredientPreview: new List<string> { "Rolled oats", "Milk", "Honey" },
+                IngredientCount: 5),
+
+            new(
+                RecipeId: 11,
+                Name: "Spaghetti Bolognese",
+                RecipeType: RecipeType.Main,
+                ImagePath: null,
+                HasSourceUrl: false,
+                CreatedByName: null,
+                CreatedByPictureUrl: null,
+                IngredientPreview: new List<string> { "Spaghetti", "Beef", "Tomato" },
+                IngredientCount: 8),
+
+            new(
+                RecipeId: 12,
+                Name: "Lemon Tart",
+                RecipeType: RecipeType.Dessert,
+                ImagePath: "/uploads/1/tart.jpg",
+                HasSourceUrl: true,
+                CreatedByName: "Amy A",
+                CreatedByPictureUrl: null,
+                IngredientPreview: new List<string>(),
+                IngredientCount: 0),
+        };
+
+        return new RecipeListDto(recipes, new List<int> { 10, 12 });
+    }
+
+    [Fact]
+    public void SerializedList_MatchesContractFixture()
+    {
+        var dto = BuildRepresentativeList();
+        var actualJson = JsonSerializer.Serialize(dto, RecipeJsonOptions);
+
+        File.Exists(FixturePath).Should().BeTrue(
+            $"the list.json contract fixture must be checked in at {FixturePath}");
+        var expectedJson = File.ReadAllText(FixturePath);
+
+        Normalize(actualJson).Should().Be(Normalize(expectedJson),
+            "the serialized RecipeListDto must match the checked-in contract fixture; if this fails after a "
+            + "deliberate DTO change, update list.json AND the island types.ts in lockstep (M9)");
+    }
+
+    [Fact]
+    public void SerializedList_UsesCamelCaseKeys_AndCamelCaseEnumStrings()
+    {
+        var json = JsonSerializer.Serialize(BuildRepresentativeList(), RecipeJsonOptions);
+        var root = JsonNode.Parse(json)!.AsObject();
+
+        root.Select(kvp => kvp.Key).Should().BeEquivalentTo("recipes", "favoriteRecipeIds");
+
+        var first = root["recipes"]!.AsArray()[0]!.AsObject();
+        first.Select(kvp => kvp.Key).Should().BeEquivalentTo(
+            "recipeId", "name", "recipeType", "imagePath", "hasSourceUrl",
+            "createdByName", "createdByPictureUrl", "ingredientPreview", "ingredientCount");
+
+        // RecipeType is a camelCase enum string (NOT an integer, NOT PascalCase).
+        first["recipeType"]!.GetValue<string>().Should().Be("breakfast");
+        first["hasSourceUrl"]!.GetValue<bool>().Should().BeTrue();
+
+        // Deleted-author card: null name + null picture.
+        var second = root["recipes"]!.AsArray()[1]!.AsObject();
+        second["recipeType"]!.GetValue<string>().Should().Be("main");
+        second["imagePath"].Should().BeNull();
+        second["createdByName"].Should().BeNull();
+        second["createdByPictureUrl"].Should().BeNull();
+
+        root["favoriteRecipeIds"]!.AsArray().Select(n => n!.GetValue<int>()).Should().Equal(10, 12);
+    }
+
+    [Fact]
+    public void RenamingAField_BreaksTheFixture()
+    {
+        var json = JsonSerializer.Serialize(BuildRepresentativeList(), RecipeJsonOptions);
+        var drifted = json.Replace("\"recipeType\"", "\"type\"");
+        var expectedJson = File.ReadAllText(FixturePath);
+
+        Normalize(drifted).Should().NotBe(Normalize(expectedJson));
+    }
+
+    private static string Normalize(string json) =>
+        JsonNode.Parse(json)!.ToJsonString(new JsonSerializerOptions { WriteIndented = false });
+}


### PR DESCRIPTION
## What

Strangles the two Blazor recipe surfaces — `Recipes.razor` (961 lines) + `RecipeEdit.razor` (619 lines) — into **one Svelte 5 island** talking to a new `/api/recipes` backend over plain HTTP/JSON. Kills the tab-away / SignalR-circuit-drop failure mode (same motivation as shopping-list / chores / meal-plan). **Behavior parity** with today; no new UX.

Ships behind `RECIPES_USE_ISLAND` (**default off**) with the original Blazor UIs kept verbatim as `RecipesBlazor` / `RecipeEditBlazor` fallbacks.

Spec (deep, council-hardened): `.planning/recipes-island-spec.md`.

## Commits
- `a0030bc` — backend `/api/recipes` (20 routes) + DTOs + `IRecipeProjectionService` + contract/integration tests (WP-1..3)
- `164b53e` — the Svelte island frontend + host pages + build wiring (WP-4..8)
- `183757c` — round-1 review-council fixes

## Backend (WP-1..3)
- `Endpoints/RecipesEndpoints.cs` — 20 routes under `/api/recipes`, M1 (`UserContextResolver`, every query household-scoped), multipart image upload, import dup-detect, connected-household 403 gating, non-empty 404 bodies.
- `Services/Dtos/RecipeDtos.cs` + `IRecipeProjectionService` (one projection — `ToListItem`/`ToFull`/`ToParsed`).
- Two latent Blazor bugs fixed: `UpdateRecipeAsync` dropped `RecipeType` (D12); `DraftService` threw on null-`RecipeId` new-recipe drafts.
- Contract tests + fixtures (`RecipeList/list.json`, `RecipeFull/recipe.json`) + 25 real-Postgres integration tests incl. cross-household M1 + connected 403.

## Frontend (WP-4..8)
One bundle, two host pages, view chosen by a `data-view` root attr (D1):
- **List** (`/recipes`): card grid, server search (debounced), client favorites filter, connected-household selector, lazy detail drawer + **live servings scaler**, URL-import dialog, delete confirm, 20s liveness.
- **Edit** (`/recipes/new`, `/recipes/edit/{id}`): full form, parse-on-blur ingredient entry, `svelte-dnd-action` reorder, bulk paste, image upload + household picker, autosave drafts (2s) + `beforeunload` nav-lock, Save/Cancel/Delete.
- `types.ts`/`api.ts` mirror the C# DTOs exactly (camelCase, 20 routes); `quantity.ts` ports the **two distinct** scaled-range vs exact-equality fraction formatters.
- **Loop-safety** (the #1 risk): both `ListApp` + `EditApp` wrap the one-time setup `$effect` in `untrack()`.

## Build wiring
`CopyRecipesIsland` MSBuild target · `recipes-node-build` Dockerfile stage + COPY · `docker-build.sh` entry · `RECIPES_USE_ISLAND` in `docker-compose.yml` (default off). `Dockerfile.runtime-only` untouched. **Prod**: flip the flag in the host `~/familyapp/.env.local` after verify (ships off).

## Review council (round 1, codex + gemini)
Fixed in `183757c`: list `load()` request-sequence guard (stale-response race); autosave flush-before-`deleteDraft` (a late draft PUT could resurrect a cleared draft); drawer ingredient sort moved to `$derived`. Deferred with reasons (parity / already-harvested quests / faithful ports / matches other islands): edit-page route-param reload, `recipeType`-on-draft, remove-and-re-add edit, exact-equality formatter, no frontend unit tests.

## Gates
- `dotnet build` clean · `dotnet test` **707/707** · `svelte-check` **0/0** · `vite build` clean
- **Loop-check: 0 background GETs/sec on both views** (the mandatory gate)
- Browser-verified on `:8080` (flag on): list/search/favorites/detail+scaler, edit load/parse-on-blur/autosave/save — no console errors

## Follow-up quests (harvested, not in this PR)
Recipe edit optimistic concurrency (xmin) · import scrape→preview · enhanced (no-reload) cross-view nav · inline ingredient edit · delete the Blazor recipe pages once prod-stable.

https://claude.ai/code/session_01BZrsjpKLrHVzNhQueskyiU
