### PR TITLE
feat(dashboard): strangle Home/dashboard into a Svelte island

### DIFF
--- a/.planning/home-dashboard-island-spec.md
+++ b/.planning/home-dashboard-island-spec.md
@@ -1,0 +1,282 @@
+# Spec — Home/dashboard → Svelte island (strangler)
+
+**Quest:** Spine `62fe9326-af6f-43c3-bc0c-ff3031b9d354` (campaign "Family Coordination App", horizon `next` → pull to `now` on build).
+**Decisions (this session, 2026-06-24):** spec-first **focused**; **parity-first** — migrate today's read-only dashboard as-is, no new UX. **One aggregate endpoint** (`GET /api/dashboard`), **Landing.razor stays Blazor**, **read-only island** (no writes). Rationale in §5.
+**Status:** spec (awaiting operator review gate).
+**Template:** mirrors the shipped **meal-plan island** (`frontend/meal-plan/`) + its focused spec (`.planning/meal-plan-island-spec.md`) — the closest precedent for a *light* island. Recipes (`frontend/recipes/`, `.planning/recipes-island-spec.md`) is the secondary reference for the freshest scaffold conventions.
+
+---
+
+## 1. Goal & scope
+
+Replace the Blazor `Components/Pages/Home.razor` circuit-bound dashboard (`@page "/dashboard"`, 402 lines) with a Svelte 5 island that talks to the server over plain HTTP/JSON — killing the tab-away / SignalR-circuit-drop failure mode (same motivation as shopping-list + chores + meal-plan + recipes). **Behavior parity** with today; **no new UX**.
+
+This is the **lightest island so far**: read-only, **no mutations**. The whole page is quick-action cards that *aggregate* other domains (chores / shopping / meals) plus navigation links. The endpoint surface is a **single read-aggregate** (`GET /api/dashboard` → one `DashboardDto`), not a multi-route CRUD surface.
+
+### In scope (parity)
+
+- **Welcome banner** — "Welcome back, {greetingName}! 👋" + "{householdName} • {today, 'dddd, MMMM d'}". `Home.razor:17-24`.
+- **Chores card** — heading + one-line status ("No chores yet" / "{N} need attention" / "All caught up"), and a body that is either the empty CTA, the "all caught up 🎉" line, or the stats rows (overdue / due-today / up-for-grabs with icons). Arrow → `/chores`; empty CTA → `/chores`. `Home.razor:27-103`.
+- **Shopping List card** — heading + "{N} items remaining" / "All done!"; body is either the empty CTA ("Generate from meal plan" → `/shopping-list`) or a progress bar + "{checked} of {total} items checked". Arrow → `/shopping-list`. `Home.razor:106-155`.
+- **Today's Meals card** — heading + "{today, 'MMM d'}"; body is either the empty CTA ("Plan something" → `/meal-plan`) or meal-type-grouped rows (icon + type label + each meal's display name). Arrow → `/meal-plan`. `Home.razor:158-206`.
+- **Quick Actions** — 5 outlined link buttons: New Recipe (`/recipes/new`), Browse Recipes (`/recipes`), This Week (`/meal-plan`), Chores (`/chores`), Invite Family (`/settings/users`). `Home.razor:209-263`.
+- **Cross-user freshness** — another member's chore/shopping/meal change appears within ~20s while visible + immediately on tab refocus (mirror meal-plan `liveness.ts`; **not** Blazor `DataNotifier`/`PollingService`). One `reconcile()` re-GETs `/api/dashboard`.
+- **Dark-mode bridge, MudBlazor token CSS, the `.NET 10` circuit-resume self-heal mount machinery** — copied verbatim from meal-plan, re-scoped.
+
+### Out of scope (this island)
+
+- **`Components/Pages/Landing.razor` (`@page "/"`, 91 lines) — stays Blazor** (D2). It's the unauth marketing entry + redirect-to-`/dashboard` for authed users; near-zero circuit-drop exposure and the auth-state redirect is awkward to host in an island.
+- **Any new UX.** All quick-actions remain plain navigations (today they're `Href` links). No new interactions.
+- **Any writes.** The dashboard mutates nothing today (D3) — so no autosave/draft/optimistic/flush-before-delete patterns. The only async-race guard that applies is `loadSeq` (§8).
+- The existing per-domain island endpoints (`/api/meal-plan`, `/api/chores`, `/api/shopping-list`) stay as-is — `/api/dashboard` reads through the **services**, it does not call those endpoints (D1).
+
+---
+
+## 2. Pattern being mirrored (the template)
+
+The **meal-plan island** is the freshest *light* end-to-end example (`frontend/meal-plan/`). Mirror it; do not invent. What dashboard **drops** vs meal-plan (it is even simpler):
+
+| Concern | meal-plan | dashboard |
+|---|---|---|
+| Endpoint routes | 6 (board + entries + recipes) | **1** (`GET /api/dashboard`) |
+| Writes / mutations | add + remove entries | **none** (read-only) |
+| Concurrency token | versionless | **N/A** (no writes) |
+| Week / date math | `dates.ts` week-stepping | **no week math** — one display-label formatter only (§6) |
+| `svelte-dnd-action` | none | none |
+| State surface | week board + picker | **one `DashboardDto`** + liveness |
+
+What dashboard **keeps identical** to meal-plan (copy verbatim, re-scope `mp-`→`db-`, `meal-plan`→`dashboard`, `MealPlanIsland`→`DashboardIsland`, `mp-dark-mode`→`db-dark-mode`, root id → `dashboard-root`):
+- `src/main.ts` — mount/destroy + the **circuit-resume self-heal** (`isHealthy`/`MutationObserver`/`pageshow`) + dark-class observer. Load-bearing reliability — do **not** reinvent.
+- `src/lib/liveness.ts` — 20s visible-only poll + `visibilitychange` immediate refetch.
+- `src/lib/toasts.svelte.ts` + `lib/components/Toasts.svelte` — toast store + region (used only for the calm reconcile-error toast).
+- `src/lib/api.ts` — `ApiError` + `request<T>` (`credentials:'include'`, any-4xx = client rejection).
+- `src/styles/{tokens,app}.css` — MudBlazor token bridge + dark-mode scoping.
+- The **`untrack()` one-time-load pattern** in `App.svelte` (§10) — **non-negotiable**.
+
+---
+
+## 3. Endpoint surface — `GET /api/dashboard`
+
+New file `Endpoints/DashboardEndpoints.cs`, group:
+```csharp
+app.MapGroup("/api/dashboard").RequireAuthorization().DisableAntiforgery()
+```
+(`.DisableAntiforgery()` kept for consistency with the other island groups even though there are no writes.) **One route**, `GET /`. The handler resolves the caller via `UserContextResolver.ResolveUserAsync(principal, dbFactory, ct)` → `(HouseholdId, UserId)` **server-side (M1, never client-supplied)**; computes `greetingName` from the principal's claims (§5 D5); then delegates to a new `IDashboardService.GetDashboardAsync(householdId, userId, greetingName, ct)` which returns the whole `DashboardDto`. Register with `app.MapDashboardEndpoints();` in `Program.cs` (after `MapRecipesEndpoints()`). All services it needs are already DI-registered.
+
+| # | Method & route | Body | Returns | Delegates to / notes |
+|---|---|---|---|---|
+| 1 | `GET /` | — | `DashboardDto` (200) | Own household only. Aggregates: household name + chore counts (`ChoreBoardService.GetBoardAsync` → `ChoreHomeStats.Compute`) + shopping summary (`ShoppingListService.GetActiveShoppingListsAsync` → checked/unchecked) + today's meals (focused EF query, today only). `greetingName` from claims chain. **Read-only** — never creates a meal plan/list/board row. `user is null` ⇒ 401. |
+
+> No 404 path exists (the aggregate always returns a well-formed DTO with zero counts / empty lists for an empty household), so the empty-body-4xx quirk (§11.1) doesn't bite here — but the rule still holds for any future endpoint added to this group.
+
+**Greeting helper** (private static in `DashboardEndpoints.cs`, mirrors `Home.razor:312-316`):
+```csharp
+private static string ResolveGreetingName(ClaimsPrincipal p) =>
+    p.FindFirst(ClaimTypes.GivenName)?.Value
+    ?? p.FindFirst(ClaimTypes.Name)?.Value?.Split(' ').FirstOrDefault()
+    ?? p.FindFirst(ClaimTypes.Email)?.Value?.Split('@').FirstOrDefault()
+    ?? "there";
+```
+The endpoint reads the principal (it has it) and passes the resolved string into the service, so the service stays claims-free and unit-testable with a literal name.
+
+---
+
+## 4. DTO contract (M9 lockstep)
+
+New file `Services/Dtos/DashboardDtos.cs` + a new **single-projection** service `IDashboardService` (mirrors `IMealPlanBoardService`'s one-projection rule). **`MealType` is a real enum *type* on the DTO** ⇒ camelCase (`breakfast`/`lunch`/`dinner`/`snack`) via the globally-registered `JsonStringEnumConverter(CamelCase)` (`Program.cs:125-127`). `DateOnly Today` serializes as `"YYYY-MM-DD"`. `int` counts serialize as JSON numbers.
+
+```csharp
+public sealed record DashboardDto(
+    string GreetingName,                          // claims chain (server) — never client-supplied
+    string HouseholdName,
+    DateOnly Today,                               // the SERVER "today" used for the meals query + the labels
+                                                  // (echoed so the card header matches the data; client formats it)
+    DashboardChoreSummaryDto Chores,
+    DashboardShoppingSummaryDto Shopping,
+    IReadOnlyList<DashboardMealDto> TodaysMeals); // ordered by MealType (parity: Home.razor OrderBy(MealType))
+
+// Mirrors ChoreHomeStats.Result field-for-field (the four Home counts). "needs attention" = Overdue + DueToday
+// is DISPLAY logic — computed client-side ($derived), NOT a wire field (keep the DTO = the raw reducer output).
+public sealed record DashboardChoreSummaryDto(
+    int ActiveTotal, int Overdue, int DueToday, int UpForGrabs);
+
+// Progress % = Total>0 ? Checked*100/Total : 0 is DISPLAY logic — client-side. Total echoed for the "X of Y" label.
+public sealed record DashboardShoppingSummaryDto(
+    int Remaining, int Checked, int Total);       // Total = Remaining + Checked (across ALL active lists)
+
+public sealed record DashboardMealDto(
+    MealType MealType,                            // real enum ⇒ camelCase
+    string DisplayName);                          // recipe name ?? customMealName ?? "Unnamed meal" (server applies)
+```
+
+**Why no nested full board/list DTOs** (D1): the dashboard needs *summary counts + today's meal names only*, not the chore board / shopping list / week board shapes. A lean purpose-built DTO keeps the payload tiny and the contract test trivial; reusing the heavy domain DTOs would couple the dashboard's contract to three other shipped contracts.
+
+**TS mirror** (`frontend/dashboard/src/lib/types.ts`) — camelCase keys, doc-commented:
+```ts
+export type MealType = 'breakfast' | 'lunch' | 'dinner' | 'snack';
+export interface DashboardChoreSummaryDto {
+  activeTotal: number; overdue: number; dueToday: number; upForGrabs: number }
+export interface DashboardShoppingSummaryDto {
+  remaining: number; checked: number; total: number }
+export interface DashboardMealDto { mealType: MealType; displayName: string }
+export interface DashboardDto {
+  greetingName: string; householdName: string;
+  today: string;                                  // "YYYY-MM-DD" — format at NOON-UTC, never new Date(it)
+  chores: DashboardChoreSummaryDto;
+  shopping: DashboardShoppingSummaryDto;
+  todaysMeals: DashboardMealDto[] }
+export interface ShellContext { householdId: number; userId: number; userName: string }
+```
+
+**Projection** lives in **one place** — `IDashboardService.GetDashboardAsync(householdId, userId, greetingName, ct)` assembles the whole `DashboardDto`:
+- **Household name** — `context.Users.Include(u => u.Household).FirstOrDefault(u => u.Id == userId)` → `Household?.Name ?? "Your Household"` (parity `Home.razor:329`). (One context; the chore/shopping/meal reads use their own services.)
+- **Chores** — `ChoreBoardService.GetBoardAsync(householdId, userId, ct)` → `ChoreHomeStats.Compute(board.Chores)` → map `Result`→`DashboardChoreSummaryDto`. `ChoreHomeStats` is `internal static` in `FamilyCoordinationApp.Services` — the same assembly — so the service calls it directly (no re-implementation; the snooze guard on up-for-grabs stays server-side + already unit-tested). *(Parity note: `GetBoardAsync` builds the full board incl. rooms/rollups just to count — exactly what Home.razor does today. A leaner count-only query is harvested as a provisional perf quest, §14.)*
+- **Shopping** — `ShoppingListService.GetActiveShoppingListsAsync(householdId, ct)` → flatten `.Items`; `Checked = count(IsChecked)`, `Remaining = count(!IsChecked)`, `Total = Checked + Remaining` (parity `Home.razor:357-369`, summing across **all** active lists).
+- **Today's meals** — `today = DateOnly.FromDateTime(DateTime.Today)`; `weekStart = MealPlanService.GetWeekStartDate(today)`; focused EF query for that week's plan with `Entries.Where(Date == today)` + `.ThenInclude(Recipe)`; order by `MealType`; project each to `DashboardMealDto(e.MealType, GetMealDisplayName(e))`. `GetMealDisplayName` = `Recipe?.Name` (non-blank) ?? `CustomMealName` (non-blank) ?? `"Unnamed meal"` (parity `Home.razor:394-400`). Echo `Today = today`.
+
+---
+
+## 5. Decisions
+
+**D1 — One aggregate `GET /api/dashboard`, NOT reuse of per-domain endpoints.** The dashboard reads chore counts + shopping summary + today's meals. The chore counts come from `ChoreHomeStats.Compute` — a server-side, unit-tested reducer whose up-for-grabs branch has a subtle `!IsSnoozed` guard (`ChoreHomeStats.cs:27`). Reusing the per-domain island endpoints would mean (a) **porting that reducer to TS** (the same parity-drift trap the recipes spec rejected for the NL ingredient parser — D2 there) and (b) **over-fetching** the full chore board + full meal-plan week for four counts + a handful of meal names. One aggregate keeps the reducer server-side, makes **one lean round-trip**, and yields one clean M9 contract. *Alt considered:* 3 client calls + client-side reduction — rejected on parity-drift + payload. *Tradeoff:* a new endpoint + service vs zero new backend — but the new surface is one route + one projection, smaller than reusing-and-reducing.
+
+**D2 — `Landing.razor` (`/`) stays Blazor (out of scope).** It's the unauthenticated marketing page that redirects authed users to `/dashboard` (`Landing.razor:84-89`). It has effectively no interactive circuit state to drop, and hosting the `AuthenticationStateProvider` redirect inside an island is awkward cross-framework coupling for no reliability gain. Leave it. *(If the shell-keystone quest later de-Blazors the layout, Landing can ride along then.)*
+
+**D3 — Read-only island: no writes ⇒ no autosave/optimistic/draft machinery.** Every interaction on Home.razor today is a navigation (`Href`), not a mutation. So the island has **no** POST/PUT/DELETE, no optimistic update, no draft autosave, no flush-in-flight-before-delete. The store is load + reconcile only. The single relevant async-race guard is `loadSeq` (§8) — a liveness/refocus refetch could land out of order against the initial load or another tick. Bake it in (cheap; the council flags it on every island even when marginal — memory `fca-island-async-race-guards`).
+
+**D4 — Dates: server is authoritative on "today"; client formats labels only (no week math).** The server picks `today = DateTime.Today` (household-server tz, parity), runs the today-meals query against it, and **echoes `today`** in the DTO. The island formats two display labels from that one ISO string — the welcome banner (`"dddd, MMMM d"`) and the meals-card header (`"MMM d"`) — using a **noon-UTC** parse (`Date.UTC(y, m-1, d, 12)`), **never `new Date('YYYY-MM-DD')`** (global CORRECTION / MN4: bare string parse is UTC-midnight → wrong day in US tz). There is **no** week-stepping (unlike meal-plan), so `dates.ts` is a tiny two-formatter file. *Tradeoff:* around local midnight the server-"today" and the browser's wall-clock day can differ by one; today's Blazor uses server `DateTime.Today`, so echoing it is exact parity (and the card's data + header stay consistent because both derive from the one echoed date).
+
+**D5 — Greeting resolved server-side from claims (parity chain).** `greetingName` = `GivenName` ?? first word of `Name` ?? email local-part ?? `"there"` (`Home.razor:312-316`). Resolved in the endpoint (it holds the `ClaimsPrincipal`) and passed into the service, so the service is claims-free + unit-testable. *Alt:* pass it as a host data-attr like `userName` — rejected: the host already only carries `userName` (full name); the fallback chain belongs server-side once, in the endpoint, not duplicated in Razor.
+
+**D6 — Reuse `ChoreHomeStats` + the existing services verbatim; add no new query logic.** The aggregate service is pure composition over `IChoreBoardService` / `IShoppingListService` / `IMealPlanService` + a focused today-meals query that mirrors `Home.razor:338-355`. No new business logic, no recomputation — minimizes parity risk and rides the existing tests for those services.
+
+---
+
+## 6. Island structure — `frontend/dashboard/`
+
+Copy the meal-plan scaffold; re-scope; **drop** `dates.ts` week math (replace with the tiny label formatter), drop the picker/board state. Renames: root id `dashboard-root`, global `window.DashboardIsland`, dark class `db-dark-mode`, CSS prefix `db-`, store `dashboardStore`.
+
+- **Build config:** `package.json` (name `dashboard-island`; deps: svelte + vite toolchain only — no `svelte-dnd-action`), `tsconfig.json`, `svelte.config.js`, `vite.config.ts` (port **5177** — meal-plan=5175, recipes=5176; `outDir:dist`, `input:src/main.ts`, `entryFileNames:index.js`, css→`index.css`, `/api` proxy→`:5000`), `index.html` (dev auto-mount).
+- **`src/main.ts`** — copy meal-plan verbatim; rename (root `dashboard-root`, global `DashboardIsland`, `db-dark-mode`). Keep the self-heal + dark observer **unchanged** (single root — no `data-view` branch needed, unlike recipes).
+- **`src/lib/types.ts`** — §4.
+- **`src/lib/api.ts`** — copy meal-plan's `request<T>`/`ApiError`; `BASE='/api/dashboard'`; **one** function `getDashboard(): Promise<DashboardDto>` (`GET /`). Any 4xx ⇒ `ApiError` → reconcile keeps the last good data + calm toast.
+- **`src/lib/liveness.ts`** — copy verbatim (20s visible-only poll + `visibilitychange` immediate refetch).
+- **`src/lib/toasts.svelte.ts` + `components/Toasts.svelte`** — copy + re-scope `db-`.
+- **`src/lib/dates.ts`** — NEW (tiny): `formatLongDate(iso)` → `"dddd, MMMM d"` and `formatShortDate(iso)` → `"MMM d"`, both via `Date.UTC(y, m-1, d, 12)` then `toLocaleDateString`/manual month arrays (no `new Date('YYYY-MM-DD')`). No week math.
+- **`src/lib/dashboardStore.svelte.ts`** — `DashboardStore` (class-instance export — Svelte-5 rune rule: export the instance, never a reassigned `$state`):
+  - `data = $state<DashboardDto|null>(null)`, `loading = $state(true)`, `error = $state<string|null>(null)`, `currentUserId`, **private `loadSeq = 0`**.
+  - `choreAttention = $derived(data ? data.chores.overdue + data.chores.dueToday : 0)`; `shoppingProgress = $derived(...)` (Total>0 ? checked/total*100 : 0); `mealsByType = $derived(...)` (group `todaysMeals` by `mealType` preserving order — parity `GroupBy(MealType).OrderBy(Key)`).
+  - `init(ctx)` (set `currentUserId`), `setRefresh(fn)`, `load()` — `const seq = ++this.loadSeq; try { const d = await getDashboard(); if (seq === this.loadSeq) this.data = d; } catch { if (seq === this.loadSeq) … keep last good + set error } finally { if (seq === this.loadSeq) this.loading = false }`. `reconcile()` = `load()` (liveness + error path; the `loadSeq` guard makes a stale tick a no-op — memory `fca-island-async-race-guards`).
+- **`src/App.svelte`** — read `ShellContext` from `dashboard-root` data-attrs; the **`untrack()` one-time load** (§10); render the welcome banner, the three cards (`ChoreCard`, `ShoppingCard`, `MealsCard`), `QuickActions`, `Toasts`; wire `liveness` → `reconcile`. While `loading && !data`, render a lightweight skeleton/spinner (parity: today the page renders after `OnInitializedAsync`).
+- **`src/lib/components/`** (re-scope `db-`, Svelte-5 `$props`/`$derived`; plain HTML + token CSS mirroring the Mud cards):
+  - `ChoreCard.svelte` — header (icon avatar, "Chores", status line via `choreAttention`/`activeTotal`), arrow→`/chores`; body branches: empty (CTA→`/chores`) / all-caught-up (🎉) / stats rows (overdue/due-today/up-for-grabs with the three icons). Mirror `Home.razor:27-103`.
+  - `ShoppingCard.svelte` — header + "{remaining} items remaining"/"All done!", arrow→`/shopping-list`; body: empty (CTA→`/shopping-list`) / progress bar + "{checked} of {total} items checked". Mirror `Home.razor:106-155`.
+  - `MealsCard.svelte` — header + short-date, arrow→`/meal-plan`; body: empty (CTA→`/meal-plan`) / `mealsByType` groups (type icon + label + each `displayName`). Meal-type icon map ports `GetMealTypeIcon` (`Home.razor:385-392`). Mirror `Home.razor:158-206`.
+  - `QuickActions.svelte` — 5 anchor "buttons" (New Recipe / Browse Recipes / This Week / Chores / Invite Family) → plain `<a href>` full navigations. Mirror `Home.razor:209-263`.
+  - `Toasts.svelte` — copy meal-plan's.
+- **`src/styles/{tokens,app}.css`** — copy meal-plan; re-scope `db-`/`#dashboard-root` + `db-dark-mode`. Port the small inline `<style>` from `Home.razor:267-292` (`.welcome-section`, `.dashboard-card`, `.meal-group`, `.quick-action-btn`) into `app.css` with the `db-` scope. **No `dates.ts` week CSS.**
+
+---
+
+## 7. Host page + build wiring
+
+- **`Components/Pages/Home.razor`** — convert to a thin island host, mirror `MealPlan.razor` exactly. Flag **`DASHBOARD_USE_ISLAND`** (same `IsIslandEnabled()` config-or-env helper, `MealPlan.razor:98-108`). **ON →** `<div id="dashboard-root" data-household-id data-user-id data-user-name>`, `<HeadContent>` `index.css?v=`, `OnAfterRenderAsync` `ensureIslandStylesheet` + `import('/islands/dashboard/index.js?v=')` + `DashboardIsland.mount("dashboard-root")`, `IslandVersion` cache-bust, `IAsyncDisposable` + `JSDisconnectedException` teardown calling `DashboardIsland.destroy`. **OFF →** `<HomeBlazor />`.
+- **`Components/Pages/HomeBlazor.razor`** — NEW: the current `Home.razor` body extracted **verbatim** (the `@inject`s for `IMealPlanService`/`IShoppingListService`/`IChoreBoardService`/`IDbContextFactory`/`IHttpContextAccessor`, the cards, the `@code` block incl. `ChoreHomeStats` usage and the inline `<style>`). Zero-regression fallback — flip the flag to switch; delete in a later cleanup (§14). *(Note: `HomeBlazor` is NOT routable — no `@page` — it's a child component of the host. Move `@attribute [Authorize]` to the host `Home.razor`.)*
+- **`CopyDashboardIsland`** MSBuild target in `FamilyCoordinationApp.csproj` — copy of `CopyMealPlanIsland`/`CopyRecipesIsland`: `frontend/dashboard/dist/**` → `wwwroot/islands/dashboard/`, `BeforeTargets="AssignTargetPaths"`, `Condition="Exists('…/frontend/dashboard/dist')"`, `SkipUnchangedFiles`.
+- **Dockerfile** — edit the **multi-stage `Dockerfile`** (prod deploy + CI): add a `dashboard-node-build` stage (copy of `recipes-node-build`/`mealplan-node-build`): `node:20-alpine`, `npm ci`/`npm install`, `npm run build` in `frontend/dashboard/`; then `COPY --from=dashboard-node-build /frontend/dist/ ./FamilyCoordinationApp/wwwroot/islands/dashboard/` in the .NET build stage. **Do NOT touch `Dockerfile.runtime-only`** (the local `docker-build.sh` path relies on `build_island` + the `CopyDashboardIsland` MSBuild target during `dotnet publish`).
+- **`docker-build.sh`** — add `build_island "./frontend/dashboard" "dashboard"` (after the recipes line).
+- **`Program.cs`** — `app.MapDashboardEndpoints();` (after `MapRecipesEndpoints()`); register `IDashboardService` (scoped). Already registered: `IChoreBoardService`, `IShoppingListService`, `IMealPlanService`, `JsonStringEnumConverter(CamelCase)` (`:125-127`).
+- **Feature flag** — add `DASHBOARD_USE_ISLAND` to `docker-compose.yml` `app.environment` (`${DASHBOARD_USE_ISLAND:-false}`, next to the other island flags) and the repo's **`.env`** (local dev = `true`; match the other island flags — none are in `.env.example`). **Prod** flips it in the host's `~/familyapp/.env.local` after verify (deploy regenerates `.env` from it; `.claude/rules/deployment.md`) — ship **OFF** first, flip after verify.
+- **`ensureIslandStylesheet` / `import` glue** — reuse the existing `window.ensureIslandStylesheet` in `Components/App.razor`; do not duplicate.
+
+---
+
+## 8. Concurrency / liveness
+
+**No writes ⇒ no concurrency token, no conflict story.** The only ordering concern is overlapping reads: the initial load, a 20s liveness tick, and a `visibilitychange` refocus refetch can race. The **`loadSeq` monotonic guard** (§6 store) ensures only the newest response is applied — a slow earlier response that resolves after a newer one is dropped (memory `fca-island-async-race-guards`: "search/liveness/switch can apply a stale older response"). On a failed reconcile the store **keeps the last good `data`** and shows a calm toast (no blank-out). This matches today's Blazor (the page re-renders on `PollingService`/`DataNotifier` ticks; here liveness re-GETs the aggregate).
+
+---
+
+## 9. Contract & integration tests (M9)
+
+- **`DashboardDtoContractTests`** (mirror `MealPlanBoardDtoContractTests`): build a representative `DashboardDto` — non-empty `greetingName`/`householdName`, a fixed `today`, chore counts with all four non-zero, a shopping summary mid-progress (checked + remaining), and `todaysMeals` spanning ≥2 meal types incl. a custom-meal name and an "Unnamed meal" — serialize with the **same global options** (`JsonSerializerDefaults.Web` + `JsonStringEnumConverter(CamelCase)`, `WriteIndented`); assert byte-equality against checked-in `Fixtures/Dashboard/dashboard.json`. The island `types.ts` mirrors the fixture → any shape/casing drift (esp. `mealType` camelCase + `today` as `"YYYY-MM-DD"`) breaks the test.
+- **Greeting helper unit test** — `ResolveGreetingName` over: GivenName present; GivenName absent → first word of Name; Name absent → email local-part; all absent → `"there"`.
+- **Endpoint integration (real Postgres, mirror chores/meal-plan endpoint tests):**
+  - **Populated household** → chore counts equal `ChoreHomeStats.Compute(board.Chores)` (seed an overdue, a due-today, an unassigned/up-for-grabs incl. **a snoozed unclaimed chore that must NOT count as up-for-grabs**); shopping counts sum across **two** active lists; `todaysMeals` includes today's entries **but excludes tomorrow's** (date-filter guard) and reflects recipe-name vs custom-name vs unnamed.
+  - **Empty household** → zero counts, `total:0`, `todaysMeals:[]`, `householdName` still set, well-formed 200 (no 404, no created rows).
+  - **Read-only guarantee** → after the GET, assert no `MealPlan`/`ShoppingList`/`ChoreBoard` rows were created for a household that had none.
+  - **Cross-household isolation (M1)** → a user in household A's `/api/dashboard` reflects **only** A's chores/shopping/meals, never B's (counts + meal names differ); the resolved household comes from the cookie, not any client input.
+
+---
+
+## 10. Loop safety (⚠ the #1 regression risk — bake in from day one)
+
+Memory `svelte5-setup-effect-async-loader-loop`: a one-time setup `$effect` that synchronously reads `$state`/`$derived` it (transitively) writes subscribes to that state → infinite fetch→write→re-run loop (~30–46 req/s). It broke meal-plan visibly and chores silently (PR #52). `App.svelte`'s setup effect calls `store.load()` whose sync prefix reads/writes store state.
+
+**Fix preemptively** — copy the meal-plan `App.svelte` pattern verbatim: wrap the **entire** setup-effect body in `untrack(() => { … })` so it has zero reactive deps and runs exactly once; liveness + refocus drive later refreshes:
+```svelte
+import { untrack } from 'svelte';
+$effect(() => {
+  untrack(() => {
+    store.init(ctx);
+    store.setRefresh(load);
+    load();                                         // reads then writes store state — MUST be inside untrack
+    liveness = startLiveness(() => store.reconcile());
+  });
+  return () => { liveness?.stop(); };
+});
+```
+
+**MANDATORY GATE (WP-Verify):** open `/dashboard` on `:8080`, install a `fetch` counter in the console, confirm `/api/dashboard` does **~0 background GETs over several seconds** (initial load + one tick per 20s liveness) — **NOT tens/sec.** Re-check on prod after flipping the flag.
+
+---
+
+## 11. Gotchas to carry (from shopping-list + chores + meal-plan + recipes)
+
+1. **Empty-body 4xx quirk** — `UseStatusCodePagesWithReExecute` re-executes empty-body 4xx through the GET-only Blazor `/not-found` page (memory `fca-empty-404-surfaces-as-405-on-delete`). This endpoint has no 4xx path (always 200 or 401), so it doesn't bite — but if a future route here can 404, return a **non-empty body** (`Results.NotFound(new { message })`).
+2. **Casing** — `MealType` is a real enum on the DTO ⇒ **camelCase** (`"breakfast"`…); `DateOnly Today` ⇒ `"YYYY-MM-DD"`. Document at the top of `types.ts`.
+3. **Dates (MN4 / global CORRECTION)** — never `new Date('YYYY-MM-DD')`. Format the echoed `today` for **display only** via `Date.UTC(...,12)`; the server is authoritative on which day is "today".
+4. **Multi-tenant (M1)** — household/user always server-resolved via `UserContextResolver`; every read filters `HouseholdId`; cross-household integration test mandatory.
+5. **Island resilience** — reuse `main.ts`'s mount/heal/dark-mode self-heal verbatim (the `.NET 10` circuit-resume root-replacement fix). Load-bearing; don't reinvent.
+6. **DbContextFactory** — services inject `IDbContextFactory<ApplicationDbContext>`, short-lived contexts (already true of every service the aggregate touches).
+7. **`ChoreHomeStats` is `internal`** — same assembly, so `DashboardService` calls `ChoreHomeStats.Compute` directly; do **not** copy its logic. If a future test project needs it, it's already reachable via `InternalsVisibleTo` (the existing `ChoreHomeStats` tests prove this).
+8. **`HomeBlazor` is not routable** — the `@page "/dashboard"` + `@attribute [Authorize]` live on the host `Home.razor`; the extracted fallback is a plain child component (no `@page`). Keep its `@inject`s intact (zero-regression).
+
+---
+
+## 12. Build sequence (work packages)
+
+- **WP-1 — Backend.** `Services/Dtos/DashboardDtos.cs` (§4), `IDashboardService`+impl (`GetDashboardAsync` — household name + `ChoreHomeStats` + shopping summary + focused today-meals query, §4 projection), `Endpoints/DashboardEndpoints.cs` (1 route + greeting helper), `Program.cs` wiring (`MapDashboardEndpoints`, register `IDashboardService`). Builds clean.
+- **WP-2 — Backend tests.** `DashboardDtoContractTests` + `Fixtures/Dashboard/dashboard.json`; `ResolveGreetingName` unit test; endpoint integration (real PG) incl. snooze-guard chore counts, multi-list shopping sum, today-only meal filter, empty household, **read-only guarantee**, cross-household M1 (§9).
+- **WP-3 — Island scaffold.** `frontend/dashboard/` config, `types.ts`, `api.ts` (1 fn), `main.ts` (single-root + self-heal), `liveness.ts`/`toasts*`/`styles` (copied + re-scoped from meal-plan), **`dates.ts` (tiny label formatters, §6)**, `App.svelte` skeleton. `svelte-check` 0/0, `vite build` green.
+- **WP-4 — Island UI.** `DashboardStore` (loadSeq guard), `App` (the **`untrack` load**), `ChoreCard`/`ShoppingCard`/`MealsCard`/`QuickActions`/`Toasts`, welcome banner, liveness. `svelte-check` 0/0, `vite build`.
+- **WP-5 — Host + build wiring.** `Home.razor` → thin host (flag + mount), `HomeBlazor.razor` (verbatim fallback extract), `CopyDashboardIsland`, Dockerfile `dashboard-node-build` stage + COPY, `docker-build.sh` entry, `DASHBOARD_USE_ISLAND` in compose + `.env`.
+- **WP-6 — Verify.** Browser-verify on `:8080` (rebuild `familyapp:latest`, swap app container, DOM+psql — Chrome screenshots flake; memory `fca-local-browser-verify-recipe`); flip `DASHBOARD_USE_ISLAND=true`; exercise the three cards (populated + empty), the welcome banner date, quick-action navigations, and cross-user freshness (mutate a chore/shopping/meal as another member → appears ≤20s); **the LOOP-CHECK gate** (§10).
+
+---
+
+## 13. Gates (chores/meal-plan/recipes precedent; worktree baseline = memory `fca-worktree-gate-baseline`)
+
+- `dotnet build` clean.
+- `dotnet test` full suite green incl. new contract + integration tests. *Worktree baseline:* 2 `ApiKeySecurityTests` fail (`.git` is a file) + 49 pre-existing `dotnet format` whitespace errors on master — "green" = **no NEW failures**.
+- `svelte-check` 0 errors / 0 warnings in `frontend/dashboard/`.
+- `vite build` → `dist/index.js` + `dist/index.css`.
+- Real-Postgres integration for the new endpoint passes (incl. cross-household M1 + read-only guarantee).
+- **Loop-check** (§10): ~0 background GETs/sec.
+- Browser-verify on `:8080` (flag ON) confirms parity.
+
+---
+
+## 14. Provisional quests to harvest (don't build now — author in the Spine)
+
+- **Delete the Home Blazor fallback (`HomeBlazor.razor`).** Cleanup once the island is prod-stable (mirrors the meal-plan/recipes fallback-removal follow-ups).
+- **Leaner chore-count query for the dashboard.** `GetBoardAsync` builds the full board (rooms/rollups/equity) just to count overdue/due-today/up-for-grabs; a dedicated count query (or a `GetChoreHomeStatsAsync`) would cut the dashboard's heaviest read. Perf-only; parity unaffected.
+- **Fold `Landing.razor` into the strangler.** Migrate the `/` marketing/redirect page when the shell keystone de-Blazors the layout (D2).
+
+---
+
+## 15. Open items (non-blocking — resolve in-build)
+
+- **Exact Dockerfile stage placement / COPY line** — confirm against the real Dockerfile at WP-5 (mirror the `recipes-node-build` stage just added in #53).
+- **`HomeBlazor` extraction** — confirm the `@inject`s + `ChoreHomeStats` usage + inline `<style>` move cleanly and the host's `[Authorize]`/`@page` placement compiles (WP-5).
+- **Skeleton/empty-state feel** — confirm the loading skeleton + empty-card CTAs read well on `:8080` (WP-6); they're parity but the island's first paint differs slightly from Blazor's server-prerender.

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,15 @@ RUN if [ -f package-lock.json ]; then npm ci; else npm install --no-audit --no-f
 COPY frontend/recipes/ ./
 RUN npm run build
 
+# Stage 1e: Build the Svelte dashboard island (strangler; parallel to the others).
+# Emits ./dist/ which the .NET stage copies into wwwroot/islands/dashboard/.
+FROM node:20-alpine AS dashboard-node-build
+WORKDIR /frontend
+COPY frontend/dashboard/package.json frontend/dashboard/package-lock.json* ./
+RUN if [ -f package-lock.json ]; then npm ci; else npm install --no-audit --no-fund; fi
+COPY frontend/dashboard/ ./
+RUN npm run build
+
 # Stage 2: Build the .NET app.
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
@@ -49,6 +58,7 @@ COPY --from=node-build /frontend/dist/ ./FamilyCoordinationApp/wwwroot/islands/s
 COPY --from=chores-node-build /frontend/dist/ ./FamilyCoordinationApp/wwwroot/islands/chores/
 COPY --from=mealplan-node-build /frontend/dist/ ./FamilyCoordinationApp/wwwroot/islands/meal-plan/
 COPY --from=recipes-node-build /frontend/dist/ ./FamilyCoordinationApp/wwwroot/islands/recipes/
+COPY --from=dashboard-node-build /frontend/dist/ ./FamilyCoordinationApp/wwwroot/islands/dashboard/
 
 # Explicitly set working directory to project folder before publish
 WORKDIR /src/FamilyCoordinationApp

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -62,6 +62,7 @@ build_island "./frontend/shopping-list" "shopping-list"
 build_island "./frontend/chores" "chores"
 build_island "./frontend/meal-plan" "meal-plan"
 build_island "./frontend/recipes" "recipes"
+build_island "./frontend/dashboard" "dashboard"
 echo ""
 
 # Step 3: Publish locally

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
       CHORES_USE_ISLAND: ${CHORES_USE_ISLAND:-false}
       MEAL_PLAN_USE_ISLAND: ${MEAL_PLAN_USE_ISLAND:-false}
       RECIPES_USE_ISLAND: ${RECIPES_USE_ISLAND:-false}
+      DASHBOARD_USE_ISLAND: ${DASHBOARD_USE_ISLAND:-false}
       # Chores v1.1 digest. The token gates POST /api/chores/digest/run (cron trigger); unset ⇒ endpoint
       # returns 503 (feature off). MUST be mapped here — .env is only used for ${VAR} substitution, not
       # auto-injected, so the documented go-live step (set CHORES_DIGEST_TRIGGER_TOKEN) is inert without this.

--- a/frontend/dashboard/.gitignore
+++ b/frontend/dashboard/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.log
+.DS_Store

--- a/frontend/dashboard/index.html
+++ b/frontend/dashboard/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dashboard (dev)</title>
+  </head>
+  <body>
+    <!-- Dev-only host. In production the Razor shell (Home.razor) provides these attrs. -->
+    <div
+      id="dashboard-root"
+      data-household-id="1"
+      data-user-id="1"
+      data-user-name="Dev User"
+    ></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/frontend/dashboard/package-lock.json
+++ b/frontend/dashboard/package-lock.json
@@ -1,0 +1,1541 @@
+{
+  "name": "dashboard-island",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dashboard-island",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@sveltejs/vite-plugin-svelte": "^5.0.3",
+        "@tsconfig/svelte": "^5.0.4",
+        "svelte": "^5.19.0",
+        "svelte-check": "^4.1.4",
+        "tslib": "^2.8.1",
+        "typescript": "~5.7.2",
+        "vite": "^6.0.7"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sveltejs/acorn-typescript": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.10.tgz",
+      "integrity": "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8.9.0"
+      }
+    },
+    "node_modules/@sveltejs/load-config": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@sveltejs/load-config/-/load-config-0.2.0.tgz",
+      "integrity": "sha512-1LgZ/qUqSoq+QorD83lk2hka79Px0wXNW2q5V1nZlxGhQgw1jrsIbVz5YiCeucVLo4XvFLjXukUaQjIiqowkcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-5.1.1.tgz",
+      "integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
+        "debug": "^4.4.1",
+        "deepmerge": "^4.3.1",
+        "kleur": "^4.1.5",
+        "magic-string": "^0.30.17",
+        "vitefu": "^1.0.6"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22"
+      },
+      "peerDependencies": {
+        "svelte": "^5.0.0",
+        "vite": "^6.0.0"
+      }
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte-inspector": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-4.0.1.tgz",
+      "integrity": "sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.7"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22"
+      },
+      "peerDependencies": {
+        "@sveltejs/vite-plugin-svelte": "^5.0.0",
+        "svelte": "^5.0.0",
+        "vite": "^6.0.0"
+      }
+    },
+    "node_modules/@tsconfig/svelte": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-5.0.8.tgz",
+      "integrity": "sha512-UkNnw1/oFEfecR8ypyHIQuWYdkPvHiwcQ78sh+ymIiYoF+uc5H1UBetbjyqT+vgGJ3qQN6nhucJviX6HesWtKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
+      "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/devalue": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esrap": {
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.12.tgz",
+      "integrity": "sha512-On0QbLyaiAkVC4eXtgnXK9Kh2opit+3rcUSOc45DqJ2s/X2eXAHsGOKRSJ6IDagQEW5vPyivANfXUiqgXC67Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/types": "^8.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/is-reference": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.6"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/locate-character": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/svelte": {
+      "version": "5.56.4",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.4.tgz",
+      "integrity": "sha512-/d0QHehmRuJW8gVz395MTkPcPozxzdjBMBE8oEYGz8O3b9KTMzzQ9ZHJQLuFKOHOPQbU6kx/X4iid/EBBzH7iw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.4",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@sveltejs/acorn-typescript": "^1.0.10",
+        "@types/estree": "^1.0.5",
+        "@types/trusted-types": "^2.0.7",
+        "acorn": "^8.12.1",
+        "aria-query": "5.3.1",
+        "axobject-query": "^4.1.0",
+        "clsx": "^2.1.1",
+        "devalue": "^5.8.1",
+        "esm-env": "^1.2.1",
+        "esrap": "^2.2.12",
+        "is-reference": "^3.0.3",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.11",
+        "zimmerframe": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/svelte-check": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.7.1.tgz",
+      "integrity": "sha512-FGUOmAqxXdN/H9Zm8slrqO7SLtFisXRB7rfOsHNJ3MLTD2po/+Stg8XyErkpumPHbuUiYTcqrEIzxpVWKTLqtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "@sveltejs/load-config": "^0.2.0",
+        "chokidar": "^4.0.1",
+        "fdir": "^6.2.0",
+        "picocolors": "^1.0.0",
+        "sade": "^1.7.4"
+      },
+      "bin": {
+        "svelte-check": "bin/svelte-check"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "svelte": "^4.0.0 || ^5.0.0-next.0",
+        "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitefu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+      "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "tests/deps/*",
+        "tests/projects/*",
+        "tests/projects/workspace/packages/*"
+      ],
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zimmerframe": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
+      "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/frontend/dashboard/package.json
+++ b/frontend/dashboard/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "dashboard-island",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "check": "svelte-check --tsconfig ./tsconfig.json"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^5.0.3",
+    "@tsconfig/svelte": "^5.0.4",
+    "svelte": "^5.19.0",
+    "svelte-check": "^4.1.4",
+    "tslib": "^2.8.1",
+    "typescript": "~5.7.2",
+    "vite": "^6.0.7"
+  }
+}

--- a/frontend/dashboard/src/App.svelte
+++ b/frontend/dashboard/src/App.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+  // Root of the dashboard island. Reads the ShellContext from #dashboard-root
+  // data-attrs (passed by main.ts), loads the read-only aggregate once, and
+  // refreshes via liveness (20s visible + refocus). No writes — the only state
+  // the island mutates is its own loaded `data`.
+  import { untrack } from 'svelte';
+  import type { ShellContext } from './lib/types';
+  import { dashboardStore as store } from './lib/dashboardStore.svelte';
+  import { startLiveness, type LivenessHandle } from './lib/liveness';
+  import { showToast } from './lib/toasts.svelte';
+  import { formatLongDate, formatShortDate } from './lib/dates';
+  import ChoreCard from './lib/components/ChoreCard.svelte';
+  import ShoppingCard from './lib/components/ShoppingCard.svelte';
+  import MealsCard from './lib/components/MealsCard.svelte';
+  import QuickActions from './lib/components/QuickActions.svelte';
+  import Toasts from './lib/components/Toasts.svelte';
+
+  let { ctx }: { ctx: ShellContext } = $props();
+
+  let liveness: LivenessHandle | null = null;
+
+  async function load(): Promise<void> {
+    await store.load();
+  }
+
+  // Background refresh: keep the last good data and surface a calm toast on failure.
+  async function reconcile(): Promise<void> {
+    const hadData = store.data !== null;
+    await store.load();
+    if (store.error && hadData) {
+      showToast({ message: 'Could not refresh — showing the last update.', kind: 'error' });
+    }
+  }
+
+  // ⚠ Loop safety (memory svelte5-setup-effect-async-loader-loop): the one-time
+  // setup effect calls load(), whose sync prefix reads THEN writes store state.
+  // Wrapping the whole body in untrack() gives the effect zero reactive deps so
+  // it runs exactly once; liveness + refocus drive every later refresh.
+  $effect(() => {
+    untrack(() => {
+      store.init(ctx);
+      void load();
+      liveness = startLiveness(() => void reconcile());
+    });
+    return () => {
+      liveness?.stop();
+      liveness = null;
+    };
+  });
+</script>
+
+<div class="db-container">
+  {#if store.loading && !store.data}
+    <div class="db-loading">Loading your dashboard…</div>
+  {:else if store.error && !store.data}
+    <div class="db-inline-error" role="alert">
+      <span>Couldn't load the dashboard.</span>
+      <button type="button" class="db-retry" onclick={() => void load()}>Retry</button>
+    </div>
+  {:else if store.data}
+    <div class="db-welcome">
+      <h1 class="db-welcome-title">Welcome back, {store.data.greetingName}! 👋</h1>
+      <p class="db-welcome-sub">{store.data.householdName} • {formatLongDate(store.data.today)}</p>
+    </div>
+
+    <div class="db-grid">
+      <ChoreCard chores={store.data.chores} attention={store.choreAttention} />
+      <ShoppingCard shopping={store.data.shopping} progress={store.shoppingProgress} />
+      <MealsCard groups={store.mealsByType} dateLabel={formatShortDate(store.data.today)} />
+    </div>
+
+    <QuickActions />
+  {/if}
+</div>
+
+<Toasts />

--- a/frontend/dashboard/src/lib/api.ts
+++ b/frontend/dashboard/src/lib/api.ts
@@ -1,0 +1,43 @@
+import type { DashboardDto } from './types';
+
+const BASE = '/api/dashboard';
+
+/**
+ * Thrown on any non-2xx response. The dashboard is READ-ONLY (one GET), so any
+ * 4xx is simply a non-retryable rejection — the store keeps its last good data
+ * and surfaces a calm toast. (Carried from the other islands: the app can
+ * re-execute empty-body 404s as empty 400s — `isClientRejection` covers any 4xx.)
+ */
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+
+  get isClientRejection(): boolean {
+    return this.status >= 400 && this.status < 500;
+  }
+}
+
+async function request<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    // Same-origin cookie auth — the host page is already authenticated.
+    credentials: 'include',
+    headers: { Accept: 'application/json', ...(init?.headers ?? {}) },
+    ...init,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new ApiError(res.status, text || res.statusText);
+  }
+  if (res.status === 204) return undefined as T;
+  return (await res.json()) as T;
+}
+
+/** The whole dashboard aggregate (greeting + household + chores + shopping + today's meals). */
+export async function getDashboard(): Promise<DashboardDto> {
+  return request<DashboardDto>(BASE);
+}

--- a/frontend/dashboard/src/lib/components/ChoreCard.svelte
+++ b/frontend/dashboard/src/lib/components/ChoreCard.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  // Chores summary card — parity with Home.razor lines 27-103. Read-only; the
+  // arrow + empty CTA both navigate to /chores (full-document anchor nav).
+  import type { DashboardChoreSummaryDto } from '../types';
+
+  let { chores, attention }: { chores: DashboardChoreSummaryDto; attention: number } = $props();
+</script>
+
+<div class="db-card">
+  <div class="db-card-header">
+    <div class="db-card-avatar" aria-hidden="true">🧹</div>
+    <div class="db-card-headings">
+      <h2 class="db-card-title">Chores</h2>
+      <p class="db-card-status">
+        {#if chores.activeTotal === 0}
+          No chores yet
+        {:else if attention > 0}
+          {attention} need attention
+        {:else}
+          All caught up
+        {/if}
+      </p>
+    </div>
+    <a class="db-card-arrow" href="/chores" aria-label="Go to chores">→</a>
+  </div>
+
+  <div class="db-card-body">
+    {#if chores.activeTotal === 0}
+      <p class="db-empty">No chores set up yet</p>
+      <div class="db-empty-action">
+        <a class="db-link" href="/chores">Set up the chore board</a>
+      </div>
+    {:else if attention === 0 && chores.upForGrabs === 0}
+      <p class="db-empty">All caught up — nothing needs attention 🎉</p>
+    {:else}
+      <div>
+        {#if chores.overdue > 0}
+          <div class="db-stat-row">
+            <span class="db-stat-icon db-stat-overdue" aria-hidden="true">⚠️</span>
+            <span><b>{chores.overdue}</b> overdue</span>
+          </div>
+        {/if}
+        {#if chores.dueToday > 0}
+          <div class="db-stat-row">
+            <span class="db-stat-icon db-stat-due" aria-hidden="true">📅</span>
+            <span><b>{chores.dueToday}</b> due today</span>
+          </div>
+        {/if}
+        {#if chores.upForGrabs > 0}
+          <div class="db-stat-row">
+            <span class="db-stat-icon" aria-hidden="true">✋</span>
+            <span><b>{chores.upForGrabs}</b> up for grabs</span>
+          </div>
+        {/if}
+      </div>
+    {/if}
+  </div>
+</div>

--- a/frontend/dashboard/src/lib/components/MealsCard.svelte
+++ b/frontend/dashboard/src/lib/components/MealsCard.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  // Today's meals card — parity with Home.razor lines 158-206. Meals are
+  // pre-grouped by meal type (server-ordered); each group shows its meals.
+  import type { MealType } from '../types';
+  import type { MealGroup } from '../dashboardStore.svelte';
+
+  let { groups, dateLabel }: { groups: MealGroup[]; dateLabel: string } = $props();
+
+  // Parity with Home.razor GetMealTypeIcon (Material icons → emoji equivalents).
+  const MEAL_ICONS: Record<MealType, string> = {
+    breakfast: '🍳',
+    lunch: '🥪',
+    dinner: '🍽️',
+    snack: '🍦',
+  };
+
+  const label = (t: MealType) => t.charAt(0).toUpperCase() + t.slice(1);
+</script>
+
+<div class="db-card">
+  <div class="db-card-header">
+    <div class="db-card-avatar" aria-hidden="true">📅</div>
+    <div class="db-card-headings">
+      <h2 class="db-card-title">Today's Meals</h2>
+      <p class="db-card-status">{dateLabel}</p>
+    </div>
+    <a class="db-card-arrow" href="/meal-plan" aria-label="Go to meal plan">→</a>
+  </div>
+
+  <div class="db-card-body">
+    {#if groups.length === 0}
+      <p class="db-empty">No meals planned for today</p>
+      <div class="db-empty-action">
+        <a class="db-link" href="/meal-plan">Plan something</a>
+      </div>
+    {:else}
+      {#each groups as group (group.mealType)}
+        <div class="db-meal-group">
+          <div class="db-meal-group-head">
+            <span aria-hidden="true">{MEAL_ICONS[group.mealType]}</span>
+            <span>{label(group.mealType)}</span>
+          </div>
+          {#each group.meals as meal, i (i)}
+            <div class="db-meal-item">{meal.displayName}</div>
+          {/each}
+        </div>
+      {/each}
+    {/if}
+  </div>
+</div>

--- a/frontend/dashboard/src/lib/components/QuickActions.svelte
+++ b/frontend/dashboard/src/lib/components/QuickActions.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  // Quick-action buttons — parity with Home.razor lines 209-263. Plain anchor
+  // navigations (full-document); the destinations are still Blazor / other islands.
+  const ACTIONS = [
+    { href: '/recipes/new', icon: '➕', label: 'New Recipe' },
+    { href: '/recipes', icon: '📖', label: 'Browse Recipes' },
+    { href: '/meal-plan', icon: '🗓️', label: 'This Week' },
+    { href: '/chores', icon: '🧹', label: 'Chores' },
+    { href: '/settings/users', icon: '👤', label: 'Invite Family' },
+  ];
+</script>
+
+<section class="db-quick">
+  <h2 class="db-quick-title">Quick Actions</h2>
+  <div class="db-quick-grid">
+    {#each ACTIONS as action (action.href)}
+      <a class="db-quick-btn" href={action.href}>
+        <span aria-hidden="true">{action.icon}</span>
+        <span>{action.label}</span>
+      </a>
+    {/each}
+  </div>
+</section>

--- a/frontend/dashboard/src/lib/components/ShoppingCard.svelte
+++ b/frontend/dashboard/src/lib/components/ShoppingCard.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  // Shopping list summary card — parity with Home.razor lines 106-155.
+  import type { DashboardShoppingSummaryDto } from '../types';
+
+  let { shopping, progress }: { shopping: DashboardShoppingSummaryDto; progress: number } = $props();
+</script>
+
+<div class="db-card">
+  <div class="db-card-header">
+    <div class="db-card-avatar" aria-hidden="true">🛒</div>
+    <div class="db-card-headings">
+      <h2 class="db-card-title">Shopping List</h2>
+      <p class="db-card-status">
+        {#if shopping.remaining > 0}
+          {shopping.remaining} items remaining
+        {:else}
+          All done!
+        {/if}
+      </p>
+    </div>
+    <a class="db-card-arrow" href="/shopping-list" aria-label="Go to shopping list">→</a>
+  </div>
+
+  <div class="db-card-body">
+    {#if shopping.total === 0}
+      <p class="db-empty">Shopping list is empty</p>
+      <div class="db-empty-action">
+        <a class="db-link" href="/shopping-list">Generate from meal plan</a>
+      </div>
+    {:else}
+      <div class="db-progress" role="progressbar" aria-valuenow={progress} aria-valuemin="0" aria-valuemax="100">
+        <div class="db-progress-fill" style="width: {progress}%"></div>
+      </div>
+      <p class="db-progress-caption">
+        {shopping.checked} of {shopping.total} items checked
+      </p>
+    {/if}
+  </div>
+</div>

--- a/frontend/dashboard/src/lib/components/Toasts.svelte
+++ b/frontend/dashboard/src/lib/components/Toasts.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+  // The toast region. Mirrors the chores island's Toasts component, re-scoped
+  // to `db-`. Mounted once at the App root.
+  import { toasts, dismissToast } from '../toasts.svelte';
+</script>
+
+<div class="db-toast-region" role="status" aria-live="polite">
+  {#each toasts() as toast (toast.id)}
+    <div class="db-toast db-toast-{toast.kind}">
+      <span class="db-toast-msg">{toast.message}</span>
+      <button
+        type="button"
+        class="db-toast-close"
+        aria-label="Dismiss"
+        onclick={() => dismissToast(toast.id)}
+      >
+        ×
+      </button>
+    </div>
+  {/each}
+</div>
+
+<style>
+  .db-toast-region {
+    position: fixed;
+    left: 50%;
+    bottom: 24px;
+    transform: translateX(-50%);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    z-index: 1100;
+    pointer-events: none;
+    max-width: min(560px, calc(100vw - 32px));
+  }
+  /* Mobile: clear the MainLayout bottom nav so toasts aren't hidden behind it. */
+  @media (max-width: 960px) {
+    .db-toast-region {
+      bottom: calc(80px + env(safe-area-inset-bottom, 0px));
+    }
+  }
+  .db-toast {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 12px 10px 16px;
+    border-radius: var(--radius-sm);
+    color: #fff;
+    background: #323232;
+    box-shadow: var(--shadow-4);
+    font-size: 0.875rem;
+    pointer-events: auto;
+    animation: db-toast-in 0.2s ease-out;
+  }
+  .db-toast-success {
+    background: var(--color-success);
+  }
+  .db-toast-error {
+    background: var(--color-error);
+  }
+  .db-toast-msg {
+    flex: 1;
+    min-width: 0;
+  }
+  .db-toast-close {
+    background: transparent;
+    border: none;
+    color: rgba(255, 255, 255, 0.8);
+    font-size: 1.25rem;
+    line-height: 1;
+    padding: 0 4px;
+    cursor: pointer;
+  }
+  .db-toast-close:hover {
+    color: #fff;
+  }
+  @keyframes db-toast-in {
+    from {
+      opacity: 0;
+      transform: translateY(8px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+</style>

--- a/frontend/dashboard/src/lib/dashboardStore.svelte.ts
+++ b/frontend/dashboard/src/lib/dashboardStore.svelte.ts
@@ -1,0 +1,76 @@
+import type { DashboardDto, DashboardMealDto, MealType, ShellContext } from './types';
+import { getDashboard } from './api';
+
+/** A meal-type group for the Today's Meals card (preserves the server's MealType ordering). */
+export interface MealGroup {
+  mealType: MealType;
+  meals: DashboardMealDto[];
+}
+
+/**
+ * The dashboard island store (Svelte-5 rune rule: export the class INSTANCE, never a
+ * reassigned `$state`). Read-only — one aggregate GET, then liveness/refocus reconcile.
+ * No writes ⇒ no optimistic/draft machinery; the one race guard is `#seq` (a slow earlier
+ * load that resolves after a newer one is dropped).
+ */
+export class DashboardStore {
+  data = $state<DashboardDto | null>(null);
+  loading = $state(true);
+  error = $state<string | null>(null);
+  currentUserId = $state(0);
+
+  // Monotonic load guard — only the newest load's response is applied.
+  #seq = 0;
+
+  /** "needs attention" = overdue + due-today (display logic, not a wire field). */
+  choreAttention = $derived(this.data ? this.data.chores.overdue + this.data.chores.dueToday : 0);
+
+  /** Shopping progress percent (0 when nothing to buy). */
+  shoppingProgress = $derived.by(() => {
+    const s = this.data?.shopping;
+    if (!s || s.total <= 0) return 0;
+    return Math.round((s.checked / s.total) * 100);
+  });
+
+  /** Today's meals grouped by type, preserving the server's MealType order (parity: GroupBy(MealType)). */
+  mealsByType = $derived.by(() => {
+    const groups: MealGroup[] = [];
+    for (const meal of this.data?.todaysMeals ?? []) {
+      let g = groups.find((x) => x.mealType === meal.mealType);
+      if (!g) {
+        g = { mealType: meal.mealType, meals: [] };
+        groups.push(g);
+      }
+      g.meals.push(meal);
+    }
+    return groups;
+  });
+
+  init(ctx: ShellContext): void {
+    this.currentUserId = ctx.userId;
+  }
+
+  /** Load the aggregate. Guarded so an out-of-order (stale) response is ignored. */
+  async load(): Promise<void> {
+    const seq = ++this.#seq;
+    try {
+      const d = await getDashboard();
+      if (seq !== this.#seq) return; // superseded by a newer load
+      this.data = d;
+      this.error = null;
+    } catch (e) {
+      if (seq !== this.#seq) return;
+      // Keep the last good data (no blank-out) and surface a calm error.
+      this.error = e instanceof Error ? e.message : 'Failed to load the dashboard.';
+    } finally {
+      if (seq === this.#seq) this.loading = false;
+    }
+  }
+
+  /** Liveness tick + error reconcile — just re-load; the seq guard drops stale ticks. */
+  reconcile(): void {
+    void this.load();
+  }
+}
+
+export const dashboardStore = new DashboardStore();

--- a/frontend/dashboard/src/lib/dates.ts
+++ b/frontend/dashboard/src/lib/dates.ts
@@ -1,0 +1,35 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Tiny display-only date formatters for the dashboard's two labels (the
+// welcome banner's long date + the meals card's short date). The dashboard has
+// NO week math (unlike meal-plan) — it only formats the server-echoed `today`.
+//
+// ⚠ MN4 / global CORRECTION: never `new Date("YYYY-MM-DD")` — that parses as
+//   UTC midnight, which renders the PREVIOUS day in US timezones. We parse the
+//   components and build the date at NOON-UTC, which is the same calendar day in
+//   every timezone, then format with the user's locale.
+// ─────────────────────────────────────────────────────────────────────────
+
+/** Parse a "YYYY-MM-DD" into a Date pinned at noon UTC (tz-stable calendar day). */
+function parseIsoNoon(iso: string): Date {
+  const [y, m, d] = iso.split('-').map(Number);
+  return new Date(Date.UTC(y, m - 1, d, 12));
+}
+
+/** "Wednesday, June 24" — the welcome-banner date (parity with Home.razor "dddd, MMMM d"). */
+export function formatLongDate(iso: string): string {
+  return parseIsoNoon(iso).toLocaleDateString(undefined, {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
+/** "Jun 24" — the meals-card date (parity with Home.razor "MMM d"). */
+export function formatShortDate(iso: string): string {
+  return parseIsoNoon(iso).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+}

--- a/frontend/dashboard/src/lib/liveness.ts
+++ b/frontend/dashboard/src/lib/liveness.ts
@@ -1,0 +1,73 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Liveness — lightweight collaboration refresh for the dashboard island.
+//
+// A change made by another household member should appear within ~20s while
+// the tab is VISIBLE, and immediately when the tab regains focus. We do this
+// with a plain interval + `visibilitychange`, NOT Blazor's DataNotifier /
+// PresenceService / PollingService (those are SignalR-circuit-bound — MN2).
+//
+// The poll PAUSES while the tab is hidden (D11): no interval ticks fire when
+// `document.hidden` is true, and on re-show we refetch once immediately, then
+// resume the interval. This keeps background tabs quiet.
+// ─────────────────────────────────────────────────────────────────────────
+
+const POLL_INTERVAL_MS = 20_000;
+
+export interface LivenessHandle {
+  /** Tear down the interval + visibility listener. Call on unmount. */
+  stop(): void;
+}
+
+/**
+ * Start polling. `refresh` is the board reload (App.svelte's loader). It is
+ * only invoked while the document is visible. Returns a handle whose `stop()`
+ * removes the interval + listener.
+ */
+export function startLiveness(refresh: () => void): LivenessHandle {
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  function tick() {
+    // Guard: never poll while hidden (the interval is cleared on hide, but this
+    // is belt-and-suspenders in case a tick is queued at the moment of hiding).
+    if (document.visibilityState === 'visible') {
+      refresh();
+    }
+  }
+
+  function startInterval() {
+    if (timer != null) return;
+    timer = setInterval(tick, POLL_INTERVAL_MS);
+  }
+
+  function stopInterval() {
+    if (timer != null) {
+      clearInterval(timer);
+      timer = null;
+    }
+  }
+
+  function handleVisibility() {
+    if (document.visibilityState === 'visible') {
+      // Re-show: refetch immediately, then resume the interval.
+      refresh();
+      startInterval();
+    } else {
+      // Hidden: pause polling entirely.
+      stopInterval();
+    }
+  }
+
+  document.addEventListener('visibilitychange', handleVisibility);
+
+  // Begin polling only if we start visible.
+  if (document.visibilityState === 'visible') {
+    startInterval();
+  }
+
+  return {
+    stop() {
+      stopInterval();
+      document.removeEventListener('visibilitychange', handleVisibility);
+    },
+  };
+}

--- a/frontend/dashboard/src/lib/toasts.svelte.ts
+++ b/frontend/dashboard/src/lib/toasts.svelte.ts
@@ -1,0 +1,47 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Transient toast notices for the dashboard island (mirrors the chores
+// island's toast store). Used for non-alarming 4xx/network surfacing and the
+// "someone changed this — refreshed" reconcile notice. Kept deliberately
+// small: a module-level `$state` list + helpers.
+//
+// ⚠ Svelte 5 rune rule: we never export a reassigned `$state` rune directly.
+// The list lives inside a module-private `$state` object; callers read it via
+// the `toasts()` accessor and mutate it only through the exported functions.
+// ─────────────────────────────────────────────────────────────────────────
+
+export type ToastKind = 'info' | 'success' | 'error';
+
+export interface Toast {
+  id: number;
+  message: string;
+  kind: ToastKind;
+  durationMs: number;
+}
+
+let nextId = 1;
+const store = $state<{ items: Toast[] }>({ items: [] });
+
+/** The live toast list (reactive — read inside markup). */
+export function toasts(): readonly Toast[] {
+  return store.items;
+}
+
+/** Push a toast. Auto-dismisses after `durationMs` (default 3.5s). */
+export function showToast(toast: { message: string; kind: ToastKind; durationMs?: number }): number {
+  const id = nextId++;
+  const full: Toast = {
+    id,
+    message: toast.message,
+    kind: toast.kind,
+    durationMs: toast.durationMs ?? 3500,
+  };
+  store.items = [...store.items, full];
+  if (full.durationMs > 0) {
+    setTimeout(() => dismissToast(id), full.durationMs);
+  }
+  return id;
+}
+
+export function dismissToast(id: number): void {
+  store.items = store.items.filter((t) => t.id !== id);
+}

--- a/frontend/dashboard/src/lib/types.ts
+++ b/frontend/dashboard/src/lib/types.ts
@@ -1,0 +1,52 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Dashboard island TS contract. MIRRORS the server DTOs in
+// src/FamilyCoordinationApp/Services/Dtos/DashboardDtos.cs — kept in lockstep
+// with tests/.../Fixtures/Dashboard/dashboard.json (DashboardDtoContractTests
+// is the tripwire). A field rename / casing change here means the same change
+// in that DTO + fixture (M9).
+//
+// ⚠ CASING: MealType is a real enum on the server DTO → it arrives as a
+//   camelCase string ("breakfast"/"lunch"/"dinner"/"snack"). `today` is a
+//   DateOnly → "YYYY-MM-DD"; format it for DISPLAY at noon-UTC, never
+//   `new Date("YYYY-MM-DD")` (UTC-midnight parse = wrong day in US tz).
+// ─────────────────────────────────────────────────────────────────────────
+
+export type MealType = 'breakfast' | 'lunch' | 'dinner' | 'snack';
+
+/** The four Home chore-card counts (mirrors ChoreHomeStats.Result). */
+export interface DashboardChoreSummaryDto {
+  activeTotal: number;
+  overdue: number;
+  dueToday: number;
+  upForGrabs: number;
+}
+
+/** Shopping totals summed across all active (non-archived) lists. */
+export interface DashboardShoppingSummaryDto {
+  remaining: number;
+  checked: number;
+  total: number;
+}
+
+/** One of today's planned meals — type + resolved display name. */
+export interface DashboardMealDto {
+  mealType: MealType;
+  displayName: string;
+}
+
+/** The whole dashboard read-aggregate (one round-trip). */
+export interface DashboardDto {
+  greetingName: string;
+  householdName: string;
+  today: string; // "YYYY-MM-DD"
+  chores: DashboardChoreSummaryDto;
+  shopping: DashboardShoppingSummaryDto;
+  todaysMeals: DashboardMealDto[];
+}
+
+/** Shell context the Razor host hands the island via root data-attrs. */
+export interface ShellContext {
+  householdId: number;
+  userId: number;
+  userName: string;
+}

--- a/frontend/dashboard/src/main.ts
+++ b/frontend/dashboard/src/main.ts
@@ -1,0 +1,204 @@
+import { mount as svelteMount, unmount } from 'svelte';
+import App from './App.svelte';
+import './styles/app.css';
+import type { ShellContext } from './lib/types';
+
+type MountedApp = ReturnType<typeof svelteMount>;
+
+interface Instance {
+  app: MountedApp;
+  /** The exact node we mounted into — lets us detect a Blazor resume that
+   *  replaced or emptied the root out from under us. */
+  el: HTMLElement;
+}
+
+// Blazor Server inserts component output via DOM diff, and inline <script>
+// tags in that output are NOT executed by the browser. The Razor shell
+// (MealPlan.razor) uses IJSRuntime.InvokeAsync("import", ...) to load this
+// module, then calls the global mounter below. Exposing a named entry on
+// window is the simplest way to survive enhanced-nav round-trips.
+declare global {
+  interface Window {
+    DashboardIsland?: {
+      mount(rootId: string): void;
+      destroy(rootId: string): void;
+    };
+  }
+}
+
+const ROOT_ID = 'dashboard-root';
+
+const instances = new Map<string, Instance>();
+
+// Roots the Razor shell has asked us to mount. We re-assert these when the page
+// is restored so a Blazor circuit resume / enhanced-nav merge that wiped our
+// content can't leave the island permanently blank (see reassertMounts below).
+const desiredRoots = new Set<string>();
+
+function readContext(el: HTMLElement): ShellContext {
+  const householdId = Number(el.dataset.householdId ?? '0');
+  const userId = Number(el.dataset.userId ?? '0');
+  const userName = el.dataset.userName ?? '';
+  if (!householdId || !userId) {
+    throw new Error('dashboard: missing data-household-id / data-user-id');
+  }
+  return { householdId, userId, userName };
+}
+
+// Track dark-mode state and mirror it as a class on the island root so the
+// CSS override wins even when MudBlazor's runtime toggle doesn't propagate
+// the class down to us (we've seen it stay on <html> at load but go missing
+// after runtime toggles, leaving the island stuck in light mode).
+const darkObservers = new Map<string, () => void>();
+
+function isDarkActive(): boolean {
+  if (document.documentElement.classList.contains('mud-theme-dark')) return true;
+  if (document.body?.classList.contains('mud-theme-dark')) return true;
+  try {
+    if (localStorage.getItem('darkMode') === 'true') return true;
+  } catch { /* storage blocked */ }
+  return false;
+}
+
+function syncDarkClass(el: HTMLElement) {
+  el.classList.toggle('db-dark-mode', isDarkActive());
+}
+
+function installDarkObserver(rootId: string, el: HTMLElement) {
+  syncDarkClass(el);
+  const htmlObs = new MutationObserver(() => syncDarkClass(el));
+  htmlObs.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
+  const bodyObs = new MutationObserver(() => syncDarkClass(el));
+  if (document.body) bodyObs.observe(document.body, { attributes: true, attributeFilter: ['class'] });
+  const storageHandler = (e: StorageEvent) => {
+    if (e.key === 'darkMode') syncDarkClass(el);
+  };
+  window.addEventListener('storage', storageHandler);
+  darkObservers.set(rootId, () => {
+    htmlObs.disconnect();
+    bodyObs.disconnect();
+    window.removeEventListener('storage', storageHandler);
+  });
+}
+
+/**
+ * A mount is healthy only if the CURRENT root element is the exact node we
+ * mounted into, it's still in the document, and it still holds our rendered
+ * children. Blazor's .NET 10 circuit resume (the path that fires on a mobile
+ * background→return) REPLACES the root node and re-runs the host component's
+ * lifecycle — a fresh firstRender re-calls mount(). The old mount-once guard
+ * (`instances.has`) refused to re-mount into that new node, leaving the board
+ * blank until a full reload. Comparing the live node to the one we mounted into
+ * lets the re-invoked mount() rebuild instead of no-op.
+ */
+function isHealthy(rootId: string): boolean {
+  const inst = instances.get(rootId);
+  if (!inst) return false;
+  const el = document.getElementById(rootId);
+  return el != null && el === inst.el && el.isConnected && el.childElementCount > 0;
+}
+
+function mountRoot(rootId: string) {
+  desiredRoots.add(rootId);
+  // Already mounted AND still intact — nothing to do.
+  if (isHealthy(rootId)) return;
+  // A stale prior mount (root emptied / replaced / detached): tear it down first
+  // so we don't leak the Svelte instance or its observers before remounting.
+  if (instances.has(rootId)) destroyRoot(rootId, /* internal */ true);
+  const el = document.getElementById(rootId) as HTMLElement | null;
+  if (!el) {
+    console.warn('[dashboard-island] root element not found:', rootId);
+    return;
+  }
+  installDarkObserver(rootId, el);
+  const app = svelteMount(App, { target: el, props: { ctx: readContext(el) } });
+  instances.set(rootId, { app, el });
+  ensureHealObserver();
+}
+
+function destroyRoot(rootId: string, internal = false) {
+  const inst = instances.get(rootId);
+  if (!inst) {
+    if (!internal) desiredRoots.delete(rootId);
+    return;
+  }
+  // Blazor's circuit resume disposes the OLD page component AFTER it has already
+  // re-initialised the new one — whose firstRender re-calls mount(), which we use
+  // to rebuild into the freshly-replaced root. That trailing destroy() targets a
+  // SUPERSEDED component and would otherwise tear our live island back down.
+  // Ignore an external destroy while the current mount is healthy; a genuine
+  // navigation-away leaves no healthy root (the page is gone), so real teardown
+  // still runs then. `internal` is our own self-heal replacing a stale mount — it
+  // must always proceed.
+  if (!internal && isHealthy(rootId)) return;
+  if (!internal) desiredRoots.delete(rootId);
+  unmount(inst.app);
+  instances.delete(rootId);
+  const disposer = darkObservers.get(rootId);
+  if (disposer) {
+    disposer();
+    darkObservers.delete(rootId);
+  }
+}
+
+window.DashboardIsland = { mount: mountRoot, destroy: destroyRoot };
+
+// ── Resilience: self-heal after a Blazor circuit resume ────────────────────
+// Mobile browsers background the tab on an app/tab switch; Blazor Server's .NET
+// 10 circuit pause/resume then reconciles the DOM on return and can REPLACE the
+// island root — sometimes re-invoking our mount() (handled in mountRoot), and
+// sometimes NOT (observed: nondeterministic). Either way the swap is a DOM
+// mutation, so we watch a STABLE anchor (document.body — Blazor replaces a chunk
+// of the island's ancestors, so observing the root or its parent misses it) and
+// rebuild any desired root that has gone unhealthy.
+//
+// The heal runs SYNCHRONOUSLY in the observer microtask — NOT via
+// requestAnimationFrame, which is paused while the tab is hidden (the wipe can
+// land a beat after the tab is technically still settling). `healing` guards
+// re-entrancy (mountRoot mutates the DOM, which re-queues this callback); once
+// the root is healthy again the next pass no-ops, so it can't loop. The cost on
+// every unrelated DOM change is one getElementById + isHealthy per desired root
+// (normally one), which is negligible.
+let healObserver: MutationObserver | null = null;
+let healing = false;
+function runHeal() {
+  if (healing) return;
+  healing = true;
+  try {
+    for (const rootId of desiredRoots) {
+      // Only rebuild when the root EXISTS but is stale/empty. A missing root is
+      // a navigation-away (or mid-reconcile) — not ours to remount; the next
+      // mutation re-checks once the fresh root lands.
+      if (document.getElementById(rootId) && !isHealthy(rootId)) mountRoot(rootId);
+    }
+  } finally {
+    healing = false;
+  }
+}
+function ensureHealObserver() {
+  if (healObserver || !document.body) return;
+  healObserver = new MutationObserver(runHeal);
+  healObserver.observe(document.body, { childList: true, subtree: true });
+}
+
+// bfcache restore re-attaches the frozen DOM without any mutation, so the body
+// observer won't fire — re-assert directly on pageshow as a cheap belt.
+window.addEventListener('pageshow', () => {
+  ensureHealObserver();
+  for (const rootId of desiredRoots) {
+    if (document.getElementById(rootId) && !isHealthy(rootId)) mountRoot(rootId);
+  }
+});
+
+// Standalone dev auto-mount: if the root is already on the page when the
+// module loads (Vite's index.html), mount immediately. In production the
+// Razor shell calls window.DashboardIsland.mount() explicitly via JS interop.
+function autoMountIfReady() {
+  const el = document.getElementById(ROOT_ID);
+  if (el) mountRoot(ROOT_ID);
+}
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', autoMountIfReady);
+} else {
+  autoMountIfReady();
+}

--- a/frontend/dashboard/src/styles/app.css
+++ b/frontend/dashboard/src/styles/app.css
@@ -1,0 +1,273 @@
+@import './tokens.css';
+
+/*
+ * The island renders inside the host page, which also loads Bootstrap + MudBlazor.
+ * Bootstrap defines .row / .container globally, and those names collide with
+ * ambient island styles. We avoid the collision by prefixing all island class
+ * names with `db-` (dashboard) rather than overriding globals here.
+ */
+
+#dashboard-root {
+  font-family: var(--font-family);
+  color: var(--color-text);
+  background: var(--color-background);
+  min-height: 100%;
+}
+
+#dashboard-root,
+#dashboard-root *,
+#dashboard-root *::before,
+#dashboard-root *::after {
+  box-sizing: border-box;
+}
+
+/*
+ * Suppress the outer Blazor ReconnectModal while the island is on the page.
+ * It's a showModal() <dialog>, which blocks all interaction behind it —
+ * including our HTTP-driven island that doesn't need the circuit to work.
+ * This CSS only ships on the dashboard page (via <HeadContent>), so other
+ * pages still get the normal reconnect UX.
+ */
+#components-reconnect-modal {
+  display: none !important;
+}
+
+/* ───────────────────────────────────────────────────────────────────────────
+ * Dashboard layout — ported from Home.razor's inline <style> + the MudGrid/
+ * MudCard structure, re-scoped to `db-`. Kept in app.css (not a component
+ * <style>) so Svelte's unused-selector pruning can't drop a shared class.
+ * ─────────────────────────────────────────────────────────────────────────── */
+
+.db-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 24px 16px;
+}
+
+/* Welcome banner */
+.db-welcome {
+  padding: 16px 0;
+  margin-bottom: 24px;
+}
+.db-welcome-title {
+  font-size: 1.5rem;
+  font-weight: 500;
+  margin: 0 0 4px;
+}
+.db-welcome-sub {
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+/* Card grid: 1 col mobile, 2 cols desktop (cards are md=6 in the Blazor grid). */
+.db-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+}
+@media (min-width: 960px) {
+  .db-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* Card shell (MudCard Elevation=2 / .dashboard-card) */
+.db-card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 200px;
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-2);
+}
+.db-card-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px;
+}
+.db-card-avatar {
+  width: 40px;
+  height: 40px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  border: 1px solid var(--color-line-strong);
+  display: grid;
+  place-items: center;
+  font-size: 1.25rem;
+}
+.db-card-headings {
+  flex: 1;
+  min-width: 0;
+}
+.db-card-title {
+  font-size: 1.125rem;
+  font-weight: 500;
+  margin: 0;
+}
+.db-card-status {
+  margin: 2px 0 0;
+  color: var(--color-text-muted);
+  font-size: 0.875rem;
+}
+.db-card-arrow {
+  flex-shrink: 0;
+  padding: 8px;
+  border-radius: 50%;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  font-size: 1.25rem;
+  line-height: 1;
+}
+.db-card-arrow:hover {
+  background: var(--color-action-hover);
+}
+.db-card-body {
+  flex: 1;
+  padding: 0 16px 16px;
+}
+
+/* Empty states + text link buttons */
+.db-empty {
+  padding: 16px 0;
+  text-align: center;
+  color: var(--color-text-muted);
+}
+.db-empty-action {
+  text-align: center;
+}
+.db-link {
+  display: inline-block;
+  padding: 6px 8px;
+  color: var(--color-primary);
+  background: none;
+  border: none;
+  font: inherit;
+  text-decoration: none;
+  cursor: pointer;
+}
+.db-link:hover {
+  text-decoration: underline;
+}
+
+/* Chore stats rows */
+.db-stat-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+}
+.db-stat-icon {
+  font-size: 1rem;
+}
+.db-stat-overdue {
+  color: var(--color-error);
+}
+.db-stat-due {
+  color: var(--color-warning);
+}
+
+/* Shopping progress */
+.db-progress {
+  height: 8px;
+  margin: 12px 0;
+  border-radius: 999px;
+  background: var(--color-divider);
+  overflow: hidden;
+}
+.db-progress-fill {
+  height: 100%;
+  border-radius: 999px;
+  background: var(--color-success);
+  transition: width 0.3s ease;
+}
+.db-progress-caption {
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
+}
+
+/* Today's meals groups */
+.db-meal-group {
+  padding: 8px 0;
+  border-bottom: 1px solid var(--color-divider);
+}
+.db-meal-group:last-child {
+  border-bottom: none;
+}
+.db-meal-group-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+  color: var(--color-text-muted);
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+.db-meal-item {
+  padding: 2px 0 2px 28px;
+}
+
+/* Quick actions */
+.db-quick {
+  margin-top: 24px;
+}
+.db-quick-title {
+  font-size: 1.125rem;
+  font-weight: 500;
+  margin: 0 0 12px;
+}
+.db-quick-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+}
+@media (min-width: 600px) {
+  .db-quick-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+.db-quick-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  height: 56px;
+  border: 1px solid var(--color-primary);
+  border-radius: var(--radius-md);
+  color: var(--color-primary);
+  background: transparent;
+  text-decoration: none;
+  font-size: 0.9rem;
+  text-align: center;
+}
+.db-quick-btn:hover {
+  background: var(--color-action-hover);
+}
+
+/* Inline error + loading (mirrors the other islands) */
+.db-inline-error {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+  padding: 10px 14px;
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--color-error) 12%, transparent);
+  color: var(--color-error);
+}
+.db-retry {
+  margin-left: auto;
+  padding: 4px 12px;
+  border: 1px solid currentColor;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+.db-loading {
+  padding: 48px 0;
+  text-align: center;
+  color: var(--color-text-muted);
+}

--- a/frontend/dashboard/src/styles/tokens.css
+++ b/frontend/dashboard/src/styles/tokens.css
@@ -1,0 +1,95 @@
+/*
+ * Design tokens mirrored from the MudBlazor theme used elsewhere in the app
+ * (kept in sync with frontend/chores/src/styles/tokens.css).
+ * Light mode = :root. Dark mode = html.mud-theme-dark (set by App.razor)
+ * plus #dashboard-root.db-dark-mode (mirrored by main.ts's dark observer).
+ */
+
+:root {
+  /* brand */
+  --color-primary: rgb(46, 125, 50);
+  --color-primary-hover: rgb(36, 97, 39);
+  --color-primary-soft: rgb(58, 156, 63);
+  --color-secondary: rgb(255, 111, 0);
+
+  /* surfaces */
+  --color-surface: rgb(255, 255, 255);
+  --color-background: rgb(250, 250, 250);
+  --color-appbar: rgb(46, 125, 50);
+  --color-drawer: rgb(245, 245, 245);
+
+  /* text */
+  --color-text: rgb(66, 66, 66);
+  --color-text-muted: rgba(0, 0, 0, 0.54);
+  --color-text-disabled: rgba(0, 0, 0, 0.38);
+
+  /* structure */
+  --color-line: rgba(0, 0, 0, 0.12);
+  --color-line-strong: rgb(189, 189, 189);
+  --color-divider: rgb(224, 224, 224);
+  --color-action-hover: rgba(0, 0, 0, 0.06);
+  --color-action-disabled: rgba(0, 0, 0, 0.26);
+
+  /* semantic */
+  --color-success: rgb(67, 160, 71);
+  --color-error: rgb(229, 57, 53);
+  --color-warning: rgb(251, 140, 0);
+  --color-info: rgb(30, 136, 229);
+
+  /* typography */
+  --font-family: Roboto, Helvetica, Arial, sans-serif;
+
+  /* shape */
+  --radius-sm: 4px;
+  --radius-md: 4px;
+
+  /* elevation (MudBlazor 1, 2, 4) */
+  --shadow-1:
+    0 2px 1px -1px rgba(0, 0, 0, 0.2),
+    0 1px 1px 0 rgba(0, 0, 0, 0.14),
+    0 1px 3px 0 rgba(0, 0, 0, 0.12);
+  --shadow-2:
+    0 3px 1px -2px rgba(0, 0, 0, 0.2),
+    0 2px 2px 0 rgba(0, 0, 0, 0.14),
+    0 1px 5px 0 rgba(0, 0, 0, 0.12);
+  --shadow-4:
+    0 2px 4px -1px rgba(0, 0, 0, 0.2),
+    0 4px 5px 0 rgba(0, 0, 0, 0.14),
+    0 1px 10px 0 rgba(0, 0, 0, 0.12);
+}
+
+/*
+ * Dark-mode override. MudBlazor v8 + the App.razor bootstrap script both
+ * toggle `mud-theme-dark` on <html>, but runtime theme toggles sometimes
+ * land on <body> or deeper. Matching the bare class is a superset that
+ * works regardless of where the ancestor lives.
+ */
+.mud-theme-dark,
+html.mud-theme-dark,
+body.mud-theme-dark,
+#dashboard-root.db-dark-mode {
+  --color-primary: rgb(102, 187, 106);
+  --color-primary-hover: rgb(77, 172, 82);
+  --color-primary-soft: rgb(128, 198, 132);
+  --color-secondary: rgb(255, 183, 77);
+
+  --color-surface: rgb(30, 30, 30);
+  --color-background: rgb(18, 18, 18);
+  --color-appbar: rgb(26, 26, 26);
+  --color-drawer: rgb(26, 26, 26);
+
+  --color-text: rgba(255, 255, 255, 0.87);
+  --color-text-muted: rgba(255, 255, 255, 0.6);
+  --color-text-disabled: rgba(255, 255, 255, 0.2);
+
+  --color-line: rgba(255, 255, 255, 0.12);
+  --color-line-strong: rgba(255, 255, 255, 0.3);
+  --color-divider: rgba(255, 255, 255, 0.12);
+  --color-action-hover: rgba(173, 173, 177, 0.06);
+  --color-action-disabled: rgba(255, 255, 255, 0.26);
+
+  --color-success: rgb(102, 187, 106);
+  --color-error: rgb(239, 83, 80);
+  --color-warning: rgb(255, 167, 38);
+  --color-info: rgb(66, 165, 245);
+}

--- a/frontend/dashboard/src/vite-env.d.ts
+++ b/frontend/dashboard/src/vite-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="svelte" />
+/// <reference types="vite/client" />

--- a/frontend/dashboard/svelte.config.js
+++ b/frontend/dashboard/svelte.config.js
@@ -1,0 +1,8 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+export default {
+  preprocess: vitePreprocess(),
+  compilerOptions: {
+    runes: true,
+  },
+};

--- a/frontend/dashboard/tsconfig.json
+++ b/frontend/dashboard/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "@tsconfig/svelte/tsconfig.json",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowJs": false,
+    "checkJs": false,
+    "isolatedModules": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitAny": true,
+    "skipLibCheck": true,
+    "types": ["svelte", "vite/client"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.svelte", "src/vite-env.d.ts"]
+}

--- a/frontend/dashboard/vite.config.ts
+++ b/frontend/dashboard/vite.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+
+// The dashboard island is embedded into a Razor shell at /dashboard.
+// Build output goes to ./dist/ — the CopyDashboardIsland MSBuild target in
+// FamilyCoordinationApp.csproj copies this into wwwroot/islands/dashboard/.
+// Keeping the output local here makes the Docker build cleaner
+// (the mealplan-node-build stage emits dist/, the .NET stage reads it via COPY --from).
+// Mirrors frontend/chores/vite.config.ts (output index.js + index.css).
+export default defineConfig({
+  plugins: [svelte()],
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    rollupOptions: {
+      input: 'src/main.ts',
+      output: {
+        entryFileNames: 'index.js',
+        chunkFileNames: 'chunks/[name]-[hash].js',
+        assetFileNames: (info) =>
+          info.name?.endsWith('.css') ? 'index.css' : 'assets/[name]-[hash][extname]',
+      },
+    },
+    sourcemap: true,
+  },
+  server: {
+    port: 5177,
+    // Dev server proxies /api to the running .NET app so `npm run dev` works
+    // standalone against a locally-running Blazor host on :5000.
+    proxy: {
+      '/api': {
+        target: 'http://localhost:5000',
+        changeOrigin: false,
+      },
+    },
+  },
+});

--- a/src/FamilyCoordinationApp/Components/Pages/Home.razor
+++ b/src/FamilyCoordinationApp/Components/Pages/Home.razor
@@ -1,402 +1,124 @@
 @page "/dashboard"
 @attribute [Authorize]
-@using System.Security.Claims
-@using Microsoft.EntityFrameworkCore
 @using FamilyCoordinationApp.Data
-@using FamilyCoordinationApp.Data.Entities
-@using FamilyCoordinationApp.Services
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.EntityFrameworkCore
+@using Microsoft.JSInterop
+@using System.Security.Claims
+@implements IAsyncDisposable
+
+@inject IConfiguration Config
+@inject AuthenticationStateProvider AuthStateProvider
 @inject IDbContextFactory<ApplicationDbContext> DbFactory
-@inject IHttpContextAccessor HttpContextAccessor
-@inject IMealPlanService MealPlanService
-@inject IShoppingListService ShoppingListService
-@inject IChoreBoardService ChoreBoardService
+@inject IJSRuntime JS
+@inject IWebHostEnvironment HostEnv
 
-<PageTitle>Home - Family Kitchen</PageTitle>
+@*
+    Thin island host (strangler). Flag ON (DASHBOARD_USE_ISLAND=true) → mount the Svelte island; flag OFF →
+    the existing Blazor dashboard (<HomeBlazor/>) as the zero-regression fallback. Mirrors MealPlan.razor /
+    Recipes.razor. Flip the flag to switch; delete HomeBlazor once the island is the only path.
+*@
 
-<MudContainer MaxWidth="MaxWidth.Large" Class="py-6">
-    <div class="welcome-section mb-6">
-        <MudText Typo="Typo.h4" Class="mb-1">
-            Welcome back, @_displayName! 👋
-        </MudText>
-        <MudText Typo="Typo.body1" Color="Color.Secondary">
-            @_householdName • @DateTime.Now.ToString("dddd, MMMM d")
-        </MudText>
-    </div>
+@if (_useIsland && _shell is not null)
+{
+    <PageTitle>Home - Family Kitchen</PageTitle>
 
-    <MudGrid Spacing="4">
-        <!-- Chores Card -->
-        <MudItem xs="12" md="6">
-            <MudCard Elevation="2" Class="dashboard-card">
-                <MudCardHeader>
-                    <CardHeaderAvatar>
-                        <MudAvatar Color="Color.Tertiary" Variant="Variant.Outlined">
-                            <MudIcon Icon="@Icons.Material.Filled.CleaningServices" />
-                        </MudAvatar>
-                    </CardHeaderAvatar>
-                    <CardHeaderContent>
-                        <MudText Typo="Typo.h6">Chores</MudText>
-                        <MudText Typo="Typo.body2" Color="Color.Secondary">
-                            @if (_choreActiveTotal == 0)
-                            {
-                                @:No chores yet
-                            }
-                            else if (ChoreAttention > 0)
-                            {
-                                @:@ChoreAttention need attention
-                            }
-                            else
-                            {
-                                @:All caught up
-                            }
-                        </MudText>
-                    </CardHeaderContent>
-                    <CardHeaderActions>
-                        <MudIconButton Icon="@Icons.Material.Filled.ArrowForward" Href="/chores" />
-                    </CardHeaderActions>
-                </MudCardHeader>
-                <MudCardContent Class="pt-0">
-                    @if (_choreActiveTotal == 0)
-                    {
-                        <MudText Color="Color.Secondary" Class="text-center py-4">
-                            No chores set up yet
-                        </MudText>
-                        <div class="text-center">
-                            <MudButton Variant="Variant.Text" Color="Color.Primary" Href="/chores">
-                                Set up the chore board
-                            </MudButton>
-                        </div>
-                    }
-                    else if (ChoreAttention == 0 && _choreUpForGrabs == 0)
-                    {
-                        <MudText Color="Color.Secondary" Class="text-center py-4">
-                            All caught up — nothing needs attention 🎉
-                        </MudText>
-                    }
-                    else
-                    {
-                        <div class="chore-stats py-2">
-                            @if (_choreOverdue > 0)
-                            {
-                                <div class="d-flex align-center gap-2 py-1">
-                                    <MudIcon Icon="@Icons.Material.Filled.ErrorOutline" Size="Size.Small" Color="Color.Error" />
-                                    <MudText><b>@_choreOverdue</b> overdue</MudText>
-                                </div>
-                            }
-                            @if (_choreDueToday > 0)
-                            {
-                                <div class="d-flex align-center gap-2 py-1">
-                                    <MudIcon Icon="@Icons.Material.Filled.Today" Size="Size.Small" Color="Color.Warning" />
-                                    <MudText><b>@_choreDueToday</b> due today</MudText>
-                                </div>
-                            }
-                            @if (_choreUpForGrabs > 0)
-                            {
-                                <div class="d-flex align-center gap-2 py-1">
-                                    <MudIcon Icon="@Icons.Material.Filled.PanTool" Size="Size.Small" Color="Color.Secondary" />
-                                    <MudText><b>@_choreUpForGrabs</b> up for grabs</MudText>
-                                </div>
-                            }
-                        </div>
-                    }
-                </MudCardContent>
-            </MudCard>
-        </MudItem>
+    <HeadContent>
+        <link rel="stylesheet" href="/islands/dashboard/index.css?v=@IslandVersion" />
+    </HeadContent>
 
-        <!-- Shopping List Card -->
-        <MudItem xs="12" md="6">
-            <MudCard Elevation="2" Class="dashboard-card">
-                <MudCardHeader>
-                    <CardHeaderAvatar>
-                        <MudAvatar Color="Color.Secondary" Variant="Variant.Outlined">
-                            <MudIcon Icon="@Icons.Material.Filled.ShoppingCart" />
-                        </MudAvatar>
-                    </CardHeaderAvatar>
-                    <CardHeaderContent>
-                        <MudText Typo="Typo.h6">Shopping List</MudText>
-                        <MudText Typo="Typo.body2" Color="Color.Secondary">
-                            @if (_shoppingListCount > 0)
-                            {
-                                @:@_shoppingListCount items remaining
-                            }
-                            else
-                            {
-                                @:All done!
-                            }
-                        </MudText>
-                    </CardHeaderContent>
-                    <CardHeaderActions>
-                        <MudIconButton Icon="@Icons.Material.Filled.ArrowForward" Href="/shopping-list" />
-                    </CardHeaderActions>
-                </MudCardHeader>
-                <MudCardContent Class="pt-0">
-                    @if (_shoppingListCount == 0)
-                    {
-                        <MudText Color="Color.Secondary" Class="text-center py-4">
-                            Shopping list is empty
-                        </MudText>
-                        <div class="text-center">
-                            <MudButton Variant="Variant.Text" Color="Color.Primary" Href="/shopping-list">
-                                Generate from meal plan
-                            </MudButton>
-                        </div>
-                    }
-                    else
-                    {
-                        <MudProgressLinear Color="Color.Success" 
-                                           Value="@_shoppingListProgress" 
-                                           Class="my-3" 
-                                           Rounded="true" />
-                        <MudText Typo="Typo.caption" Color="Color.Secondary" Class="text-center">
-                            @_shoppingListChecked of @(_shoppingListChecked + _shoppingListCount) items checked
-                        </MudText>
-                    }
-                </MudCardContent>
-            </MudCard>
-        </MudItem>
-
-        <!-- Today's Meals Card -->
-        <MudItem xs="12" md="6">
-            <MudCard Elevation="2" Class="dashboard-card">
-                <MudCardHeader>
-                    <CardHeaderAvatar>
-                        <MudAvatar Color="Color.Primary" Variant="Variant.Outlined">
-                            <MudIcon Icon="@Icons.Material.Filled.Today" />
-                        </MudAvatar>
-                    </CardHeaderAvatar>
-                    <CardHeaderContent>
-                        <MudText Typo="Typo.h6">Today's Meals</MudText>
-                        <MudText Typo="Typo.body2" Color="Color.Secondary">@DateTime.Today.ToString("MMM d")</MudText>
-                    </CardHeaderContent>
-                    <CardHeaderActions>
-                        <MudIconButton Icon="@Icons.Material.Filled.ArrowForward" Href="/meal-plan" />
-                    </CardHeaderActions>
-                </MudCardHeader>
-                <MudCardContent Class="pt-0">
-                    @if (_todaysMeals.Count == 0)
-                    {
-                        <MudText Color="Color.Secondary" Class="text-center py-4">
-                            No meals planned for today
-                        </MudText>
-                        <div class="text-center">
-                            <MudButton Variant="Variant.Text" Color="Color.Primary" Href="/meal-plan">
-                                Plan something
-                            </MudButton>
-                        </div>
-                    }
-                    else
-                    {
-                        @foreach (var mealGroup in _todaysMeals.GroupBy(m => m.MealType).OrderBy(g => g.Key))
-                        {
-                            <div class="meal-group py-2">
-                                <div class="d-flex align-center gap-2 mb-1">
-                                    <MudIcon Icon="@GetMealTypeIcon(mealGroup.Key)" Size="Size.Small" Color="Color.Secondary" />
-                                    <MudText Typo="Typo.subtitle2" Color="Color.Secondary">@mealGroup.Key</MudText>
-                                </div>
-                                @foreach (var meal in mealGroup)
-                                {
-                                    <div class="meal-item ps-6 py-1">
-                                        <MudText>@GetMealDisplayName(meal)</MudText>
-                                    </div>
-                                }
-                            </div>
-                        }
-                    }
-                </MudCardContent>
-            </MudCard>
-        </MudItem>
-
-        <!-- Quick Actions -->
-        <MudItem xs="12">
-            <MudText Typo="Typo.h6" Class="mb-3">Quick Actions</MudText>
-            <MudGrid Spacing="3">
-                <MudItem xs="6" sm="3">
-                    <MudButton Variant="Variant.Outlined" 
-                               Color="Color.Primary" 
-                               FullWidth="true"
-                               Href="/recipes/new"
-                               StartIcon="@Icons.Material.Filled.Add"
-                               Class="quick-action-btn">
-                        New Recipe
-                    </MudButton>
-                </MudItem>
-                <MudItem xs="6" sm="3">
-                    <MudButton Variant="Variant.Outlined" 
-                               Color="Color.Primary" 
-                               FullWidth="true"
-                               Href="/recipes"
-                               StartIcon="@Icons.Material.Filled.MenuBook"
-                               Class="quick-action-btn">
-                        Browse Recipes
-                    </MudButton>
-                </MudItem>
-                <MudItem xs="6" sm="3">
-                    <MudButton Variant="Variant.Outlined"
-                               Color="Color.Primary"
-                               FullWidth="true"
-                               Href="/meal-plan"
-                               StartIcon="@Icons.Material.Filled.CalendarMonth"
-                               Class="quick-action-btn">
-                        This Week
-                    </MudButton>
-                </MudItem>
-                <MudItem xs="6" sm="3">
-                    <MudButton Variant="Variant.Outlined"
-                               Color="Color.Primary"
-                               FullWidth="true"
-                               Href="/chores"
-                               StartIcon="@Icons.Material.Filled.CleaningServices"
-                               Class="quick-action-btn">
-                        Chores
-                    </MudButton>
-                </MudItem>
-                <MudItem xs="6" sm="3">
-                    <MudButton Variant="Variant.Outlined"
-                               Color="Color.Primary"
-                               FullWidth="true"
-                               Href="/settings/users"
-                               StartIcon="@Icons.Material.Filled.PersonAdd"
-                               Class="quick-action-btn">
-                        Invite Family
-                    </MudButton>
-                </MudItem>
-            </MudGrid>
-        </MudItem>
-    </MudGrid>
-</MudContainer>
-
-<style>
-    .welcome-section {
-        padding: 1rem 0;
-    }
-    
-    .dashboard-card {
-        height: 100%;
-        min-height: 200px;
-    }
-    
-    .meal-group {
-        border-bottom: 1px solid var(--mud-palette-divider);
-    }
-    
-    .meal-group:last-child {
-        border-bottom: none;
-    }
-    
-    .meal-item {
-        /* Individual meal items within a group */
-    }
-    
-    .quick-action-btn {
-        height: 56px;
-    }
-</style>
+    <div id="dashboard-root"
+         data-household-id="@_shell.HouseholdId"
+         data-user-id="@_shell.UserId"
+         data-user-name="@_shell.UserName"></div>
+}
+else
+{
+    <HomeBlazor />
+}
 
 @code {
-    private string _displayName = "";
-    private string _householdName = "";
-    private int _householdId;
-    private List<MealPlanEntry> _todaysMeals = new();
-    private int _shoppingListCount;
-    private int _shoppingListChecked;
-    private double _shoppingListProgress;
-    private int _choreActiveTotal;
-    private int _choreOverdue;
-    private int _choreDueToday;
-    private int _choreUpForGrabs;
-
-    // Chores needing a look = overdue + due today (names chores, not people — collective framing).
-    private int ChoreAttention => _choreOverdue + _choreDueToday;
+    private bool _useIsland;
+    private ShellData? _shell;
+    private IJSObjectReference? _islandModule;
 
     protected override async Task OnInitializedAsync()
     {
-        var claimsPrincipal = HttpContextAccessor.HttpContext?.User;
-        _displayName = claimsPrincipal?.FindFirst(ClaimTypes.GivenName)?.Value
-            ?? claimsPrincipal?.FindFirst(ClaimTypes.Name)?.Value?.Split(' ').FirstOrDefault()
-            ?? claimsPrincipal?.FindFirst(ClaimTypes.Email)?.Value?.Split('@').FirstOrDefault()
-            ?? "there";
+        _useIsland = IsIslandEnabled();
+        if (!_useIsland) return;
 
-        var email = claimsPrincipal?.FindFirst(ClaimTypes.Email)?.Value;
-        if (!string.IsNullOrEmpty(email))
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        var email = authState.User.FindFirst(ClaimTypes.Email)?.Value;
+        var userName = authState.User.FindFirst(ClaimTypes.Name)?.Value ?? string.Empty;
+
+        await using var context = await DbFactory.CreateDbContextAsync();
+        var user = await context.Users.FirstOrDefaultAsync(u => u.Email == email);
+        if (user is null)
         {
-            await using var context = await DbFactory.CreateDbContextAsync();
-            var user = await context.Users
-                .Include(u => u.Household)
-                .FirstOrDefaultAsync(u => u.Email == email);
-            
-            if (user != null)
-            {
-                _householdId = user.HouseholdId;
-                _householdName = user.Household?.Name ?? "Your Household";
-                
-                await LoadTodaysMeals(context);
-                await LoadShoppingListStats();
-                await LoadChoreStats(user.Id);
-            }
+            throw new InvalidOperationException("User not found. Please log in again.");
+        }
+
+        _shell = new ShellData(user.HouseholdId, user.Id, userName);
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender || !_useIsland || _shell is null) return;
+
+        // Blazor enhanced navigation does not apply this page's <HeadContent>, so the island stylesheet is
+        // missing on in-app navigation. (Re)inject it here (idempotent) — OnAfterRender runs for both full
+        // loads and enhanced nav, so the island is styled either way.
+        await JS.InvokeVoidAsync("ensureIslandStylesheet", $"/islands/dashboard/index.css?v={IslandVersion}");
+
+        // Load the Svelte bundle as an ES module, then call its exposed mounter. mountRoot is idempotent and
+        // re-mounts against the fresh <div id="dashboard-root">.
+        _islandModule = await JS.InvokeAsync<IJSObjectReference>(
+            "import", $"/islands/dashboard/index.js?v={IslandVersion}");
+        await JS.InvokeVoidAsync("DashboardIsland.mount", "dashboard-root");
+    }
+
+    // Cache-bust the island URLs per deploy via the published bundle's mtime (mirrors MealPlan.razor).
+    private static string? _islandVersion;
+    private string IslandVersion => _islandVersion ??= ComputeIslandVersion();
+
+    private string ComputeIslandVersion()
+    {
+        try
+        {
+            var path = Path.Combine(HostEnv.WebRootPath, "islands", "dashboard", "index.js");
+            return new DateTimeOffset(File.GetLastWriteTimeUtc(path)).ToUnixTimeSeconds().ToString();
+        }
+        catch
+        {
+            return "0";
         }
     }
 
-    private async Task LoadTodaysMeals(ApplicationDbContext context)
+    private bool IsIslandEnabled()
     {
-        var today = DateOnly.FromDateTime(DateTime.Today);
-        var weekStart = MealPlanService.GetWeekStartDate(today);
-        
-        var mealPlan = await context.MealPlans
-            .Where(mp => mp.HouseholdId == _householdId && mp.WeekStartDate == weekStart)
-            .Include(mp => mp.Entries.Where(e => e.Date == today))
-            .ThenInclude(e => e.Recipe)
-            .FirstOrDefaultAsync();
-
-        if (mealPlan != null)
+        var configValue = Config["DASHBOARD_USE_ISLAND"];
+        if (!string.IsNullOrEmpty(configValue))
         {
-            _todaysMeals = mealPlan.Entries
-                .OrderBy(e => e.MealType)
-                .ToList();
+            return configValue.Equals("true", StringComparison.OrdinalIgnoreCase);
+        }
+
+        var envValue = Environment.GetEnvironmentVariable("DASHBOARD_USE_ISLAND");
+        return string.Equals(envValue, "true", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_islandModule is null) return;
+        try
+        {
+            await JS.InvokeVoidAsync("DashboardIsland.destroy", "dashboard-root");
+            await _islandModule.DisposeAsync();
+        }
+        catch (JSDisconnectedException)
+        {
+            // Circuit already gone (user navigated away after disconnect) — nothing to clean up.
         }
     }
 
-    private async Task LoadShoppingListStats()
-    {
-        // Summarize across ALL active (non-archived) lists, not just the most recent one —
-        // the household may have several lists going at once and the home card should reflect
-        // everything still to buy.
-        var lists = await ShoppingListService.GetActiveShoppingListsAsync(_householdId);
-        var allItems = lists.SelectMany(l => l.Items).ToList();
-
-        _shoppingListCount = allItems.Count(i => !i.IsChecked);
-        _shoppingListChecked = allItems.Count(i => i.IsChecked);
-        var total = _shoppingListCount + _shoppingListChecked;
-        _shoppingListProgress = total > 0 ? (_shoppingListChecked * 100.0 / total) : 0;
-    }
-
-    private async Task LoadChoreStats(int userId)
-    {
-        // Household-level, collective framing (never a per-person leaderboard). The board's SERVER-computed
-        // dueState + assignment + snooze drive the counts — no client-side date math (M5). The count logic
-        // (incl. the snooze guard on up-for-grabs) lives in the unit-tested ChoreHomeStats helper, since a
-        // private Razor method has no test harness.
-        var board = await ChoreBoardService.GetBoardAsync(_householdId, userId);
-        var stats = ChoreHomeStats.Compute(board.Chores);
-        _choreActiveTotal = stats.Total;
-        _choreOverdue = stats.Overdue;
-        _choreDueToday = stats.DueToday;
-        _choreUpForGrabs = stats.UpForGrabs;
-    }
-
-    private static string GetMealTypeIcon(MealType mealType) => mealType switch
-    {
-        MealType.Breakfast => Icons.Material.Filled.FreeBreakfast,
-        MealType.Lunch => Icons.Material.Filled.LunchDining,
-        MealType.Dinner => Icons.Material.Filled.DinnerDining,
-        MealType.Snack => Icons.Material.Filled.Icecream,
-        _ => Icons.Material.Filled.Restaurant
-    };
-
-    private static string GetMealDisplayName(MealPlanEntry meal)
-    {
-        if (meal.Recipe != null && !string.IsNullOrWhiteSpace(meal.Recipe.Name))
-            return meal.Recipe.Name;
-        if (!string.IsNullOrWhiteSpace(meal.CustomMealName))
-            return meal.CustomMealName;
-        return "Unnamed meal";
-    }
+    private sealed record ShellData(int HouseholdId, int UserId, string UserName);
 }

--- a/src/FamilyCoordinationApp/Components/Pages/HomeBlazor.razor
+++ b/src/FamilyCoordinationApp/Components/Pages/HomeBlazor.razor
@@ -1,0 +1,404 @@
+@using System.Security.Claims
+@using Microsoft.EntityFrameworkCore
+@using FamilyCoordinationApp.Data
+@using FamilyCoordinationApp.Data.Entities
+@using FamilyCoordinationApp.Services
+@inject IDbContextFactory<ApplicationDbContext> DbFactory
+@inject IHttpContextAccessor HttpContextAccessor
+@inject IMealPlanService MealPlanService
+@inject IShoppingListService ShoppingListService
+@inject IChoreBoardService ChoreBoardService
+
+@*
+    The original Blazor dashboard body, extracted verbatim from Home.razor as the zero-regression
+    fallback for the strangler (flag DASHBOARD_USE_ISLAND=false → this renders). NOT routable — the
+    @page "/dashboard" + [Authorize] live on the host Home.razor. Delete once the island is prod-stable.
+*@
+
+<MudContainer MaxWidth="MaxWidth.Large" Class="py-6">
+    <div class="welcome-section mb-6">
+        <MudText Typo="Typo.h4" Class="mb-1">
+            Welcome back, @_displayName! 👋
+        </MudText>
+        <MudText Typo="Typo.body1" Color="Color.Secondary">
+            @_householdName • @DateTime.Now.ToString("dddd, MMMM d")
+        </MudText>
+    </div>
+
+    <MudGrid Spacing="4">
+        <!-- Chores Card -->
+        <MudItem xs="12" md="6">
+            <MudCard Elevation="2" Class="dashboard-card">
+                <MudCardHeader>
+                    <CardHeaderAvatar>
+                        <MudAvatar Color="Color.Tertiary" Variant="Variant.Outlined">
+                            <MudIcon Icon="@Icons.Material.Filled.CleaningServices" />
+                        </MudAvatar>
+                    </CardHeaderAvatar>
+                    <CardHeaderContent>
+                        <MudText Typo="Typo.h6">Chores</MudText>
+                        <MudText Typo="Typo.body2" Color="Color.Secondary">
+                            @if (_choreActiveTotal == 0)
+                            {
+                                @:No chores yet
+                            }
+                            else if (ChoreAttention > 0)
+                            {
+                                @:@ChoreAttention need attention
+                            }
+                            else
+                            {
+                                @:All caught up
+                            }
+                        </MudText>
+                    </CardHeaderContent>
+                    <CardHeaderActions>
+                        <MudIconButton Icon="@Icons.Material.Filled.ArrowForward" Href="/chores" />
+                    </CardHeaderActions>
+                </MudCardHeader>
+                <MudCardContent Class="pt-0">
+                    @if (_choreActiveTotal == 0)
+                    {
+                        <MudText Color="Color.Secondary" Class="text-center py-4">
+                            No chores set up yet
+                        </MudText>
+                        <div class="text-center">
+                            <MudButton Variant="Variant.Text" Color="Color.Primary" Href="/chores">
+                                Set up the chore board
+                            </MudButton>
+                        </div>
+                    }
+                    else if (ChoreAttention == 0 && _choreUpForGrabs == 0)
+                    {
+                        <MudText Color="Color.Secondary" Class="text-center py-4">
+                            All caught up — nothing needs attention 🎉
+                        </MudText>
+                    }
+                    else
+                    {
+                        <div class="chore-stats py-2">
+                            @if (_choreOverdue > 0)
+                            {
+                                <div class="d-flex align-center gap-2 py-1">
+                                    <MudIcon Icon="@Icons.Material.Filled.ErrorOutline" Size="Size.Small" Color="Color.Error" />
+                                    <MudText><b>@_choreOverdue</b> overdue</MudText>
+                                </div>
+                            }
+                            @if (_choreDueToday > 0)
+                            {
+                                <div class="d-flex align-center gap-2 py-1">
+                                    <MudIcon Icon="@Icons.Material.Filled.Today" Size="Size.Small" Color="Color.Warning" />
+                                    <MudText><b>@_choreDueToday</b> due today</MudText>
+                                </div>
+                            }
+                            @if (_choreUpForGrabs > 0)
+                            {
+                                <div class="d-flex align-center gap-2 py-1">
+                                    <MudIcon Icon="@Icons.Material.Filled.PanTool" Size="Size.Small" Color="Color.Secondary" />
+                                    <MudText><b>@_choreUpForGrabs</b> up for grabs</MudText>
+                                </div>
+                            }
+                        </div>
+                    }
+                </MudCardContent>
+            </MudCard>
+        </MudItem>
+
+        <!-- Shopping List Card -->
+        <MudItem xs="12" md="6">
+            <MudCard Elevation="2" Class="dashboard-card">
+                <MudCardHeader>
+                    <CardHeaderAvatar>
+                        <MudAvatar Color="Color.Secondary" Variant="Variant.Outlined">
+                            <MudIcon Icon="@Icons.Material.Filled.ShoppingCart" />
+                        </MudAvatar>
+                    </CardHeaderAvatar>
+                    <CardHeaderContent>
+                        <MudText Typo="Typo.h6">Shopping List</MudText>
+                        <MudText Typo="Typo.body2" Color="Color.Secondary">
+                            @if (_shoppingListCount > 0)
+                            {
+                                @:@_shoppingListCount items remaining
+                            }
+                            else
+                            {
+                                @:All done!
+                            }
+                        </MudText>
+                    </CardHeaderContent>
+                    <CardHeaderActions>
+                        <MudIconButton Icon="@Icons.Material.Filled.ArrowForward" Href="/shopping-list" />
+                    </CardHeaderActions>
+                </MudCardHeader>
+                <MudCardContent Class="pt-0">
+                    @if (_shoppingListCount == 0)
+                    {
+                        <MudText Color="Color.Secondary" Class="text-center py-4">
+                            Shopping list is empty
+                        </MudText>
+                        <div class="text-center">
+                            <MudButton Variant="Variant.Text" Color="Color.Primary" Href="/shopping-list">
+                                Generate from meal plan
+                            </MudButton>
+                        </div>
+                    }
+                    else
+                    {
+                        <MudProgressLinear Color="Color.Success"
+                                           Value="@_shoppingListProgress"
+                                           Class="my-3"
+                                           Rounded="true" />
+                        <MudText Typo="Typo.caption" Color="Color.Secondary" Class="text-center">
+                            @_shoppingListChecked of @(_shoppingListChecked + _shoppingListCount) items checked
+                        </MudText>
+                    }
+                </MudCardContent>
+            </MudCard>
+        </MudItem>
+
+        <!-- Today's Meals Card -->
+        <MudItem xs="12" md="6">
+            <MudCard Elevation="2" Class="dashboard-card">
+                <MudCardHeader>
+                    <CardHeaderAvatar>
+                        <MudAvatar Color="Color.Primary" Variant="Variant.Outlined">
+                            <MudIcon Icon="@Icons.Material.Filled.Today" />
+                        </MudAvatar>
+                    </CardHeaderAvatar>
+                    <CardHeaderContent>
+                        <MudText Typo="Typo.h6">Today's Meals</MudText>
+                        <MudText Typo="Typo.body2" Color="Color.Secondary">@DateTime.Today.ToString("MMM d")</MudText>
+                    </CardHeaderContent>
+                    <CardHeaderActions>
+                        <MudIconButton Icon="@Icons.Material.Filled.ArrowForward" Href="/meal-plan" />
+                    </CardHeaderActions>
+                </MudCardHeader>
+                <MudCardContent Class="pt-0">
+                    @if (_todaysMeals.Count == 0)
+                    {
+                        <MudText Color="Color.Secondary" Class="text-center py-4">
+                            No meals planned for today
+                        </MudText>
+                        <div class="text-center">
+                            <MudButton Variant="Variant.Text" Color="Color.Primary" Href="/meal-plan">
+                                Plan something
+                            </MudButton>
+                        </div>
+                    }
+                    else
+                    {
+                        @foreach (var mealGroup in _todaysMeals.GroupBy(m => m.MealType).OrderBy(g => g.Key))
+                        {
+                            <div class="meal-group py-2">
+                                <div class="d-flex align-center gap-2 mb-1">
+                                    <MudIcon Icon="@GetMealTypeIcon(mealGroup.Key)" Size="Size.Small" Color="Color.Secondary" />
+                                    <MudText Typo="Typo.subtitle2" Color="Color.Secondary">@mealGroup.Key</MudText>
+                                </div>
+                                @foreach (var meal in mealGroup)
+                                {
+                                    <div class="meal-item ps-6 py-1">
+                                        <MudText>@GetMealDisplayName(meal)</MudText>
+                                    </div>
+                                }
+                            </div>
+                        }
+                    }
+                </MudCardContent>
+            </MudCard>
+        </MudItem>
+
+        <!-- Quick Actions -->
+        <MudItem xs="12">
+            <MudText Typo="Typo.h6" Class="mb-3">Quick Actions</MudText>
+            <MudGrid Spacing="3">
+                <MudItem xs="6" sm="3">
+                    <MudButton Variant="Variant.Outlined"
+                               Color="Color.Primary"
+                               FullWidth="true"
+                               Href="/recipes/new"
+                               StartIcon="@Icons.Material.Filled.Add"
+                               Class="quick-action-btn">
+                        New Recipe
+                    </MudButton>
+                </MudItem>
+                <MudItem xs="6" sm="3">
+                    <MudButton Variant="Variant.Outlined"
+                               Color="Color.Primary"
+                               FullWidth="true"
+                               Href="/recipes"
+                               StartIcon="@Icons.Material.Filled.MenuBook"
+                               Class="quick-action-btn">
+                        Browse Recipes
+                    </MudButton>
+                </MudItem>
+                <MudItem xs="6" sm="3">
+                    <MudButton Variant="Variant.Outlined"
+                               Color="Color.Primary"
+                               FullWidth="true"
+                               Href="/meal-plan"
+                               StartIcon="@Icons.Material.Filled.CalendarMonth"
+                               Class="quick-action-btn">
+                        This Week
+                    </MudButton>
+                </MudItem>
+                <MudItem xs="6" sm="3">
+                    <MudButton Variant="Variant.Outlined"
+                               Color="Color.Primary"
+                               FullWidth="true"
+                               Href="/chores"
+                               StartIcon="@Icons.Material.Filled.CleaningServices"
+                               Class="quick-action-btn">
+                        Chores
+                    </MudButton>
+                </MudItem>
+                <MudItem xs="6" sm="3">
+                    <MudButton Variant="Variant.Outlined"
+                               Color="Color.Primary"
+                               FullWidth="true"
+                               Href="/settings/users"
+                               StartIcon="@Icons.Material.Filled.PersonAdd"
+                               Class="quick-action-btn">
+                        Invite Family
+                    </MudButton>
+                </MudItem>
+            </MudGrid>
+        </MudItem>
+    </MudGrid>
+</MudContainer>
+
+<style>
+    .welcome-section {
+        padding: 1rem 0;
+    }
+
+    .dashboard-card {
+        height: 100%;
+        min-height: 200px;
+    }
+
+    .meal-group {
+        border-bottom: 1px solid var(--mud-palette-divider);
+    }
+
+    .meal-group:last-child {
+        border-bottom: none;
+    }
+
+    .meal-item {
+        /* Individual meal items within a group */
+    }
+
+    .quick-action-btn {
+        height: 56px;
+    }
+</style>
+
+@code {
+    private string _displayName = "";
+    private string _householdName = "";
+    private int _householdId;
+    private List<MealPlanEntry> _todaysMeals = new();
+    private int _shoppingListCount;
+    private int _shoppingListChecked;
+    private double _shoppingListProgress;
+    private int _choreActiveTotal;
+    private int _choreOverdue;
+    private int _choreDueToday;
+    private int _choreUpForGrabs;
+
+    // Chores needing a look = overdue + due today (names chores, not people — collective framing).
+    private int ChoreAttention => _choreOverdue + _choreDueToday;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var claimsPrincipal = HttpContextAccessor.HttpContext?.User;
+        _displayName = claimsPrincipal?.FindFirst(ClaimTypes.GivenName)?.Value
+            ?? claimsPrincipal?.FindFirst(ClaimTypes.Name)?.Value?.Split(' ').FirstOrDefault()
+            ?? claimsPrincipal?.FindFirst(ClaimTypes.Email)?.Value?.Split('@').FirstOrDefault()
+            ?? "there";
+
+        var email = claimsPrincipal?.FindFirst(ClaimTypes.Email)?.Value;
+        if (!string.IsNullOrEmpty(email))
+        {
+            await using var context = await DbFactory.CreateDbContextAsync();
+            var user = await context.Users
+                .Include(u => u.Household)
+                .FirstOrDefaultAsync(u => u.Email == email);
+
+            if (user != null)
+            {
+                _householdId = user.HouseholdId;
+                _householdName = user.Household?.Name ?? "Your Household";
+
+                await LoadTodaysMeals(context);
+                await LoadShoppingListStats();
+                await LoadChoreStats(user.Id);
+            }
+        }
+    }
+
+    private async Task LoadTodaysMeals(ApplicationDbContext context)
+    {
+        var today = DateOnly.FromDateTime(DateTime.Today);
+        var weekStart = MealPlanService.GetWeekStartDate(today);
+
+        var mealPlan = await context.MealPlans
+            .Where(mp => mp.HouseholdId == _householdId && mp.WeekStartDate == weekStart)
+            .Include(mp => mp.Entries.Where(e => e.Date == today))
+            .ThenInclude(e => e.Recipe)
+            .FirstOrDefaultAsync();
+
+        if (mealPlan != null)
+        {
+            _todaysMeals = mealPlan.Entries
+                .OrderBy(e => e.MealType)
+                .ToList();
+        }
+    }
+
+    private async Task LoadShoppingListStats()
+    {
+        // Summarize across ALL active (non-archived) lists, not just the most recent one —
+        // the household may have several lists going at once and the home card should reflect
+        // everything still to buy.
+        var lists = await ShoppingListService.GetActiveShoppingListsAsync(_householdId);
+        var allItems = lists.SelectMany(l => l.Items).ToList();
+
+        _shoppingListCount = allItems.Count(i => !i.IsChecked);
+        _shoppingListChecked = allItems.Count(i => i.IsChecked);
+        var total = _shoppingListCount + _shoppingListChecked;
+        _shoppingListProgress = total > 0 ? (_shoppingListChecked * 100.0 / total) : 0;
+    }
+
+    private async Task LoadChoreStats(int userId)
+    {
+        // Household-level, collective framing (never a per-person leaderboard). The board's SERVER-computed
+        // dueState + assignment + snooze drive the counts — no client-side date math (M5). The count logic
+        // (incl. the snooze guard on up-for-grabs) lives in the unit-tested ChoreHomeStats helper, since a
+        // private Razor method has no test harness.
+        var board = await ChoreBoardService.GetBoardAsync(_householdId, userId);
+        var stats = ChoreHomeStats.Compute(board.Chores);
+        _choreActiveTotal = stats.Total;
+        _choreOverdue = stats.Overdue;
+        _choreDueToday = stats.DueToday;
+        _choreUpForGrabs = stats.UpForGrabs;
+    }
+
+    private static string GetMealTypeIcon(MealType mealType) => mealType switch
+    {
+        MealType.Breakfast => Icons.Material.Filled.FreeBreakfast,
+        MealType.Lunch => Icons.Material.Filled.LunchDining,
+        MealType.Dinner => Icons.Material.Filled.DinnerDining,
+        MealType.Snack => Icons.Material.Filled.Icecream,
+        _ => Icons.Material.Filled.Restaurant
+    };
+
+    private static string GetMealDisplayName(MealPlanEntry meal)
+    {
+        if (meal.Recipe != null && !string.IsNullOrWhiteSpace(meal.Recipe.Name))
+            return meal.Recipe.Name;
+        if (!string.IsNullOrWhiteSpace(meal.CustomMealName))
+            return meal.CustomMealName;
+        return "Unnamed meal";
+    }
+}

--- a/src/FamilyCoordinationApp/Endpoints/DashboardEndpoints.cs
+++ b/src/FamilyCoordinationApp/Endpoints/DashboardEndpoints.cs
@@ -1,0 +1,58 @@
+using System.Security.Claims;
+using FamilyCoordinationApp.Data;
+using FamilyCoordinationApp.Services.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace FamilyCoordinationApp.Endpoints;
+
+/// <summary>
+/// Minimal-API surface for the dashboard island (strangler — mirrors <see cref="MealPlanEndpoints"/>): a
+/// <c>/api/dashboard</c> group behind <c>.RequireAuthorization().DisableAntiforgery()</c>. ONE read route —
+/// the dashboard is a pure read-aggregate (D1). The handler resolves the HouseholdId/UserId from the
+/// authenticated caller (M1, never client-supplied) via <see cref="UserContextResolver"/>, resolves the
+/// greeting name from the caller's claims, and delegates the whole <c>DashboardDto</c> assembly to
+/// <see cref="IDashboardService"/> (ONE projection — no drift, M9).
+///
+/// <para>Read-only: no writes ⇒ no concurrency token, no 4xx-on-missing path (an empty household yields a
+/// well-formed 200 with zero counts / empty meals), so the empty-body-4xx re-execute quirk does not apply.</para>
+/// </summary>
+public static class DashboardEndpoints
+{
+    public static IEndpointRouteBuilder MapDashboardEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/dashboard")
+            .RequireAuthorization()
+            // Kept consistent with the other island endpoint groups (the island calls this with same-origin
+            // credentialed fetch; there are no writes here, so antiforgery is moot either way).
+            .DisableAntiforgery();
+
+        group.MapGet("/", GetDashboard);
+
+        return app;
+    }
+
+    private static async Task<IResult> GetDashboard(
+        ClaimsPrincipal principal,
+        IDashboardService dashboardService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        var greetingName = ResolveGreetingName(principal);
+        var dashboard = await dashboardService.GetDashboardAsync(user.HouseholdId, user.UserId, greetingName, ct);
+        return Results.Ok(dashboard);
+    }
+
+    /// <summary>
+    /// The greeting fallback chain (parity with Home.razor): given name → first word of the full name → the
+    /// email local-part → "there". Resolved here (the endpoint holds the principal) so the service stays
+    /// claims-free and unit-testable.
+    /// </summary>
+    private static string ResolveGreetingName(ClaimsPrincipal principal) =>
+        principal.FindFirst(ClaimTypes.GivenName)?.Value
+        ?? principal.FindFirst(ClaimTypes.Name)?.Value?.Split(' ').FirstOrDefault()
+        ?? principal.FindFirst(ClaimTypes.Email)?.Value?.Split('@').FirstOrDefault()
+        ?? "there";
+}

--- a/src/FamilyCoordinationApp/FamilyCoordinationApp.csproj
+++ b/src/FamilyCoordinationApp/FamilyCoordinationApp.csproj
@@ -88,6 +88,23 @@
           SkipUnchangedFiles="true" />
   </Target>
 
+  <!--
+    Copy the built dashboard island into wwwroot before build (strangler). Run `npm run build` in
+    frontend/dashboard/ first (or let the Docker build do it via the dashboard-node-build stage). If dist/
+    doesn't exist, the target is skipped silently and the island endpoint 404s — Home.razor renders the
+    Blazor fallback (<HomeBlazor/>) via the DASHBOARD_USE_ISLAND toggle. Parallel to CopyRecipesIsland.
+  -->
+  <Target Name="CopyDashboardIsland"
+          BeforeTargets="AssignTargetPaths"
+          Condition="Exists('$(MSBuildThisFileDirectory)..\..\frontend\dashboard\dist')">
+    <ItemGroup>
+      <_DashboardIslandFiles Include="$(MSBuildThisFileDirectory)..\..\frontend\dashboard\dist\**\*.*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_DashboardIslandFiles)"
+          DestinationFiles="@(_DashboardIslandFiles->'$(MSBuildThisFileDirectory)wwwroot\islands\dashboard\%(RecursiveDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true" />
+  </Target>
+
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.4.0" />
     <PackageReference Include="blazor-dragdrop" Version="2.6.1" />

--- a/src/FamilyCoordinationApp/Program.cs
+++ b/src/FamilyCoordinationApp/Program.cs
@@ -91,6 +91,8 @@ builder.Services.AddScoped<IMealPlanService, MealPlanService>();
 builder.Services.AddScoped<IMealPlanBoardService, MealPlanBoardService>();
 // Recipes island (strangler): the single recipe→DTO projection (list card / full detail / parsed ingredient).
 builder.Services.AddScoped<IRecipeProjectionService, RecipeProjectionService>();
+// Dashboard island (strangler): the read-only aggregate (chore summary + shopping summary + today's meals).
+builder.Services.AddScoped<IDashboardService, DashboardService>();
 builder.Services.AddScoped<IShoppingListService, ShoppingListService>();
 builder.Services.AddScoped<UnitConverter>();
 builder.Services.AddScoped<IShoppingListGenerator, ShoppingListGenerator>();
@@ -402,6 +404,7 @@ app.MapChoresEndpoints();
 app.MapRoomsEndpoints();
 app.MapMealPlanEndpoints();
 app.MapRecipesEndpoints();
+app.MapDashboardEndpoints();
 
 // Health check endpoint for Docker
 app.MapGet("/health", () => Results.Ok("healthy"));

--- a/src/FamilyCoordinationApp/Services/DashboardService.cs
+++ b/src/FamilyCoordinationApp/Services/DashboardService.cs
@@ -1,0 +1,101 @@
+using FamilyCoordinationApp.Data;
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Services.Dtos;
+using FamilyCoordinationApp.Services.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace FamilyCoordinationApp.Services;
+
+/// <summary>
+/// Aggregates the dashboard island payload (strangler — mirrors <see cref="MealPlanBoardService"/>). Pure
+/// composition over the existing domain services + a focused today-meals query; adds NO new business logic so
+/// it rides those services' existing tests. The chore counts reuse the server-side, unit-tested
+/// <see cref="ChoreHomeStats"/> reducer directly (same assembly) rather than re-implementing the snooze guard.
+/// Read-only — never creates a plan/list/board row (an empty household yields zero counts / empty meals). All
+/// reads create short-lived contexts via the factory and filter by <c>HouseholdId</c> (M1).
+/// </summary>
+public class DashboardService(
+    IDbContextFactory<ApplicationDbContext> dbFactory,
+    IChoreBoardService choreBoardService,
+    IShoppingListService shoppingListService,
+    IMealPlanService mealPlanService) : IDashboardService
+{
+    public async Task<DashboardDto> GetDashboardAsync(
+        int householdId,
+        int userId,
+        string greetingName,
+        CancellationToken cancellationToken = default)
+    {
+        var householdName = await GetHouseholdNameAsync(userId, cancellationToken);
+
+        // Chores: reuse the board read + the SERVER-side, unit-tested ChoreHomeStats reducer (incl. the
+        // snooze guard on up-for-grabs). Parity with Home.razor's LoadChoreStats.
+        var board = await choreBoardService.GetBoardAsync(householdId, userId, cancellationToken: cancellationToken);
+        var choreStats = ChoreHomeStats.Compute(board.Chores);
+        var chores = new DashboardChoreSummaryDto(
+            choreStats.Total, choreStats.Overdue, choreStats.DueToday, choreStats.UpForGrabs);
+
+        // Shopping: sum across ALL active (non-archived) lists — the household may have several going at once
+        // and the card reflects everything still to buy (parity with Home.razor's LoadShoppingListStats).
+        var lists = await shoppingListService.GetActiveShoppingListsAsync(householdId, cancellationToken);
+        var allItems = lists.SelectMany(l => l.Items).ToList();
+        var checkedCount = allItems.Count(i => i.IsChecked);
+        var remaining = allItems.Count - checkedCount;
+        var shopping = new DashboardShoppingSummaryDto(remaining, checkedCount, allItems.Count);
+
+        // Today's meals: SERVER decides "today", queries that week's plan for today's entries only.
+        var today = DateOnly.FromDateTime(DateTime.Today);
+        var todaysMeals = await GetTodaysMealsAsync(householdId, today, cancellationToken);
+
+        return new DashboardDto(greetingName, householdName, today, chores, shopping, todaysMeals);
+    }
+
+    private async Task<string> GetHouseholdNameAsync(int userId, CancellationToken ct)
+    {
+        await using var context = await dbFactory.CreateDbContextAsync(ct);
+        var name = await context.Users
+            .AsNoTracking()
+            .Where(u => u.Id == userId)
+            .Select(u => u.Household != null ? u.Household.Name : null)
+            .FirstOrDefaultAsync(ct);
+        return string.IsNullOrWhiteSpace(name) ? "Your Household" : name;
+    }
+
+    private async Task<IReadOnlyList<DashboardMealDto>> GetTodaysMealsAsync(
+        int householdId, DateOnly today, CancellationToken ct)
+    {
+        var weekStart = mealPlanService.GetWeekStartDate(today);
+
+        await using var context = await dbFactory.CreateDbContextAsync(ct);
+        var plan = await context.MealPlans
+            .AsNoTracking()
+            .Where(mp => mp.HouseholdId == householdId && mp.WeekStartDate == weekStart)
+            .Include(mp => mp.Entries.Where(e => e.Date == today))
+                .ThenInclude(e => e.Recipe)
+            .FirstOrDefaultAsync(ct);
+
+        if (plan is null)
+        {
+            return Array.Empty<DashboardMealDto>();
+        }
+
+        return plan.Entries
+            .OrderBy(e => e.MealType)
+            .Select(e => new DashboardMealDto(e.MealType, ResolveDisplayName(e)))
+            .ToList();
+    }
+
+    // Parity with Home.razor's GetMealDisplayName: recipe name, else custom-meal name, else a placeholder.
+    private static string ResolveDisplayName(MealPlanEntry meal)
+    {
+        if (meal.Recipe != null && !string.IsNullOrWhiteSpace(meal.Recipe.Name))
+        {
+            return meal.Recipe.Name;
+        }
+        if (!string.IsNullOrWhiteSpace(meal.CustomMealName))
+        {
+            return meal.CustomMealName;
+        }
+        return "Unnamed meal";
+    }
+}

--- a/src/FamilyCoordinationApp/Services/Dtos/DashboardDtos.cs
+++ b/src/FamilyCoordinationApp/Services/Dtos/DashboardDtos.cs
@@ -1,0 +1,59 @@
+using FamilyCoordinationApp.Data.Entities;
+
+namespace FamilyCoordinationApp.Services.Dtos;
+
+// ─────────────────────────────────────────────────────────────────────────
+// Dashboard island aggregate DTOs (strangler — mirrors the meal-plan/chores
+// M9 lockstep). Source of truth for the island TS contract:
+// tests/FamilyCoordinationApp.Tests/Fixtures/Dashboard/dashboard.json +
+// frontend/dashboard/src/lib/types.ts. A shape/casing change updates THIS file,
+// that fixture, and types.ts in lockstep (DashboardDtoContractTests is the tripwire).
+//
+// ⚠ CASING: MealType is a real enum TYPE on the DTO → it serializes as a camelCase
+//   string ("breakfast"/"lunch"/"dinner"/"snack") via the globally-registered
+//   JsonStringEnumConverter(CamelCase) (Program.cs ConfigureHttpJsonOptions).
+//   DateOnly serializes as "YYYY-MM-DD".
+//
+// Read-only island: the dashboard mutates NOTHING — no write DTOs, no concurrency
+// token. The card counts are pure aggregation over the existing services.
+// ─────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// The whole dashboard read-aggregate in one payload (one round-trip, D1). <see cref="Today"/> is the
+/// SERVER's "today" (used for the meals query AND the display labels) echoed so the card header can't drift
+/// from the data — the island formats it client-side (noon-UTC, never <c>new Date("YYYY-MM-DD")</c>).
+/// </summary>
+public sealed record DashboardDto(
+    string GreetingName,
+    string HouseholdName,
+    DateOnly Today,
+    DashboardChoreSummaryDto Chores,
+    DashboardShoppingSummaryDto Shopping,
+    IReadOnlyList<DashboardMealDto> TodaysMeals);
+
+/// <summary>
+/// The four Home chore-card counts — mirrors <see cref="ChoreHomeStats.Result"/> field-for-field. The
+/// "needs attention" figure (<c>Overdue + DueToday</c>) is DISPLAY logic the island derives; it is not a
+/// wire field (the DTO stays the raw reducer output).
+/// </summary>
+public sealed record DashboardChoreSummaryDto(
+    int ActiveTotal,
+    int Overdue,
+    int DueToday,
+    int UpForGrabs);
+
+/// <summary>
+/// Shopping summary across ALL active (non-archived) lists. The progress percentage
+/// (<c>Total &gt; 0 ? Checked * 100 / Total : 0</c>) is DISPLAY logic the island derives; <see cref="Total"/>
+/// is echoed for the "{Checked} of {Total} items checked" label.
+/// </summary>
+public sealed record DashboardShoppingSummaryDto(
+    int Remaining,
+    int Checked,
+    int Total);
+
+/// <summary>One of today's planned meals — its meal type and the resolved display name (recipe name, else
+/// the custom-meal name, else "Unnamed meal"). The list is pre-ordered by <see cref="MealType"/>.</summary>
+public sealed record DashboardMealDto(
+    MealType MealType,
+    string DisplayName);

--- a/src/FamilyCoordinationApp/Services/Interfaces/IDashboardService.cs
+++ b/src/FamilyCoordinationApp/Services/Interfaces/IDashboardService.cs
@@ -1,0 +1,26 @@
+using FamilyCoordinationApp.Services.Dtos;
+
+namespace FamilyCoordinationApp.Services.Interfaces;
+
+/// <summary>
+/// Read + projection for the dashboard island aggregate (strangler — mirrors <c>IMealPlanBoardService</c>).
+/// Assembles the single <see cref="DashboardDto"/> by composing the existing domain services — the chore
+/// summary via <c>ChoreHomeStats.Compute</c> over <see cref="IChoreBoardService"/>, the shopping summary via
+/// <see cref="IShoppingListService"/>, and today's meals via a focused household-scoped query. Read-only: no
+/// writes, no row creation (an empty household yields zero counts / empty lists). All reads filter by
+/// <c>HouseholdId</c> (M1, resolved server-side — never client-supplied).
+/// </summary>
+public interface IDashboardService
+{
+    /// <summary>
+    /// Build the dashboard for the caller. <paramref name="greetingName"/> is resolved from the caller's
+    /// claims by the endpoint (so this service stays claims-free + unit-testable); everything else is read
+    /// from <paramref name="householdId"/> / <paramref name="userId"/>. Never creates a meal plan, list, or
+    /// board row.
+    /// </summary>
+    Task<DashboardDto> GetDashboardAsync(
+        int householdId,
+        int userId,
+        string greetingName,
+        CancellationToken cancellationToken = default);
+}

--- a/tests/FamilyCoordinationApp.Tests/Fixtures/Dashboard/dashboard.json
+++ b/tests/FamilyCoordinationApp.Tests/Fixtures/Dashboard/dashboard.json
@@ -1,0 +1,30 @@
+{
+  "greetingName": "Alex",
+  "householdName": "The Smiths",
+  "today": "2026-06-24",
+  "chores": {
+    "activeTotal": 7,
+    "overdue": 2,
+    "dueToday": 1,
+    "upForGrabs": 3
+  },
+  "shopping": {
+    "remaining": 5,
+    "checked": 3,
+    "total": 8
+  },
+  "todaysMeals": [
+    {
+      "mealType": "breakfast",
+      "displayName": "Overnight Oats"
+    },
+    {
+      "mealType": "lunch",
+      "displayName": "Leftovers"
+    },
+    {
+      "mealType": "dinner",
+      "displayName": "Unnamed meal"
+    }
+  ]
+}

--- a/tests/FamilyCoordinationApp.Tests/Integration/DashboardEndpointTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Integration/DashboardEndpointTests.cs
@@ -1,0 +1,197 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FamilyCoordinationApp.Data;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FamilyCoordinationApp.Tests.Integration;
+
+/// <summary>
+/// End-to-end coverage of the dashboard island endpoint through the real HTTP pipeline against real Postgres
+/// (reuses <see cref="ChoresWebAppFactory"/>'s two-household seed). Proves: the aggregate read composes the
+/// greeting + household name + chore counts (via the server-side <c>ChoreHomeStats</c> reducer) + shopping
+/// summary (summed across active lists, archived excluded) + today's meals (today-only, recipe vs custom name),
+/// the empty-household zero case creates NO rows (read-only), the 401 gate, and the M1 cross-household isolation
+/// invariant (a household-B caller's dashboard never reflects household-A's data). Read-only — no writes anywhere.
+///
+/// <para>Shopping/meal seeding is confined to household A so household B stays pristine for the empty +
+/// read-only assertions regardless of test execution order (the shared per-class DB has no method ordering).
+/// The chore-snooze guard on up-for-grabs is unit-tested separately in <c>ChoreHomeStatsTests</c>; here we assert
+/// the reducer is wired through the real board.</para>
+/// </summary>
+[Collection(IntegrationCollection.Name)]
+[Trait("kind", "integration")]
+public sealed class DashboardEndpointTests(PostgresContainerFixture postgres) : IAsyncLifetime
+{
+    private readonly ChoresWebAppFactory _factory = new(postgres);
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    public async Task InitializeAsync() => await _factory.EnsureSeededAsync();
+
+    public async Task DisposeAsync() => await _factory.DisposeAsync();
+
+    // Wire shapes (camelCase via JsonSerializerDefaults.Web). `@checked` escapes the C# keyword; the JSON key is "checked".
+    private sealed record ChoreSummary(int activeTotal, int overdue, int dueToday, int upForGrabs);
+    private sealed record ShoppingSummary(int remaining, int @checked, int total);
+    private sealed record Meal(string mealType, string displayName);
+    private sealed record Dashboard(
+        string greetingName, string householdName, string today,
+        ChoreSummary chores, ShoppingSummary shopping, List<Meal> todaysMeals);
+
+    private HttpClient ClientA => _factory.CreateClientAs(ChoresWebAppFactory.UserAEmail);
+    private HttpClient ClientB => _factory.CreateClientAs(ChoresWebAppFactory.UserBEmail);
+
+    private static readonly DateOnly Today = DateOnly.FromDateTime(DateTime.Today);
+    private static string Iso(DateOnly d) => d.ToString("yyyy-MM-dd");
+
+    // ─── Seeding helpers (real API — parity-correct) ─────────────────────────────
+
+    private async Task<int> CreateListAsync(HttpClient client, string name)
+    {
+        var resp = await client.PostAsJsonAsync("/api/shopping-lists", new { name }, Json);
+        resp.StatusCode.Should().Be(HttpStatusCode.Created);
+        var doc = await resp.Content.ReadFromJsonAsync<JsonElement>(Json);
+        return doc.GetProperty("id").GetInt32();
+    }
+
+    private async Task<int> AddItemAsync(HttpClient client, int listId, string name)
+    {
+        var resp = await client.PostAsJsonAsync($"/api/shopping-lists/{listId}/items", new { name }, Json);
+        resp.StatusCode.Should().Be(HttpStatusCode.Created);
+        var doc = await resp.Content.ReadFromJsonAsync<JsonElement>(Json);
+        return doc.GetProperty("id").GetInt32();
+    }
+
+    private async Task CheckItemAsync(HttpClient client, int listId, int itemId)
+    {
+        var resp = await client.PatchAsJsonAsync(
+            $"/api/shopping-lists/{listId}/items/{itemId}", new { isChecked = true }, Json);
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    private async Task ArchiveListAsync(HttpClient client, int listId)
+    {
+        var resp = await client.PostAsync($"/api/shopping-lists/{listId}/actions/archive", content: null);
+        resp.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    private async Task<int> QuickCreateRecipeAsync(HttpClient client, string name, string type = "main")
+    {
+        var resp = await client.PostAsJsonAsync("/api/meal-plan/recipes", new { name, recipeType = type }, Json);
+        resp.StatusCode.Should().Be(HttpStatusCode.Created);
+        var doc = await resp.Content.ReadFromJsonAsync<JsonElement>(Json);
+        return doc.GetProperty("recipeId").GetInt32();
+    }
+
+    private async Task AddMealAsync(HttpClient client, DateOnly date, string mealType, int? recipeId, string? customMealName)
+    {
+        var resp = await client.PostAsJsonAsync("/api/meal-plan/entries", new
+        {
+            date = Iso(date),
+            mealType,
+            recipeId,
+            customMealName,
+            notes = (string?)null
+        }, Json);
+        resp.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    // ─── Tests ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Dashboard_Unauthenticated_Returns401()
+    {
+        var client = _factory.CreateAnonymousClient();
+
+        var resp = await client.GetAsync("/api/dashboard");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Dashboard_EmptyHouseholdB_ZeroShoppingAndNoMeals_CreatesNoRows()
+    {
+        // Household B has one seeded chore but NO shopping lists and NO meal plans, and nothing seeds them
+        // (all shopping/meal seeding is confined to household A) — so the empty branches are exercised cleanly.
+        var resp = await ClientB.GetAsync("/api/dashboard");
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dash = (await resp.Content.ReadFromJsonAsync<Dashboard>(Json))!;
+
+        dash.householdName.Should().Be("Household B");
+        dash.greetingName.Should().Be(ChoresWebAppFactory.UserBEmail); // no GivenName claim ⇒ Name (= email) first word
+        dash.today.Should().Be(Iso(Today));
+
+        dash.chores.activeTotal.Should().Be(1, "household B has exactly one seeded active chore");
+        dash.chores.upForGrabs.Should().Be(1, "B's chore is unassigned (AssignmentKind.None) and not snoozed");
+
+        dash.shopping.remaining.Should().Be(0);
+        dash.shopping.@checked.Should().Be(0);
+        dash.shopping.total.Should().Be(0);
+        dash.todaysMeals.Should().BeEmpty();
+
+        // Read-only guarantee: the GET must not have created a MealPlan or ShoppingList row for B.
+        using var scope = _factory.Services.CreateScope();
+        var dbFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<ApplicationDbContext>>();
+        await using var db = await dbFactory.CreateDbContextAsync();
+        (await db.MealPlans.AnyAsync(mp => mp.HouseholdId == ChoresWebAppFactory.HouseholdBId))
+            .Should().BeFalse("a dashboard read must never create a meal plan");
+        (await db.ShoppingLists.AnyAsync(l => l.HouseholdId == ChoresWebAppFactory.HouseholdBId))
+            .Should().BeFalse("a dashboard read must never create a shopping list");
+    }
+
+    [Fact]
+    public async Task Dashboard_PopulatedHouseholdA_AggregatesChoresShoppingMeals_AndIsolatesFromB()
+    {
+        var client = ClientA;
+
+        // ── Shopping: two active lists (with a check) + one archived list (must be excluded) ──
+        var list1 = await CreateListAsync(client, "Groceries");
+        var m1 = await AddItemAsync(client, list1, "Milk");
+        await AddItemAsync(client, list1, "Eggs");
+        await AddItemAsync(client, list1, "Bread");
+        await CheckItemAsync(client, list1, m1);          // list1: 2 remaining, 1 checked
+
+        var list2 = await CreateListAsync(client, "Hardware");
+        await AddItemAsync(client, list2, "Nails");        // list2: 1 remaining, 0 checked
+
+        var archived = await CreateListAsync(client, "Old list");
+        await AddItemAsync(client, archived, "Should not count");
+        await ArchiveListAsync(client, archived);          // excluded from active sums
+
+        // ── Meals: today recipe + today custom + tomorrow recipe (tomorrow must be excluded) ──
+        var dinnerRecipe = await QuickCreateRecipeAsync(client, "Today Dinner Recipe", "main");
+        await AddMealAsync(client, Today, "dinner", dinnerRecipe, null);
+        await AddMealAsync(client, Today, "lunch", null, "Today Custom Lunch");
+        var tomorrowRecipe = await QuickCreateRecipeAsync(client, "Tomorrow Breakfast", "breakfast");
+        await AddMealAsync(client, Today.AddDays(1), "breakfast", tomorrowRecipe, null);
+
+        // ── Assert A's aggregate ──
+        var dash = (await client.GetFromJsonAsync<Dashboard>("/api/dashboard", Json))!;
+
+        dash.householdName.Should().Be("Household A");
+        dash.greetingName.Should().Be(ChoresWebAppFactory.UserAEmail);
+        dash.today.Should().Be(Iso(Today));
+
+        dash.chores.activeTotal.Should().Be(1, "household A has exactly one seeded active chore");
+        dash.chores.upForGrabs.Should().Be(1, "the seeded pile chore is unassigned and not snoozed");
+
+        dash.shopping.remaining.Should().Be(3, "list1 (2) + list2 (1); the archived list is excluded");
+        dash.shopping.@checked.Should().Be(1, "one item checked on list1");
+        dash.shopping.total.Should().Be(4, "remaining + checked across the two active lists");
+
+        dash.todaysMeals.Should().HaveCount(2, "tomorrow's entry is excluded; today has a lunch + a dinner");
+        dash.todaysMeals[0].mealType.Should().Be("lunch");       // ordered by MealType (Lunch < Dinner)
+        dash.todaysMeals[0].displayName.Should().Be("Today Custom Lunch");
+        dash.todaysMeals[1].mealType.Should().Be("dinner");
+        dash.todaysMeals[1].displayName.Should().Be("Today Dinner Recipe");
+        dash.todaysMeals.Should().NotContain(m => m.displayName == "Tomorrow Breakfast");
+
+        // ── M1 isolation: household B's dashboard reflects NONE of A's shopping/meals ──
+        var bDash = (await ClientB.GetFromJsonAsync<Dashboard>("/api/dashboard", Json))!;
+        bDash.householdName.Should().Be("Household B");
+        bDash.shopping.total.Should().Be(0, "A's lists must never bleed into B (M1)");
+        bDash.todaysMeals.Should().BeEmpty("A's meals must never bleed into B (M1)");
+    }
+}

--- a/tests/FamilyCoordinationApp.Tests/Services/DashboardDtoContractTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/DashboardDtoContractTests.cs
@@ -1,0 +1,116 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Services.Dtos;
+
+namespace FamilyCoordinationApp.Tests.Services;
+
+/// <summary>
+/// Contract / consumer-audit tests for the dashboard aggregate DTO (M9 — mirrors
+/// <see cref="MealPlanBoardDtoContractTests"/>). Serializes a representative <see cref="DashboardDto"/> with the
+/// SAME <see cref="JsonSerializerOptions"/> the app registers globally (camelCase properties +
+/// <see cref="JsonStringEnumConverter"/> with camelCase naming — Program.cs ConfigureHttpJsonOptions) and asserts
+/// it matches the checked-in <c>Fixtures/Dashboard/dashboard.json</c> fixture EXACTLY. The island's <c>types.ts</c>
+/// mirrors this fixture; any DTO shape/casing change (field rename, enum casing drift, added/removed property)
+/// breaks this test → forcing the island contract to update in lockstep (M9).
+/// </summary>
+public class DashboardDtoContractTests
+{
+    /// <summary>The canonical dashboard-DTO serialization options — equivalent to the app's global config.</summary>
+    public static readonly JsonSerializerOptions DashboardJsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+    };
+
+    private static readonly string FixturePath =
+        Path.Combine(AppContext.BaseDirectory, "Fixtures", "Dashboard", "dashboard.json");
+
+    /// <summary>
+    /// A representative dashboard covering: a greeting + household name, an echoed <c>today</c>, the four chore
+    /// counts (all non-zero), a shopping summary mid-progress (checked + remaining), and today's meals spanning
+    /// multiple meal types incl. a recipe name, a custom-meal name, and the "Unnamed meal" placeholder (the
+    /// deleted-recipe edge). Static values only — no clocks — so the serialization is byte-deterministic.
+    /// </summary>
+    public static DashboardDto BuildRepresentativeDashboard() => new(
+        GreetingName: "Alex",
+        HouseholdName: "The Smiths",
+        Today: new DateOnly(2026, 6, 24),
+        Chores: new DashboardChoreSummaryDto(ActiveTotal: 7, Overdue: 2, DueToday: 1, UpForGrabs: 3),
+        Shopping: new DashboardShoppingSummaryDto(Remaining: 5, Checked: 3, Total: 8),
+        TodaysMeals: new List<DashboardMealDto>
+        {
+            new(MealType.Breakfast, "Overnight Oats"),   // recipe name
+            new(MealType.Lunch, "Leftovers"),            // custom-meal name
+            new(MealType.Dinner, "Unnamed meal"),        // deleted-recipe placeholder
+        });
+
+    [Fact]
+    public void SerializedDashboard_MatchesContractFixture()
+    {
+        var dashboard = BuildRepresentativeDashboard();
+
+        var actualJson = JsonSerializer.Serialize(dashboard, DashboardJsonOptions);
+
+        File.Exists(FixturePath).Should().BeTrue(
+            $"the dashboard.json contract fixture must be checked in at {FixturePath}");
+        var expectedJson = File.ReadAllText(FixturePath);
+
+        Normalize(actualJson).Should().Be(Normalize(expectedJson),
+            "the serialized dashboard DTO must match the checked-in contract fixture; if this fails after a "
+            + "deliberate DTO change, update dashboard.json AND the island types.ts interface in lockstep (M9)");
+    }
+
+    [Fact]
+    public void SerializedDashboard_UsesCamelCaseKeys_AndCamelCaseEnumStrings()
+    {
+        var dashboard = BuildRepresentativeDashboard();
+        var json = JsonSerializer.Serialize(dashboard, DashboardJsonOptions);
+        var root = JsonNode.Parse(json)!.AsObject();
+
+        // Top-level camelCase property set is frozen (M9 — added/removed keys break this).
+        root.Select(kvp => kvp.Key).Should().BeEquivalentTo(
+            "greetingName", "householdName", "today", "chores", "shopping", "todaysMeals");
+
+        // DateOnly serializes as "YYYY-MM-DD".
+        root["today"]!.GetValue<string>().Should().Be("2026-06-24");
+
+        var chores = root["chores"]!.AsObject();
+        chores.Select(kvp => kvp.Key).Should().BeEquivalentTo(
+            "activeTotal", "overdue", "dueToday", "upForGrabs");
+        chores["activeTotal"]!.GetValue<int>().Should().Be(7);
+
+        var shopping = root["shopping"]!.AsObject();
+        shopping.Select(kvp => kvp.Key).Should().BeEquivalentTo("remaining", "checked", "total");
+        shopping["total"]!.GetValue<int>().Should().Be(8);
+
+        var meals = root["todaysMeals"]!.AsArray();
+        meals.Count.Should().Be(3);
+        var firstMeal = meals[0]!.AsObject();
+        firstMeal.Select(kvp => kvp.Key).Should().BeEquivalentTo("mealType", "displayName");
+        // MealType serializes as a camelCase enum string (NOT an integer, NOT PascalCase).
+        firstMeal["mealType"]!.GetValue<string>().Should().Be("breakfast");
+        firstMeal["displayName"]!.GetValue<string>().Should().Be("Overnight Oats");
+        meals[1]!.AsObject()["mealType"]!.GetValue<string>().Should().Be("lunch");
+        meals[2]!.AsObject()["displayName"]!.GetValue<string>().Should().Be("Unnamed meal");
+    }
+
+    /// <summary>A deliberate rename of any contract field must break the fixture test (tripwire).</summary>
+    [Fact]
+    public void RenamingAField_BreaksTheFixture()
+    {
+        var dashboard = BuildRepresentativeDashboard();
+        var json = JsonSerializer.Serialize(dashboard, DashboardJsonOptions);
+
+        // Simulate a drift: rename "upForGrabs" -> "grabbable". The mutated payload must NOT match the fixture.
+        var drifted = json.Replace("\"upForGrabs\"", "\"grabbable\"");
+        var expectedJson = File.ReadAllText(FixturePath);
+
+        Normalize(drifted).Should().NotBe(Normalize(expectedJson));
+    }
+
+    private static string Normalize(string json) =>
+        JsonNode.Parse(json)!.ToJsonString(new JsonSerializerOptions { WriteIndented = false });
+}


### PR DESCRIPTION
## What

Strangles the Blazor circuit-bound dashboard (`Home.razor`, `@page "/dashboard"`) into a **read-only Svelte 5 island** talking to a single aggregate endpoint — killing the tab-away / SignalR-circuit-drop failure mode, same pattern as shopping-list → chores → meal-plan → recipes (#53). **Behavior parity, no new UX.** The lightest island so far: one read route, zero mutations.

Spec: [`.planning/home-dashboard-island-spec.md`](.planning/home-dashboard-island-spec.md).

## Backend

- **`GET /api/dashboard` → `DashboardDto`** — one read-aggregate composing the chore summary (the server-side, unit-tested `ChoreHomeStats` reducer — **no TS port**, avoids the parity-drift trap), the shopping summary (summed across active lists, archived excluded), and today's meals. Identity is server-resolved (`UserContextResolver`, M1).
- New `IDashboardService` (pure composition over existing services) + `DashboardDtos` + `DashboardEndpoints`, wired in `Program.cs`. **Read-only** — no writes, no row creation (an empty household → zero counts / empty meals).
- **Why one aggregate, not reuse of per-domain endpoints:** keeps the snooze-guarded `ChoreHomeStats` reducer server-side and makes one lean round-trip vs over-fetching three boards for a handful of counts.

## Frontend (`frontend/dashboard/`, prefix `db-`, port 5177)

- Mirrors the meal-plan island verbatim where it counts: `main.ts` circuit-resume self-heal, `liveness.ts` (20s visible + refocus), toasts, MudBlazor token CSS — copied + re-scoped. `ChoreCard` / `ShoppingCard` / `MealsCard` / `QuickActions`.
- **Loop-safe:** the setup `$effect` is wrapped in `untrack()` (the runaway-fetch fix from #52); a `loadSeq` guard drops stale liveness responses.
- Read-only ⇒ no autosave / optimistic / draft machinery. Dates are server-authoritative (`today` echoed, formatted client-side at noon-UTC — no off-by-one).

## Host + build wiring

- `Home.razor` → thin island host gated on **`DASHBOARD_USE_ISLAND`**; the original body extracted **verbatim** to `HomeBlazor.razor` (zero-regression fallback — flip the flag to switch).
- `CopyDashboardIsland` MSBuild target, `dashboard-node-build` Dockerfile stage, `docker-build.sh` entry, `DASHBOARD_USE_ISLAND` in `docker-compose.yml` (default **off**).
- `Landing.razor` (`/`) intentionally stays Blazor (unauth marketing + redirect; near-zero circuit exposure).

## Tests / gates

- `DashboardDtoContractTests` (×3) + `Fixtures/Dashboard/dashboard.json` — M9 contract mirroring the island `types.ts` (camelCase enum, `DateOnly` → `"YYYY-MM-DD"`).
- `DashboardEndpointTests` (×3, real Postgres) — chore-count wiring, shopping sum across active lists (archived excluded), today-only meal filter, **empty-household read-only guarantee**, cross-household **M1 isolation**, 401 gate.
- ✅ `dotnet build` clean · **full suite 713/713** · `svelte-check` 0/0 · `vite build` · **browser-verified on `:8080`** (flag on) incl. the mandatory **loop-check** (0 background GETs/sec; liveness correctly pauses on hidden tab).

## Rollout

Ships with `DASHBOARD_USE_ISLAND` **off**. After merge: pre-stage `DASHBOARD_USE_ISLAND=true` in the host `~/familyapp/.env.local`, deploy, verify, then it's live (same flow as #53).

## Follow-ups (harvested, not in this PR)

- Delete the `HomeBlazor.razor` fallback once prod-stable.
- Leaner chore-count query (the dashboard builds the full board just to count) — perf only.
- Fold `Landing.razor` into the strangler at the shell-keystone step.

https://claude.ai/code/session_011EGSwdx4MbEZQQ4H1GxP9r
