### PR TITLE
feat(settings): strangle Household settings (Categories + Manage Users) into a Svelte island (cluster A)

### DIFF
--- a/.planning/settings-admin-island-spec.md
+++ b/.planning/settings-admin-island-spec.md
@@ -1,0 +1,141 @@
+# Spec (first pass) — Settings island C: Admin (Household requests + Feedback) → Svelte island (strangler)
+
+**Quest:** Spine `fd629f11-ff18-4539-ace1-6bda47b72fe2` (campaign "Family Coordination App"). Cluster **C** of the settings strangler (sequenced last — most backend net-new).
+**Decisions (this session, 2026-06-25):** spec-first focused; parity-first; **one island, two routes** (`/settings/households` + `/settings/feedback`) via the recipes data-view pattern; prefix `adm-`, port 5180.
+**Status:** first-pass spec — **for the cross-plan review session** to harden alongside A and B. Open questions flagged inline — this cluster has the most net-new backend + a **new auth shape**, so it most needs the review.
+**Template:** scaffold mirrors recipes (two-route bundle) + dashboard; backend introduces **two new services** + a **site-admin authorization gate**.
+
+---
+
+## 1. Goal & scope
+
+Replace the two **site-admin-leaning** settings pages with one Svelte island. Both are **direct-EF today (no service layer)** — the strangler must lift their logic into testable services. This is the heaviest cluster.
+
+### In scope (parity)
+
+**Household requests (`/settings/households`) — SITE-ADMIN ONLY** (`HouseholdAdmin.razor`, 353L, gated by `SiteAdminService.IsSiteAdmin`, `:19,184`):
+- List requests (pending-first, then newest, `:196-199`) with a **pending/all** filter (`:157-161`).
+- List existing households + member counts (`:201-204`).
+- **Approve** a pending request → a multi-entity transaction: create `Household` + create whitelisted `User` + mark request Approved (ReviewedAt/ReviewedBy) + **seed default categories** (`SeedData.SeedDefaultCategoriesAsync`) + log (`:213-274`).
+- **Reject** → reason dialog → mark Rejected + reason + ReviewedAt/ReviewedBy + log (`:276-317`).
+- 30s auto-refresh poll (`:172-174`).
+
+**Feedback (`/settings/feedback`) — DUAL-MODE** (`FeedbackAdmin.razor`, 326L; **not** site-admin-gated, but visibility differs, `:209-213`):
+- Site admin sees **all** feedback; a regular user sees **only their household's** (`:178-180,210-212`).
+- List (newest-first) with **all/unread/open** filter (`:133-138`); type chip (Bug/FeatureRequest/…), New/Resolved chips, author (or "Deleted user"), message, current-page link (`:38-107`).
+- **Mark read** / **mark resolved** (sets read+resolved) / **reopen** (`:227-267`).
+- 15s **smart** poll — reload only when the count changed (`:171-194`).
+
+### Out of scope
+- New UX. The `RejectReasonDialog` becomes an in-island dialog (parity).
+- Changing who can do what — **preserve today's authorization exactly** (see the Feedback-mutation open question, §7).
+
+---
+
+## 2. Auth shape (the new bit — review focus)
+
+This cluster breaks the "just `.RequireAuthorization()`" pattern of A/B:
+- **Household-requests routes are site-admin-only.** The endpoint must check `ISiteAdminService.IsSiteAdmin(callerEmail)` → **403** otherwise (not just authenticated). Proposed: a small endpoint filter or a per-handler guard resolving the caller's email from claims.
+- **Feedback routes are dual-mode.** Visibility (and possibly mutation — §7) depends on `IsSiteAdmin`: admin → all households; regular → own household only (M1-scoped). The GET must apply the household filter server-side for non-admins; a non-admin must never receive another household's feedback.
+- The island needs to know `isSiteAdmin` to render the households view (or show "Access denied") and to scope feedback — carry it in a `GET /api/settings/admin/context` or fold an `isSiteAdmin` flag into each list response. (Review: pick one.)
+
+---
+
+## 3. Endpoint surface (two new services)
+
+New `Endpoints/SettingsAdminEndpoints.cs`, `.RequireAuthorization().DisableAntiforgery()`, caller via `UserContextResolver` + claims email for the site-admin check.
+
+### 3a. `/api/settings/household-requests` — **site-admin only** → new `IHouseholdRequestService`
+
+| # | Method & route | Body | Returns | Notes |
+|---|---|---|---|---|
+| 1 | `GET /?filter=pending\|all` | — | `HouseholdRequestsDto` (requests + households) | 403 if not site-admin. Pending-first ordering (parity). |
+| 2 | `POST /{id:int}/approve` | — | `HouseholdSummaryDto` (201) | The **transaction**: household+user+seed+status. Lift `:225-267` into `IHouseholdRequestService.ApproveAsync(id, reviewerEmail)` (testable; today it's inline EF). Already-reviewed ⇒ 409. |
+| 3 | `POST /{id:int}/reject` | `{ reason }` | 204 | `RejectAsync(id, reason, reviewerEmail)`. Already-reviewed ⇒ 409. |
+
+### 3b. `/api/settings/feedback` — **dual-mode** → new `IFeedbackService`
+
+| # | Method & route | Body | Returns | Notes |
+|---|---|---|---|---|
+| 4 | `GET /?filter=all\|unread\|open` | — | `FeedbackListDto` | Admin → all; regular → own household (server-scoped, M1). Includes `isSiteAdmin` for the island. |
+| 5 | `POST /{id:int}/read` | — | 204 | `MarkReadAsync`. Authorize: admin any; regular only own-household item ⇒ else 404 (no leak). |
+| 6 | `POST /{id:int}/resolve` | — | 204 | `MarkResolvedAsync` (sets read+resolved). Same authz. |
+| 7 | `POST /{id:int}/reopen` | — | 204 | `ReopenAsync`. Same authz. |
+
+```csharp
+public sealed record RejectRequest(string Reason);
+```
+
+---
+
+## 4. DTO contract (M9)
+
+New `Services/Dtos/SettingsAdminDtos.cs`. `HouseholdRequestStatus` + `FeedbackType` are **real enums** ⇒ camelCase via the global converter. Dates → ISO (format client-side, noon-UTC).
+
+```csharp
+public sealed record HouseholdRequestsDto(
+    IReadOnlyList<HouseholdRequestDto> Requests, IReadOnlyList<HouseholdSummaryDto> Households);
+public sealed record HouseholdRequestDto(
+    int Id, string HouseholdName, string DisplayName, string Email,
+    HouseholdRequestStatus Status, string RequestedAt,
+    string? ReviewedAt, string? ReviewedBy, string? RejectionReason);
+public sealed record HouseholdSummaryDto(int HouseholdId, string Name, int MemberCount, string CreatedAt);
+
+public sealed record FeedbackListDto(bool IsSiteAdmin, IReadOnlyList<FeedbackDto> Items);
+public sealed record FeedbackDto(
+    int Id, FeedbackType Type, string Message, string? CurrentPage,
+    bool IsRead, bool IsResolved, string CreatedAt,
+    string? AuthorName, bool AuthorDeleted);   // AuthorName null + AuthorDeleted true ⇒ "Deleted user" (parity :67-70)
+```
+
+**TS mirror** + contract tests + fixtures for both list DTOs (mirror `DashboardDtoContractTests`).
+
+---
+
+## 5. Island structure — `frontend/admin/` (prefix `adm-`, roots `admin-households-root` / `admin-feedback-root`)
+
+Copy the recipes scaffold (two-route bundle); **KEEP `liveness.ts`** — this is the one settings cluster that polls (households 30s, feedback 15s). Re-scope `adm-`.
+- `HouseholdsApp.svelte` (view `households`): access-denied if `!isSiteAdmin`; pending/all filter; request cards with approve/reject (+ reason dialog); existing-households table; liveness 30s.
+- `FeedbackApp.svelte` (view `feedback`): all/unread/open filter; feedback cards + the read/resolve/reopen menu; liveness 15s (smart: reconcile only refetches — the `loadSeq` guard makes the count-check optional, but porting "reload only if count changed" is a cheap parity win).
+- Stores: `householdRequestsStore`, `feedbackStore` — `untrack` load + `loadSeq` guard; mutations await-then-reload.
+- Components: `RequestCard`, `RejectReasonDialog`, `HouseholdsTable`, `FeedbackCard`, `ConfirmDialog`, `Toasts`.
+
+## 6. Host + wiring
+- `HouseholdAdmin.razor` + `FeedbackAdmin.razor` → thin hosts (flag) + verbatim Blazor fallbacks.
+- `CopyAdminIsland`, `admin-node-build` Dockerfile stage, `docker-build.sh`, flag in compose + `.env`.
+- `Program.cs`: register `IHouseholdRequestService` + `IFeedbackService`; `MapSettingsAdminEndpoints`. `ISiteAdminService` already registered.
+
+## 7. Tests
+- Contract: `HouseholdRequestsDtoContractTests` + `FeedbackListDtoContractTests` + fixtures.
+- `IHouseholdRequestService` integration (real PG): **approve creates household+user+seeds categories+marks approved** (the load-bearing transaction); reject sets reason; double-review ⇒ 409.
+- `IFeedbackService`: dual-mode visibility (admin all vs regular own-household), read/resolve/reopen, cross-household item ⇒ 404 for a non-admin.
+- **Auth:** non-site-admin → 403 on every household-requests route; non-admin feedback GET returns only own household.
+
+## 8. Open items — RESOLVED (plan-review session, 2026-06-24)
+- **Feedback mutation authorization.** RESOLVED: **parity = allow-on-visible, but enforce "visible" server-side.** Endpoints 5-7 authorize: site-admin → any item; non-admin → only an item in their **own household**, else **404** (non-empty body, no existence leak). See **R-C1** — this is REQUIRED, not optional: the naive lift is an IDOR. The question "should feedback mgmt be admin-only at all?" is harvested as a separate provisional quest (don't change behavior in the strangler).
+- **Site-admin signal.** RESOLVED: **no dedicated context endpoint.** Household-requests routes 403 for non-admins → the island renders "Access denied" on a 403 from its list GET (the 403 IS the signal). `FeedbackListDto.isSiteAdmin` already carries it for the feedback view. Drop the `/context` idea (R-C4).
+- **Approve transaction boundary.** RESOLVED: wrap household+user+status+seed in ONE explicit transaction (R-C2). Confirmed atomicity gap is real.
+- **Polling vs liveness.** RESOLVED: reuse the shared **`liveness.ts`** (visible-only), per-view intervals **30s (households) / 15s (feedback)**, keep feedback's count-check as a cheap bandwidth win (R-C9).
+- **Flag granularity.** RESOLVED: per-cluster **`SETTINGS_ADMIN_USE_ISLAND`** (covers both C routes; see X1).
+
+---
+
+## 9. Review resolutions (plan-review session, 2026-06-24) — this cluster has the load-bearing findings
+
+*See the cross-plan memo `D:/Development/data/outputs/reviews/settings-strangler-plan-review/`. The review-council was run on the set but produced no usable signal (opus lens crashed; gemini hallucinated an unrelated spec; gpt rubric-refused) — findings below are source-grounded, not council-derived.*
+
+**Cross-cutting (apply to C):** X1 flag `SETTINGS_ADMIN_USE_ISLAND`; X2 own file `SettingsAdminEndpoints.cs`; **X5 dates** — `RequestedAt`/`ReviewedAt`/`Feedback.CreatedAt` are **full instants** (today rendered with time-of-day), emit ISO-8601 (UTC, `Z`), render local with `new Date(iso).toLocaleString()`. The §4 "noon-UTC" note is wrong for these instants — fix it.
+
+**Cluster-C hardening:**
+- **R-C1 — FEEDBACK MUTATION IDOR (must-fix; the circuit→REST lift introduces it).** Today `MarkAsRead/Resolved/Reopen` do `Feedbacks.FindAsync(id)` then flip flags with **NO household scoping** — safe ONLY because the Blazor list never renders other households' IDs to a non-admin. As a REST endpoint, a non-admin could POST an arbitrary `{id}` and mutate another household's feedback. **Endpoints 5-7 MUST enforce: admin → any; non-admin → own-household item only, else 404.** Not optional — shipping the naive lift is a vuln. Integration test: non-admin POST against another household's feedback id → 404, no mutation.
+- **R-C2 — Approve transaction atomicity.** Today = **three separate commits**: (1) `SaveChanges` after `Households.Add`; (2) `SaveChanges` after adding User + setting request status; (3) separate `SeedData.SeedDefaultCategoriesAsync` on its own context. Mid-failure → orphan household w/ no user (req still pending), or household+user+approved but **no categories**. `ApproveAsync` must wrap all four in ONE `BeginTransactionAsync` (multiple SaveChanges inside the tx — the user FK needs `household.Id` so a single SaveChanges won't do — commit once). Test: a forced failure mid-approve rolls back fully.
+- **R-C3 — Missing already-reviewed guard = latent duplicate-household bug.** Today approve/reject re-fetch and set status with **no check** that the request is still `Pending` (only the buttons + a 30s poll gate it). Two admins (or one on a 30s-stale view) can both approve → **two households for one request**. Endpoint #2/#3 must reject a non-Pending request with **409**. This is a real bug fix under the strangler (invisible to honest users) — confirm OK with operator.
+- **R-C4 — Site-admin signal:** 403-on-list (households) + `isSiteAdmin` in `FeedbackListDto`; no context endpoint.
+- **R-C5 — Site-admin email plumbing + 403 gate.** `UserContextResolver` drops the email; `IsSiteAdmin(email)` needs it. The site-admin handlers read `principal.FindFirst(ClaimTypes.Email)` directly AND call the resolver for household scope (don't re-thread email through the resolver). Per-handler 403 guard (3 routes don't justify a filter): `Results.Json(new { message = "Site admin access required." }, statusCode: 403)` — **non-empty body** (4xx quirk).
+- **R-C6 — Feedback author 3-way mapping:** `User != null` → `AuthorName=DisplayName, AuthorDeleted=false`; `User==null && UserId!=null` → `AuthorName=null, AuthorDeleted=true` ("Deleted user"); `User==null && UserId==null` → `AuthorName=null, AuthorDeleted=false` (anonymous → render no author line). Spell all three out so the build doesn't show "Deleted user" for anonymous feedback.
+- **R-C7 — Reject reason is OPTIONAL.** `RejectReasonDialog` labels it "(optional)", MaxLength 500, may return empty. `RejectRequest.Reason` is nullable/allow-empty — do NOT 400 on an empty reason.
+- **R-C8 — Household-requests are site-admin GLOBAL, not household-scoped.** `HouseholdRequest` has no `HouseholdId`; the list reads ALL requests + ALL households cross-tenant, legitimately, gated by site-admin. The C test for these routes verifies the **403 gate**, not M1 household-scoping. (M1 still applies to feedback.) `MemberCount` = `Households.Include(Users)` → `Users.Count`.
+- **R-C9 — Liveness:** keep it (only polling cluster); shared `liveness.ts` visible-only, 30s/15s, smart count-check on feedback. Visible-only is a tiny, strictly-better behavior change (no poll when tab hidden) — accepted. `loadSeq` guard still required.
+- **R-C10 — Feedback type label:** the enum serializes camelCase on the wire (`featureRequest`); the island needs a label/icon/color map (today the chip shows the raw PascalCase enum name).
+
+**Verdict: build-ready, but C is the one to code carefully** — R-C1 (IDOR), R-C2 (transaction), R-C3 (409 guard) are correctness/security-load-bearing and each needs its own test. Build last, after A and B verify.

--- a/.planning/settings-connections-island-spec.md
+++ b/.planning/settings-connections-island-spec.md
@@ -1,0 +1,107 @@
+# Spec (first pass) — Settings island B: Connections → Svelte island (strangler)
+
+**Quest:** Spine `b60c13cb-c5b3-4d7d-ac59-3d873ac0675d` (campaign "Family Coordination App"). Cluster **B** of the settings strangler (sequenced after A).
+**Decisions (this session, 2026-06-25):** spec-first focused; parity-first; **single-route island** (`/settings/connections` only); flag `SETTINGS_CONNECTIONS_USE_ISLAND` (or reuse a shared settings flag — see Open items); prefix `con-`, port 5179.
+**Status:** first-pass spec — **for the cross-plan review session** to harden alongside A and C. Open questions flagged inline.
+**Template:** mirrors the **dashboard island** (single-route, single root) for the scaffold; backend mirrors `RecipesEndpoints.cs` (thin `/api` over the existing service, M1).
+
+---
+
+## 1. Goal & scope
+
+Replace `Connections.razor` (498L, `@rendermode InteractiveServer`) — the household-connection invite flow — with a Svelte island over plain HTTP/JSON. **Behavior parity, no new UX.** The backend is thin: `IHouseholdConnectionService` already exposes every operation; the work is **the client-side state machine**.
+
+### In scope (parity, all over the existing `IHouseholdConnectionService`)
+- **Share section:** generate an invite code (`GenerateInviteAsync`) → display the 6-char code + expiry text + Copy-to-clipboard + Cancel (`InvalidateInviteAsync`). `Connections.razor:32-82,305-348`.
+- **Enter-a-code section:** input (auto-uppercase, strip non-alphanumeric, max 6, `:361-370`) → Submit (`ValidateInviteCodeAsync`) → on valid, a **pre-connection confirmation** ("Connecting with X lets both families browse…") → Connect (`AcceptInviteAsync`) or Cancel. Error messages mapped from service error codes (`MapValidationError`, `:403-415`). `:84-151,372-457`.
+- **Connected families section:** list (`GetConnectedHouseholdsAsync`) with connected-date + "Stop Sharing" → a **disconnect confirmation dialog** (3 bullet consequences) → `DisconnectHouseholdsAsync`. `:153-220,459-496`.
+
+### Out of scope
+- New UX. The invite ceremony is preserved exactly.
+- Liveness/real-time (parity — no poll today).
+- The recipes island's connected-household *browsing* (`/api/recipes/connected/*`) — separate, already shipped; this island only manages the *connections themselves*.
+
+---
+
+## 2. Endpoint surface — `/api/settings/connections` (thin, over `IHouseholdConnectionService`)
+
+New group in `Endpoints/SettingsEndpoints.cs` (or its own file), `.RequireAuthorization().DisableAntiforgery()`, `(HouseholdId, UserId)` via `UserContextResolver` (M1).
+
+| # | Method & route | Body | Returns | Delegates to |
+|---|---|---|---|---|
+| 1 | `GET /` | — | `ConnectionsDto` | `GetActiveInviteAsync` + `GetConnectedHouseholdsAsync` in one payload (parity `LoadData`). |
+| 2 | `POST /invite` | — | `InviteDto` (201) | `GenerateInviteAsync(hh, uid)` → `{ code, expiresAt }`. |
+| 3 | `DELETE /invite` | — | 204 | `InvalidateInviteAsync(hh)`. |
+| 4 | `POST /validate` | `{ code }` | `ValidateResultDto` | `ValidateInviteCodeAsync(code, hh)` → `{ isValid, householdName, error }` (error is a stable code string the TS maps to copy). |
+| 5 | `POST /accept` | `{ code }` | `AcceptResultDto` | `AcceptInviteAsync(code, hh, uid)` → `{ success, connectedHouseholdName, error }`. |
+| 6 | `DELETE /connected/{householdId:int}` | — | 204 | `DisconnectHouseholdsAsync(hh, householdId)`. Validate the pairing is the caller's (the service is symmetric; M1 — only disconnect a pairing involving `hh`). |
+
+```csharp
+public sealed record ValidateRequest(string Code);
+public sealed record AcceptRequest(string Code);
+```
+
+> **Validate/accept return a 200 with an outcome envelope** (not 4xx) because "invalid code" is an expected user-flow result, not an error — mirrors the service's `(bool, …, error)` tuples and keeps the island's error-mapping client-side. (The review should confirm this vs. a 422 convention.)
+
+---
+
+## 3. DTO contract (M9)
+
+New `Services/Dtos/SettingsConnectionDtos.cs`. `ExpiresAt`/`ConnectedAt` are `DateTime` (UTC) → emit ISO; the island formats relative/absolute text client-side (port `GetExpiryText` `:350-357` + the connected-date format). No enums.
+
+```csharp
+public sealed record ConnectionsDto(InviteDto? ActiveInvite, IReadOnlyList<ConnectedDto> Connected);
+public sealed record InviteDto(string Code, DateTime ExpiresAt);
+public sealed record ConnectedDto(int HouseholdId, string HouseholdName, DateTime ConnectedAt);
+public sealed record ValidateResultDto(bool IsValid, string? HouseholdName, string? Error);
+public sealed record AcceptResultDto(bool Success, string? ConnectedHouseholdName, string? Error);
+```
+
+**TS mirror** + a `mapValidationError(code)` port of `:403-415` (codes: `self_connection`, `already_connected`, `expired`, `invalid`/`not_found`). Contract test + fixture for `ConnectionsDto` (mirror `DashboardDtoContractTests`).
+
+---
+
+## 4. Island structure — `frontend/connections/` (prefix `con-`, single root `connections-root`)
+
+Copy the **dashboard** scaffold (single-route, single root, `untrack` load); **no `svelte-dnd-action`, no liveness**.
+- **`connectionsStore.svelte.ts`** — `activeInvite`/`connected = $state`, plus the **flow state**: `enteredCode`, `validating`, `pendingHouseholdName`, `showConfirm`, `accepting`, `codeError`, `generating`, `disconnecting`, `#seq`. Methods: `load()`, `generate()`, `cancelInvite()`, `validate(code)`, `accept()`, `cancelConfirm()`, `confirmDisconnect(id)`/`disconnect()`. All `await`-then-update; `loadSeq` guard on `load()`.
+- **`App.svelte`** — `untrack` one-time `load()`; the three sections (Share / Enter-a-code / Connected) + the disconnect confirm dialog + Toasts. Clipboard via `navigator.clipboard.writeText` directly (no Blazor JS interop).
+- Components: `InviteShare`, `CodeEntry` (uppercase/strip/maxlen input + confirm step), `ConnectedList`, `ConfirmDialog`, `Toasts`. Re-scope `con-`.
+- `dates.ts` — port `GetExpiryText` (relative "in N minutes/hours", absolute fallback) + connected-date format (noon-UTC, MN4).
+
+---
+
+## 5. Host + wiring
+- `Connections.razor` → thin host (flag), `ConnectionsBlazor.razor` verbatim fallback. (Note: today it's `@rendermode InteractiveServer` explicitly — the host keeps that; the global rendermode covers it.)
+- `CopyConnectionsIsland` target, `connections-node-build` Dockerfile stage, `docker-build.sh` entry, flag in compose + `.env`. `MapSettingsConnectionsEndpoints` in `Program.cs` (`IHouseholdConnectionService` already registered).
+
+## 6. Tests
+- Contract: `ConnectionsDtoContractTests` + fixture.
+- Endpoint integration (real PG, two households): generate→get→validate (valid + self + already-connected + bad code) → accept → connected reflects it → disconnect → gone. Cross-household M1 (can't disconnect a pairing you're not in). 401 gate.
+
+## 7. Build sequence
+WP-1 backend (DTOs + endpoints) → WP-2 tests → WP-3 scaffold → WP-4 the flow (store + components + state machine) → WP-5 host+wiring → WP-6 `:8080` verify (full ceremony, two browser sessions to exercise accept) + loop-check.
+
+## 8. Open items — RESOLVED (plan-review session, 2026-06-24)
+- **Validate/accept envelope.** RESOLVED: **200-with-outcome** (not 422). An invalid/expired/self/already-connected code is an expected user-flow result rendered inline as a **warning** today, not an HTTP error. The endpoints return `{ isValid, householdName, error }` / `{ success, connectedName, error }`; the island maps the stable `error` code to copy (port of `MapValidationError`). Keeps api.ts on the happy path.
+- **Flag granularity.** RESOLVED: per-cluster **`SETTINGS_CONNECTIONS_USE_ISLAND`** (see X1).
+- **Clipboard fallback.** RESOLVED: keep today's try/catch → "Unable to copy — please select the code manually" (warning). Secure-context holds (localhost-as-secure; prod is https).
+- **Two-session verify.** RESOLVED approach: seed a second household + an active invite via `psql` against the `:8080` PG, then drive accept from the primary auth session; assert connected-list reflects it and disconnect removes it. (Build-session detail.)
+
+---
+
+## 9. Review resolutions (plan-review session, 2026-06-24)
+
+*See the cross-plan memo `D:/Development/data/outputs/reviews/settings-strangler-plan-review/`.*
+
+**Cross-cutting (apply to B):**
+- **X5 — Dates:** `Invite.ExpiresAt` and `Connected.ConnectedAt` are **full instants** — emit ISO-8601 (UTC, `Z`) and render with `new Date(iso)` in local tz (relative for expiry via `GetExpiryText` port, absolute for connected-date). **Do NOT** noon-UTC these (§3's "noon-UTC, MN4" note is wrong for instants — noon-UTC is only for bare date-only values). Update §3/§4.
+- **X1/X2** as above; endpoints in their own `SettingsConnectionsEndpoints.cs` (own `Map…` + `Program.cs` registration), route namespace `/api/settings/connections`.
+
+**Cluster-B hardening (verified against `Connections.razor`):**
+- **R-B1 — Entity field name:** the invite entity exposes **`InviteCode`** (not `Code`) and `ExpiresAt`. The projection maps `InviteCode → code`; don't reference a non-existent `.Code`.
+- **R-B2 — Disconnect M1 + idempotency:** `DELETE /connected/{householdId}` → `DisconnectHouseholdsAsync(callerHh, householdId)`. M1 holds because one arg is always the server-resolved caller household (a caller can only affect a pairing involving their own household). Confirm the service no-ops to **204** if the pairing is already gone (double-click safe). M1 test: a third household cannot disconnect a pairing it isn't part of.
+- **R-B3 — Accept-failure state:** on accept failure, today returns to the **entry** view with the mapped error (hides the confirm step). The island state machine must replicate (error shows on entry, not confirm).
+- **R-B4 — 4xx bodies** non-empty; 401 via `UserContextResolver` null → `Results.Unauthorized()`.
+
+**Verdict: build-ready.** Thin backend; the risk is the client state machine — port the validate→confirm→accept / disconnect-confirm flows exactly. Build after A.

--- a/.planning/settings-household-island-spec.md
+++ b/.planning/settings-household-island-spec.md
@@ -1,0 +1,197 @@
+# Spec — Settings island A: Household settings (Categories + Manage Users) → Svelte island (strangler)
+
+**Quest:** Spine `57544e66-65b7-4680-853b-74aed5b014f7` (campaign "Family Coordination App", horizon `now`). Cluster **A** of the 3-island settings strangler (`dbee5aea` decomposed 2026-06-25; operator chose cluster-into-islands).
+**Decisions (this session, 2026-06-25):** spec-first **focused**; parity-first; **one island, two routes** (`/settings/categories` + `/settings/users`) via the recipes data-view-one-bundle pattern; one flag `SETTINGS_USE_ISLAND`, one PR.
+**Status:** spec (awaiting operator review gate).
+**Template:** mirrors the shipped **recipes island** (`frontend/recipes/`, multi-route bundle + `svelte-dnd-action` drag-reorder) and the **dashboard island** (`frontend/dashboard/`, the freshest light scaffold). Backend mirrors `RecipesEndpoints.cs` (greenfield `/api` over existing/new services, M1).
+
+---
+
+## 1. Goal & scope
+
+Replace the two Blazor circuit-bound household-settings pages with **one** Svelte 5 island over plain HTTP/JSON — same strangler motivation, but here the sequencing driver is **stripping MudBlazor deps before the shell keystone** (settings are low-traffic; circuit-drop ROI is low). **Behavior parity, no new UX.**
+
+This cluster is **write-heavy** (unlike the read-only dashboard) but each surface is simple CRUD. Two routes, two domains, one bundle.
+
+### In scope (parity)
+
+**Categories (`/settings/categories`)** — `Categories.razor` (305L), over the existing `ICategoryService`:
+- Add a category (name required, emoji, color). `Categories.razor:169-191`.
+- Active list with **drag-reorder** (persists `SortOrder`). `:67-95,258-273`.
+- Edit a category (the `CategoryEditDialog` — name/emoji/color). `:193-216`.
+- Delete (soft) with an **"in use" confirm** when the category has ingredients (`HasIngredientsAsync` → "Delete Anyway"). `:218-242`.
+- Deleted-categories section with **Restore**. `:98-123,244-256`.
+- "Default" chip on default categories (read-only flag).
+
+**Manage Users (`/settings/users`)** — `WhitelistAdmin.razor` (291L), currently **direct EF** (no service):
+- List the household's members (email, name, whitelist status, "You" chip). `:141-160`.
+- Add a member by email: re-enable if a disabled row exists; else create a new whitelisted `User`; **reject if the email belongs to another household** (cross-household collision). `:162-228`.
+- Toggle whitelist (Enable/Disable) — hidden for self; Disable hidden when the member is the **last active** one. `:230-239,85-102`.
+- Delete a member with a confirm — blocked for **self** and when it's the **last user**; FK `ON DELETE SET NULL` keeps their recipes/feedback. `:241-284`.
+
+**Cross-cutting:**
+- The `.NET 10` circuit-resume self-heal mount machinery, dark-mode bridge, MudBlazor token CSS — copied verbatim from recipes/dashboard, re-scoped (`set-`).
+- Cross-user freshness is **out of scope** here (parity: neither page polls today — both are static load-on-init). No `liveness.ts` wiring. (A late add by another member is rare on settings; matches today's no-refresh behavior.)
+
+### Out of scope
+- Any new UX. The drag-reorder already exists (parity-keep).
+- `CategoryEditDialog`/`RejectReasonDialog` MudDialogs → replaced by in-island dialogs (parity behavior).
+- The other settings clusters (Connections = island B `b60c13cb`; HouseholdAdmin+FeedbackAdmin = island C `fd629f11`).
+- Real-time/liveness (neither page has it today).
+
+---
+
+## 2. Pattern being mirrored (the template)
+
+- **Multi-route one-bundle** (recipes D1): two Razor host pages (`Categories.razor`, `WhitelistAdmin.razor`) both import `/islands/settings/index.js` and mount `window.SettingsIsland`; the root carries `data-view="categories"|"users"`. `main.ts` reads `view` and mounts `CategoriesApp` or `UsersApp`. Cross-view nav is full-document (parity: separate Blazor pages today).
+- **Drag-reorder** = `svelte-dnd-action` (mirror recipes' `IngredientList`); reorder updates `sortOrder` then persists via the sort-order endpoint (parity: today reorder persists immediately, `Categories.razor:258`).
+- Copy verbatim + re-scope (`rc-`→`set-`, `recipes`→`settings`, `RecipesIsland`→`SettingsIsland`, `rc-dark-mode`→`set-dark-mode`): `main.ts` self-heal, `lib/api.ts` (`request<T>`/`ApiError`), `toasts*`, `styles/{tokens,app}.css`. **No `liveness.ts`** (§1).
+- **`untrack()` one-time-load** + **`loadSeq` guard** (memories `svelte5-setup-effect-async-loader-loop`, `fca-island-async-race-guards`) — non-negotiable, even though this is write-heavy: each app loads once, mutations reload.
+- **Write-race guard:** because this island mutates, each mutation `await`s then reloads the affected list; a `loadSeq` guard drops a stale reload that resolves after a newer one. (No autosave/draft — these are explicit button actions, not debounced edits.)
+
+---
+
+## 3. Endpoint surface
+
+Two groups in a new `Endpoints/SettingsEndpoints.cs`, both `.RequireAuthorization().DisableAntiforgery()`, every handler resolving `(HouseholdId, UserId)` via `UserContextResolver` (M1, never client-supplied). Register `app.MapSettingsEndpoints()` in `Program.cs`.
+
+### 3a. `/api/settings/categories` — over the existing `ICategoryService`
+
+| # | Method & route | Body | Returns | Notes |
+|---|---|---|---|---|
+| 1 | `GET /` | — | `CategoryListDto` | `GetCategoriesAsync(hh, includeDeleted:true)` split into `active` (sorted) + `deleted` (parity `:162-167`). |
+| 2 | `POST /` | `CategoryWriteRequest` | `CategoryDto` (201) | Name required ⇒ else 400. `CreateCategoryAsync(new Category{…, HouseholdId=hh, IsDefault=false})` (`:179-181`). |
+| 3 | `PUT /{categoryId:int}` | `CategoryWriteRequest` | `CategoryDto` | `GetCategoryAsync` first → 404 (non-empty body) if missing/cross-household; else `UpdateCategoryAsync`. |
+| 4 | `DELETE /{categoryId:int}` | — | 204 | Soft delete. `DeleteCategoryAsync` — household-scoped; missing ⇒ 404. |
+| 5 | `POST /{categoryId:int}/restore` | — | 204 | `RestoreCategoryAsync`. |
+| 6 | `PUT /sort-order` | `{ orderedIds: int[] }` | 204 | Map to `List<(CategoryId, SortOrder)>` by index → `UpdateSortOrderAsync`. |
+| 7 | `GET /{categoryId:int}/in-use` | — | `{ inUse: bool }` | `HasIngredientsAsync(hh, name)` for the delete confirm (look up the category's name server-side from the id, M1). |
+
+### 3b. `/api/settings/members` — greenfield (today's logic is in the Razor; lift it to a thin `IHouseholdMemberService` for testability)
+
+| # | Method & route | Body | Returns | Notes |
+|---|---|---|---|---|
+| 8 | `GET /` | — | `MemberListDto` | Household users ordered by email + the **caller's** `currentUserId` (so the island can render "You" + gate self-actions without a second call). |
+| 9 | `POST /` | `{ email }` | `MemberActionDto` | Add/re-enable (parity `:162-228`): normalize lower; **another household ⇒ 409** (`{ message }`); existing-disabled ⇒ re-enable; existing-active ⇒ 409/no-op message; else create whitelisted `User`. |
+| 10 | `PUT /{userId:int}` | `{ isWhitelisted: bool }` | `MemberDto` | Toggle. **Reject toggling self ⇒ 400**; reject disabling the **last active** member ⇒ 409 (parity `:85,250-252`). |
+| 11 | `DELETE /{userId:int}` | — | 204 | Delete. **Reject self ⇒ 400**; reject last user ⇒ 409 (parity `:244-254`). FK SET NULL keeps recipes/feedback. |
+
+> The member rules (self-guard, last-user-guard, cross-household collision) are the **whole risk surface** here — they live in `IHouseholdMemberService` so they're unit-/integration-testable (the Razor had no test harness). Mirrors the dashboard `ChoreHomeStats`-stays-server-side principle.
+
+**Request DTOs** (`SettingsEndpoints.cs`):
+```csharp
+public sealed record CategoryWriteRequest(string Name, string? IconEmoji, string Color);
+public sealed record SortOrderRequest(IReadOnlyList<int> OrderedIds);
+public sealed record AddMemberRequest(string Email);
+public sealed record SetWhitelistRequest(bool IsWhitelisted);
+```
+
+---
+
+## 4. DTO contract (M9 lockstep)
+
+New `Services/Dtos/SettingsDtos.cs` + projections (a thin `ISettingsProjectionService` or static mappers). No enums here ⇒ plain camelCase; no dates on the wire except `Category.DeletedAt` (render-only) — emit as ISO string and format client-side at noon-UTC (MN4).
+
+```csharp
+public sealed record CategoryListDto(
+    IReadOnlyList<CategoryDto> Active, IReadOnlyList<CategoryDto> Deleted);
+public sealed record CategoryDto(
+    int CategoryId, string Name, string? IconEmoji, string Color,
+    bool IsDefault, int SortOrder, string? DeletedAt);   // DeletedAt: "YYYY-MM-DD" or null
+
+public sealed record MemberListDto(
+    int CurrentUserId, IReadOnlyList<MemberDto> Members);
+public sealed record MemberDto(
+    int UserId, string Email, string? DisplayName, bool IsWhitelisted);
+public sealed record MemberActionDto(MemberDto Member, string Outcome); // "created"|"reenabled" (for the toast)
+```
+
+**TS mirror** (`frontend/settings/src/lib/types.ts`) — camelCase, doc-commented; `IslandView = 'categories' | 'users'`; `ShellContext { householdId, userId, userName, view }`.
+
+**Contract tests** (mirror `DashboardDtoContractTests`): `CategoryListDtoContractTests` + `Fixtures/Settings/categories.json`; `MemberListDtoContractTests` + `Fixtures/Settings/members.json` — byte-equality, camelCase, the island `types.ts` mirrors the fixtures.
+
+---
+
+## 5. Decisions
+
+- **D1 — One island, two routes (recipes pattern).** Both pages cluster (operator's choice); one bundle, view by `data-view`. Cross-view nav is full-document. *Alt:* two separate islands — rejected: they share scaffold + flag + a settings nav, and clustering was the chosen granularity.
+- **D2 — Lift the member logic into `IHouseholdMemberService`.** Today it's direct EF in the Razor (the one M1/safety risk surface). A thin service makes the self-guard / last-user / cross-household rules testable and keeps the endpoint thin (parity-correctness, mirrors dashboard's reuse-the-tested-reducer principle). Categories already has `ICategoryService` — reuse as-is.
+- **D3 — Categories drag-reorder persists immediately** (parity `:258-273`): reorder → `PUT /sort-order { orderedIds }`; on failure, reload to restore order + toast. `svelte-dnd-action` (mirror recipes).
+- **D4 — No liveness** (parity: neither page polls). Mutations reload the affected list; `loadSeq` guards stale reloads. Drop `liveness.ts` from the scaffold.
+- **D5 — Delete-in-use confirm stays a round-trip** (`GET /{id}/in-use` before the soft delete, parity `:221`), shown as an in-island confirm dialog ("Delete Anyway").
+
+---
+
+## 6. Island structure — `frontend/settings/` (prefix `set-`, port 5178, roots `settings-categories-root`/`settings-users-root`)
+
+Copy the recipes scaffold (it already has the two-root `data-view` branch + `svelte-dnd-action`); strip recipes-specific stores/components; **drop `liveness.ts`/`quantity.ts`/`dates`-week**. Add a tiny `dates.ts` (format `DeletedAt` only).
+
+- **Build config:** `package.json` (name `settings-island`, deps incl. `svelte-dnd-action`), `vite.config.ts` (port 5178), tsconfig/svelte.config, `index.html` (dev auto-mount both roots).
+- **`main.ts`** — recipes' two-root `data-view` branch, re-scoped; mounts `CategoriesApp` (`view==='categories'`) or `UsersApp` (`'users'`). Self-heal + dark observer unchanged.
+- **`lib/types.ts`** §4; **`lib/api.ts`** — `request<T>`/`ApiError` + the 11 functions; **`lib/toasts*`** copied.
+- **`lib/categoriesStore.svelte.ts`** — `active`/`deleted = $state`, `loading`/`error`, `#seq`; `load()`, `add()`, `update()`, `remove(id)` (in-use check → confirm → delete), `restore(id)`, `reorder(orderedIds)` (optimistic local + persist + reload-on-error).
+- **`lib/membersStore.svelte.ts`** — `members`/`currentUserId = $state`, `loading`/`error`, `#seq`; `load()`, `add(email)` (handle 409 outcomes → toast), `toggle(id)`, `remove(id)`. Self/last-user gating mirrors the server (also enforced client-side for button visibility, parity `:83-113`).
+- **`CategoriesApp.svelte`** / **`UsersApp.svelte`** — each: read `ShellContext`, the **`untrack()` one-time load**, render the page. Categories: add form, `svelte-dnd-action` active list (`CategoryRow`), deleted list, `CategoryEditDialog`, `ConfirmDialog` (in-use + delete). Users: add-by-email form, members table (`MemberRow`), enable/disable/delete with confirm.
+- **`lib/components/`** (re-scope `set-`): `CategoryRow`, `CategoryEditDialog`, `MemberRow`, `ConfirmDialog` (copy recipes'), `Toasts`.
+- **`styles/{tokens,app}.css`** copied + re-scoped; port the small inline styles.
+
+---
+
+## 7. Host pages + build wiring
+
+- **`Categories.razor`** + **`WhitelistAdmin.razor`** → thin island hosts, flag **`SETTINGS_USE_ISLAND`** (mirror `Home.razor`/`MealPlan.razor` `IsIslandEnabled`). ON → `<div id="settings-{categories|users}-root" data-… data-view="…">` + mount; OFF → `<CategoriesBlazor/>` / `<WhitelistAdminBlazor/>` verbatim fallbacks (extract the current bodies). One flag toggles both.
+- **`CopySettingsIsland`** MSBuild target (copy of `CopyDashboardIsland`).
+- **Dockerfile** — `settings-node-build` stage + `COPY --from` (next to dashboard).
+- **`docker-build.sh`** — `build_island "./frontend/settings" "settings"`.
+- **`Program.cs`** — `app.MapSettingsEndpoints()`; register `IHouseholdMemberService` (+ projection if used). `ICategoryService` already registered.
+- **Flag** — `SETTINGS_USE_ISLAND` in `docker-compose.yml` (`:-false`) + local `.env` (=true). Ship OFF; flip after verify.
+
+---
+
+## 8. Tests (M9)
+
+- **Contract:** `CategoryListDtoContractTests` + `MemberListDtoContractTests` + fixtures (§4).
+- **`HouseholdMemberService` unit/integration:** add-new, add-reenable, add-cross-household ⇒ 409, toggle-self ⇒ 400, disable-last-active ⇒ 409, delete-self ⇒ 400, delete-last ⇒ 409, delete keeps recipes (FK SET NULL).
+- **Endpoint integration (real PG, mirror `DashboardEndpointTests`):** categories CRUD + reorder + restore + in-use; members list/add/toggle/delete with all guards; **cross-household M1** (A cannot read/mutate B's categories or members); 401 gate.
+
+---
+
+## 9. Build sequence (work packages)
+
+- **WP-1 — Backend.** `SettingsDtos`, `IHouseholdMemberService`+impl, `SettingsEndpoints` (categories 7 + members 4), `Program.cs` wiring.
+- **WP-2 — Backend tests.** Contract + fixtures; member-service guards; endpoint integration (real PG) incl. M1.
+- **WP-3 — Island scaffold.** Copy recipes; re-scope `set-`; drop liveness/quantity; `types.ts`/`api.ts`/`main.ts`/styles; two App skeletons. `svelte-check` 0/0, `vite build`.
+- **WP-4 — Categories view.** `categoriesStore`, `CategoriesApp` (untrack load), `CategoryRow` (dnd), `CategoryEditDialog`, in-use/delete confirms, restore.
+- **WP-5 — Users view.** `membersStore`, `UsersApp` (untrack load), `MemberRow`, add/toggle/delete + guards.
+- **WP-6 — Host + wiring.** Two thin hosts + verbatim Blazor fallbacks, `CopySettingsIsland`, Dockerfile stage, `docker-build.sh`, `SETTINGS_USE_ISLAND`.
+- **WP-7 — Verify.** `:8080` (rebuild, swap, DOM/psql); flip flag; exercise both views (add/edit/delete/restore/reorder/toggle/guards); the **loop-check** gate (~0 bg GETs/sec — both apps load-once, no liveness).
+
+## 10. Gates
+`dotnet build` clean · full suite green incl. new tests · `svelte-check` 0/0 · `vite build` · real-PG integration (incl. M1) · loop-check · `:8080` parity verify.
+
+## 11. Open items — RESOLVED (plan-review session, 2026-06-24)
+- **Member rules → `IHouseholdMemberService`.** RESOLVED: yes, lift to the service (testability; also fixes the long-lived `_context` anti-pattern below). All three guards (self, last-active, last-user) and the cross-household collision check move server-side.
+- **Emoji field.** RESOLVED: keep a plain freeform text field (parity); no emoji picker.
+- **Flag.** RESOLVED: one flag **`SETTINGS_HOUSEHOLD_USE_ISLAND`** for cluster A's two routes (renamed from `SETTINGS_USE_ISLAND` — see X1). Per-cluster, not one shared settings flag.
+
+---
+
+## 12. Review resolutions (plan-review session, 2026-06-24)
+
+*Decisions below are locked; fold into the build. Cross-cutting items (X*) are decided identically across A/B/C — see the cross-plan review memo `D:/Development/data/outputs/reviews/settings-strangler-plan-review/`.*
+
+**Cross-cutting (apply to A):**
+- **X1 — Flag = `SETTINGS_HOUSEHOLD_USE_ISLAND`** (per-cluster). Rename every `SETTINGS_USE_ISLAND` reference in this spec accordingly. Rationale: clusters ship in separate PRs and flip independently after their own verify; a single shared flag couldn't flip until all three islands exist.
+- **X2 — Endpoints file:** `Endpoints/SettingsEndpoints.cs` (categories + members), its own `MapSettingsEndpoints()` + `Program.cs` registration.
+- **X5 — Dates:** emit `Category.DeletedAt` as a **full ISO-8601 instant (UTC, `Z`)**, NOT `"YYYY-MM-DD"`. Format client-side with `new Date(iso).toLocaleDateString()`. (Noon-UTC normalization is only for bare date-only wire values; `DeletedAt` is a real timestamp. Update §4's DTO comment from `"YYYY-MM-DD" or null` to "ISO-8601 instant or null".)
+
+**Cluster-A hardening (verified against the Razor source):**
+- **R-A1 — Add-member outcome severity.** Today `AddUser` yields three severities: another-household → **Error** (abort); already-active-here → **Warning** (then clears+reloads); disabled→re-enable / new→create → **Success**. Endpoint #9 must therefore: return **409** ONLY for the cross-household collision; return **200** with `MemberActionDto.Outcome ∈ {created, reenabled, alreadyActive}` for the benign cases. The island toasts `alreadyActive` as a **warning** (not an error). Do NOT map "already active" to 409 (would flip warning→error, a parity regression).
+- **R-A2 — Guards become server-enforced (deliberate, beyond strict parity).** Today the self / last-active guards are **UI-only** (buttons simply not rendered; `ToggleUser` does no re-check). The service WILL enforce toggle-self → 400, disable-last-active → 409, delete-self → 400, delete-last-user → 409. This rejects crafted requests that would succeed today — the right call for a testable service, but flagged as a deliberate behavior addition, not silent. Note the two distinct guards: **toggle** = last-*active* (`Count(IsWhitelisted) > 1`); **delete** = last-*user* (`Count > 1`, total incl. disabled).
+- **R-A3 — Enumerate User-creation fields** in the service (a build will drop them otherwise): `DisplayName = email.Split('@')[0]`, `GoogleId = null`, `IsWhitelisted = true`, `CreatedAt = DateTime.UtcNow`, `HouseholdId = caller`.
+- **R-A4 — Intentional cross-household read.** The collision check (`Users.Where(Email == x && HouseholdId != mine)`) is the one intentional cross-tenant query; it leaks no data (returns only a 409). The M1 test asserts the 409 AND that no row data crosses.
+- **R-A5 — Route ordering (learned in #53):** register literal routes BEFORE parameterized ones in the group — `PUT /sort-order` before `PUT /{categoryId:int}`; `POST /{id}/restore` and `GET /{id}/in-use` are literal-suffixed so fine, but keep all literals ahead of bare `PUT/DELETE /{categoryId:int}`. Otherwise the parameterized route shadows the literal → 404 → re-executed to 405.
+- **R-A6 — Side benefit:** lifting to `IHouseholdMemberService` with short-lived factory contexts retires today's long-lived `_context` field in `WhitelistAdmin.razor` (a Blazor-Server anti-pattern).
+- **R-A7 — 4xx bodies:** every 400/404/409 carries a non-empty `{ message }` body (empty-body quirk). `MudColorPicker` → an `<input type="color">` (hex parity, e.g. default `#808080`).
+
+**Verdict: build-ready.** A is the simplest cluster and the `now` quest — proceed to WP-1 after the operator clears the gate.

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,15 @@ RUN if [ -f package-lock.json ]; then npm ci; else npm install --no-audit --no-f
 COPY frontend/dashboard/ ./
 RUN npm run build
 
+# Stage 1f: Build the Svelte settings island (cluster A; parallel to the others).
+# Emits ./dist/ which the .NET stage copies into wwwroot/islands/settings/.
+FROM node:20-alpine AS settings-node-build
+WORKDIR /frontend
+COPY frontend/settings/package.json frontend/settings/package-lock.json* ./
+RUN if [ -f package-lock.json ]; then npm ci; else npm install --no-audit --no-fund; fi
+COPY frontend/settings/ ./
+RUN npm run build
+
 # Stage 2: Build the .NET app.
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
@@ -59,6 +68,7 @@ COPY --from=chores-node-build /frontend/dist/ ./FamilyCoordinationApp/wwwroot/is
 COPY --from=mealplan-node-build /frontend/dist/ ./FamilyCoordinationApp/wwwroot/islands/meal-plan/
 COPY --from=recipes-node-build /frontend/dist/ ./FamilyCoordinationApp/wwwroot/islands/recipes/
 COPY --from=dashboard-node-build /frontend/dist/ ./FamilyCoordinationApp/wwwroot/islands/dashboard/
+COPY --from=settings-node-build /frontend/dist/ ./FamilyCoordinationApp/wwwroot/islands/settings/
 
 # Explicitly set working directory to project folder before publish
 WORKDIR /src/FamilyCoordinationApp

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -63,6 +63,7 @@ build_island "./frontend/chores" "chores"
 build_island "./frontend/meal-plan" "meal-plan"
 build_island "./frontend/recipes" "recipes"
 build_island "./frontend/dashboard" "dashboard"
+build_island "./frontend/settings" "settings"
 echo ""
 
 # Step 3: Publish locally

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       MEAL_PLAN_USE_ISLAND: ${MEAL_PLAN_USE_ISLAND:-false}
       RECIPES_USE_ISLAND: ${RECIPES_USE_ISLAND:-false}
       DASHBOARD_USE_ISLAND: ${DASHBOARD_USE_ISLAND:-false}
+      SETTINGS_HOUSEHOLD_USE_ISLAND: ${SETTINGS_HOUSEHOLD_USE_ISLAND:-false}
       # Chores v1.1 digest. The token gates POST /api/chores/digest/run (cron trigger); unset ⇒ endpoint
       # returns 503 (feature off). MUST be mapped here — .env is only used for ${VAR} substitution, not
       # auto-injected, so the documented go-live step (set CHORES_DIGEST_TRIGGER_TOKEN) is inert without this.

--- a/frontend/settings/.gitignore
+++ b/frontend/settings/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.log
+.DS_Store

--- a/frontend/settings/index.html
+++ b/frontend/settings/index.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Settings (dev)</title>
+  </head>
+  <body>
+    <!--
+      Dev-only host. In production the Razor shells (Categories.razor / WhitelistAdmin.razor)
+      provide these attrs. main.ts mounts whichever root id is present (spec D1):
+      #settings-categories-root (data-view="categories") or #settings-users-root (data-view="users").
+      Swap the block below to test the users view standalone.
+    -->
+    <div
+      id="settings-categories-root"
+      data-household-id="1"
+      data-user-id="1"
+      data-user-name="Dev User"
+      data-view="categories"
+    ></div>
+    <!--
+    <div
+      id="settings-users-root"
+      data-household-id="1"
+      data-user-id="1"
+      data-user-name="Dev User"
+      data-view="users"
+    ></div>
+    -->
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/frontend/settings/package-lock.json
+++ b/frontend/settings/package-lock.json
@@ -1,0 +1,1533 @@
+{
+  "name": "settings-island",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "settings-island",
+      "version": "0.1.0",
+      "dependencies": {
+        "svelte-dnd-action": "^0.9.69"
+      },
+      "devDependencies": {
+        "@sveltejs/vite-plugin-svelte": "^5.0.3",
+        "@tsconfig/svelte": "^5.0.4",
+        "svelte": "^5.19.0",
+        "svelte-check": "^4.1.4",
+        "tslib": "^2.8.1",
+        "typescript": "~5.7.2",
+        "vite": "^6.0.7"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sveltejs/acorn-typescript": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.10.tgz",
+      "integrity": "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8.9.0"
+      }
+    },
+    "node_modules/@sveltejs/load-config": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@sveltejs/load-config/-/load-config-0.2.0.tgz",
+      "integrity": "sha512-1LgZ/qUqSoq+QorD83lk2hka79Px0wXNW2q5V1nZlxGhQgw1jrsIbVz5YiCeucVLo4XvFLjXukUaQjIiqowkcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-5.1.1.tgz",
+      "integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
+        "debug": "^4.4.1",
+        "deepmerge": "^4.3.1",
+        "kleur": "^4.1.5",
+        "magic-string": "^0.30.17",
+        "vitefu": "^1.0.6"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22"
+      },
+      "peerDependencies": {
+        "svelte": "^5.0.0",
+        "vite": "^6.0.0"
+      }
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte-inspector": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-4.0.1.tgz",
+      "integrity": "sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.7"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22"
+      },
+      "peerDependencies": {
+        "@sveltejs/vite-plugin-svelte": "^5.0.0",
+        "svelte": "^5.0.0",
+        "vite": "^6.0.0"
+      }
+    },
+    "node_modules/@tsconfig/svelte": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-5.0.8.tgz",
+      "integrity": "sha512-UkNnw1/oFEfecR8ypyHIQuWYdkPvHiwcQ78sh+ymIiYoF+uc5H1UBetbjyqT+vgGJ3qQN6nhucJviX6HesWtKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
+      "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/devalue": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "license": "MIT"
+    },
+    "node_modules/esrap": {
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.12.tgz",
+      "integrity": "sha512-On0QbLyaiAkVC4eXtgnXK9Kh2opit+3rcUSOc45DqJ2s/X2eXAHsGOKRSJ6IDagQEW5vPyivANfXUiqgXC67Rw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/types": "^8.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/is-reference": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.6"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/locate-character": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/svelte": {
+      "version": "5.56.4",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.4.tgz",
+      "integrity": "sha512-/d0QHehmRuJW8gVz395MTkPcPozxzdjBMBE8oEYGz8O3b9KTMzzQ9ZHJQLuFKOHOPQbU6kx/X4iid/EBBzH7iw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.4",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@sveltejs/acorn-typescript": "^1.0.10",
+        "@types/estree": "^1.0.5",
+        "@types/trusted-types": "^2.0.7",
+        "acorn": "^8.12.1",
+        "aria-query": "5.3.1",
+        "axobject-query": "^4.1.0",
+        "clsx": "^2.1.1",
+        "devalue": "^5.8.1",
+        "esm-env": "^1.2.1",
+        "esrap": "^2.2.12",
+        "is-reference": "^3.0.3",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.11",
+        "zimmerframe": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/svelte-check": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.7.1.tgz",
+      "integrity": "sha512-FGUOmAqxXdN/H9Zm8slrqO7SLtFisXRB7rfOsHNJ3MLTD2po/+Stg8XyErkpumPHbuUiYTcqrEIzxpVWKTLqtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "@sveltejs/load-config": "^0.2.0",
+        "chokidar": "^4.0.1",
+        "fdir": "^6.2.0",
+        "picocolors": "^1.0.0",
+        "sade": "^1.7.4"
+      },
+      "bin": {
+        "svelte-check": "bin/svelte-check"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "svelte": "^4.0.0 || ^5.0.0-next.0",
+        "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/svelte-dnd-action": {
+      "version": "0.9.70",
+      "resolved": "https://registry.npmjs.org/svelte-dnd-action/-/svelte-dnd-action-0.9.70.tgz",
+      "integrity": "sha512-iVqDAW1PtQArA96dHhM5Lwxj39iKNjIuYE+tqpq9DUaBWfv410SpGGFJ3NzPtvptx+YkXBzMYV3lpey8s07q+w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "svelte": ">=3.23.0 || ^5.0.0-next.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitefu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+      "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "tests/deps/*",
+        "tests/projects/*",
+        "tests/projects/workspace/packages/*"
+      ],
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zimmerframe": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
+      "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
+      "license": "MIT"
+    }
+  }
+}

--- a/frontend/settings/package.json
+++ b/frontend/settings/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "settings-island",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "check": "svelte-check --tsconfig ./tsconfig.json"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^5.0.3",
+    "@tsconfig/svelte": "^5.0.4",
+    "svelte": "^5.19.0",
+    "svelte-check": "^4.1.4",
+    "tslib": "^2.8.1",
+    "typescript": "~5.7.2",
+    "vite": "^6.0.7"
+  },
+  "dependencies": {
+    "svelte-dnd-action": "^0.9.69"
+  }
+}

--- a/frontend/settings/src/CategoriesApp.svelte
+++ b/frontend/settings/src/CategoriesApp.svelte
@@ -1,0 +1,360 @@
+<script lang="ts">
+  // Categories view (#settings-categories-root). Parity with Categories.razor:
+  // add form, active list with drag-reorder (svelte-dnd-action), edit dialog,
+  // soft-delete with an "in use" confirm, and a deleted-list with restore.
+  import { onMount } from 'svelte';
+  import { dndzone, type DndEvent } from 'svelte-dnd-action';
+  import type { ShellContext, CategoryDto, CategoryWriteRequest } from './lib/types';
+  import { categoriesStore } from './lib/categoriesStore.svelte';
+  import { formatDeletedDate } from './lib/dates';
+  import { showToast } from './lib/toasts.svelte';
+  import CategoryEditDialog from './lib/components/CategoryEditDialog.svelte';
+  import ConfirmDialog from './lib/components/ConfirmDialog.svelte';
+  import Toasts from './lib/components/Toasts.svelte';
+
+  // ctx is provided by the Razor host; the store calls /api directly (household resolved server-side).
+  let { ctx }: { ctx: ShellContext } = $props();
+
+  const store = categoriesStore;
+
+  // One-time load — onMount is not reactive, so it can't form the setup-effect fetch loop.
+  onMount(() => {
+    void ctx; // host context available; not needed by the store
+    void store.load();
+  });
+
+  // Add form.
+  let newName = $state('');
+  let newEmoji = $state('');
+  let newColor = $state('#808080');
+
+  async function add() {
+    if (!newName.trim()) {
+      showToast({ message: 'Category name is required.', kind: 'error' });
+      return;
+    }
+    const body: CategoryWriteRequest = { name: newName.trim(), iconEmoji: newEmoji.trim() || null, color: newColor };
+    if (await store.add(body)) {
+      newName = '';
+      newEmoji = '';
+      newColor = '#808080';
+    }
+  }
+
+  // Drag-reorder: a local copy svelte-dnd-action mutates during a drag, resynced
+  // from the store whenever we're NOT dragging (the chores/recipes pattern).
+  let rows = $state<CategoryDto[]>([]);
+  let dragging = $state(false);
+  $effect(() => {
+    if (!dragging) rows = [...store.active];
+  });
+  function handleConsider(e: CustomEvent<DndEvent<CategoryDto>>) {
+    dragging = true;
+    rows = e.detail.items;
+  }
+  function handleFinalize(e: CustomEvent<DndEvent<CategoryDto>>) {
+    rows = e.detail.items;
+    dragging = false;
+    void store.reorder(rows.map((c) => c.categoryId));
+  }
+
+  // Edit dialog.
+  let editing = $state<CategoryDto | null>(null);
+  function openEdit(c: CategoryDto) {
+    editing = c;
+  }
+  async function saveEdit(body: CategoryWriteRequest) {
+    const target = editing;
+    if (!target) return;
+    editing = null;
+    await store.update(target.categoryId, body);
+  }
+
+  // Delete confirm (with the in-use round-trip, parity).
+  let confirmCategory = $state<CategoryDto | null>(null);
+  let confirmMessage = $state('');
+  async function askDelete(c: CategoryDto) {
+    const inUse = await store.checkInUse(c.categoryId);
+    confirmMessage = inUse
+      ? `"${c.name}" is used by ingredients in your recipes. You can still delete it, but those ingredients keep their category.`
+      : `Delete the "${c.name}" category?`;
+    confirmCategory = c;
+  }
+  async function confirmDelete() {
+    const target = confirmCategory;
+    confirmCategory = null;
+    if (target) await store.remove(target.categoryId);
+  }
+</script>
+
+<div class="set-page">
+  <h1 class="set-title">Manage Categories</h1>
+  <p class="set-subtitle">Customize ingredient categories for your household. Drag to reorder to match your store layout.</p>
+
+  {#if store.loading}
+    <div class="set-skeleton">Loading…</div>
+  {:else if store.error}
+    <div class="set-error">{store.error}</div>
+  {:else}
+    <!-- Add new -->
+    <section class="set-card">
+      <h2 class="set-card-title">Add New Category</h2>
+      <div class="set-add-row">
+        <input class="set-input set-grow" type="text" placeholder="Name" bind:value={newName} onkeydown={(e) => e.key === 'Enter' && add()} />
+        <input class="set-input" type="text" placeholder="Emoji" bind:value={newEmoji} />
+        <input class="set-color" type="color" bind:value={newColor} aria-label="Color" />
+        <button type="button" class="set-btn-primary" onclick={add}>Add</button>
+      </div>
+    </section>
+
+    <!-- Active list (drag-reorder) -->
+    <section class="set-card">
+      <h2 class="set-card-title">Active Categories</h2>
+      {#if rows.length === 0}
+        <div class="set-empty">No categories yet. Add one above.</div>
+      {:else}
+        <ul
+          class="set-list"
+          use:dndzone={{ items: rows, flipDurationMs: 150, dropTargetStyle: {}, delayTouchStart: 250 }}
+          onconsider={handleConsider}
+          onfinalize={handleFinalize}
+        >
+          {#each rows as cat (cat.categoryId)}
+            <li class="set-row">
+              <div class="set-row-main">
+                <span class="set-grip" aria-hidden="true">⠿</span>
+                <span class="set-swatch" style="background-color: {cat.color}"></span>
+                <span class="set-name">{cat.name}</span>
+                {#if cat.isDefault}
+                  <span class="set-chip set-chip-info">Default</span>
+                {/if}
+              </div>
+              <div class="set-row-actions">
+                <button type="button" class="set-icon-btn" aria-label="Edit category" onclick={() => openEdit(cat)}>✎</button>
+                <button type="button" class="set-icon-btn set-danger" aria-label="Delete category" onclick={() => askDelete(cat)}>🗑</button>
+              </div>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </section>
+
+    <!-- Deleted list -->
+    {#if store.deleted.length > 0}
+      <section class="set-card">
+        <h2 class="set-card-title">Deleted Categories</h2>
+        {#each store.deleted as cat (cat.categoryId)}
+          <div class="set-row set-row-muted">
+            <div class="set-row-main">
+              <span class="set-swatch" style="background-color: {cat.color}"></span>
+              <span class="set-name">{cat.name}</span>
+              <span class="set-deleted-note">(deleted {formatDeletedDate(cat.deletedAt)})</span>
+            </div>
+            <button type="button" class="set-btn-text" onclick={() => store.restore(cat.categoryId)}>Restore</button>
+          </div>
+        {/each}
+      </section>
+    {/if}
+  {/if}
+</div>
+
+<CategoryEditDialog open={editing != null} category={editing} onCancel={() => (editing = null)} onSave={saveEdit} />
+<ConfirmDialog
+  open={confirmCategory != null}
+  title="Delete Category"
+  message={confirmMessage}
+  confirmLabel="Delete"
+  onCancel={() => (confirmCategory = null)}
+  onConfirm={confirmDelete}
+/>
+<Toasts />
+
+<style>
+  .set-page {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 24px 16px 96px;
+  }
+  .set-title {
+    margin: 0 0 4px;
+    font-size: 1.5rem;
+    font-weight: 500;
+  }
+  .set-subtitle {
+    margin: 0 0 20px;
+    color: var(--color-text-muted);
+    font-size: 0.875rem;
+  }
+  .set-card {
+    background: var(--color-surface);
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-1);
+    padding: 16px;
+    margin-bottom: 16px;
+  }
+  .set-card-title {
+    margin: 0 0 12px;
+    font-size: 1rem;
+    font-weight: 500;
+  }
+  .set-add-row {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+  .set-input {
+    font: inherit;
+    padding: 10px 12px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--color-line-strong);
+    background: var(--color-surface);
+    color: var(--color-text);
+    min-width: 120px;
+  }
+  .set-input:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -1px;
+  }
+  .set-grow {
+    flex: 1;
+    min-width: 160px;
+  }
+  .set-color {
+    width: 48px;
+    height: 42px;
+    padding: 2px;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    cursor: pointer;
+  }
+  .set-btn-primary {
+    font: inherit;
+    font-weight: 500;
+    padding: 10px 20px;
+    min-height: 42px;
+    border: none;
+    border-radius: var(--radius-sm);
+    background: var(--color-primary);
+    color: #fff;
+    cursor: pointer;
+  }
+  .set-btn-primary:hover {
+    background: var(--color-primary-hover);
+  }
+  .set-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-height: 48px;
+  }
+  .set-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 10px 12px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-1);
+    cursor: grab;
+  }
+  .set-row:active {
+    cursor: grabbing;
+  }
+  .set-row-muted {
+    opacity: 0.65;
+    cursor: default;
+    box-shadow: none;
+  }
+  .set-row-main {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+  }
+  .set-grip {
+    color: var(--color-text-disabled);
+  }
+  .set-swatch {
+    width: 22px;
+    height: 22px;
+    border-radius: 4px;
+    flex-shrink: 0;
+    border: 1px solid var(--color-line);
+  }
+  .set-name {
+    overflow-wrap: anywhere;
+  }
+  .set-deleted-note {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .set-chip {
+    font-size: 0.6875rem;
+    font-weight: 500;
+    padding: 2px 10px;
+    border-radius: 12px;
+    white-space: nowrap;
+  }
+  .set-chip-info {
+    border: 1px solid var(--color-info);
+    color: var(--color-info);
+  }
+  .set-row-actions {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+  }
+  .set-icon-btn {
+    width: 34px;
+    height: 34px;
+    display: grid;
+    place-items: center;
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    font-size: 0.95rem;
+  }
+  .set-icon-btn:hover {
+    background: var(--color-action-hover);
+  }
+  .set-danger:hover {
+    color: var(--color-error);
+  }
+  .set-btn-text {
+    font: inherit;
+    font-weight: 500;
+    background: transparent;
+    border: none;
+    color: var(--color-primary);
+    cursor: pointer;
+    padding: 6px 10px;
+    border-radius: var(--radius-sm);
+  }
+  .set-btn-text:hover {
+    background: var(--color-action-hover);
+  }
+  .set-empty,
+  .set-skeleton,
+  .set-error {
+    padding: 16px;
+    border-radius: var(--radius-sm);
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+  .set-error {
+    background: rgba(229, 57, 53, 0.08);
+    border-left: 4px solid var(--color-error);
+    color: var(--color-text);
+  }
+</style>

--- a/frontend/settings/src/UsersApp.svelte
+++ b/frontend/settings/src/UsersApp.svelte
@@ -1,0 +1,294 @@
+<script lang="ts">
+  // Manage Users view (#settings-users-root). Parity with WhitelistAdmin.razor:
+  // add-by-email, a member list with "You" + status, and enable/disable/delete.
+  // Button visibility mirrors the server guards (self / last-active / last-user);
+  // the server is the source of truth (review R-A2) — the client gate is cosmetic.
+  import { onMount } from 'svelte';
+  import type { ShellContext, MemberDto } from './lib/types';
+  import { membersStore } from './lib/membersStore.svelte';
+  import ConfirmDialog from './lib/components/ConfirmDialog.svelte';
+  import Toasts from './lib/components/Toasts.svelte';
+
+  let { ctx }: { ctx: ShellContext } = $props();
+
+  const store = membersStore;
+
+  onMount(() => {
+    void ctx; // host context available; not needed by the store
+    void store.load();
+  });
+
+  let newEmail = $state('');
+  async function add() {
+    if (!newEmail.trim()) return;
+    if (await store.add(newEmail)) newEmail = '';
+  }
+
+  function isSelf(m: MemberDto): boolean {
+    return m.userId === store.currentUserId;
+  }
+  // Disable is offered only for an active member while more than one remains active.
+  function canDisable(m: MemberDto): boolean {
+    return !isSelf(m) && m.isWhitelisted && store.activeCount > 1;
+  }
+  function canEnable(m: MemberDto): boolean {
+    return !isSelf(m) && !m.isWhitelisted;
+  }
+  // Delete is offered for a non-self member while more than one user remains.
+  function canDelete(m: MemberDto): boolean {
+    return !isSelf(m) && store.members.length > 1;
+  }
+
+  // Delete confirm.
+  let confirmMember = $state<MemberDto | null>(null);
+  let confirmMessage = $state('');
+  function askDelete(m: MemberDto) {
+    confirmMessage =
+      `Permanently delete ${m.displayName ?? m.email} (${m.email})? ` +
+      `This removes their account from the household. Their recipes and feedback are kept. This can't be undone.`;
+    confirmMember = m;
+  }
+  async function confirmDelete() {
+    const target = confirmMember;
+    confirmMember = null;
+    if (target) await store.remove(target.userId);
+  }
+</script>
+
+<div class="set-page">
+  <h1 class="set-title">Manage Family Members</h1>
+
+  {#if store.loading}
+    <div class="set-skeleton">Loading…</div>
+  {:else if store.error}
+    <div class="set-error">{store.error}</div>
+  {:else}
+    <!-- Add member -->
+    <section class="set-card">
+      <h2 class="set-card-title">Add Family Member</h2>
+      <div class="set-add-row">
+        <input
+          class="set-input set-grow"
+          type="email"
+          placeholder="email@example.com"
+          bind:value={newEmail}
+          onkeydown={(e) => e.key === 'Enter' && add()}
+        />
+        <button type="button" class="set-btn-primary" onclick={add}>Add</button>
+      </div>
+    </section>
+
+    <!-- Members -->
+    <section class="set-card">
+      <h2 class="set-card-title">Current Members</h2>
+      <div class="set-members">
+        {#each store.members as m (m.userId)}
+          <div class="set-row set-row-static">
+            <div class="set-member-info">
+              <div class="set-member-line">
+                <span class="set-member-email">{m.email}</span>
+                {#if isSelf(m)}
+                  <span class="set-chip set-chip-info">You</span>
+                {/if}
+                {#if m.isWhitelisted}
+                  <span class="set-chip set-chip-success">Active</span>
+                {:else}
+                  <span class="set-chip set-chip-muted">Disabled</span>
+                {/if}
+              </div>
+              {#if m.displayName}
+                <span class="set-member-name">{m.displayName}</span>
+              {/if}
+            </div>
+            <div class="set-row-actions">
+              {#if isSelf(m)}
+                <span class="set-muted-note">Cannot modify self</span>
+              {:else}
+                {#if canDisable(m)}
+                  <button type="button" class="set-btn-text set-warn" onclick={() => store.toggle(m.userId, false)}>Disable</button>
+                {:else if canEnable(m)}
+                  <button type="button" class="set-btn-text set-ok" onclick={() => store.toggle(m.userId, true)}>Enable</button>
+                {/if}
+                {#if canDelete(m)}
+                  <button type="button" class="set-btn-text set-danger-text" onclick={() => askDelete(m)}>Delete</button>
+                {/if}
+              {/if}
+            </div>
+          </div>
+        {/each}
+      </div>
+    </section>
+  {/if}
+</div>
+
+<ConfirmDialog
+  open={confirmMember != null}
+  title="Delete User"
+  message={confirmMessage}
+  confirmLabel="Delete"
+  onCancel={() => (confirmMember = null)}
+  onConfirm={confirmDelete}
+/>
+<Toasts />
+
+<style>
+  .set-page {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 24px 16px 96px;
+  }
+  .set-title {
+    margin: 0 0 20px;
+    font-size: 1.5rem;
+    font-weight: 500;
+  }
+  .set-card {
+    background: var(--color-surface);
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-1);
+    padding: 16px;
+    margin-bottom: 16px;
+  }
+  .set-card-title {
+    margin: 0 0 12px;
+    font-size: 1rem;
+    font-weight: 500;
+  }
+  .set-add-row {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+  .set-input {
+    font: inherit;
+    padding: 10px 12px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--color-line-strong);
+    background: var(--color-surface);
+    color: var(--color-text);
+    min-width: 120px;
+  }
+  .set-input:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -1px;
+  }
+  .set-grow {
+    flex: 1;
+    min-width: 200px;
+  }
+  .set-btn-primary {
+    font: inherit;
+    font-weight: 500;
+    padding: 10px 20px;
+    min-height: 42px;
+    border: none;
+    border-radius: var(--radius-sm);
+    background: var(--color-primary);
+    color: #fff;
+    cursor: pointer;
+  }
+  .set-btn-primary:hover {
+    background: var(--color-primary-hover);
+  }
+  .set-members {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .set-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 10px 12px;
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-sm);
+  }
+  .set-row-static {
+    background: var(--color-surface);
+  }
+  .set-member-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+  .set-member-line {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .set-member-email {
+    overflow-wrap: anywhere;
+  }
+  .set-member-name {
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+  }
+  .set-chip {
+    font-size: 0.6875rem;
+    font-weight: 500;
+    padding: 2px 10px;
+    border-radius: 12px;
+    white-space: nowrap;
+  }
+  .set-chip-info {
+    border: 1px solid var(--color-info);
+    color: var(--color-info);
+  }
+  .set-chip-success {
+    border: 1px solid var(--color-success);
+    color: var(--color-success);
+  }
+  .set-chip-muted {
+    border: 1px solid var(--color-line-strong);
+    color: var(--color-text-muted);
+  }
+  .set-row-actions {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+  }
+  .set-btn-text {
+    font: inherit;
+    font-weight: 500;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 6px 10px;
+    border-radius: var(--radius-sm);
+    color: var(--color-primary);
+  }
+  .set-btn-text:hover {
+    background: var(--color-action-hover);
+  }
+  .set-warn {
+    color: var(--color-warning);
+  }
+  .set-ok {
+    color: var(--color-success);
+  }
+  .set-danger-text {
+    color: var(--color-error);
+  }
+  .set-muted-note {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .set-skeleton,
+  .set-error {
+    padding: 16px;
+    border-radius: var(--radius-sm);
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+  .set-error {
+    background: rgba(229, 57, 53, 0.08);
+    border-left: 4px solid var(--color-error);
+    color: var(--color-text);
+  }
+</style>

--- a/frontend/settings/src/lib/api.ts
+++ b/frontend/settings/src/lib/api.ts
@@ -1,0 +1,122 @@
+import type {
+  CategoryListDto,
+  CategoryDto,
+  CategoryWriteRequest,
+  MemberListDto,
+  MemberActionDto,
+  MemberDto,
+} from './types';
+
+const CATEGORIES = '/api/settings/categories';
+const MEMBERS = '/api/settings/members';
+
+/**
+ * Thrown on any non-2xx response. `status` lets callers react to a rejection.
+ *
+ * ⚠ Carried from the other islands: the app re-executes empty-body API 4xx
+ * through a Blazor `/not-found` page, so a server-side "not found" can arrive
+ * as an empty 400 (a bare DELETE 404 even surfaces as 405). Every settings
+ * endpoint returns a NON-EMPTY body on 4xx, and the island treats ANY 4xx as a
+ * non-retryable client rejection → reconcile (refetch) + a calm toast.
+ */
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+
+  /** A non-retryable client rejection (validation / not found / conflict). Any 4xx. */
+  get isClientRejection(): boolean {
+    return this.status >= 400 && this.status < 500;
+  }
+}
+
+async function request<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    credentials: 'include',
+    headers: { Accept: 'application/json', ...(init?.headers ?? {}) },
+    ...init,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    let message = text || res.statusText;
+    // The endpoints return { message } on 4xx — surface it for the toast.
+    try {
+      const parsed = JSON.parse(text);
+      if (parsed && typeof parsed.message === 'string') message = parsed.message;
+    } catch { /* not JSON — use the raw text */ }
+    throw new ApiError(res.status, message);
+  }
+  if (res.status === 204) return undefined as T;
+  return (await res.json()) as T;
+}
+
+function jsonBody(body: unknown): RequestInit {
+  return {
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  };
+}
+
+// ─── Categories ─────────────────────────────────────────────────────────────
+
+/** #1 Active + deleted categories for the household. */
+export async function getCategories(): Promise<CategoryListDto> {
+  return request<CategoryListDto>(`${CATEGORIES}/`);
+}
+
+/** #2 Create → the saved category (201). Empty name → 400. */
+export async function createCategory(body: CategoryWriteRequest): Promise<CategoryDto> {
+  return request<CategoryDto>(`${CATEGORIES}/`, { method: 'POST', ...jsonBody(body) });
+}
+
+/** #3 Update name/emoji/color (sort order preserved) → the updated category. 404 if missing. */
+export async function updateCategory(categoryId: number, body: CategoryWriteRequest): Promise<CategoryDto> {
+  return request<CategoryDto>(`${CATEGORIES}/${categoryId}`, { method: 'PUT', ...jsonBody(body) });
+}
+
+/** #4 Soft-delete → 204 (idempotent). 404 if missing. */
+export async function deleteCategory(categoryId: number): Promise<void> {
+  await request<void>(`${CATEGORIES}/${categoryId}`, { method: 'DELETE' });
+}
+
+/** #5 Restore a soft-deleted category → 204 (idempotent). */
+export async function restoreCategory(categoryId: number): Promise<void> {
+  await request<void>(`${CATEGORIES}/${categoryId}/restore`, { method: 'POST' });
+}
+
+/** #6 Persist a new order (index ⇒ sortOrder) → 204. */
+export async function updateSortOrder(orderedIds: number[]): Promise<void> {
+  await request<void>(`${CATEGORIES}/sort-order`, { method: 'PUT', ...jsonBody({ orderedIds }) });
+}
+
+/** #7 Whether the category's name is used by any ingredient (for the delete confirm). */
+export async function categoryInUse(categoryId: number): Promise<boolean> {
+  const res = await request<{ inUse: boolean }>(`${CATEGORIES}/${categoryId}/in-use`);
+  return res.inUse;
+}
+
+// ─── Members ──────────────────────────────────────────────────────────────────
+
+/** #8 Household members + the caller's id (for "You" + self-gating). */
+export async function getMembers(): Promise<MemberListDto> {
+  return request<MemberListDto>(`${MEMBERS}/`);
+}
+
+/** #9 Add/re-enable by email → outcome envelope (200). Another household ⇒ 409 (ApiError). */
+export async function addMember(email: string): Promise<MemberActionDto> {
+  return request<MemberActionDto>(`${MEMBERS}/`, { method: 'POST', ...jsonBody({ email }) });
+}
+
+/** #10 Enable/disable → the updated member. Self ⇒ 400; last-active ⇒ 409 (ApiError). */
+export async function setWhitelist(userId: number, isWhitelisted: boolean): Promise<MemberDto> {
+  return request<MemberDto>(`${MEMBERS}/${userId}`, { method: 'PUT', ...jsonBody({ isWhitelisted }) });
+}
+
+/** #11 Delete a member → 204. Self ⇒ 400; last-user / has-activity ⇒ 409 (ApiError). */
+export async function deleteMember(userId: number): Promise<void> {
+  await request<void>(`${MEMBERS}/${userId}`, { method: 'DELETE' });
+}

--- a/frontend/settings/src/lib/categoriesStore.svelte.ts
+++ b/frontend/settings/src/lib/categoriesStore.svelte.ts
@@ -1,0 +1,139 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Categories view store (#settings-categories-root). Source of truth for the
+// active + deleted category lists.
+//
+// ⚠ Svelte 5 rune rule (global CORRECTION): never `export` a reassigned
+// `$state`. We wrap the mutable state in a class instance and export the instance.
+//
+// Parity-first ⇒ versionless / last-write-wins. This view is WRITE-heavy but
+// each surface is simple CRUD: every mutation `await`s then reloads the affected
+// lists; a `loadSeq` guard drops a stale reload that resolves after a newer one
+// (memory fca-island-async-race-guards). No autosave/draft — these are explicit
+// button actions. No liveness (parity: the page doesn't poll).
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { CategoryDto, CategoryWriteRequest } from './types';
+import {
+  ApiError,
+  getCategories,
+  createCategory,
+  updateCategory,
+  deleteCategory,
+  restoreCategory,
+  updateSortOrder,
+  categoryInUse,
+} from './api';
+import { showToast } from './toasts.svelte';
+
+class CategoriesStore {
+  active = $state<CategoryDto[]>([]);
+  deleted = $state<CategoryDto[]>([]);
+  loading = $state(true);
+  error = $state<string | null>(null);
+
+  /** True once the first load resolved — gates the skeleton so reloads don't reflash it. */
+  private hasLoaded = false;
+  /** Monotonic load id — a slower older response must not overwrite a newer one. */
+  private seq = 0;
+
+  /** Load both lists. Spinner only on the FIRST load; reloads refresh in place. */
+  async load(): Promise<void> {
+    const s = ++this.seq;
+    try {
+      if (!this.hasLoaded) this.loading = true;
+      this.error = null;
+      const dto = await getCategories();
+      if (s !== this.seq) return; // a newer load superseded this one
+      this.active = dto.active;
+      this.deleted = dto.deleted;
+      this.hasLoaded = true;
+    } catch (e) {
+      if (s !== this.seq) return;
+      this.error = describe(e, 'load categories');
+    } finally {
+      if (s === this.seq) this.loading = false;
+    }
+  }
+
+  async add(body: CategoryWriteRequest): Promise<boolean> {
+    try {
+      const created = await createCategory(body);
+      await this.load();
+      showToast({ message: `Category "${created.name}" created.`, kind: 'success' });
+      return true;
+    } catch (e) {
+      showToast({ message: describe(e, 'create category'), kind: 'error' });
+      return false;
+    }
+  }
+
+  async update(categoryId: number, body: CategoryWriteRequest): Promise<boolean> {
+    try {
+      await updateCategory(categoryId, body);
+      await this.load();
+      showToast({ message: 'Category updated.', kind: 'success' });
+      return true;
+    } catch (e) {
+      if (e instanceof ApiError) await this.load(); // reconcile to truth on 4xx
+      showToast({ message: describe(e, 'update category'), kind: 'error' });
+      return false;
+    }
+  }
+
+  /** Whether the category's name is used by an ingredient (drives the delete confirm copy). */
+  async checkInUse(categoryId: number): Promise<boolean> {
+    try {
+      return await categoryInUse(categoryId);
+    } catch {
+      return false; // non-critical — fall back to the plain confirm
+    }
+  }
+
+  async remove(categoryId: number): Promise<void> {
+    try {
+      await deleteCategory(categoryId);
+      await this.load();
+      showToast({ message: 'Category deleted.', kind: 'success' });
+    } catch (e) {
+      if (e instanceof ApiError) await this.load();
+      showToast({ message: describe(e, 'delete category'), kind: 'error' });
+    }
+  }
+
+  async restore(categoryId: number): Promise<void> {
+    try {
+      await restoreCategory(categoryId);
+      await this.load();
+      showToast({ message: 'Category restored.', kind: 'success' });
+    } catch (e) {
+      if (e instanceof ApiError) await this.load();
+      showToast({ message: describe(e, 'restore category'), kind: 'error' });
+    }
+  }
+
+  /**
+   * Persist a new order (parity: reorder commits immediately). Optimistic local
+   * reorder so the UI is responsive, then persist; on failure reload to restore
+   * the authoritative order + a toast.
+   */
+  async reorder(orderedIds: number[]): Promise<void> {
+    const byId = new Map(this.active.map((c) => [c.categoryId, c]));
+    const next = orderedIds.map((id) => byId.get(id)).filter((c): c is CategoryDto => c != null);
+    if (next.length === this.active.length) this.active = next;
+    try {
+      await updateSortOrder(orderedIds);
+    } catch (e) {
+      await this.load(); // restore the real order
+      showToast({ message: describe(e, 'reorder categories'), kind: 'error' });
+    }
+  }
+}
+
+function describe(e: unknown, action: string): string {
+  if (e instanceof ApiError) return e.message || `Couldn't ${action} (HTTP ${e.status}).`;
+  if (e instanceof Error) return e.message;
+  return `Couldn't ${action}.`;
+}
+
+/** The single shared categories-view store instance (export the instance, not the runes). */
+export const categoriesStore = new CategoriesStore();

--- a/frontend/settings/src/lib/components/CategoryEditDialog.svelte
+++ b/frontend/settings/src/lib/components/CategoryEditDialog.svelte
@@ -1,0 +1,157 @@
+<script lang="ts">
+  // In-island edit dialog — replaces the Blazor CategoryEditDialog MudDialog.
+  // Parity: plain freeform name + emoji text fields + a color input (the emoji is
+  // freeform text today, e.g. "meat_on_bone"; no emoji picker — that'd be new UX).
+  import type { CategoryDto, CategoryWriteRequest } from '../types';
+
+  interface Props {
+    open: boolean;
+    category: CategoryDto | null;
+    onCancel: () => void;
+    onSave: (body: CategoryWriteRequest) => void;
+  }
+
+  let { open, category, onCancel, onSave }: Props = $props();
+
+  let dialogEl = $state<HTMLDialogElement | null>(null);
+  let name = $state('');
+  let iconEmoji = $state('');
+  let color = $state('#808080');
+
+  // Seed the form from the category when the dialog opens. Reads open/category
+  // (props) and writes the form $state — it does NOT read the form fields, so
+  // there's no self-triggering loop.
+  $effect(() => {
+    if (open && category) {
+      name = category.name;
+      iconEmoji = category.iconEmoji ?? '';
+      color = category.color || '#808080';
+    }
+  });
+
+  $effect(() => {
+    if (!dialogEl) return;
+    if (open && !dialogEl.open) dialogEl.showModal();
+    else if (!open && dialogEl.open) dialogEl.close();
+  });
+
+  function save() {
+    if (!name.trim()) return;
+    onSave({ name: name.trim(), iconEmoji: iconEmoji.trim() || null, color });
+  }
+</script>
+
+<dialog bind:this={dialogEl} onclose={onCancel} class="rc-confirm">
+  {#if open}
+    <div class="rc-confirm-body">
+      <h2>Edit Category</h2>
+      <label class="set-field">
+        <span>Name</span>
+        <input type="text" bind:value={name} class="set-input" />
+      </label>
+      <label class="set-field">
+        <span>Emoji</span>
+        <input type="text" bind:value={iconEmoji} class="set-input" placeholder="e.g., meat_on_bone" />
+      </label>
+      <label class="set-field">
+        <span>Color</span>
+        <input type="color" bind:value={color} class="set-color" />
+      </label>
+      <div class="rc-confirm-actions">
+        <button type="button" class="rc-btn-ghost" onclick={onCancel}>Cancel</button>
+        <button type="button" class="rc-btn-primary" onclick={save} disabled={!name.trim()}>Save</button>
+      </div>
+    </div>
+  {/if}
+</dialog>
+
+<style>
+  .rc-confirm[open] {
+    position: fixed;
+    inset: 0;
+    margin: auto;
+    border: none;
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text);
+    padding: 0;
+    width: min(420px, calc(100vw - 32px));
+    box-shadow: var(--shadow-4);
+  }
+  .rc-confirm::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+  }
+  .rc-confirm-body {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 24px;
+  }
+  .rc-confirm h2 {
+    margin: 0 0 4px;
+    font-size: 1.25rem;
+    font-weight: 500;
+  }
+  .set-field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+  }
+  .set-input {
+    font: inherit;
+    padding: 10px 12px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--color-line-strong);
+    background: var(--color-surface);
+    color: var(--color-text);
+  }
+  .set-input:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -1px;
+  }
+  .set-color {
+    width: 64px;
+    height: 40px;
+    padding: 2px;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    cursor: pointer;
+  }
+  .rc-confirm-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 8px;
+  }
+  .rc-btn-ghost,
+  .rc-btn-primary {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    border: none;
+    cursor: pointer;
+    min-height: 40px;
+    font-weight: 500;
+  }
+  .rc-btn-ghost {
+    background: transparent;
+    color: var(--color-text-muted);
+  }
+  .rc-btn-ghost:hover {
+    background: var(--color-action-hover);
+  }
+  .rc-btn-primary {
+    background: var(--color-primary);
+    color: #fff;
+  }
+  .rc-btn-primary:hover {
+    background: var(--color-primary-hover);
+  }
+  .rc-btn-primary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+</style>

--- a/frontend/settings/src/lib/components/ConfirmDialog.svelte
+++ b/frontend/settings/src/lib/components/ConfirmDialog.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+  // A tiny confirm dialog — replaces the Blazor delete-confirm MudDialog.
+  // Hosted in ListApp; opened with a message + a confirm callback.
+  interface Props {
+    open: boolean;
+    title: string;
+    message: string;
+    confirmLabel?: string;
+    cancelLabel?: string;
+    onCancel: () => void;
+    onConfirm: () => void;
+  }
+
+  let {
+    open,
+    title,
+    message,
+    confirmLabel = 'Delete',
+    cancelLabel = 'Cancel',
+    onCancel,
+    onConfirm,
+  }: Props = $props();
+
+  let dialogEl: HTMLDialogElement | null = $state(null);
+
+  $effect(() => {
+    if (!dialogEl) return;
+    if (open && !dialogEl.open) {
+      dialogEl.showModal();
+    } else if (!open && dialogEl.open) {
+      dialogEl.close();
+    }
+  });
+</script>
+
+<dialog bind:this={dialogEl} onclose={onCancel} class="rc-confirm">
+  {#if open}
+    <div class="rc-confirm-body">
+      <h2>{title}</h2>
+      <p class="rc-confirm-msg">{message}</p>
+      <div class="rc-confirm-actions">
+        <button type="button" class="rc-btn-ghost" onclick={onCancel}>{cancelLabel}</button>
+        <button type="button" class="rc-btn-danger" onclick={onConfirm}>{confirmLabel}</button>
+      </div>
+    </div>
+  {/if}
+</dialog>
+
+<style>
+  .rc-confirm[open] {
+    position: fixed;
+    inset: 0;
+    margin: auto;
+    border: none;
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text);
+    padding: 0;
+    width: min(400px, calc(100vw - 32px));
+    box-shadow: var(--shadow-4);
+  }
+  .rc-confirm::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+  }
+  .rc-confirm-body {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 24px;
+  }
+  .rc-confirm h2 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 500;
+  }
+  .rc-confirm-msg {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+  .rc-confirm-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 8px;
+  }
+  .rc-btn-ghost,
+  .rc-btn-danger {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    border: none;
+    cursor: pointer;
+    min-height: 40px;
+    font-weight: 500;
+  }
+  .rc-btn-ghost {
+    background: transparent;
+    color: var(--color-text-muted);
+  }
+  .rc-btn-ghost:hover {
+    background: var(--color-action-hover);
+  }
+  .rc-btn-danger {
+    background: var(--color-error);
+    color: #fff;
+  }
+  .rc-btn-danger:hover {
+    filter: brightness(0.95);
+  }
+</style>

--- a/frontend/settings/src/lib/components/Toasts.svelte
+++ b/frontend/settings/src/lib/components/Toasts.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+  // The toast region. Mirrors the meal-plan island's Toasts component, re-scoped
+  // to `rc-`. Mounted once at each App root (ListApp / EditApp).
+  import { toasts, dismissToast } from '../toasts.svelte';
+</script>
+
+<div class="rc-toast-region" role="status" aria-live="polite">
+  {#each toasts() as toast (toast.id)}
+    <div class="rc-toast rc-toast-{toast.kind}">
+      <span class="rc-toast-msg">{toast.message}</span>
+      {#if toast.action}
+        <button
+          type="button"
+          class="rc-toast-action"
+          onclick={() => {
+            toast.action?.onClick();
+            dismissToast(toast.id);
+          }}
+        >
+          {toast.action.label}
+        </button>
+      {/if}
+      <button
+        type="button"
+        class="rc-toast-close"
+        aria-label="Dismiss"
+        onclick={() => dismissToast(toast.id)}
+      >
+        ×
+      </button>
+    </div>
+  {/each}
+</div>
+
+<style>
+  .rc-toast-region {
+    position: fixed;
+    left: 50%;
+    bottom: 24px;
+    transform: translateX(-50%);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    z-index: 1100;
+    pointer-events: none;
+    max-width: min(560px, calc(100vw - 32px));
+  }
+  /* Mobile: clear the MainLayout bottom nav so toasts aren't hidden behind it. */
+  @media (max-width: 960px) {
+    .rc-toast-region {
+      bottom: calc(80px + env(safe-area-inset-bottom, 0px));
+    }
+  }
+  .rc-toast {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 12px 10px 16px;
+    border-radius: var(--radius-sm);
+    color: #fff;
+    background: #323232;
+    box-shadow: var(--shadow-4);
+    font-size: 0.875rem;
+    pointer-events: auto;
+    animation: rc-toast-in 0.2s ease-out;
+  }
+  .rc-toast-success {
+    background: var(--color-success);
+  }
+  .rc-toast-error {
+    background: var(--color-error);
+  }
+  .rc-toast-msg {
+    flex: 1;
+    min-width: 0;
+  }
+  .rc-toast-action {
+    background: transparent;
+    border: none;
+    color: #fff;
+    font: inherit;
+    font-weight: 600;
+    text-transform: uppercase;
+    font-size: 0.8125rem;
+    cursor: pointer;
+    padding: 0 4px;
+    flex-shrink: 0;
+  }
+  .rc-toast-action:hover {
+    text-decoration: underline;
+  }
+  .rc-toast-close {
+    background: transparent;
+    border: none;
+    color: rgba(255, 255, 255, 0.8);
+    font-size: 1.25rem;
+    line-height: 1;
+    padding: 0 4px;
+    cursor: pointer;
+  }
+  .rc-toast-close:hover {
+    color: #fff;
+  }
+  @keyframes rc-toast-in {
+    from {
+      opacity: 0;
+      transform: translateY(8px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+</style>

--- a/frontend/settings/src/lib/dates.ts
+++ b/frontend/settings/src/lib/dates.ts
@@ -1,0 +1,13 @@
+// Tiny date helper for the settings island. The only date on the wire is
+// Category.deletedAt — a FULL ISO-8601 instant (UTC), review X5. We parse the
+// full instant (new Date(iso) handles the offset correctly) and format it in the
+// user's local timezone. This is NOT the noon-UTC date-only case (that trick is
+// only for bare "YYYY-MM-DD" strings); never use new Date('YYYY-MM-DD') here.
+
+/** "deleted Jun 20"-style short date for a deleted category, or "" when absent/invalid. */
+export function formatDeletedDate(iso: string | null): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}

--- a/frontend/settings/src/lib/membersStore.svelte.ts
+++ b/frontend/settings/src/lib/membersStore.svelte.ts
@@ -1,0 +1,94 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Manage-Users view store (#settings-users-root). Source of truth for the
+// household member list + the caller's id (for "You" + self-gating).
+//
+// Same discipline as the categories store: untrack one-time load (in the App),
+// `loadSeq` guard, await-then-reload mutations, no liveness. The self / last-active
+// / last-user guards are enforced SERVER-side (the source of truth); the client
+// mirror here is only for button visibility (parity WhitelistAdmin).
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { MemberDto } from './types';
+import { ApiError, getMembers, addMember, setWhitelist, deleteMember } from './api';
+import { showToast } from './toasts.svelte';
+
+class MembersStore {
+  members = $state<MemberDto[]>([]);
+  currentUserId = $state(0);
+  loading = $state(true);
+  error = $state<string | null>(null);
+
+  private hasLoaded = false;
+  private seq = 0;
+
+  /** Active (whitelisted) member count — mirrors the server's last-active guard for button visibility. */
+  activeCount = $derived(this.members.filter((m) => m.isWhitelisted).length);
+
+  async load(): Promise<void> {
+    const s = ++this.seq;
+    try {
+      if (!this.hasLoaded) this.loading = true;
+      this.error = null;
+      const dto = await getMembers();
+      if (s !== this.seq) return;
+      this.members = dto.members;
+      this.currentUserId = dto.currentUserId;
+      this.hasLoaded = true;
+    } catch (e) {
+      if (s !== this.seq) return;
+      this.error = describe(e, 'load members');
+    } finally {
+      if (s === this.seq) this.loading = false;
+    }
+  }
+
+  async add(email: string): Promise<boolean> {
+    const trimmed = email.trim();
+    if (!trimmed) return false;
+    try {
+      const res = await addMember(trimmed);
+      await this.load();
+      if (res.outcome === 'created') {
+        showToast({ message: `Added ${res.member.email}.`, kind: 'success' });
+      } else if (res.outcome === 'reenabled') {
+        showToast({ message: `Re-enabled ${res.member.email}.`, kind: 'success' });
+      } else {
+        // alreadyActive — a benign notice, NOT an error (parity: a warning today, review R-A1).
+        showToast({ message: `${res.member.email} already has access.`, kind: 'info' });
+      }
+      return true;
+    } catch (e) {
+      showToast({ message: describe(e, 'add member'), kind: 'error' });
+      return false;
+    }
+  }
+
+  async toggle(userId: number, isWhitelisted: boolean): Promise<void> {
+    try {
+      await setWhitelist(userId, isWhitelisted);
+      await this.load();
+    } catch (e) {
+      if (e instanceof ApiError) await this.load();
+      showToast({ message: describe(e, isWhitelisted ? 'enable member' : 'disable member'), kind: 'error' });
+    }
+  }
+
+  async remove(userId: number): Promise<void> {
+    try {
+      await deleteMember(userId);
+      await this.load();
+      showToast({ message: 'Member removed.', kind: 'success' });
+    } catch (e) {
+      if (e instanceof ApiError) await this.load();
+      showToast({ message: describe(e, 'remove member'), kind: 'error' });
+    }
+  }
+}
+
+function describe(e: unknown, action: string): string {
+  if (e instanceof ApiError) return e.message || `Couldn't ${action} (HTTP ${e.status}).`;
+  if (e instanceof Error) return e.message;
+  return `Couldn't ${action}.`;
+}
+
+export const membersStore = new MembersStore();

--- a/frontend/settings/src/lib/toasts.svelte.ts
+++ b/frontend/settings/src/lib/toasts.svelte.ts
@@ -1,0 +1,60 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Transient toast notices for the recipes island (mirrors the meal-plan/chores
+// toast store). Used for non-alarming 4xx/network surfacing, the "someone
+// changed this — refreshed" reconcile notice, and edit-form save outcomes. Kept
+// deliberately small: a module-level `$state` list + helpers.
+//
+// ⚠ Svelte 5 rune rule: we never export a reassigned `$state` rune directly.
+// The list lives inside a module-private `$state` object; callers read it via
+// the `toasts()` accessor and mutate it only through the exported functions.
+// ─────────────────────────────────────────────────────────────────────────
+
+export type ToastKind = 'info' | 'success' | 'error';
+
+/** Optional inline action (e.g. the ingredient delete-with-undo). */
+export interface ToastAction {
+  label: string;
+  onClick: () => void;
+}
+
+export interface Toast {
+  id: number;
+  message: string;
+  kind: ToastKind;
+  durationMs: number;
+  action?: ToastAction;
+}
+
+let nextId = 1;
+const store = $state<{ items: Toast[] }>({ items: [] });
+
+/** The live toast list (reactive — read inside markup). */
+export function toasts(): readonly Toast[] {
+  return store.items;
+}
+
+/** Push a toast. Auto-dismisses after `durationMs` (default 3.5s). */
+export function showToast(toast: {
+  message: string;
+  kind: ToastKind;
+  durationMs?: number;
+  action?: ToastAction;
+}): number {
+  const id = nextId++;
+  const full: Toast = {
+    id,
+    message: toast.message,
+    kind: toast.kind,
+    durationMs: toast.durationMs ?? 3500,
+    action: toast.action,
+  };
+  store.items = [...store.items, full];
+  if (full.durationMs > 0) {
+    setTimeout(() => dismissToast(id), full.durationMs);
+  }
+  return id;
+}
+
+export function dismissToast(id: number): void {
+  store.items = store.items.filter((t) => t.id !== id);
+}

--- a/frontend/settings/src/lib/types.ts
+++ b/frontend/settings/src/lib/types.ts
@@ -1,0 +1,65 @@
+// ─────────────────────────────────────────────────────────────────────────
+// TS mirror of the /api/settings contract (M9 lockstep). Source of truth:
+//   - Services/Dtos/SettingsDtos.cs (the C# records — named Settings* there to
+//     avoid colliding with the recipes/chores DTOs; here they are island-local)
+//   - tests/.../Fixtures/Settings/{categories,members}.json (byte-locked tripwires)
+//   - Endpoints/SettingsEndpoints.cs (request DTOs)
+//
+// ⚠ CASING: all keys camelCase. No enums.
+// ⚠ DATES (review X5): `deletedAt` is a FULL ISO-8601 instant (UTC) or null —
+//   render it local via new Date(iso) (NEVER new Date('YYYY-MM-DD')).
+// ─────────────────────────────────────────────────────────────────────────
+
+/** The per-page context the Razor host hands the island via data- attributes. */
+export interface ShellContext {
+  householdId: number;
+  userId: number;
+  userName: string;
+  view: 'categories' | 'users';
+}
+
+// ── Categories (Fixtures/Settings/categories.json) ──────────────────────────
+
+export interface CategoryDto {
+  categoryId: number;
+  name: string;
+  iconEmoji: string | null;
+  color: string;
+  isDefault: boolean;
+  sortOrder: number;
+  /** full ISO-8601 instant (UTC) for deleted rows, else null. */
+  deletedAt: string | null;
+}
+
+export interface CategoryListDto {
+  active: CategoryDto[];
+  deleted: CategoryDto[];
+}
+
+export interface CategoryWriteRequest {
+  name: string;
+  iconEmoji: string | null;
+  color: string;
+}
+
+// ── Members (Fixtures/Settings/members.json) ────────────────────────────────
+
+export interface MemberDto {
+  userId: number;
+  email: string;
+  displayName: string | null;
+  isWhitelisted: boolean;
+}
+
+export interface MemberListDto {
+  currentUserId: number;
+  members: MemberDto[];
+}
+
+/** Add-member outcome envelope (review R-A1): "alreadyActive" is a WARNING, not an error. */
+export type AddMemberOutcome = 'created' | 'reenabled' | 'alreadyActive';
+
+export interface MemberActionDto {
+  member: MemberDto;
+  outcome: AddMemberOutcome;
+}

--- a/frontend/settings/src/main.ts
+++ b/frontend/settings/src/main.ts
@@ -1,0 +1,196 @@
+import { mount as svelteMount, unmount } from 'svelte';
+import type { Component } from 'svelte';
+import CategoriesApp from './CategoriesApp.svelte';
+import UsersApp from './UsersApp.svelte';
+import './styles/app.css';
+import type { ShellContext } from './lib/types';
+
+type MountedApp = ReturnType<typeof svelteMount>;
+
+interface Instance {
+  app: MountedApp;
+  /** The exact node we mounted into — lets us detect a Blazor resume that
+   *  replaced or emptied the root out from under us. */
+  el: HTMLElement;
+}
+
+// Blazor Server inserts component output via DOM diff, and inline <script>
+// tags in that output are NOT executed by the browser. The Razor shells
+// (Categories.razor / WhitelistAdmin.razor) use IJSRuntime.InvokeAsync("import", …)
+// to load this module, then call the global mounter below. Exposing a named
+// entry on window is the simplest way to survive enhanced-nav round-trips.
+declare global {
+  interface Window {
+    SettingsIsland?: {
+      mount(rootId: string): void;
+      destroy(rootId: string): void;
+    };
+  }
+}
+
+// One bundle serves BOTH household-settings routes (spec D1): /settings/categories
+// mounts the categories root, /settings/users mounts the users root. The root's
+// `data-view` attr picks the component; only one root is present per page.
+const CATEGORIES_ROOT_ID = 'settings-categories-root';
+const USERS_ROOT_ID = 'settings-users-root';
+const ALL_ROOT_IDS = [CATEGORIES_ROOT_ID, USERS_ROOT_ID];
+
+const instances = new Map<string, Instance>();
+
+// Roots the Razor shell has asked us to mount. We re-assert these when the page
+// is restored so a Blazor circuit resume / enhanced-nav merge that wiped our
+// content can't leave the island permanently blank (see runHeal below).
+const desiredRoots = new Set<string>();
+
+function readContext(el: HTMLElement): ShellContext {
+  const householdId = Number(el.dataset.householdId ?? '0');
+  const userId = Number(el.dataset.userId ?? '0');
+  const userName = el.dataset.userName ?? '';
+  const view = el.dataset.view === 'users' ? 'users' : 'categories';
+  if (!householdId || !userId) {
+    throw new Error('settings: missing data-household-id / data-user-id');
+  }
+  return { householdId, userId, userName, view };
+}
+
+function componentForView(view: ShellContext['view']): Component<{ ctx: ShellContext }> {
+  return (view === 'users' ? UsersApp : CategoriesApp) as Component<{ ctx: ShellContext }>;
+}
+
+// Track dark-mode state and mirror it as a class on the island root so the
+// CSS override wins even when MudBlazor's runtime toggle doesn't propagate
+// the class down to us (we've seen it stay on <html> at load but go missing
+// after runtime toggles, leaving the island stuck in light mode).
+const darkObservers = new Map<string, () => void>();
+
+function isDarkActive(): boolean {
+  if (document.documentElement.classList.contains('mud-theme-dark')) return true;
+  if (document.body?.classList.contains('mud-theme-dark')) return true;
+  try {
+    if (localStorage.getItem('darkMode') === 'true') return true;
+  } catch { /* storage blocked */ }
+  return false;
+}
+
+function syncDarkClass(el: HTMLElement) {
+  el.classList.toggle('set-dark-mode', isDarkActive());
+}
+
+function installDarkObserver(rootId: string, el: HTMLElement) {
+  syncDarkClass(el);
+  const htmlObs = new MutationObserver(() => syncDarkClass(el));
+  htmlObs.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
+  const bodyObs = new MutationObserver(() => syncDarkClass(el));
+  if (document.body) bodyObs.observe(document.body, { attributes: true, attributeFilter: ['class'] });
+  const storageHandler = (e: StorageEvent) => {
+    if (e.key === 'darkMode') syncDarkClass(el);
+  };
+  window.addEventListener('storage', storageHandler);
+  darkObservers.set(rootId, () => {
+    htmlObs.disconnect();
+    bodyObs.disconnect();
+    window.removeEventListener('storage', storageHandler);
+  });
+}
+
+/**
+ * A mount is healthy only if the CURRENT root element is the exact node we
+ * mounted into, it's still in the document, and it still holds our rendered
+ * children. Blazor's .NET 10 circuit resume REPLACES the root node and re-runs
+ * the host component's lifecycle — a fresh firstRender re-calls mount().
+ * Comparing the live node to the one we mounted into lets the re-invoked
+ * mount() rebuild instead of no-op.
+ */
+function isHealthy(rootId: string): boolean {
+  const inst = instances.get(rootId);
+  if (!inst) return false;
+  const el = document.getElementById(rootId);
+  return el != null && el === inst.el && el.isConnected && el.childElementCount > 0;
+}
+
+function mountRoot(rootId: string) {
+  desiredRoots.add(rootId);
+  if (isHealthy(rootId)) return;
+  if (instances.has(rootId)) destroyRoot(rootId, /* internal */ true);
+  const el = document.getElementById(rootId) as HTMLElement | null;
+  if (!el) {
+    console.warn('[settings-island] root element not found:', rootId);
+    return;
+  }
+  installDarkObserver(rootId, el);
+  const ctx = readContext(el);
+  const app = svelteMount(componentForView(ctx.view), { target: el, props: { ctx } });
+  instances.set(rootId, { app, el });
+  ensureHealObserver();
+}
+
+function destroyRoot(rootId: string, internal = false) {
+  const inst = instances.get(rootId);
+  if (!inst) {
+    if (!internal) desiredRoots.delete(rootId);
+    return;
+  }
+  // Blazor's circuit resume disposes the OLD page component AFTER re-initialising
+  // the new one (whose firstRender re-calls mount()). Ignore an external destroy
+  // while the current mount is healthy; a genuine navigation-away leaves no healthy
+  // root, so real teardown still runs then. `internal` (self-heal) always proceeds.
+  if (!internal && isHealthy(rootId)) return;
+  if (!internal) desiredRoots.delete(rootId);
+  unmount(inst.app);
+  instances.delete(rootId);
+  const disposer = darkObservers.get(rootId);
+  if (disposer) {
+    disposer();
+    darkObservers.delete(rootId);
+  }
+}
+
+window.SettingsIsland = { mount: mountRoot, destroy: destroyRoot };
+
+// ── Resilience: self-heal after a Blazor circuit resume ────────────────────
+// Mobile browsers background the tab on an app/tab switch; Blazor Server's .NET
+// 10 circuit pause/resume then reconciles the DOM on return and can REPLACE the
+// island root. We watch a STABLE anchor (document.body) and rebuild any desired
+// root that has gone unhealthy. `healing` guards re-entrancy; once the root is
+// healthy again the next pass no-ops, so it can't loop.
+let healObserver: MutationObserver | null = null;
+let healing = false;
+function runHeal() {
+  if (healing) return;
+  healing = true;
+  try {
+    for (const rootId of desiredRoots) {
+      if (document.getElementById(rootId) && !isHealthy(rootId)) mountRoot(rootId);
+    }
+  } finally {
+    healing = false;
+  }
+}
+function ensureHealObserver() {
+  if (healObserver || !document.body) return;
+  healObserver = new MutationObserver(runHeal);
+  healObserver.observe(document.body, { childList: true, subtree: true });
+}
+
+// bfcache restore re-attaches the frozen DOM without any mutation, so the body
+// observer won't fire — re-assert directly on pageshow as a cheap belt.
+window.addEventListener('pageshow', () => {
+  ensureHealObserver();
+  for (const rootId of desiredRoots) {
+    if (document.getElementById(rootId) && !isHealthy(rootId)) mountRoot(rootId);
+  }
+});
+
+// Standalone dev auto-mount: if a known root is already on the page when the
+// module loads (Vite's index.html), mount it immediately. In production the
+// Razor shell calls window.SettingsIsland.mount() explicitly via JS interop.
+function autoMountIfReady() {
+  for (const rootId of ALL_ROOT_IDS) {
+    if (document.getElementById(rootId)) mountRoot(rootId);
+  }
+}
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', autoMountIfReady);
+} else {
+  autoMountIfReady();
+}

--- a/frontend/settings/src/styles/app.css
+++ b/frontend/settings/src/styles/app.css
@@ -1,0 +1,38 @@
+@import './tokens.css';
+
+/*
+ * The island renders inside the host page, which also loads Bootstrap + MudBlazor.
+ * Bootstrap defines .row / .container globally, and those names collide with
+ * ambient island styles. We avoid the collision by prefixing all island class
+ * names with `rc-` (recipes) rather than overriding globals here.
+ */
+
+#settings-categories-root,
+#settings-users-root {
+  font-family: var(--font-family);
+  color: var(--color-text);
+  background: var(--color-background);
+  min-height: 100%;
+}
+
+#settings-categories-root,
+#settings-categories-root *,
+#settings-categories-root *::before,
+#settings-categories-root *::after,
+#settings-users-root,
+#settings-users-root *,
+#settings-users-root *::before,
+#settings-users-root *::after {
+  box-sizing: border-box;
+}
+
+/*
+ * Suppress the outer Blazor ReconnectModal while the island is on the page.
+ * It's a showModal() <dialog>, which blocks all interaction behind it —
+ * including our HTTP-driven island that doesn't need the circuit to work.
+ * This CSS only ships on the recipes pages (via <HeadContent>), so other
+ * pages still get the normal reconnect UX.
+ */
+#components-reconnect-modal {
+  display: none !important;
+}

--- a/frontend/settings/src/styles/tokens.css
+++ b/frontend/settings/src/styles/tokens.css
@@ -1,0 +1,97 @@
+/*
+ * Design tokens mirrored from the MudBlazor theme used elsewhere in the app
+ * (kept in sync with frontend/meal-plan/src/styles/tokens.css).
+ * Light mode = :root. Dark mode = html.mud-theme-dark (set by App.razor)
+ * plus #settings-categories-root.set-dark-mode / #settings-users-root.set-dark-mode
+ * (mirrored by main.ts's dark observer).
+ */
+
+:root {
+  /* brand */
+  --color-primary: rgb(46, 125, 50);
+  --color-primary-hover: rgb(36, 97, 39);
+  --color-primary-soft: rgb(58, 156, 63);
+  --color-secondary: rgb(255, 111, 0);
+
+  /* surfaces */
+  --color-surface: rgb(255, 255, 255);
+  --color-background: rgb(250, 250, 250);
+  --color-appbar: rgb(46, 125, 50);
+  --color-drawer: rgb(245, 245, 245);
+
+  /* text */
+  --color-text: rgb(66, 66, 66);
+  --color-text-muted: rgba(0, 0, 0, 0.54);
+  --color-text-disabled: rgba(0, 0, 0, 0.38);
+
+  /* structure */
+  --color-line: rgba(0, 0, 0, 0.12);
+  --color-line-strong: rgb(189, 189, 189);
+  --color-divider: rgb(224, 224, 224);
+  --color-action-hover: rgba(0, 0, 0, 0.06);
+  --color-action-disabled: rgba(0, 0, 0, 0.26);
+
+  /* semantic */
+  --color-success: rgb(67, 160, 71);
+  --color-error: rgb(229, 57, 53);
+  --color-warning: rgb(251, 140, 0);
+  --color-info: rgb(30, 136, 229);
+
+  /* typography */
+  --font-family: Roboto, Helvetica, Arial, sans-serif;
+
+  /* shape */
+  --radius-sm: 4px;
+  --radius-md: 4px;
+
+  /* elevation (MudBlazor 1, 2, 4) */
+  --shadow-1:
+    0 2px 1px -1px rgba(0, 0, 0, 0.2),
+    0 1px 1px 0 rgba(0, 0, 0, 0.14),
+    0 1px 3px 0 rgba(0, 0, 0, 0.12);
+  --shadow-2:
+    0 3px 1px -2px rgba(0, 0, 0, 0.2),
+    0 2px 2px 0 rgba(0, 0, 0, 0.14),
+    0 1px 5px 0 rgba(0, 0, 0, 0.12);
+  --shadow-4:
+    0 2px 4px -1px rgba(0, 0, 0, 0.2),
+    0 4px 5px 0 rgba(0, 0, 0, 0.14),
+    0 1px 10px 0 rgba(0, 0, 0, 0.12);
+}
+
+/*
+ * Dark-mode override. MudBlazor v8 + the App.razor bootstrap script both
+ * toggle `mud-theme-dark` on <html>, but runtime theme toggles sometimes
+ * land on <body> or deeper. Matching the bare class is a superset that
+ * works regardless of where the ancestor lives.
+ */
+.mud-theme-dark,
+html.mud-theme-dark,
+body.mud-theme-dark,
+#settings-categories-root.set-dark-mode,
+#settings-users-root.set-dark-mode {
+  --color-primary: rgb(102, 187, 106);
+  --color-primary-hover: rgb(77, 172, 82);
+  --color-primary-soft: rgb(128, 198, 132);
+  --color-secondary: rgb(255, 183, 77);
+
+  --color-surface: rgb(30, 30, 30);
+  --color-background: rgb(18, 18, 18);
+  --color-appbar: rgb(26, 26, 26);
+  --color-drawer: rgb(26, 26, 26);
+
+  --color-text: rgba(255, 255, 255, 0.87);
+  --color-text-muted: rgba(255, 255, 255, 0.6);
+  --color-text-disabled: rgba(255, 255, 255, 0.2);
+
+  --color-line: rgba(255, 255, 255, 0.12);
+  --color-line-strong: rgba(255, 255, 255, 0.3);
+  --color-divider: rgba(255, 255, 255, 0.12);
+  --color-action-hover: rgba(173, 173, 177, 0.06);
+  --color-action-disabled: rgba(255, 255, 255, 0.26);
+
+  --color-success: rgb(102, 187, 106);
+  --color-error: rgb(239, 83, 80);
+  --color-warning: rgb(255, 167, 38);
+  --color-info: rgb(66, 165, 245);
+}

--- a/frontend/settings/src/vite-env.d.ts
+++ b/frontend/settings/src/vite-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="svelte" />
+/// <reference types="vite/client" />

--- a/frontend/settings/svelte.config.js
+++ b/frontend/settings/svelte.config.js
@@ -1,0 +1,8 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+export default {
+  preprocess: vitePreprocess(),
+  compilerOptions: {
+    runes: true,
+  },
+};

--- a/frontend/settings/tsconfig.json
+++ b/frontend/settings/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "@tsconfig/svelte/tsconfig.json",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowJs": false,
+    "checkJs": false,
+    "isolatedModules": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitAny": true,
+    "skipLibCheck": true,
+    "types": ["svelte", "vite/client"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.svelte", "src/vite-env.d.ts"]
+}

--- a/frontend/settings/vite.config.ts
+++ b/frontend/settings/vite.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+
+// The settings island (cluster A) is embedded into two Razor shells (Categories.razor
+// at /settings/categories and WhitelistAdmin.razor at /settings/users). Both host pages
+// load this single bundle and mount the matching root by a data-view attr (spec D1).
+// Build output goes to ./dist/ — the CopySettingsIsland MSBuild target in
+// FamilyCoordinationApp.csproj copies this into wwwroot/islands/settings/.
+// The settings-node-build Docker stage emits dist/; the .NET stage reads it via COPY --from.
+// Mirrors frontend/recipes/vite.config.ts (output index.js + index.css).
+export default defineConfig({
+  plugins: [svelte()],
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    rollupOptions: {
+      input: 'src/main.ts',
+      output: {
+        entryFileNames: 'index.js',
+        chunkFileNames: 'chunks/[name]-[hash].js',
+        assetFileNames: (info) =>
+          info.name?.endsWith('.css') ? 'index.css' : 'assets/[name]-[hash][extname]',
+      },
+    },
+    sourcemap: true,
+  },
+  server: {
+    port: 5178,
+    // Dev server proxies /api to the running .NET app so `npm run dev` works
+    // standalone against a locally-running Blazor host on :5000.
+    proxy: {
+      '/api': {
+        target: 'http://localhost:5000',
+        changeOrigin: false,
+      },
+    },
+  },
+});

--- a/src/FamilyCoordinationApp/Components/Pages/Settings/Categories.razor
+++ b/src/FamilyCoordinationApp/Components/Pages/Settings/Categories.razor
@@ -20,19 +20,25 @@
     the data-view attr picks the view.
 *@
 
-@if (_useIsland && _shell is not null)
+@* When the flag is ON we never render the Blazor fallback — not even during the brief async gap before
+   _shell resolves — to avoid momentarily mounting (then disposing) the Blazor page under the island flag.
+   The island-div condition is unchanged, so mounting is unaffected. *@
+@if (_useIsland)
 {
-    <PageTitle>Manage Categories - Family Kitchen</PageTitle>
+    @if (_shell is not null)
+    {
+        <PageTitle>Manage Categories - Family Kitchen</PageTitle>
 
-    <HeadContent>
-        <link rel="stylesheet" href="/islands/settings/index.css?v=@IslandVersion" />
-    </HeadContent>
+        <HeadContent>
+            <link rel="stylesheet" href="/islands/settings/index.css?v=@IslandVersion" />
+        </HeadContent>
 
-    <div id="settings-categories-root"
-         data-household-id="@_shell.HouseholdId"
-         data-user-id="@_shell.UserId"
-         data-user-name="@_shell.UserName"
-         data-view="categories"></div>
+        <div id="settings-categories-root"
+             data-household-id="@_shell.HouseholdId"
+             data-user-id="@_shell.UserId"
+             data-user-name="@_shell.UserName"
+             data-view="categories"></div>
+    }
 }
 else
 {

--- a/src/FamilyCoordinationApp/Components/Pages/Settings/Categories.razor
+++ b/src/FamilyCoordinationApp/Components/Pages/Settings/Categories.razor
@@ -1,274 +1,123 @@
 @page "/settings/categories"
 @attribute [Authorize]
-
 @using FamilyCoordinationApp.Data
-@using FamilyCoordinationApp.Data.Entities
-@using FamilyCoordinationApp.Services
+@using Microsoft.AspNetCore.Components.Web
 @using Microsoft.EntityFrameworkCore
+@using Microsoft.JSInterop
 @using System.Security.Claims
-@using Plk.Blazor.DragDrop
+@implements IAsyncDisposable
 
-@inject ICategoryService CategoryService
+@inject IConfiguration Config
+@inject AuthenticationStateProvider AuthStateProvider
 @inject IDbContextFactory<ApplicationDbContext> DbFactory
-@inject ISnackbar Snackbar
-@inject IDialogService DialogService
+@inject IJSRuntime JS
+@inject IWebHostEnvironment HostEnv
 
-<PageTitle>Manage Categories - Family Kitchen</PageTitle>
+@*
+    Thin island host (strangler). Flag ON (SETTINGS_HOUSEHOLD_USE_ISLAND=true) → mount the Svelte settings
+    island (categories view); flag OFF → the existing Blazor page (<CategoriesBlazor/>) as the zero-regression
+    fallback. Mirrors Home.razor. One bundle (/islands/settings) serves both this and WhitelistAdmin.razor;
+    the data-view attr picks the view.
+*@
 
-<MudContainer MaxWidth="MaxWidth.Medium" Class="mt-4">
-    <MudText Typo="Typo.h4" Class="mb-4">Manage Categories</MudText>
+@if (_useIsland && _shell is not null)
+{
+    <PageTitle>Manage Categories - Family Kitchen</PageTitle>
 
-    <MudText Typo="Typo.body1" Color="Color.Secondary" Class="mb-4">
-        Customize ingredient categories for your household. Drag to reorder categories to match your store layout.
-    </MudText>
+    <HeadContent>
+        <link rel="stylesheet" href="/islands/settings/index.css?v=@IslandVersion" />
+    </HeadContent>
 
-    @if (_loading)
-    {
-        <MudProgressLinear Indeterminate="true" />
-    }
-    else
-    {
-        <MudPaper Class="pa-4 mb-4" Elevation="1">
-            <MudText Typo="Typo.h6" Class="mb-3">Add New Category</MudText>
-
-            <MudGrid>
-                <MudItem xs="12" sm="4">
-                    <MudTextField @bind-Value="_newCategory.Name"
-                                  Label="Name"
-                                  Variant="Variant.Outlined"
-                                  Required="true" />
-                </MudItem>
-                <MudItem xs="12" sm="3">
-                    <MudTextField @bind-Value="_newCategory.IconEmoji"
-                                  Label="Emoji"
-                                  Variant="Variant.Outlined"
-                                  HelperText="e.g., meat_on_bone" />
-                </MudItem>
-                <MudItem xs="12" sm="3">
-                    <MudColorPicker @bind-Text="_newCategory.Color"
-                                    Label="Color"
-                                    Variant="Variant.Outlined" />
-                </MudItem>
-                <MudItem xs="12" sm="2">
-                    <MudButton Variant="Variant.Filled"
-                               Color="Color.Primary"
-                               OnClick="AddCategory"
-                               FullWidth="true"
-                               Style="height: 56px;">
-                        Add
-                    </MudButton>
-                </MudItem>
-            </MudGrid>
-        </MudPaper>
-
-        <MudPaper Class="pa-4 mb-4" Elevation="1">
-            <MudText Typo="Typo.h6" Class="mb-3">Active Categories</MudText>
-
-            <Dropzone Items="_categories"
-                      InstantReplace="true"
-                      TItem="Category"
-                      OnItemDrop="OnCategoryReordered">
-                <MudPaper Class="pa-3 mb-2 d-flex align-center justify-space-between"
-                          Elevation="1"
-                          Style="cursor: grab;">
-                    <div class="d-flex align-center">
-                        <MudIcon Icon="@Icons.Material.Filled.DragIndicator"
-                                 Class="mr-2"
-                                 Size="Size.Small" />
-                        <div style="width: 24px; height: 24px; border-radius: 4px; background-color: @context.Color; margin-right: 12px;"></div>
-                        <MudText>@context.Name</MudText>
-                        @if (context.IsDefault)
-                        {
-                            <MudChip T="string" Size="Size.Small" Color="Color.Info" Class="ml-2">Default</MudChip>
-                        }
-                    </div>
-                    <div>
-                        <MudIconButton Icon="@Icons.Material.Filled.Edit"
-                                       Size="Size.Small"
-                                       OnClick="() => EditCategory(context)" />
-                        <MudIconButton Icon="@Icons.Material.Filled.Delete"
-                                       Size="Size.Small"
-                                       Color="Color.Error"
-                                       OnClick="() => DeleteCategory(context)" />
-                    </div>
-                </MudPaper>
-            </Dropzone>
-        </MudPaper>
-
-        @if (_deletedCategories.Count > 0)
-        {
-            <MudPaper Class="pa-4" Elevation="1">
-                <MudText Typo="Typo.h6" Class="mb-3">Deleted Categories</MudText>
-
-                @foreach (var category in _deletedCategories)
-                {
-                    <MudPaper Class="pa-3 mb-2 d-flex align-center justify-space-between"
-                              Elevation="0"
-                              Style="opacity: 0.6;">
-                        <div class="d-flex align-center">
-                            <div style="width: 24px; height: 24px; border-radius: 4px; background-color: @category.Color; margin-right: 12px;"></div>
-                            <MudText>@category.Name</MudText>
-                            <MudText Typo="Typo.caption" Color="Color.Secondary" Class="ml-2">
-                                (deleted @category.DeletedAt?.ToString("MMM d"))
-                            </MudText>
-                        </div>
-                        <MudButton Variant="Variant.Text"
-                                   Color="Color.Primary"
-                                   OnClick="() => RestoreCategory(category)">
-                            Restore
-                        </MudButton>
-                    </MudPaper>
-                }
-            </MudPaper>
-        }
-    }
-</MudContainer>
+    <div id="settings-categories-root"
+         data-household-id="@_shell.HouseholdId"
+         data-user-id="@_shell.UserId"
+         data-user-name="@_shell.UserName"
+         data-view="categories"></div>
+}
+else
+{
+    <CategoriesBlazor />
+}
 
 @code {
-    [CascadingParameter] private Task<AuthenticationState>? AuthState { get; set; }
+    private bool _useIsland;
+    private ShellData? _shell;
+    private IJSObjectReference? _islandModule;
 
-    private List<Category> _categories = new();
-    private List<Category> _deletedCategories = new();
-    private Category _newCategory = new() { Color = "#808080" };
-    private bool _loading = true;
-    private int _householdId;
+    private const string RootId = "settings-categories-root";
 
     protected override async Task OnInitializedAsync()
     {
-        await LoadHouseholdId();
-        await LoadCategories();
-        _loading = false;
-    }
+        _useIsland = IsIslandEnabled();
+        if (!_useIsland) return;
 
-    private async Task LoadHouseholdId()
-    {
-        if (AuthState == null) return;
-
-        var authState = await AuthState;
-        var email = authState.User.FindFirstValue(ClaimTypes.Email);
-
-        if (string.IsNullOrEmpty(email)) return;
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        var email = authState.User.FindFirst(ClaimTypes.Email)?.Value;
+        var userName = authState.User.FindFirst(ClaimTypes.Name)?.Value ?? string.Empty;
 
         await using var context = await DbFactory.CreateDbContextAsync();
-        var user = await context.Users
-            .FirstOrDefaultAsync(u => u.Email == email);
-
-        if (user != null)
+        var user = await context.Users.FirstOrDefaultAsync(u => u.Email == email);
+        if (user is null)
         {
-            _householdId = user.HouseholdId;
+            throw new InvalidOperationException("User not found. Please log in again.");
         }
+
+        _shell = new ShellData(user.HouseholdId, user.Id, userName);
     }
 
-    private async Task LoadCategories()
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        var allCategories = await CategoryService.GetCategoriesAsync(_householdId, includeDeleted: true);
-        _categories = allCategories.Where(c => !c.IsDeleted).OrderBy(c => c.SortOrder).ToList();
-        _deletedCategories = allCategories.Where(c => c.IsDeleted).ToList();
+        if (!firstRender || !_useIsland || _shell is null) return;
+
+        await JS.InvokeVoidAsync("ensureIslandStylesheet", $"/islands/settings/index.css?v={IslandVersion}");
+
+        _islandModule = await JS.InvokeAsync<IJSObjectReference>(
+            "import", $"/islands/settings/index.js?v={IslandVersion}");
+        await JS.InvokeVoidAsync("SettingsIsland.mount", RootId);
     }
 
-    private async Task AddCategory()
-    {
-        if (string.IsNullOrWhiteSpace(_newCategory.Name))
-        {
-            Snackbar.Add("Category name is required", Severity.Warning);
-            return;
-        }
+    // Cache-bust the island URLs per deploy via the published bundle's mtime (mirrors Home.razor).
+    private static string? _islandVersion;
+    private string IslandVersion => _islandVersion ??= ComputeIslandVersion();
 
-        try
-        {
-            _newCategory.HouseholdId = _householdId;
-            _newCategory.IsDefault = false;
-            await CategoryService.CreateCategoryAsync(_newCategory);
-            Snackbar.Add($"Category \"{_newCategory.Name}\" created", Severity.Success);
-
-            _newCategory = new Category { Color = "#808080" };
-            await LoadCategories();
-        }
-        catch (Exception ex)
-        {
-            Snackbar.Add($"Failed to create category: {ex.Message}", Severity.Error);
-        }
-    }
-
-    private async Task EditCategory(Category category)
-    {
-        var parameters = new DialogParameters<CategoryEditDialog>
-        {
-            { x => x.Category, category }
-        };
-
-        var dialog = await DialogService.ShowAsync<CategoryEditDialog>("Edit Category", parameters);
-        var result = await dialog.Result;
-
-        if (!result!.Canceled && result.Data is Category updated)
-        {
-            try
-            {
-                await CategoryService.UpdateCategoryAsync(updated);
-                Snackbar.Add("Category updated", Severity.Success);
-                await LoadCategories();
-            }
-            catch (Exception ex)
-            {
-                Snackbar.Add($"Failed to update category: {ex.Message}", Severity.Error);
-            }
-        }
-    }
-
-    private async Task DeleteCategory(Category category)
-    {
-        // Check if category has ingredients
-        if (await CategoryService.HasIngredientsAsync(_householdId, category.Name))
-        {
-            var result = await DialogService.ShowMessageBox(
-                "Category In Use",
-                $"The category \"{category.Name}\" is used by ingredients in your recipes. You can still delete it, but those ingredients will keep their category assignment.",
-                yesText: "Delete Anyway",
-                cancelText: "Cancel");
-
-            if (result != true) return;
-        }
-
-        try
-        {
-            await CategoryService.DeleteCategoryAsync(_householdId, category.CategoryId);
-            Snackbar.Add($"Category \"{category.Name}\" deleted", Severity.Success);
-            await LoadCategories();
-        }
-        catch (Exception ex)
-        {
-            Snackbar.Add($"Failed to delete category: {ex.Message}", Severity.Error);
-        }
-    }
-
-    private async Task RestoreCategory(Category category)
+    private string ComputeIslandVersion()
     {
         try
         {
-            await CategoryService.RestoreCategoryAsync(_householdId, category.CategoryId);
-            Snackbar.Add($"Category \"{category.Name}\" restored", Severity.Success);
-            await LoadCategories();
+            var path = Path.Combine(HostEnv.WebRootPath, "islands", "settings", "index.js");
+            return new DateTimeOffset(File.GetLastWriteTimeUtc(path)).ToUnixTimeSeconds().ToString();
         }
-        catch (Exception ex)
+        catch
         {
-            Snackbar.Add($"Failed to restore category: {ex.Message}", Severity.Error);
+            return "0";
         }
     }
 
-    private async Task OnCategoryReordered(Category item)
+    private bool IsIslandEnabled()
     {
-        var sortOrders = _categories
-            .Select((c, i) => (c.CategoryId, SortOrder: i))
-            .ToList();
+        var configValue = Config["SETTINGS_HOUSEHOLD_USE_ISLAND"];
+        if (!string.IsNullOrEmpty(configValue))
+        {
+            return configValue.Equals("true", StringComparison.OrdinalIgnoreCase);
+        }
 
+        var envValue = Environment.GetEnvironmentVariable("SETTINGS_HOUSEHOLD_USE_ISLAND");
+        return string.Equals(envValue, "true", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_islandModule is null) return;
         try
         {
-            await CategoryService.UpdateSortOrderAsync(_householdId, sortOrders);
+            await JS.InvokeVoidAsync("SettingsIsland.destroy", RootId);
+            await _islandModule.DisposeAsync();
         }
-        catch (Exception ex)
+        catch (JSDisconnectedException)
         {
-            Snackbar.Add($"Failed to update order: {ex.Message}", Severity.Error);
-            await LoadCategories(); // Reload to restore original order
+            // Circuit already gone (user navigated away after disconnect) — nothing to clean up.
         }
     }
+
+    private sealed record ShellData(int HouseholdId, int UserId, string UserName);
 }

--- a/src/FamilyCoordinationApp/Components/Pages/Settings/CategoriesBlazor.razor
+++ b/src/FamilyCoordinationApp/Components/Pages/Settings/CategoriesBlazor.razor
@@ -1,0 +1,276 @@
+@using FamilyCoordinationApp.Data
+@using FamilyCoordinationApp.Data.Entities
+@using FamilyCoordinationApp.Services
+@using Microsoft.EntityFrameworkCore
+@using System.Security.Claims
+@using Plk.Blazor.DragDrop
+
+@inject ICategoryService CategoryService
+@inject IDbContextFactory<ApplicationDbContext> DbFactory
+@inject ISnackbar Snackbar
+@inject IDialogService DialogService
+
+@*
+    The original Blazor categories body, extracted verbatim from Categories.razor as the zero-regression
+    fallback for the strangler (flag SETTINGS_HOUSEHOLD_USE_ISLAND=false → this renders). NOT routable — the
+    @@page "/settings/categories" + [Authorize] live on the host Categories.razor. Delete once the island is
+    prod-stable.
+*@
+
+<MudContainer MaxWidth="MaxWidth.Medium" Class="mt-4">
+    <MudText Typo="Typo.h4" Class="mb-4">Manage Categories</MudText>
+
+    <MudText Typo="Typo.body1" Color="Color.Secondary" Class="mb-4">
+        Customize ingredient categories for your household. Drag to reorder categories to match your store layout.
+    </MudText>
+
+    @if (_loading)
+    {
+        <MudProgressLinear Indeterminate="true" />
+    }
+    else
+    {
+        <MudPaper Class="pa-4 mb-4" Elevation="1">
+            <MudText Typo="Typo.h6" Class="mb-3">Add New Category</MudText>
+
+            <MudGrid>
+                <MudItem xs="12" sm="4">
+                    <MudTextField @bind-Value="_newCategory.Name"
+                                  Label="Name"
+                                  Variant="Variant.Outlined"
+                                  Required="true" />
+                </MudItem>
+                <MudItem xs="12" sm="3">
+                    <MudTextField @bind-Value="_newCategory.IconEmoji"
+                                  Label="Emoji"
+                                  Variant="Variant.Outlined"
+                                  HelperText="e.g., meat_on_bone" />
+                </MudItem>
+                <MudItem xs="12" sm="3">
+                    <MudColorPicker @bind-Text="_newCategory.Color"
+                                    Label="Color"
+                                    Variant="Variant.Outlined" />
+                </MudItem>
+                <MudItem xs="12" sm="2">
+                    <MudButton Variant="Variant.Filled"
+                               Color="Color.Primary"
+                               OnClick="AddCategory"
+                               FullWidth="true"
+                               Style="height: 56px;">
+                        Add
+                    </MudButton>
+                </MudItem>
+            </MudGrid>
+        </MudPaper>
+
+        <MudPaper Class="pa-4 mb-4" Elevation="1">
+            <MudText Typo="Typo.h6" Class="mb-3">Active Categories</MudText>
+
+            <Dropzone Items="_categories"
+                      InstantReplace="true"
+                      TItem="Category"
+                      OnItemDrop="OnCategoryReordered">
+                <MudPaper Class="pa-3 mb-2 d-flex align-center justify-space-between"
+                          Elevation="1"
+                          Style="cursor: grab;">
+                    <div class="d-flex align-center">
+                        <MudIcon Icon="@Icons.Material.Filled.DragIndicator"
+                                 Class="mr-2"
+                                 Size="Size.Small" />
+                        <div style="width: 24px; height: 24px; border-radius: 4px; background-color: @context.Color; margin-right: 12px;"></div>
+                        <MudText>@context.Name</MudText>
+                        @if (context.IsDefault)
+                        {
+                            <MudChip T="string" Size="Size.Small" Color="Color.Info" Class="ml-2">Default</MudChip>
+                        }
+                    </div>
+                    <div>
+                        <MudIconButton Icon="@Icons.Material.Filled.Edit"
+                                       Size="Size.Small"
+                                       OnClick="() => EditCategory(context)" />
+                        <MudIconButton Icon="@Icons.Material.Filled.Delete"
+                                       Size="Size.Small"
+                                       Color="Color.Error"
+                                       OnClick="() => DeleteCategory(context)" />
+                    </div>
+                </MudPaper>
+            </Dropzone>
+        </MudPaper>
+
+        @if (_deletedCategories.Count > 0)
+        {
+            <MudPaper Class="pa-4" Elevation="1">
+                <MudText Typo="Typo.h6" Class="mb-3">Deleted Categories</MudText>
+
+                @foreach (var category in _deletedCategories)
+                {
+                    <MudPaper Class="pa-3 mb-2 d-flex align-center justify-space-between"
+                              Elevation="0"
+                              Style="opacity: 0.6;">
+                        <div class="d-flex align-center">
+                            <div style="width: 24px; height: 24px; border-radius: 4px; background-color: @category.Color; margin-right: 12px;"></div>
+                            <MudText>@category.Name</MudText>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary" Class="ml-2">
+                                (deleted @category.DeletedAt?.ToString("MMM d"))
+                            </MudText>
+                        </div>
+                        <MudButton Variant="Variant.Text"
+                                   Color="Color.Primary"
+                                   OnClick="() => RestoreCategory(category)">
+                            Restore
+                        </MudButton>
+                    </MudPaper>
+                }
+            </MudPaper>
+        }
+    }
+</MudContainer>
+
+@code {
+    [CascadingParameter] private Task<AuthenticationState>? AuthState { get; set; }
+
+    private List<Category> _categories = new();
+    private List<Category> _deletedCategories = new();
+    private Category _newCategory = new() { Color = "#808080" };
+    private bool _loading = true;
+    private int _householdId;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadHouseholdId();
+        await LoadCategories();
+        _loading = false;
+    }
+
+    private async Task LoadHouseholdId()
+    {
+        if (AuthState == null) return;
+
+        var authState = await AuthState;
+        var email = authState.User.FindFirstValue(ClaimTypes.Email);
+
+        if (string.IsNullOrEmpty(email)) return;
+
+        await using var context = await DbFactory.CreateDbContextAsync();
+        var user = await context.Users
+            .FirstOrDefaultAsync(u => u.Email == email);
+
+        if (user != null)
+        {
+            _householdId = user.HouseholdId;
+        }
+    }
+
+    private async Task LoadCategories()
+    {
+        var allCategories = await CategoryService.GetCategoriesAsync(_householdId, includeDeleted: true);
+        _categories = allCategories.Where(c => !c.IsDeleted).OrderBy(c => c.SortOrder).ToList();
+        _deletedCategories = allCategories.Where(c => c.IsDeleted).ToList();
+    }
+
+    private async Task AddCategory()
+    {
+        if (string.IsNullOrWhiteSpace(_newCategory.Name))
+        {
+            Snackbar.Add("Category name is required", Severity.Warning);
+            return;
+        }
+
+        try
+        {
+            _newCategory.HouseholdId = _householdId;
+            _newCategory.IsDefault = false;
+            await CategoryService.CreateCategoryAsync(_newCategory);
+            Snackbar.Add($"Category \"{_newCategory.Name}\" created", Severity.Success);
+
+            _newCategory = new Category { Color = "#808080" };
+            await LoadCategories();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Failed to create category: {ex.Message}", Severity.Error);
+        }
+    }
+
+    private async Task EditCategory(Category category)
+    {
+        var parameters = new DialogParameters<CategoryEditDialog>
+        {
+            { x => x.Category, category }
+        };
+
+        var dialog = await DialogService.ShowAsync<CategoryEditDialog>("Edit Category", parameters);
+        var result = await dialog.Result;
+
+        if (!result!.Canceled && result.Data is Category updated)
+        {
+            try
+            {
+                await CategoryService.UpdateCategoryAsync(updated);
+                Snackbar.Add("Category updated", Severity.Success);
+                await LoadCategories();
+            }
+            catch (Exception ex)
+            {
+                Snackbar.Add($"Failed to update category: {ex.Message}", Severity.Error);
+            }
+        }
+    }
+
+    private async Task DeleteCategory(Category category)
+    {
+        // Check if category has ingredients
+        if (await CategoryService.HasIngredientsAsync(_householdId, category.Name))
+        {
+            var result = await DialogService.ShowMessageBox(
+                "Category In Use",
+                $"The category \"{category.Name}\" is used by ingredients in your recipes. You can still delete it, but those ingredients will keep their category assignment.",
+                yesText: "Delete Anyway",
+                cancelText: "Cancel");
+
+            if (result != true) return;
+        }
+
+        try
+        {
+            await CategoryService.DeleteCategoryAsync(_householdId, category.CategoryId);
+            Snackbar.Add($"Category \"{category.Name}\" deleted", Severity.Success);
+            await LoadCategories();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Failed to delete category: {ex.Message}", Severity.Error);
+        }
+    }
+
+    private async Task RestoreCategory(Category category)
+    {
+        try
+        {
+            await CategoryService.RestoreCategoryAsync(_householdId, category.CategoryId);
+            Snackbar.Add($"Category \"{category.Name}\" restored", Severity.Success);
+            await LoadCategories();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Failed to restore category: {ex.Message}", Severity.Error);
+        }
+    }
+
+    private async Task OnCategoryReordered(Category item)
+    {
+        var sortOrders = _categories
+            .Select((c, i) => (c.CategoryId, SortOrder: i))
+            .ToList();
+
+        try
+        {
+            await CategoryService.UpdateSortOrderAsync(_householdId, sortOrders);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Failed to update order: {ex.Message}", Severity.Error);
+            await LoadCategories(); // Reload to restore original order
+        }
+    }
+}

--- a/src/FamilyCoordinationApp/Components/Pages/Settings/WhitelistAdmin.razor
+++ b/src/FamilyCoordinationApp/Components/Pages/Settings/WhitelistAdmin.razor
@@ -19,19 +19,25 @@
     fallback. Mirrors Categories.razor — same bundle (/islands/settings), data-view="users".
 *@
 
-@if (_useIsland && _shell is not null)
+@* When the flag is ON we never render the Blazor fallback — not even during the brief async gap before
+   _shell resolves — because WhitelistAdminBlazor holds a long-lived DbContext that crashes if it's mounted
+   then disposed mid-load. The island-div condition is unchanged, so mounting is unaffected. *@
+@if (_useIsland)
 {
-    <PageTitle>Manage Users - Family Kitchen</PageTitle>
+    @if (_shell is not null)
+    {
+        <PageTitle>Manage Users - Family Kitchen</PageTitle>
 
-    <HeadContent>
-        <link rel="stylesheet" href="/islands/settings/index.css?v=@IslandVersion" />
-    </HeadContent>
+        <HeadContent>
+            <link rel="stylesheet" href="/islands/settings/index.css?v=@IslandVersion" />
+        </HeadContent>
 
-    <div id="settings-users-root"
-         data-household-id="@_shell.HouseholdId"
-         data-user-id="@_shell.UserId"
-         data-user-name="@_shell.UserName"
-         data-view="users"></div>
+        <div id="settings-users-root"
+             data-household-id="@_shell.HouseholdId"
+             data-user-id="@_shell.UserId"
+             data-user-name="@_shell.UserName"
+             data-view="users"></div>
+    }
 }
 else
 {

--- a/src/FamilyCoordinationApp/Components/Pages/Settings/WhitelistAdmin.razor
+++ b/src/FamilyCoordinationApp/Components/Pages/Settings/WhitelistAdmin.razor
@@ -1,290 +1,121 @@
 @page "/settings/users"
 @attribute [Authorize]
-@using Microsoft.EntityFrameworkCore
-@using System.Security.Claims
 @using FamilyCoordinationApp.Data
-@using FamilyCoordinationApp.Data.Entities
-@inject IDbContextFactory<ApplicationDbContext> DbFactory
-@inject ISnackbar Snackbar
-@inject AuthenticationStateProvider AuthStateProvider
-@inject IDialogService DialogService
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.EntityFrameworkCore
+@using Microsoft.JSInterop
+@using System.Security.Claims
 @implements IAsyncDisposable
 
-<PageTitle>Manage Users - Family Kitchen</PageTitle>
+@inject IConfiguration Config
+@inject AuthenticationStateProvider AuthStateProvider
+@inject IDbContextFactory<ApplicationDbContext> DbFactory
+@inject IJSRuntime JS
+@inject IWebHostEnvironment HostEnv
 
-<MudContainer MaxWidth="MaxWidth.Medium" Class="mt-4">
-    <MudText Typo="Typo.h4" Class="mb-4">Manage Family Members</MudText>
+@*
+    Thin island host (strangler). Flag ON (SETTINGS_HOUSEHOLD_USE_ISLAND=true) → mount the Svelte settings
+    island (users view); flag OFF → the existing Blazor page (<WhitelistAdminBlazor/>) as the zero-regression
+    fallback. Mirrors Categories.razor — same bundle (/islands/settings), data-view="users".
+*@
 
-    @if (_isLoading)
-    {
-        <MudProgressLinear Indeterminate="true" />
-    }
-    else
-    {
-        <MudPaper Class="pa-4 mb-4" Elevation="1">
-            <MudText Typo="Typo.h6" Class="mb-3">Add Family Member</MudText>
+@if (_useIsland && _shell is not null)
+{
+    <PageTitle>Manage Users - Family Kitchen</PageTitle>
 
-            <MudGrid>
-                <MudItem xs="12" sm="9">
-                    <MudTextField @bind-Value="_newEmail"
-                                  Label="Email Address"
-                                  Placeholder="email@example.com"
-                                  Variant="Variant.Outlined"
-                                  InputType="InputType.Email" />
-                </MudItem>
-                <MudItem xs="12" sm="3">
-                    <MudButton Variant="Variant.Filled"
-                               Color="Color.Primary"
-                               Disabled="_isSubmitting"
-                               FullWidth="true"
-                               Style="height: 56px;"
-                               OnClick="AddUser">
-                        @if (_isSubmitting)
-                        {
-                            <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
-                        }
-                        Add
-                    </MudButton>
-                </MudItem>
-            </MudGrid>
-        </MudPaper>
+    <HeadContent>
+        <link rel="stylesheet" href="/islands/settings/index.css?v=@IslandVersion" />
+    </HeadContent>
 
-        <MudPaper Class="pa-4" Elevation="1">
-            <MudText Typo="Typo.h6" Class="mb-3">Current Members</MudText>
-
-            <MudTable Items="_users" Hover="true" Breakpoint="Breakpoint.Sm">
-                <HeaderContent>
-                    <MudTh>Email</MudTh>
-                    <MudTh>Name</MudTh>
-                    <MudTh>Status</MudTh>
-                    <MudTh Style="text-align: right;">Actions</MudTh>
-                </HeaderContent>
-                <RowTemplate>
-                    <MudTd DataLabel="Email">
-                        @context.Email
-                        @if (context.Id == _currentUserId)
-                        {
-                            <MudChip T="string" Size="Size.Small" Color="Color.Info" Class="ml-2">You</MudChip>
-                        }
-                    </MudTd>
-                    <MudTd DataLabel="Name">@context.DisplayName</MudTd>
-                    <MudTd DataLabel="Status">
-                        @if (context.IsWhitelisted)
-                        {
-                            <MudChip T="string" Color="Color.Success" Size="Size.Small">Active</MudChip>
-                        }
-                        else
-                        {
-                            <MudChip T="string" Color="Color.Default" Size="Size.Small">Disabled</MudChip>
-                        }
-                    </MudTd>
-                    <MudTd DataLabel="Actions" Style="text-align: right;">
-                        <div class="d-flex justify-end gap-1">
-                            @if (context.Id != _currentUserId)
-                            {
-                                @if (context.IsWhitelisted && _users.Count(u => u.IsWhitelisted) > 1)
-                                {
-                                    <MudButton Variant="Variant.Text"
-                                               Color="Color.Warning"
-                                               Size="Size.Small"
-                                               OnClick="() => ToggleUser(context)">
-                                        Disable
-                                    </MudButton>
-                                }
-                                else if (!context.IsWhitelisted)
-                                {
-                                    <MudButton Variant="Variant.Text"
-                                               Color="Color.Success"
-                                               Size="Size.Small"
-                                               OnClick="() => ToggleUser(context)">
-                                        Enable
-                                    </MudButton>
-                                }
-                                
-                                @if (_users.Count > 1)
-                                {
-                                    <MudButton Variant="Variant.Text"
-                                               Color="Color.Error"
-                                               Size="Size.Small"
-                                               OnClick="() => DeleteUser(context)">
-                                        Delete
-                                    </MudButton>
-                                }
-                            }
-                            else
-                            {
-                                <MudText Typo="Typo.caption" Color="Color.Secondary">Cannot modify self</MudText>
-                            }
-                        </div>
-                    </MudTd>
-                </RowTemplate>
-            </MudTable>
-        </MudPaper>
-    }
-</MudContainer>
+    <div id="settings-users-root"
+         data-household-id="@_shell.HouseholdId"
+         data-user-id="@_shell.UserId"
+         data-user-name="@_shell.UserName"
+         data-view="users"></div>
+}
+else
+{
+    <WhitelistAdminBlazor />
+}
 
 @code {
-    private ApplicationDbContext _context = default!;
-    private List<User> _users = new();
-    private string _newEmail = "";
-    private bool _isLoading = true;
-    private bool _isSubmitting;
-    private int _householdId;
-    private int _currentUserId;
+    private bool _useIsland;
+    private ShellData? _shell;
+    private IJSObjectReference? _islandModule;
+
+    private const string RootId = "settings-users-root";
 
     protected override async Task OnInitializedAsync()
     {
-        _context = DbFactory.CreateDbContext();
-        await LoadUsers();
-    }
+        _useIsland = IsIslandEnabled();
+        if (!_useIsland) return;
 
-    private async Task LoadUsers()
-    {
-        _isLoading = true;
-        
-        // Get current user's household
         var authState = await AuthStateProvider.GetAuthenticationStateAsync();
         var email = authState.User.FindFirst(ClaimTypes.Email)?.Value;
-        
-        var currentUser = await _context.Users.FirstOrDefaultAsync(u => u.Email == email);
-        if (currentUser != null)
+        var userName = authState.User.FindFirst(ClaimTypes.Name)?.Value ?? string.Empty;
+
+        await using var context = await DbFactory.CreateDbContextAsync();
+        var user = await context.Users.FirstOrDefaultAsync(u => u.Email == email);
+        if (user is null)
         {
-            _householdId = currentUser.HouseholdId;
-            _currentUserId = currentUser.Id;
-            _users = await _context.Users
-                .Where(u => u.HouseholdId == _householdId)
-                .OrderBy(u => u.Email)
-                .ToListAsync();
+            throw new InvalidOperationException("User not found. Please log in again.");
         }
-        _isLoading = false;
+
+        _shell = new ShellData(user.HouseholdId, user.Id, userName);
     }
 
-    private async Task AddUser()
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (string.IsNullOrWhiteSpace(_newEmail))
-            return;
+        if (!firstRender || !_useIsland || _shell is null) return;
 
-        _isSubmitting = true;
+        await JS.InvokeVoidAsync("ensureIslandStylesheet", $"/islands/settings/index.css?v={IslandVersion}");
 
+        _islandModule = await JS.InvokeAsync<IJSObjectReference>(
+            "import", $"/islands/settings/index.js?v={IslandVersion}");
+        await JS.InvokeVoidAsync("SettingsIsland.mount", RootId);
+    }
+
+    private static string? _islandVersion;
+    private string IslandVersion => _islandVersion ??= ComputeIslandVersion();
+
+    private string ComputeIslandVersion()
+    {
         try
         {
-            var email = _newEmail.Trim().ToLowerInvariant();
-
-            // Check if user exists in THIS household (for re-enabling)
-            var existingUserInHousehold = await _context.Users
-                .FirstOrDefaultAsync(u => u.Email == email && u.HouseholdId == _householdId);
-
-            // Check if user exists in ANY other household (security check)
-            var existingUserElsewhere = await _context.Users
-                .FirstOrDefaultAsync(u => u.Email == email && u.HouseholdId != _householdId);
-
-            if (existingUserElsewhere != null)
-            {
-                // User belongs to another household - cannot add them
-                Snackbar.Add("This email is already associated with another household", Severity.Error);
-                return;
-            }
-
-            if (existingUserInHousehold != null)
-            {
-                if (!existingUserInHousehold.IsWhitelisted)
-                {
-                    existingUserInHousehold.IsWhitelisted = true;
-                    await _context.SaveChangesAsync();
-                    Snackbar.Add($"Re-enabled {email}", Severity.Success);
-                }
-                else
-                {
-                    Snackbar.Add("User already has access", Severity.Warning);
-                }
-            }
-            else
-            {
-                var newUser = new User
-                {
-                    HouseholdId = _householdId,
-                    Email = email,
-                    DisplayName = email.Split('@')[0],
-                    GoogleId = null,  // Set when user first logs in with Google
-                    IsWhitelisted = true,
-                    CreatedAt = DateTime.UtcNow
-                };
-                _context.Users.Add(newUser);
-                await _context.SaveChangesAsync();
-                Snackbar.Add($"Added {email} to whitelist", Severity.Success);
-            }
-
-            _newEmail = "";
-            await LoadUsers();
+            var path = Path.Combine(HostEnv.WebRootPath, "islands", "settings", "index.js");
+            return new DateTimeOffset(File.GetLastWriteTimeUtc(path)).ToUnixTimeSeconds().ToString();
         }
-        catch (Exception ex)
+        catch
         {
-            Snackbar.Add($"Failed to add user: {ex.Message}", Severity.Error);
-        }
-        finally
-        {
-            _isSubmitting = false;
+            return "0";
         }
     }
 
-    private async Task ToggleUser(User user)
+    private bool IsIslandEnabled()
     {
-        user.IsWhitelisted = !user.IsWhitelisted;
-        await _context.SaveChangesAsync();
-
-        var message = user.IsWhitelisted
-            ? $"Enabled {user.Email}"
-            : $"Disabled {user.Email}";
-        Snackbar.Add(message, Severity.Success);
-    }
-
-    private async Task DeleteUser(User user)
-    {
-        // Safety checks
-        if (user.Id == _currentUserId)
+        var configValue = Config["SETTINGS_HOUSEHOLD_USE_ISLAND"];
+        if (!string.IsNullOrEmpty(configValue))
         {
-            Snackbar.Add("You cannot delete yourself", Severity.Warning);
-            return;
+            return configValue.Equals("true", StringComparison.OrdinalIgnoreCase);
         }
 
-        if (_users.Count <= 1)
-        {
-            Snackbar.Add("Cannot delete the last user in the household", Severity.Warning);
-            return;
-        }
-
-        // Confirmation dialog
-        var result = await DialogService.ShowMessageBox(
-            "Delete User",
-            $"Are you sure you want to permanently delete {user.DisplayName} ({user.Email})?\n\n" +
-            "This will:\n" +
-            "• Remove their account from the household\n" +
-            "• Keep their recipes (will show \"Deleted user\" as creator)\n" +
-            "• Keep their feedback submissions\n\n" +
-            "This action cannot be undone.",
-            yesText: "Delete",
-            cancelText: "Cancel");
-
-        if (result != true)
-            return;
-
-        try
-        {
-            // Delete the user - FK ON DELETE SET NULL will handle orphaned data
-            _context.Users.Remove(user);
-            await _context.SaveChangesAsync();
-
-            Snackbar.Add($"Deleted {user.Email}", Severity.Success);
-            await LoadUsers();
-        }
-        catch (Exception ex)
-        {
-            Snackbar.Add($"Failed to delete user: {ex.Message}", Severity.Error);
-        }
+        var envValue = Environment.GetEnvironmentVariable("SETTINGS_HOUSEHOLD_USE_ISLAND");
+        return string.Equals(envValue, "true", StringComparison.OrdinalIgnoreCase);
     }
 
     public async ValueTask DisposeAsync()
     {
-        await _context.DisposeAsync();
+        if (_islandModule is null) return;
+        try
+        {
+            await JS.InvokeVoidAsync("SettingsIsland.destroy", RootId);
+            await _islandModule.DisposeAsync();
+        }
+        catch (JSDisconnectedException)
+        {
+            // Circuit already gone — nothing to clean up.
+        }
     }
+
+    private sealed record ShellData(int HouseholdId, int UserId, string UserName);
 }

--- a/src/FamilyCoordinationApp/Components/Pages/Settings/WhitelistAdminBlazor.razor
+++ b/src/FamilyCoordinationApp/Components/Pages/Settings/WhitelistAdminBlazor.razor
@@ -1,0 +1,293 @@
+@using Microsoft.EntityFrameworkCore
+@using System.Security.Claims
+@using FamilyCoordinationApp.Data
+@using FamilyCoordinationApp.Data.Entities
+@inject IDbContextFactory<ApplicationDbContext> DbFactory
+@inject ISnackbar Snackbar
+@inject AuthenticationStateProvider AuthStateProvider
+@inject IDialogService DialogService
+@implements IAsyncDisposable
+
+@*
+    The original Blazor Manage-Users body, extracted verbatim from WhitelistAdmin.razor as the zero-regression
+    fallback for the strangler (flag SETTINGS_HOUSEHOLD_USE_ISLAND=false → this renders). NOT routable — the
+    @@page "/settings/users" + [Authorize] live on the host WhitelistAdmin.razor. Delete once the island is
+    prod-stable.
+*@
+
+<MudContainer MaxWidth="MaxWidth.Medium" Class="mt-4">
+    <MudText Typo="Typo.h4" Class="mb-4">Manage Family Members</MudText>
+
+    @if (_isLoading)
+    {
+        <MudProgressLinear Indeterminate="true" />
+    }
+    else
+    {
+        <MudPaper Class="pa-4 mb-4" Elevation="1">
+            <MudText Typo="Typo.h6" Class="mb-3">Add Family Member</MudText>
+
+            <MudGrid>
+                <MudItem xs="12" sm="9">
+                    <MudTextField @bind-Value="_newEmail"
+                                  Label="Email Address"
+                                  Placeholder="email@example.com"
+                                  Variant="Variant.Outlined"
+                                  InputType="InputType.Email" />
+                </MudItem>
+                <MudItem xs="12" sm="3">
+                    <MudButton Variant="Variant.Filled"
+                               Color="Color.Primary"
+                               Disabled="_isSubmitting"
+                               FullWidth="true"
+                               Style="height: 56px;"
+                               OnClick="AddUser">
+                        @if (_isSubmitting)
+                        {
+                            <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
+                        }
+                        Add
+                    </MudButton>
+                </MudItem>
+            </MudGrid>
+        </MudPaper>
+
+        <MudPaper Class="pa-4" Elevation="1">
+            <MudText Typo="Typo.h6" Class="mb-3">Current Members</MudText>
+
+            <MudTable Items="_users" Hover="true" Breakpoint="Breakpoint.Sm">
+                <HeaderContent>
+                    <MudTh>Email</MudTh>
+                    <MudTh>Name</MudTh>
+                    <MudTh>Status</MudTh>
+                    <MudTh Style="text-align: right;">Actions</MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd DataLabel="Email">
+                        @context.Email
+                        @if (context.Id == _currentUserId)
+                        {
+                            <MudChip T="string" Size="Size.Small" Color="Color.Info" Class="ml-2">You</MudChip>
+                        }
+                    </MudTd>
+                    <MudTd DataLabel="Name">@context.DisplayName</MudTd>
+                    <MudTd DataLabel="Status">
+                        @if (context.IsWhitelisted)
+                        {
+                            <MudChip T="string" Color="Color.Success" Size="Size.Small">Active</MudChip>
+                        }
+                        else
+                        {
+                            <MudChip T="string" Color="Color.Default" Size="Size.Small">Disabled</MudChip>
+                        }
+                    </MudTd>
+                    <MudTd DataLabel="Actions" Style="text-align: right;">
+                        <div class="d-flex justify-end gap-1">
+                            @if (context.Id != _currentUserId)
+                            {
+                                @if (context.IsWhitelisted && _users.Count(u => u.IsWhitelisted) > 1)
+                                {
+                                    <MudButton Variant="Variant.Text"
+                                               Color="Color.Warning"
+                                               Size="Size.Small"
+                                               OnClick="() => ToggleUser(context)">
+                                        Disable
+                                    </MudButton>
+                                }
+                                else if (!context.IsWhitelisted)
+                                {
+                                    <MudButton Variant="Variant.Text"
+                                               Color="Color.Success"
+                                               Size="Size.Small"
+                                               OnClick="() => ToggleUser(context)">
+                                        Enable
+                                    </MudButton>
+                                }
+
+                                @if (_users.Count > 1)
+                                {
+                                    <MudButton Variant="Variant.Text"
+                                               Color="Color.Error"
+                                               Size="Size.Small"
+                                               OnClick="() => DeleteUser(context)">
+                                        Delete
+                                    </MudButton>
+                                }
+                            }
+                            else
+                            {
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">Cannot modify self</MudText>
+                            }
+                        </div>
+                    </MudTd>
+                </RowTemplate>
+            </MudTable>
+        </MudPaper>
+    }
+</MudContainer>
+
+@code {
+    private ApplicationDbContext _context = default!;
+    private List<User> _users = new();
+    private string _newEmail = "";
+    private bool _isLoading = true;
+    private bool _isSubmitting;
+    private int _householdId;
+    private int _currentUserId;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _context = DbFactory.CreateDbContext();
+        await LoadUsers();
+    }
+
+    private async Task LoadUsers()
+    {
+        _isLoading = true;
+
+        // Get current user's household
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        var email = authState.User.FindFirst(ClaimTypes.Email)?.Value;
+
+        var currentUser = await _context.Users.FirstOrDefaultAsync(u => u.Email == email);
+        if (currentUser != null)
+        {
+            _householdId = currentUser.HouseholdId;
+            _currentUserId = currentUser.Id;
+            _users = await _context.Users
+                .Where(u => u.HouseholdId == _householdId)
+                .OrderBy(u => u.Email)
+                .ToListAsync();
+        }
+        _isLoading = false;
+    }
+
+    private async Task AddUser()
+    {
+        if (string.IsNullOrWhiteSpace(_newEmail))
+            return;
+
+        _isSubmitting = true;
+
+        try
+        {
+            var email = _newEmail.Trim().ToLowerInvariant();
+
+            // Check if user exists in THIS household (for re-enabling)
+            var existingUserInHousehold = await _context.Users
+                .FirstOrDefaultAsync(u => u.Email == email && u.HouseholdId == _householdId);
+
+            // Check if user exists in ANY other household (security check)
+            var existingUserElsewhere = await _context.Users
+                .FirstOrDefaultAsync(u => u.Email == email && u.HouseholdId != _householdId);
+
+            if (existingUserElsewhere != null)
+            {
+                // User belongs to another household - cannot add them
+                Snackbar.Add("This email is already associated with another household", Severity.Error);
+                return;
+            }
+
+            if (existingUserInHousehold != null)
+            {
+                if (!existingUserInHousehold.IsWhitelisted)
+                {
+                    existingUserInHousehold.IsWhitelisted = true;
+                    await _context.SaveChangesAsync();
+                    Snackbar.Add($"Re-enabled {email}", Severity.Success);
+                }
+                else
+                {
+                    Snackbar.Add("User already has access", Severity.Warning);
+                }
+            }
+            else
+            {
+                var newUser = new User
+                {
+                    HouseholdId = _householdId,
+                    Email = email,
+                    DisplayName = email.Split('@')[0],
+                    GoogleId = null,  // Set when user first logs in with Google
+                    IsWhitelisted = true,
+                    CreatedAt = DateTime.UtcNow
+                };
+                _context.Users.Add(newUser);
+                await _context.SaveChangesAsync();
+                Snackbar.Add($"Added {email} to whitelist", Severity.Success);
+            }
+
+            _newEmail = "";
+            await LoadUsers();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Failed to add user: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _isSubmitting = false;
+        }
+    }
+
+    private async Task ToggleUser(User user)
+    {
+        user.IsWhitelisted = !user.IsWhitelisted;
+        await _context.SaveChangesAsync();
+
+        var message = user.IsWhitelisted
+            ? $"Enabled {user.Email}"
+            : $"Disabled {user.Email}";
+        Snackbar.Add(message, Severity.Success);
+    }
+
+    private async Task DeleteUser(User user)
+    {
+        // Safety checks
+        if (user.Id == _currentUserId)
+        {
+            Snackbar.Add("You cannot delete yourself", Severity.Warning);
+            return;
+        }
+
+        if (_users.Count <= 1)
+        {
+            Snackbar.Add("Cannot delete the last user in the household", Severity.Warning);
+            return;
+        }
+
+        // Confirmation dialog
+        var result = await DialogService.ShowMessageBox(
+            "Delete User",
+            $"Are you sure you want to permanently delete {user.DisplayName} ({user.Email})?\n\n" +
+            "This will:\n" +
+            "• Remove their account from the household\n" +
+            "• Keep their recipes (will show \"Deleted user\" as creator)\n" +
+            "• Keep their feedback submissions\n\n" +
+            "This action cannot be undone.",
+            yesText: "Delete",
+            cancelText: "Cancel");
+
+        if (result != true)
+            return;
+
+        try
+        {
+            // Delete the user - FK ON DELETE SET NULL will handle orphaned data
+            _context.Users.Remove(user);
+            await _context.SaveChangesAsync();
+
+            Snackbar.Add($"Deleted {user.Email}", Severity.Success);
+            await LoadUsers();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Failed to delete user: {ex.Message}", Severity.Error);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _context.DisposeAsync();
+    }
+}

--- a/src/FamilyCoordinationApp/Endpoints/SettingsEndpoints.cs
+++ b/src/FamilyCoordinationApp/Endpoints/SettingsEndpoints.cs
@@ -1,0 +1,300 @@
+using System.Security.Claims;
+using FamilyCoordinationApp.Data;
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Services.Dtos;
+using FamilyCoordinationApp.Services.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace FamilyCoordinationApp.Endpoints;
+
+/// <summary>
+/// Minimal-API surface for Settings island A (Household settings, strangler — mirrors <see cref="RecipesEndpoints"/>):
+/// an <c>/api/settings</c> group behind <c>.RequireAuthorization().DisableAntiforgery()</c>, every handler resolving
+/// the HouseholdId/UserId from the authenticated caller (M1, never client-supplied) via <see cref="UserContextResolver"/>.
+/// Categories ride the existing <see cref="ICategoryService"/>; members go through the new
+/// <see cref="IHouseholdMemberService"/> (the safety rules live there, server-enforced — review R-A2).
+///
+/// <para>Parity-first ⇒ versionless / last-write-wins. Not-found / rejection responses carry a NON-EMPTY body so
+/// the app-global <c>UseStatusCodePagesWithReExecute</c> leaves them as clean 4xx (an empty 404 on a non-GET
+/// surfaces as a 405). Add-member returns 200 + an outcome envelope for the benign cases and 409 ONLY for the
+/// cross-household collision (review R-A1). LITERAL routes (<c>/categories/sort-order</c>) are registered BEFORE the
+/// parameterized <c>/categories/{id}</c> routes so the matcher doesn't shadow them (the #53 route-order gotcha).</para>
+/// </summary>
+public static class SettingsEndpoints
+{
+    public static IEndpointRouteBuilder MapSettingsEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/settings")
+            .RequireAuthorization()
+            .DisableAntiforgery();
+
+        // ── Categories ──────────────────────────────────────────────────────────
+        var categories = group.MapGroup("/categories");
+        categories.MapGet("/", ListCategories);
+        categories.MapPost("/", CreateCategory);
+        // ⚠ literal BEFORE the parameterized /{categoryId:int} PUT (route-order gotcha, #53).
+        categories.MapPut("/sort-order", UpdateSortOrder);
+        categories.MapGet("/{categoryId:int}/in-use", CategoryInUse);
+        categories.MapPut("/{categoryId:int}", UpdateCategory);
+        categories.MapDelete("/{categoryId:int}", DeleteCategory);
+        categories.MapPost("/{categoryId:int}/restore", RestoreCategory);
+
+        // ── Members ─────────────────────────────────────────────────────────────
+        var members = group.MapGroup("/members");
+        members.MapGet("/", ListMembers);
+        members.MapPost("/", AddMember);
+        members.MapPut("/{userId:int}", SetWhitelist);
+        members.MapDelete("/{userId:int}", DeleteMember);
+
+        return app;
+    }
+
+    // ─── Categories ───────────────────────────────────────────────────────────────
+
+    private static async Task<IResult> ListCategories(
+        ClaimsPrincipal principal,
+        ICategoryService categoryService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        var all = await categoryService.GetCategoriesAsync(user.HouseholdId, includeDeleted: true, ct);
+        var active = all.Where(c => !c.IsDeleted).OrderBy(c => c.SortOrder).Select(ToDto).ToList();
+        var deleted = all.Where(c => c.IsDeleted).Select(ToDto).ToList();
+        return Results.Ok(new CategoryListDto(active, deleted));
+    }
+
+    private static async Task<IResult> CreateCategory(
+        CategoryWriteRequest req,
+        ClaimsPrincipal principal,
+        ICategoryService categoryService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        if (string.IsNullOrWhiteSpace(req.Name))
+        {
+            return Results.BadRequest(new { message = "Category name is required." });
+        }
+
+        var created = await categoryService.CreateCategoryAsync(new Category
+        {
+            HouseholdId = user.HouseholdId,
+            Name = req.Name.Trim(),
+            IconEmoji = req.IconEmoji ?? string.Empty,
+            Color = string.IsNullOrWhiteSpace(req.Color) ? "#808080" : req.Color,
+            IsDefault = false,
+        }, ct);
+
+        return Results.Created($"/api/settings/categories/{created.CategoryId}", ToDto(created));
+    }
+
+    private static async Task<IResult> UpdateCategory(
+        int categoryId,
+        CategoryWriteRequest req,
+        ClaimsPrincipal principal,
+        ICategoryService categoryService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        if (string.IsNullOrWhiteSpace(req.Name))
+        {
+            return Results.BadRequest(new { message = "Category name is required." });
+        }
+
+        var existing = await categoryService.GetCategoryAsync(user.HouseholdId, categoryId, ct);
+        if (existing is null) return Results.NotFound(new { message = "Category not found." });
+
+        existing.Name = req.Name.Trim();
+        existing.IconEmoji = req.IconEmoji ?? string.Empty;
+        existing.Color = string.IsNullOrWhiteSpace(req.Color) ? "#808080" : req.Color;
+        var updated = await categoryService.UpdateCategoryAsync(existing, ct);
+        return Results.Ok(ToDto(updated));
+    }
+
+    private static async Task<IResult> DeleteCategory(
+        int categoryId,
+        ClaimsPrincipal principal,
+        ICategoryService categoryService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        var existing = await categoryService.GetCategoryAsync(user.HouseholdId, categoryId, ct);
+        if (existing is null) return Results.NotFound(new { message = "Category not found." });
+        if (existing.IsDeleted) return Results.NoContent(); // already soft-deleted (idempotent)
+
+        await categoryService.DeleteCategoryAsync(user.HouseholdId, categoryId, ct);
+        return Results.NoContent();
+    }
+
+    private static async Task<IResult> RestoreCategory(
+        int categoryId,
+        ClaimsPrincipal principal,
+        ICategoryService categoryService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        var existing = await categoryService.GetCategoryAsync(user.HouseholdId, categoryId, ct);
+        if (existing is null) return Results.NotFound(new { message = "Category not found." });
+        if (!existing.IsDeleted) return Results.NoContent(); // already active (idempotent)
+
+        await categoryService.RestoreCategoryAsync(user.HouseholdId, categoryId, ct);
+        return Results.NoContent();
+    }
+
+    private static async Task<IResult> UpdateSortOrder(
+        SortOrderRequest req,
+        ClaimsPrincipal principal,
+        ICategoryService categoryService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        var orders = req.OrderedIds.Select((id, index) => (CategoryId: id, SortOrder: index)).ToList();
+        await categoryService.UpdateSortOrderAsync(user.HouseholdId, orders, ct);
+        return Results.NoContent();
+    }
+
+    private static async Task<IResult> CategoryInUse(
+        int categoryId,
+        ClaimsPrincipal principal,
+        ICategoryService categoryService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        var existing = await categoryService.GetCategoryAsync(user.HouseholdId, categoryId, ct);
+        if (existing is null) return Results.NotFound(new { message = "Category not found." });
+
+        var inUse = await categoryService.HasIngredientsAsync(user.HouseholdId, existing.Name, ct);
+        return Results.Ok(new { inUse });
+    }
+
+    // ─── Members ────────────────────────────────────────────────────────────────
+
+    private static async Task<IResult> ListMembers(
+        ClaimsPrincipal principal,
+        IHouseholdMemberService memberService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        var members = await memberService.GetMembersAsync(user.HouseholdId, ct);
+        return Results.Ok(new MemberListDto(user.UserId, members.Select(ToMemberDto).ToList()));
+    }
+
+    private static async Task<IResult> AddMember(
+        AddMemberRequest req,
+        ClaimsPrincipal principal,
+        IHouseholdMemberService memberService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        if (string.IsNullOrWhiteSpace(req.Email))
+        {
+            return Results.BadRequest(new { message = "Email is required." });
+        }
+
+        var result = await memberService.AddMemberAsync(user.HouseholdId, req.Email, ct);
+        return result.Outcome switch
+        {
+            AddMemberOutcome.OtherHousehold => Results.Conflict(
+                new { message = "This email is already associated with another household." }),
+            AddMemberOutcome.AlreadyActive => Results.Ok(
+                new MemberActionDto(ToMemberDto(result.User!), "alreadyActive")),
+            AddMemberOutcome.Reenabled => Results.Ok(
+                new MemberActionDto(ToMemberDto(result.User!), "reenabled")),
+            _ => Results.Ok(new MemberActionDto(ToMemberDto(result.User!), "created")),
+        };
+    }
+
+    private static async Task<IResult> SetWhitelist(
+        int userId,
+        SetWhitelistRequest req,
+        ClaimsPrincipal principal,
+        IHouseholdMemberService memberService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        var (result, updated) = await memberService.SetWhitelistAsync(
+            user.HouseholdId, user.UserId, userId, req.IsWhitelisted, ct);
+        return result switch
+        {
+            MemberMutationResult.Ok => Results.Ok(ToMemberDto(updated!)),
+            MemberMutationResult.SelfForbidden => Results.BadRequest(new { message = "You can't change your own access." }),
+            MemberMutationResult.LastActiveForbidden => Results.Conflict(new { message = "Can't disable the last active member." }),
+            _ => Results.NotFound(new { message = "Member not found." }),
+        };
+    }
+
+    private static async Task<IResult> DeleteMember(
+        int userId,
+        ClaimsPrincipal principal,
+        IHouseholdMemberService memberService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        var result = await memberService.DeleteMemberAsync(user.HouseholdId, user.UserId, userId, ct);
+        return result switch
+        {
+            MemberMutationResult.Ok => Results.NoContent(),
+            MemberMutationResult.SelfForbidden => Results.BadRequest(new { message = "You can't delete yourself." }),
+            MemberMutationResult.LastUserForbidden => Results.Conflict(new { message = "Can't delete the last user in the household." }),
+            MemberMutationResult.Blocked => Results.Conflict(
+                new { message = "Can't delete this member — they have activity history (e.g. completed chores). Disable them instead." }),
+            _ => Results.NotFound(new { message = "Member not found." }),
+        };
+    }
+
+    // ─── Projection ───────────────────────────────────────────────────────────────
+
+    private static SettingsCategoryDto ToDto(Category c) => new(
+        c.CategoryId,
+        c.Name,
+        string.IsNullOrEmpty(c.IconEmoji) ? null : c.IconEmoji,
+        c.Color,
+        c.IsDefault,
+        c.SortOrder,
+        c.DeletedAt);
+
+    private static SettingsMemberDto ToMemberDto(User u) => new(
+        u.Id,
+        u.Email,
+        string.IsNullOrEmpty(u.DisplayName) ? null : u.DisplayName,
+        u.IsWhitelisted);
+}
+
+// ─── Request DTOs ───────────────────────────────────────────────────────────────
+
+public sealed record CategoryWriteRequest(string Name, string? IconEmoji, string Color);
+public sealed record SortOrderRequest(IReadOnlyList<int> OrderedIds);
+public sealed record AddMemberRequest(string Email);
+public sealed record SetWhitelistRequest(bool IsWhitelisted);

--- a/src/FamilyCoordinationApp/FamilyCoordinationApp.csproj
+++ b/src/FamilyCoordinationApp/FamilyCoordinationApp.csproj
@@ -105,6 +105,24 @@
           SkipUnchangedFiles="true" />
   </Target>
 
+  <!--
+    Copy the built settings island (cluster A: Categories + Manage Users) into wwwroot before build
+    (strangler). Run `npm run build` in frontend/settings/ first (or let the Docker build do it via the
+    settings-node-build stage). If dist/ doesn't exist, the target is skipped silently and the island endpoint
+    404s — Categories.razor / WhitelistAdmin.razor render the Blazor fallback via the SETTINGS_HOUSEHOLD_USE_ISLAND
+    toggle. Parallel to CopyDashboardIsland (one bundle serves both host pages).
+  -->
+  <Target Name="CopySettingsIsland"
+          BeforeTargets="AssignTargetPaths"
+          Condition="Exists('$(MSBuildThisFileDirectory)..\..\frontend\settings\dist')">
+    <ItemGroup>
+      <_SettingsIslandFiles Include="$(MSBuildThisFileDirectory)..\..\frontend\settings\dist\**\*.*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_SettingsIslandFiles)"
+          DestinationFiles="@(_SettingsIslandFiles->'$(MSBuildThisFileDirectory)wwwroot\islands\settings\%(RecursiveDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true" />
+  </Target>
+
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.4.0" />
     <PackageReference Include="blazor-dragdrop" Version="2.6.1" />

--- a/src/FamilyCoordinationApp/Program.cs
+++ b/src/FamilyCoordinationApp/Program.cs
@@ -97,6 +97,9 @@ builder.Services.AddScoped<IShoppingListService, ShoppingListService>();
 builder.Services.AddScoped<UnitConverter>();
 builder.Services.AddScoped<IShoppingListGenerator, ShoppingListGenerator>();
 builder.Services.AddScoped<IHouseholdConnectionService, HouseholdConnectionService>();
+// Settings island A (strangler): household member management lifted out of WhitelistAdmin.razor's direct EF
+// (the self / last-active / last-user guards are enforced here, server-side, and unit-testable).
+builder.Services.AddScoped<IHouseholdMemberService, HouseholdMemberService>();
 
 // Chores (Phase 10): room CRUD, chore writes/state-machine, and the board read model. Date math is
 // timezone-aware: the calculator is a stateless singleton; the household timezone (default America/Chicago,
@@ -405,6 +408,7 @@ app.MapRoomsEndpoints();
 app.MapMealPlanEndpoints();
 app.MapRecipesEndpoints();
 app.MapDashboardEndpoints();
+app.MapSettingsEndpoints();
 
 // Health check endpoint for Docker
 app.MapGet("/health", () => Results.Ok("healthy"));

--- a/src/FamilyCoordinationApp/Services/Dtos/SettingsDtos.cs
+++ b/src/FamilyCoordinationApp/Services/Dtos/SettingsDtos.cs
@@ -1,0 +1,55 @@
+namespace FamilyCoordinationApp.Services.Dtos;
+
+// ─────────────────────────────────────────────────────────────────────────
+// Settings island A (Household settings) aggregate DTOs — Categories + Manage
+// Users (strangler; mirrors the dashboard/recipes M9 lockstep). Source of truth
+// for the island TS contract:
+//   tests/.../Fixtures/Settings/{categories,members}.json + frontend/settings/src/lib/types.ts.
+// A shape/casing change updates THIS file, those fixtures, and types.ts in
+// lockstep (CategoryListDtoContractTests / MemberListDtoContractTests are the tripwires).
+//
+// ⚠ CASING: all keys camelCase (JsonSerializerDefaults.Web).
+// ⚠ DATES (review X5): Category.DeletedAt is a FULL INSTANT (DateTime?, UTC) —
+//   it serializes as a round-trip ISO-8601 string ("2026-06-20T14:30:00Z"), NOT
+//   a bare "YYYY-MM-DD". The island renders it local via new Date(iso) (never
+//   new Date('YYYY-MM-DD')). No enums here ⇒ plain camelCase.
+// ─────────────────────────────────────────────────────────────────────────
+
+// NOTE: named Settings* to avoid colliding with the recipes-island CategoryDto (RecipeDtos.cs) and the
+// chores MemberDto (ChoreDtos.cs) — each island keeps its own DTO shape in this shared namespace.
+
+/// <summary>Categories view payload: the active list (sorted) + the deleted list (parity Categories.razor:162-167).</summary>
+public sealed record CategoryListDto(
+    IReadOnlyList<SettingsCategoryDto> Active,
+    IReadOnlyList<SettingsCategoryDto> Deleted);
+
+/// <summary>One household category. <see cref="DeletedAt"/> is null for active rows; a UTC instant for deleted ones.</summary>
+public sealed record SettingsCategoryDto(
+    int CategoryId,
+    string Name,
+    string? IconEmoji,
+    string Color,
+    bool IsDefault,
+    int SortOrder,
+    DateTime? DeletedAt);
+
+/// <summary>Manage-Users payload: the caller's id (so the island renders "You" + gates self-actions without a second call) + the members.</summary>
+public sealed record MemberListDto(
+    int CurrentUserId,
+    IReadOnlyList<SettingsMemberDto> Members);
+
+/// <summary>One household member (email-ordered).</summary>
+public sealed record SettingsMemberDto(
+    int UserId,
+    string Email,
+    string? DisplayName,
+    bool IsWhitelisted);
+
+/// <summary>
+/// The result of an add-member call. <see cref="Outcome"/> is "created" | "reenabled" | "alreadyActive"
+/// (the cross-household collision is a 409, NOT an outcome here — review R-A1). The island toasts "created"/
+/// "reenabled" as success and "alreadyActive" as a WARNING (parity: today "already has access" is a warning).
+/// </summary>
+public sealed record MemberActionDto(
+    SettingsMemberDto Member,
+    string Outcome);

--- a/src/FamilyCoordinationApp/Services/HouseholdMemberService.cs
+++ b/src/FamilyCoordinationApp/Services/HouseholdMemberService.cs
@@ -1,0 +1,145 @@
+using FamilyCoordinationApp.Data;
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Services.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace FamilyCoordinationApp.Services;
+
+/// <summary>
+/// Household member management (strangler — lifts WhitelistAdmin.razor's direct-EF logic into a testable,
+/// M1-scoped service). Short-lived contexts via the factory (retires the page's long-lived <c>_context</c>
+/// anti-pattern, review R-A6). The self / last-active / last-user guards are enforced HERE (server-side),
+/// not just hidden in the UI (R-A2).
+/// </summary>
+public sealed class HouseholdMemberService(
+    IDbContextFactory<ApplicationDbContext> dbFactory,
+    ILogger<HouseholdMemberService> logger) : IHouseholdMemberService
+{
+    public async Task<List<User>> GetMembersAsync(int householdId, CancellationToken cancellationToken = default)
+    {
+        await using var context = await dbFactory.CreateDbContextAsync(cancellationToken);
+        return await context.Users
+            .Where(u => u.HouseholdId == householdId)
+            .OrderBy(u => u.Email)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<AddMemberResult> AddMemberAsync(int householdId, string email, CancellationToken cancellationToken = default)
+    {
+        var normalized = email.Trim().ToLowerInvariant();
+        await using var context = await dbFactory.CreateDbContextAsync(cancellationToken);
+
+        // Intentional cross-household read (R-A4): the email belonging to ANOTHER household is rejected — this
+        // takes precedence (parity WhitelistAdmin.AddUser:181). It returns no data, only the rejection outcome.
+        var inOtherHousehold = await context.Users
+            .AnyAsync(u => u.Email == normalized && u.HouseholdId != householdId, cancellationToken);
+        if (inOtherHousehold)
+        {
+            return new AddMemberResult(AddMemberOutcome.OtherHousehold, null);
+        }
+
+        var existing = await context.Users
+            .FirstOrDefaultAsync(u => u.Email == normalized && u.HouseholdId == householdId, cancellationToken);
+
+        if (existing is not null)
+        {
+            if (existing.IsWhitelisted)
+            {
+                return new AddMemberResult(AddMemberOutcome.AlreadyActive, existing);
+            }
+
+            existing.IsWhitelisted = true;
+            await context.SaveChangesAsync(cancellationToken);
+            logger.LogInformation("Re-enabled member {Email} in household {HouseholdId}", normalized, householdId);
+            return new AddMemberResult(AddMemberOutcome.Reenabled, existing);
+        }
+
+        var created = new User
+        {
+            HouseholdId = householdId,
+            Email = normalized,
+            DisplayName = normalized.Split('@')[0],
+            GoogleId = null, // set when the user first logs in with Google (parity)
+            IsWhitelisted = true,
+            CreatedAt = DateTime.UtcNow,
+        };
+        context.Users.Add(created);
+        await context.SaveChangesAsync(cancellationToken);
+        logger.LogInformation("Added member {Email} to household {HouseholdId}", normalized, householdId);
+        return new AddMemberResult(AddMemberOutcome.Created, created);
+    }
+
+    public async Task<(MemberMutationResult Result, User? User)> SetWhitelistAsync(
+        int householdId, int currentUserId, int targetUserId, bool isWhitelisted, CancellationToken cancellationToken = default)
+    {
+        if (targetUserId == currentUserId)
+        {
+            return (MemberMutationResult.SelfForbidden, null);
+        }
+
+        await using var context = await dbFactory.CreateDbContextAsync(cancellationToken);
+        var target = await context.Users
+            .FirstOrDefaultAsync(u => u.HouseholdId == householdId && u.Id == targetUserId, cancellationToken);
+        if (target is null)
+        {
+            return (MemberMutationResult.NotFound, null);
+        }
+
+        // Disabling the last active member would lock everyone out (parity: the page hides Disable for the
+        // last active member; we enforce it server-side).
+        if (!isWhitelisted && target.IsWhitelisted)
+        {
+            var activeCount = await context.Users
+                .CountAsync(u => u.HouseholdId == householdId && u.IsWhitelisted, cancellationToken);
+            if (activeCount <= 1)
+            {
+                return (MemberMutationResult.LastActiveForbidden, null);
+            }
+        }
+
+        target.IsWhitelisted = isWhitelisted;
+        await context.SaveChangesAsync(cancellationToken);
+        logger.LogInformation(
+            "{Action} member {UserId} in household {HouseholdId}", isWhitelisted ? "Enabled" : "Disabled", targetUserId, householdId);
+        return (MemberMutationResult.Ok, target);
+    }
+
+    public async Task<MemberMutationResult> DeleteMemberAsync(
+        int householdId, int currentUserId, int targetUserId, CancellationToken cancellationToken = default)
+    {
+        if (targetUserId == currentUserId)
+        {
+            return MemberMutationResult.SelfForbidden;
+        }
+
+        await using var context = await dbFactory.CreateDbContextAsync(cancellationToken);
+        var target = await context.Users
+            .FirstOrDefaultAsync(u => u.HouseholdId == householdId && u.Id == targetUserId, cancellationToken);
+        if (target is null)
+        {
+            return MemberMutationResult.NotFound;
+        }
+
+        var totalCount = await context.Users
+            .CountAsync(u => u.HouseholdId == householdId, cancellationToken);
+        if (totalCount <= 1)
+        {
+            return MemberMutationResult.LastUserForbidden;
+        }
+
+        context.Users.Remove(target);
+        try
+        {
+            await context.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException ex)
+        {
+            // A RESTRICT FK (e.g. ChoreCompletions.CompletedByUserId) blocks the delete. Parity: don't 500 —
+            // surface a clean "can't delete" (the island toasts it). FK SET NULL only covers recipes/feedback.
+            logger.LogWarning(ex, "Blocked deleting member {UserId} in household {HouseholdId} (FK reference)", targetUserId, householdId);
+            return MemberMutationResult.Blocked;
+        }
+        logger.LogInformation("Deleted member {UserId} from household {HouseholdId}", targetUserId, householdId);
+        return MemberMutationResult.Ok;
+    }
+}

--- a/src/FamilyCoordinationApp/Services/Interfaces/IHouseholdMemberService.cs
+++ b/src/FamilyCoordinationApp/Services/Interfaces/IHouseholdMemberService.cs
@@ -1,0 +1,71 @@
+using FamilyCoordinationApp.Data.Entities;
+
+namespace FamilyCoordinationApp.Services.Interfaces;
+
+/// <summary>
+/// Household member (whitelist) management — lifted out of the direct-EF <c>WhitelistAdmin.razor</c> so the
+/// safety rules are testable and the HouseholdId scope (M1) is enforced server-side rather than only hidden in
+/// the UI (review R-A2). Every method is household-scoped; the cross-household collision check on add is the one
+/// intentional cross-tenant read (review R-A4 — it leaks no data, only a 409).
+/// </summary>
+public interface IHouseholdMemberService
+{
+    /// <summary>The household's users, ordered by email (parity WhitelistAdmin LoadUsers).</summary>
+    Task<List<User>> GetMembersAsync(int householdId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Add a member by email (parity WhitelistAdmin.AddUser): normalize lower; another household ⇒
+    /// <see cref="AddMemberOutcome.OtherHousehold"/>; existing-disabled ⇒ re-enable; existing-active ⇒ no-op;
+    /// else create a whitelisted user (DisplayName = email local-part, GoogleId = null, CreatedAt = UtcNow).
+    /// </summary>
+    Task<AddMemberResult> AddMemberAsync(int householdId, string email, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Enable/disable a member. Server-enforced guards (R-A2): toggling SELF ⇒ <see cref="MemberMutationResult.SelfForbidden"/>;
+    /// disabling the LAST ACTIVE member ⇒ <see cref="MemberMutationResult.LastActiveForbidden"/>; unknown ⇒
+    /// <see cref="MemberMutationResult.NotFound"/>. Returns the updated user on success.
+    /// </summary>
+    Task<(MemberMutationResult Result, User? User)> SetWhitelistAsync(
+        int householdId, int currentUserId, int targetUserId, bool isWhitelisted, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Delete a member. Server-enforced guards (R-A2): deleting SELF ⇒ <see cref="MemberMutationResult.SelfForbidden"/>;
+    /// deleting the LAST user ⇒ <see cref="MemberMutationResult.LastUserForbidden"/>; unknown ⇒
+    /// <see cref="MemberMutationResult.NotFound"/>. FK ON DELETE SET NULL keeps their recipes/feedback.
+    /// </summary>
+    Task<MemberMutationResult> DeleteMemberAsync(
+        int householdId, int currentUserId, int targetUserId, CancellationToken cancellationToken = default);
+}
+
+/// <summary>Outcome of <see cref="IHouseholdMemberService.AddMemberAsync"/>.</summary>
+public enum AddMemberOutcome
+{
+    /// <summary>A brand-new whitelisted user was created.</summary>
+    Created,
+    /// <summary>An existing disabled user in this household was re-enabled.</summary>
+    Reenabled,
+    /// <summary>The email is already an active member of this household (no change).</summary>
+    AlreadyActive,
+    /// <summary>The email belongs to ANOTHER household — rejected (maps to 409, no data leak).</summary>
+    OtherHousehold,
+}
+
+/// <summary>The added/affected member (null for <see cref="AddMemberOutcome.OtherHousehold"/>).</summary>
+public sealed record AddMemberResult(AddMemberOutcome Outcome, User? User);
+
+/// <summary>Outcome of a member toggle/delete — maps to HTTP in the endpoint (Self ⇒ 400; Last*/Blocked ⇒ 409; NotFound ⇒ 404).</summary>
+public enum MemberMutationResult
+{
+    Ok,
+    NotFound,
+    SelfForbidden,
+    LastActiveForbidden,
+    LastUserForbidden,
+
+    /// <summary>
+    /// Delete refused by the database (a RESTRICT FK — e.g. the member has chore completions). Parity: the old
+    /// WhitelistAdmin caught this and surfaced a generic error rather than deleting (FK ON DELETE SET NULL only
+    /// covers recipes/feedback, not completions). Maps to 409 — disable the member instead.
+    /// </summary>
+    Blocked,
+}

--- a/tests/FamilyCoordinationApp.Tests/Fixtures/Settings/categories.json
+++ b/tests/FamilyCoordinationApp.Tests/Fixtures/Settings/categories.json
@@ -1,0 +1,33 @@
+{
+  "active": [
+    {
+      "categoryId": 1,
+      "name": "Produce",
+      "iconEmoji": "leafy_green",
+      "color": "#4CAF50",
+      "isDefault": true,
+      "sortOrder": 1,
+      "deletedAt": null
+    },
+    {
+      "categoryId": 2,
+      "name": "Snacks",
+      "iconEmoji": null,
+      "color": "#FF9800",
+      "isDefault": false,
+      "sortOrder": 2,
+      "deletedAt": null
+    }
+  ],
+  "deleted": [
+    {
+      "categoryId": 3,
+      "name": "Old Aisle",
+      "iconEmoji": null,
+      "color": "#808080",
+      "isDefault": false,
+      "sortOrder": 3,
+      "deletedAt": "2026-06-20T14:30:00Z"
+    }
+  ]
+}

--- a/tests/FamilyCoordinationApp.Tests/Fixtures/Settings/members.json
+++ b/tests/FamilyCoordinationApp.Tests/Fixtures/Settings/members.json
@@ -1,0 +1,17 @@
+{
+  "currentUserId": 1,
+  "members": [
+    {
+      "userId": 1,
+      "email": "alice@example.com",
+      "displayName": "Alice",
+      "isWhitelisted": true
+    },
+    {
+      "userId": 2,
+      "email": "bob@example.com",
+      "displayName": null,
+      "isWhitelisted": false
+    }
+  ]
+}

--- a/tests/FamilyCoordinationApp.Tests/Integration/ChoresWebAppFactory.cs
+++ b/tests/FamilyCoordinationApp.Tests/Integration/ChoresWebAppFactory.cs
@@ -307,6 +307,16 @@ public class ChoresWebAppFactory(PostgresContainerFixture postgres) : WebApplica
 
         await context.SaveChangesAsync();
 
+        // The Households/Users above were inserted with EXPLICIT identity ids (1,2 / 1,2,3) for deterministic
+        // fixtures, which does NOT advance PostgreSQL's identity sequence. Any test that then creates a
+        // Household/User through the app (e.g. the settings add-member endpoint, or cluster-C's approve flow)
+        // would get a generated id colliding with a seeded one → PK violation. Resync both sequences to MAX(id)
+        // so generated ids continue past the seed. Harmless for tests that never create these rows.
+        await context.Database.ExecuteSqlRawAsync(
+            "SELECT setval(pg_get_serial_sequence('\"Users\"', 'Id'), (SELECT MAX(\"Id\") FROM \"Users\"))");
+        await context.Database.ExecuteSqlRawAsync(
+            "SELECT setval(pg_get_serial_sequence('\"Households\"', 'Id'), (SELECT MAX(\"Id\") FROM \"Households\"))");
+
         // ── v1.1 (WP-08): both households' digest settings — enabled, due at FixedNowUtc, distinct webhooks.
         // Seeded THROUGH the real settings service so the webhook ciphertext is encrypted with the host's
         // DataProtection keys (DigestService.GetDecryptedWebhookAsync must round-trip it at send time).

--- a/tests/FamilyCoordinationApp.Tests/Integration/SettingsEndpointTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Integration/SettingsEndpointTests.cs
@@ -1,0 +1,229 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+
+namespace FamilyCoordinationApp.Tests.Integration;
+
+/// <summary>
+/// End-to-end coverage of the Settings island A endpoints (<c>/api/settings/categories</c> + <c>/api/settings/members</c>)
+/// through the real HTTP pipeline against real Postgres (reuses <see cref="ChoresWebAppFactory"/>'s two-household
+/// seed — household A has alice + amy, household B has bob). Each test method gets its OWN freshly-seeded database
+/// (the factory provisions a per-instance DB), so mutations are isolated. Proves: the category CRUD/reorder/restore
+/// lifecycle, the in-use probe, the member list + add outcomes + the self/cross-household guards, the 401 gate, and
+/// the M1 cross-household isolation invariant (a household-A caller can neither read nor mutate household-B rows).
+/// </summary>
+[Collection(IntegrationCollection.Name)]
+[Trait("kind", "integration")]
+public sealed class SettingsEndpointTests(PostgresContainerFixture postgres) : IAsyncLifetime
+{
+    private readonly ChoresWebAppFactory _factory = new(postgres);
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    public async Task InitializeAsync() => await _factory.EnsureSeededAsync();
+    public async Task DisposeAsync() => await _factory.DisposeAsync();
+
+    private HttpClient ClientA => _factory.CreateClientAs(ChoresWebAppFactory.UserAEmail);
+    private HttpClient ClientB => _factory.CreateClientAs(ChoresWebAppFactory.UserBEmail);
+
+    // Wire shapes (camelCase via JsonSerializerDefaults.Web).
+    private sealed record CategoryDto(int categoryId, string name, string? iconEmoji, string color, bool isDefault, int sortOrder, string? deletedAt);
+    private sealed record CategoryList(List<CategoryDto> active, List<CategoryDto> deleted);
+    private sealed record MemberDto(int userId, string email, string? displayName, bool isWhitelisted);
+    private sealed record MemberList(int currentUserId, List<MemberDto> members);
+    private sealed record MemberAction(MemberDto member, string outcome);
+
+    private const string CategoriesUrl = "/api/settings/categories";
+    private const string MembersUrl = "/api/settings/members";
+
+    private async Task<CategoryDto> CreateCategoryAsync(HttpClient client, string name, string color = "#123456")
+    {
+        var resp = await client.PostAsJsonAsync(CategoriesUrl, new { name, iconEmoji = (string?)null, color }, Json);
+        resp.StatusCode.Should().Be(HttpStatusCode.Created);
+        return (await resp.Content.ReadFromJsonAsync<CategoryDto>(Json))!;
+    }
+
+    // ─── Categories ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Categories_Unauthenticated_Returns401()
+    {
+        var resp = await _factory.CreateAnonymousClient().GetAsync(CategoriesUrl);
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Categories_FullLifecycle_CreateUpdateDeleteRestoreReorder()
+    {
+        var client = ClientA;
+
+        // Create two.
+        var produce = await CreateCategoryAsync(client, "Produce");
+        var dairy = await CreateCategoryAsync(client, "Dairy");
+
+        var afterCreate = (await client.GetFromJsonAsync<CategoryList>(CategoriesUrl, Json))!;
+        afterCreate.active.Select(c => c.name).Should().Contain(new[] { "Produce", "Dairy" });
+        afterCreate.deleted.Should().BeEmpty();
+
+        // Update.
+        var upd = await client.PutAsJsonAsync($"{CategoriesUrl}/{produce.categoryId}",
+            new { name = "Fresh Produce", iconEmoji = "leafy", color = "#00AA00" }, Json);
+        upd.StatusCode.Should().Be(HttpStatusCode.OK);
+        var updated = (await upd.Content.ReadFromJsonAsync<CategoryDto>(Json))!;
+        updated.name.Should().Be("Fresh Produce");
+        updated.iconEmoji.Should().Be("leafy");
+
+        // Reorder: dairy first, produce second.
+        var reorder = await client.PutAsJsonAsync($"{CategoriesUrl}/sort-order",
+            new { orderedIds = new[] { dairy.categoryId, produce.categoryId } }, Json);
+        reorder.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        var afterReorder = (await client.GetFromJsonAsync<CategoryList>(CategoriesUrl, Json))!;
+        afterReorder.active.OrderBy(c => c.sortOrder).Select(c => c.categoryId)
+            .Should().ContainInOrder(dairy.categoryId, produce.categoryId);
+
+        // Soft delete dairy → moves to the deleted list.
+        var del = await client.DeleteAsync($"{CategoriesUrl}/{dairy.categoryId}");
+        del.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        var afterDelete = (await client.GetFromJsonAsync<CategoryList>(CategoriesUrl, Json))!;
+        afterDelete.active.Select(c => c.categoryId).Should().NotContain(dairy.categoryId);
+        afterDelete.deleted.Select(c => c.categoryId).Should().Contain(dairy.categoryId);
+        afterDelete.deleted.Single(c => c.categoryId == dairy.categoryId).deletedAt.Should().NotBeNull();
+
+        // Restore dairy → back to active.
+        var restore = await client.PostAsync($"{CategoriesUrl}/{dairy.categoryId}/restore", content: null);
+        restore.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        var afterRestore = (await client.GetFromJsonAsync<CategoryList>(CategoriesUrl, Json))!;
+        afterRestore.active.Select(c => c.categoryId).Should().Contain(dairy.categoryId);
+        afterRestore.deleted.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Categories_InUse_FalseWhenNoIngredients_And404ForMissing()
+    {
+        var client = ClientA;
+        var cat = await CreateCategoryAsync(client, "Spices");
+
+        var inUse = await client.GetFromJsonAsync<JsonElement>($"{CategoriesUrl}/{cat.categoryId}/in-use", Json);
+        inUse.GetProperty("inUse").GetBoolean().Should().BeFalse();
+
+        var missing = await client.GetAsync($"{CategoriesUrl}/99999/in-use");
+        missing.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        (await missing.Content.ReadAsStringAsync()).Should().NotBeNullOrEmpty("4xx must carry a non-empty body");
+    }
+
+    [Fact]
+    public async Task Categories_CrossHousehold_IsIsolated_AndMutationsAre404()
+    {
+        // A creates a category; B must never see it, nor be able to update/delete it (M1).
+        var aCat = await CreateCategoryAsync(ClientA, "A Only");
+
+        var bList = (await ClientB.GetFromJsonAsync<CategoryList>(CategoriesUrl, Json))!;
+        bList.active.Select(c => c.name).Should().NotContain("A Only");
+
+        var bUpdate = await ClientB.PutAsJsonAsync($"{CategoriesUrl}/{aCat.categoryId}",
+            new { name = "Hijack", iconEmoji = (string?)null, color = "#000000" }, Json);
+        bUpdate.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        var bDelete = await ClientB.DeleteAsync($"{CategoriesUrl}/{aCat.categoryId}");
+        bDelete.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // ─── Members ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Members_List_ReturnsHouseholdMembers_WithCurrentUserId()
+    {
+        var list = (await ClientA.GetFromJsonAsync<MemberList>(MembersUrl, Json))!;
+        list.currentUserId.Should().Be(ChoresWebAppFactory.UserAId);
+        list.members.Select(m => m.email).Should().BeEquivalentTo(
+            new[] { ChoresWebAppFactory.UserAEmail, ChoresWebAppFactory.UserA2Email });
+        list.members.Should().NotContain(m => m.email == ChoresWebAppFactory.UserBEmail, "B's user must not leak (M1)");
+    }
+
+    [Fact]
+    public async Task Members_Add_Created_AlreadyActive_And_CrossHousehold409()
+    {
+        var client = ClientA;
+
+        // New email → created.
+        var addResp = await client.PostAsJsonAsync(MembersUrl, new { email = "newbie@household-a.test" }, Json);
+        addResp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var action = (await addResp.Content.ReadFromJsonAsync<MemberAction>(Json))!;
+        action.outcome.Should().Be("created");
+        action.member.displayName.Should().Be("newbie");
+
+        // Already active → alreadyActive (NOT an error — review R-A1).
+        var dupe = await client.PostAsJsonAsync(MembersUrl, new { email = ChoresWebAppFactory.UserA2Email }, Json);
+        dupe.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await dupe.Content.ReadFromJsonAsync<MemberAction>(Json))!.outcome.Should().Be("alreadyActive");
+
+        // Email belonging to another household → 409.
+        var collision = await client.PostAsJsonAsync(MembersUrl, new { email = ChoresWebAppFactory.UserBEmail }, Json);
+        collision.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        (await collision.Content.ReadAsStringAsync()).Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task Members_ToggleAndReenable_RoundTrips()
+    {
+        var client = ClientA;
+        // Disable amy (alice stays active so it's not the last-active guard).
+        var off = await client.PutAsJsonAsync($"{MembersUrl}/{ChoresWebAppFactory.UserA2Id}", new { isWhitelisted = false }, Json);
+        off.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await off.Content.ReadFromJsonAsync<MemberDto>(Json))!.isWhitelisted.Should().BeFalse();
+
+        var on = await client.PutAsJsonAsync($"{MembersUrl}/{ChoresWebAppFactory.UserA2Id}", new { isWhitelisted = true }, Json);
+        on.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await on.Content.ReadFromJsonAsync<MemberDto>(Json))!.isWhitelisted.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Members_SelfGuards_ToggleAndDelete_AreRejected()
+    {
+        var client = ClientA; // alice = UserAId
+
+        var toggleSelf = await client.PutAsJsonAsync($"{MembersUrl}/{ChoresWebAppFactory.UserAId}", new { isWhitelisted = false }, Json);
+        toggleSelf.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var deleteSelf = await client.DeleteAsync($"{MembersUrl}/{ChoresWebAppFactory.UserAId}");
+        deleteSelf.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Members_Delete_NonSelf_FreshMember_RemovesThem()
+    {
+        var client = ClientA;
+
+        // Add a fresh member (no chore completions / FK references), then delete them.
+        var add = await client.PostAsJsonAsync(MembersUrl, new { email = "deleteme@household-a.test" }, Json);
+        add.StatusCode.Should().Be(HttpStatusCode.OK);
+        var newId = (await add.Content.ReadFromJsonAsync<MemberAction>(Json))!.member.userId;
+
+        var del = await client.DeleteAsync($"{MembersUrl}/{newId}");
+        del.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var list = (await client.GetFromJsonAsync<MemberList>(MembersUrl, Json))!;
+        list.members.Should().NotContain(m => m.userId == newId);
+    }
+
+    [Fact]
+    public async Task Members_Delete_MemberWithActivityHistory_Is409_NotServerError()
+    {
+        // Amy (UserA2Id) has seeded chore completions ⇒ the RESTRICT FK blocks the delete. Parity: surface a
+        // clean 409 (the island toasts it), NOT a 500 (review R-A: graceful FK handling).
+        var del = await ClientA.DeleteAsync($"{MembersUrl}/{ChoresWebAppFactory.UserA2Id}");
+        del.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        (await del.Content.ReadAsStringAsync()).Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task Members_CrossHousehold_Mutation_Is404()
+    {
+        // Alice (household A) cannot toggle or delete bob (household B's UserBId) — M1.
+        var toggle = await ClientA.PutAsJsonAsync($"{MembersUrl}/{ChoresWebAppFactory.UserBId}", new { isWhitelisted = false }, Json);
+        toggle.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        var delete = await ClientA.DeleteAsync($"{MembersUrl}/{ChoresWebAppFactory.UserBId}");
+        delete.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/tests/FamilyCoordinationApp.Tests/Services/HouseholdMemberServiceTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/HouseholdMemberServiceTests.cs
@@ -1,0 +1,181 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using FamilyCoordinationApp.Data;
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Services;
+using FamilyCoordinationApp.Services.Interfaces;
+
+namespace FamilyCoordinationApp.Tests.Services;
+
+/// <summary>
+/// Unit coverage for <see cref="HouseholdMemberService"/> — the safety rules lifted out of WhitelistAdmin.razor
+/// (review R-A2). InMemory EF (mirrors <see cref="CategoryServiceTests"/>); the service opens a fresh context per
+/// call via the mocked factory (same in-memory DB ⇒ state persists across calls). The DB-level FK ON DELETE SET
+/// NULL behaviour (recipes survive a member delete) is schema, not service logic, so it is exercised by the
+/// real-Postgres endpoint suite, not here.
+/// </summary>
+public class HouseholdMemberServiceTests : IDisposable
+{
+    private const int HhA = 1;
+    private const int HhB = 2;
+    private readonly ApplicationDbContext _seedContext;
+    private readonly HouseholdMemberService _service;
+
+    public HouseholdMemberServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        _seedContext = new ApplicationDbContext(options);
+        var factory = new Mock<IDbContextFactory<ApplicationDbContext>>();
+        factory.Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new ApplicationDbContext(options));
+        _service = new HouseholdMemberService(factory.Object, Mock.Of<ILogger<HouseholdMemberService>>());
+
+        Seed();
+    }
+
+    private void Seed()
+    {
+        _seedContext.Households.AddRange(
+            new Household { Id = HhA, Name = "Household A" },
+            new Household { Id = HhB, Name = "Household B" });
+        _seedContext.Users.AddRange(
+            new User { Id = 1, HouseholdId = HhA, Email = "alice@a.test", DisplayName = "Alice", IsWhitelisted = true, CreatedAt = DateTime.UtcNow },
+            new User { Id = 2, HouseholdId = HhA, Email = "amy@a.test", DisplayName = "Amy", IsWhitelisted = true, CreatedAt = DateTime.UtcNow },
+            new User { Id = 3, HouseholdId = HhA, Email = "dan@a.test", DisplayName = "Dan", IsWhitelisted = false, CreatedAt = DateTime.UtcNow },
+            new User { Id = 9, HouseholdId = HhB, Email = "bob@b.test", DisplayName = "Bob", IsWhitelisted = true, CreatedAt = DateTime.UtcNow });
+        _seedContext.SaveChanges();
+    }
+
+    public void Dispose() => _seedContext.Dispose();
+
+    // ─── GetMembers ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetMembers_ReturnsOwnHouseholdOnly_OrderedByEmail()
+    {
+        var members = await _service.GetMembersAsync(HhA);
+        members.Select(m => m.Email).Should().ContainInOrder("alice@a.test", "amy@a.test", "dan@a.test");
+        members.Should().OnlyContain(m => m.HouseholdId == HhA);
+    }
+
+    // ─── AddMember ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AddMember_NewEmail_Creates_WhitelistedWithLocalPartDisplayName()
+    {
+        var result = await _service.AddMemberAsync(HhA, "  NEWBIE@A.test ");
+        result.Outcome.Should().Be(AddMemberOutcome.Created);
+        result.User!.Email.Should().Be("newbie@a.test", "the email is trimmed + lowercased");
+        result.User.DisplayName.Should().Be("newbie", "DisplayName is the email local-part (parity)");
+        result.User.IsWhitelisted.Should().BeTrue();
+        result.User.GoogleId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task AddMember_ExistingDisabled_ReenablesThem()
+    {
+        var result = await _service.AddMemberAsync(HhA, "dan@a.test");
+        result.Outcome.Should().Be(AddMemberOutcome.Reenabled);
+        result.User!.IsWhitelisted.Should().BeTrue();
+
+        var persisted = await _service.GetMembersAsync(HhA);
+        persisted.Single(m => m.Email == "dan@a.test").IsWhitelisted.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task AddMember_ExistingActive_IsNoOp()
+    {
+        var result = await _service.AddMemberAsync(HhA, "alice@a.test");
+        result.Outcome.Should().Be(AddMemberOutcome.AlreadyActive);
+    }
+
+    [Fact]
+    public async Task AddMember_EmailInAnotherHousehold_IsRejected_NoDataLeak()
+    {
+        var result = await _service.AddMemberAsync(HhA, "bob@b.test");
+        result.Outcome.Should().Be(AddMemberOutcome.OtherHousehold);
+        result.User.Should().BeNull("the cross-household reject leaks no user data");
+
+        // And no row was created in household A for that email.
+        (await _service.GetMembersAsync(HhA)).Should().NotContain(m => m.Email == "bob@b.test");
+    }
+
+    // ─── SetWhitelist (toggle) ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SetWhitelist_Self_IsForbidden()
+    {
+        var (result, _) = await _service.SetWhitelistAsync(HhA, currentUserId: 1, targetUserId: 1, isWhitelisted: false);
+        result.Should().Be(MemberMutationResult.SelfForbidden);
+    }
+
+    [Fact]
+    public async Task SetWhitelist_DisableOneOfTwoActive_IsAllowed()
+    {
+        // HhA has alice + amy active (dan is disabled) ⇒ disabling amy still leaves alice active.
+        var (result, user) = await _service.SetWhitelistAsync(HhA, currentUserId: 1, targetUserId: 2, isWhitelisted: false);
+        result.Should().Be(MemberMutationResult.Ok);
+        user!.IsWhitelisted.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SetWhitelist_DisableLastActive_IsForbidden()
+    {
+        // Drive HhA down to a single active member (alice), then attempt to disable her as a non-self caller.
+        await _service.SetWhitelistAsync(HhA, currentUserId: 1, targetUserId: 2, isWhitelisted: false); // amy off
+        var (result, _) = await _service.SetWhitelistAsync(HhA, currentUserId: 2, targetUserId: 1, isWhitelisted: false);
+        result.Should().Be(MemberMutationResult.LastActiveForbidden);
+    }
+
+    [Fact]
+    public async Task SetWhitelist_UnknownMember_IsNotFound()
+    {
+        var (result, _) = await _service.SetWhitelistAsync(HhA, currentUserId: 1, targetUserId: 999, isWhitelisted: false);
+        result.Should().Be(MemberMutationResult.NotFound);
+    }
+
+    [Fact]
+    public async Task SetWhitelist_CrossHousehold_IsNotFound()
+    {
+        // Bob (id 9) lives in HhB ⇒ a HhA-scoped toggle must not find him (M1).
+        var (result, _) = await _service.SetWhitelistAsync(HhA, currentUserId: 1, targetUserId: 9, isWhitelisted: false);
+        result.Should().Be(MemberMutationResult.NotFound);
+    }
+
+    // ─── DeleteMember ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DeleteMember_Self_IsForbidden()
+    {
+        var result = await _service.DeleteMemberAsync(HhA, currentUserId: 1, targetUserId: 1);
+        result.Should().Be(MemberMutationResult.SelfForbidden);
+    }
+
+    [Fact]
+    public async Task DeleteMember_NonSelf_WhenMultipleUsers_Deletes()
+    {
+        var result = await _service.DeleteMemberAsync(HhA, currentUserId: 1, targetUserId: 2);
+        result.Should().Be(MemberMutationResult.Ok);
+        (await _service.GetMembersAsync(HhA)).Should().NotContain(m => m.Id == 2);
+    }
+
+    [Fact]
+    public async Task DeleteMember_LastUser_IsForbidden()
+    {
+        // HhB has a single user (bob). A non-self caller deleting him would empty the household.
+        var result = await _service.DeleteMemberAsync(HhB, currentUserId: 999, targetUserId: 9);
+        result.Should().Be(MemberMutationResult.LastUserForbidden);
+    }
+
+    [Fact]
+    public async Task DeleteMember_CrossHousehold_IsNotFound()
+    {
+        var result = await _service.DeleteMemberAsync(HhA, currentUserId: 1, targetUserId: 9);
+        result.Should().Be(MemberMutationResult.NotFound);
+    }
+}

--- a/tests/FamilyCoordinationApp.Tests/Services/SettingsDtoContractTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/SettingsDtoContractTests.cs
@@ -1,0 +1,100 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using FamilyCoordinationApp.Services.Dtos;
+
+namespace FamilyCoordinationApp.Tests.Services;
+
+/// <summary>
+/// Contract / consumer-audit tests for the Settings island A aggregate DTOs (M9 — mirrors
+/// <see cref="DashboardDtoContractTests"/>). Serializes a representative <see cref="CategoryListDto"/> /
+/// <see cref="MemberListDto"/> with the SAME options the app registers globally (camelCase, Web defaults) and
+/// asserts byte-equality with the checked-in <c>Fixtures/Settings/{categories,members}.json</c>. The island's
+/// <c>types.ts</c> mirrors these fixtures; any DTO shape/casing change breaks this test → forcing the island
+/// contract to update in lockstep (M9).
+///
+/// <para>⚠ DATES (review X5): <see cref="SettingsCategoryDto.DeletedAt"/> is a FULL INSTANT (DateTime?, UTC) →
+/// serializes as a round-trip ISO-8601 string ("2026-06-20T14:30:00Z"), NOT a bare "YYYY-MM-DD". The island
+/// renders it local via new Date(iso).</para>
+/// </summary>
+public class SettingsDtoContractTests
+{
+    /// <summary>Web defaults (camelCase) — equivalent to the app's global Minimal-API JSON config for these (enum-free) DTOs.</summary>
+    public static readonly JsonSerializerOptions SettingsJsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+    };
+
+    private static string FixturePath(string file) =>
+        Path.Combine(AppContext.BaseDirectory, "Fixtures", "Settings", file);
+
+    public static CategoryListDto BuildRepresentativeCategories() => new(
+        Active: new List<SettingsCategoryDto>
+        {
+            new(CategoryId: 1, Name: "Produce", IconEmoji: "leafy_green", Color: "#4CAF50", IsDefault: true, SortOrder: 1, DeletedAt: null),
+            new(CategoryId: 2, Name: "Snacks", IconEmoji: null, Color: "#FF9800", IsDefault: false, SortOrder: 2, DeletedAt: null),
+        },
+        Deleted: new List<SettingsCategoryDto>
+        {
+            new(CategoryId: 3, Name: "Old Aisle", IconEmoji: null, Color: "#808080", IsDefault: false, SortOrder: 3,
+                DeletedAt: new DateTime(2026, 6, 20, 14, 30, 0, DateTimeKind.Utc)),
+        });
+
+    public static MemberListDto BuildRepresentativeMembers() => new(
+        CurrentUserId: 1,
+        Members: new List<SettingsMemberDto>
+        {
+            new(UserId: 1, Email: "alice@example.com", DisplayName: "Alice", IsWhitelisted: true),
+            new(UserId: 2, Email: "bob@example.com", DisplayName: null, IsWhitelisted: false),
+        });
+
+    [Fact]
+    public void SerializedCategories_MatchesContractFixture()
+    {
+        var json = JsonSerializer.Serialize(BuildRepresentativeCategories(), SettingsJsonOptions);
+        File.Exists(FixturePath("categories.json")).Should().BeTrue();
+        Normalize(json).Should().Be(Normalize(File.ReadAllText(FixturePath("categories.json"))),
+            "the serialized CategoryListDto must match categories.json; update the fixture AND types.ts in lockstep (M9)");
+    }
+
+    [Fact]
+    public void SerializedMembers_MatchesContractFixture()
+    {
+        var json = JsonSerializer.Serialize(BuildRepresentativeMembers(), SettingsJsonOptions);
+        File.Exists(FixturePath("members.json")).Should().BeTrue();
+        Normalize(json).Should().Be(Normalize(File.ReadAllText(FixturePath("members.json"))),
+            "the serialized MemberListDto must match members.json; update the fixture AND types.ts in lockstep (M9)");
+    }
+
+    [Fact]
+    public void Categories_UseCamelCaseKeys_AndIsoInstantDeletedAt()
+    {
+        var json = JsonSerializer.Serialize(BuildRepresentativeCategories(), SettingsJsonOptions);
+        var root = JsonNode.Parse(json)!.AsObject();
+        root.Select(kvp => kvp.Key).Should().BeEquivalentTo("active", "deleted");
+
+        var first = root["active"]!.AsArray()[0]!.AsObject();
+        first.Select(kvp => kvp.Key).Should().BeEquivalentTo(
+            "categoryId", "name", "iconEmoji", "color", "isDefault", "sortOrder", "deletedAt");
+        first["deletedAt"].Should().BeNull("a JSON null property reads back as a null JsonNode");
+
+        // DeletedAt is a full ISO-8601 instant (NOT a bare date) — review X5.
+        var deleted = root["deleted"]!.AsArray()[0]!.AsObject();
+        deleted["deletedAt"]!.GetValue<string>().Should().Be("2026-06-20T14:30:00Z");
+    }
+
+    [Fact]
+    public void Members_UseCamelCaseKeys()
+    {
+        var json = JsonSerializer.Serialize(BuildRepresentativeMembers(), SettingsJsonOptions);
+        var root = JsonNode.Parse(json)!.AsObject();
+        root.Select(kvp => kvp.Key).Should().BeEquivalentTo("currentUserId", "members");
+        var first = root["members"]!.AsArray()[0]!.AsObject();
+        first.Select(kvp => kvp.Key).Should().BeEquivalentTo("userId", "email", "displayName", "isWhitelisted");
+    }
+
+    private static string Normalize(string json) =>
+        JsonNode.Parse(json)!.ToJsonString(new JsonSerializerOptions { WriteIndented = false });
+}


### PR DESCRIPTION
## Settings strangler — Cluster A: Household settings → Svelte island

Converts the two household-settings Blazor pages into **one** Svelte 5 island over plain `/api` JSON, behind a flag (**ships OFF** — zero prod impact until `SETTINGS_HOUSEHOLD_USE_ISLAND=true` is flipped). First of the 3 clustered settings islands (A → B → C); the sequencing driver is stripping MudBlazor deps before the shell keystone. **Parity-first, no new UX.**

### What's in it
- **Backend** — `/api/settings/{categories,members}` (`SettingsEndpoints.cs`) over the existing `ICategoryService` + a new **`IHouseholdMemberService`** that lifts `WhitelistAdmin.razor`'s direct-EF logic into a testable, M1-scoped service. The self / last-active / last-user guards are now **server-enforced** (were UI-only); cross-household add → 409; add returns a **200 outcome envelope** (`created`/`reenabled`/`alreadyActive` — `alreadyActive` is a warning, not an error); FK-blocked delete → a clean **409** (parity, not a 500). `Category.DeletedAt` emitted as a full ISO-8601 instant.
- **Island** — `frontend/settings/` (copied + rescoped from the recipes island, `set-`/port 5178): Categories with `svelte-dnd-action` reorder + in-island edit/delete-confirm/restore; Manage Users with server-mirrored self/guard button gating. `onMount` one-time load + `loadSeq` guard; no liveness (parity).
- **Wiring** — thin Razor hosts + **verbatim** Blazor fallbacks (`CategoriesBlazor` / `WhitelistAdminBlazor`), `CopySettingsIsland` MSBuild target, `settings-node-build` Dockerfile stage, `docker-build.sh` entry, compose flag.

### Two real findings surfaced while building + verifying
1. **Test harness identity-sequence gap** — the shared seed inserts Users/Households with explicit IDs but never advanced the PG identity sequence, so API-created rows collided on PK. Fixed with a `setval` resync in `ChoresWebAppFactory` (also unblocks Cluster C's approve-flow tests).
2. **Prerender-race 500** — caught only by the `:8080` browser verify (not the backend tests): the host momentarily mounted the long-lived-`_context` Blazor fallback during the async gap before `_shell` resolves → `ObjectDisposedException`. Fixed both hosts to render the fallback only when the flag is OFF (the template for clusters B/C).

### Verification
- `dotnet build` clean · **608 unit + 11 real-PG integration** tests (M1 cross-household isolation, 401 gate, every CRUD/guard/outcome path, FK-blocked-delete → 409) · `svelte-check` 0/0 · `vite build` · `dotnet format` = no new violations.
- **`:8080` browser-verified** (flag ON): both views mount + load real data, dark-mode bridge works, self-gating correct, and the **loop-check is clean** (one GET per view, no runaway fetch).

Plan-review provenance: `.planning/settings-household-island-spec.md` (§11–12 review resolutions) + the cross-plan review memo.

https://claude.ai/code/session_01MHJbyCChh3jkrcjQgaMcaN
