### PR TITLE
feat(settings): strangle Connections (invite flow) into a Svelte island (cluster B)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,15 @@ RUN if [ -f package-lock.json ]; then npm ci; else npm install --no-audit --no-f
 COPY frontend/settings/ ./
 RUN npm run build
 
+# Stage 1g: Build the Svelte connections island (settings cluster B; parallel to the others).
+# Emits ./dist/ which the .NET stage copies into wwwroot/islands/connections/.
+FROM node:20-alpine AS connections-node-build
+WORKDIR /frontend
+COPY frontend/connections/package.json frontend/connections/package-lock.json* ./
+RUN if [ -f package-lock.json ]; then npm ci; else npm install --no-audit --no-fund; fi
+COPY frontend/connections/ ./
+RUN npm run build
+
 # Stage 2: Build the .NET app.
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
@@ -69,6 +78,7 @@ COPY --from=mealplan-node-build /frontend/dist/ ./FamilyCoordinationApp/wwwroot/
 COPY --from=recipes-node-build /frontend/dist/ ./FamilyCoordinationApp/wwwroot/islands/recipes/
 COPY --from=dashboard-node-build /frontend/dist/ ./FamilyCoordinationApp/wwwroot/islands/dashboard/
 COPY --from=settings-node-build /frontend/dist/ ./FamilyCoordinationApp/wwwroot/islands/settings/
+COPY --from=connections-node-build /frontend/dist/ ./FamilyCoordinationApp/wwwroot/islands/connections/
 
 # Explicitly set working directory to project folder before publish
 WORKDIR /src/FamilyCoordinationApp

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -64,6 +64,7 @@ build_island "./frontend/meal-plan" "meal-plan"
 build_island "./frontend/recipes" "recipes"
 build_island "./frontend/dashboard" "dashboard"
 build_island "./frontend/settings" "settings"
+build_island "./frontend/connections" "connections"
 echo ""
 
 # Step 3: Publish locally

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       RECIPES_USE_ISLAND: ${RECIPES_USE_ISLAND:-false}
       DASHBOARD_USE_ISLAND: ${DASHBOARD_USE_ISLAND:-false}
       SETTINGS_HOUSEHOLD_USE_ISLAND: ${SETTINGS_HOUSEHOLD_USE_ISLAND:-false}
+      SETTINGS_CONNECTIONS_USE_ISLAND: ${SETTINGS_CONNECTIONS_USE_ISLAND:-false}
       # Chores v1.1 digest. The token gates POST /api/chores/digest/run (cron trigger); unset ⇒ endpoint
       # returns 503 (feature off). MUST be mapped here — .env is only used for ${VAR} substitution, not
       # auto-injected, so the documented go-live step (set CHORES_DIGEST_TRIGGER_TOKEN) is inert without this.

--- a/frontend/connections/.gitignore
+++ b/frontend/connections/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.log
+.DS_Store

--- a/frontend/connections/index.html
+++ b/frontend/connections/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Connections (dev)</title>
+  </head>
+  <body>
+    <!-- Dev-only host. In production the Razor shell (Connections.razor) provides these attrs. -->
+    <div
+      id="connections-root"
+      data-household-id="1"
+      data-user-id="1"
+      data-user-name="Dev User"
+    ></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/frontend/connections/package-lock.json
+++ b/frontend/connections/package-lock.json
@@ -1,0 +1,1541 @@
+{
+  "name": "connections-island",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "connections-island",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@sveltejs/vite-plugin-svelte": "^5.0.3",
+        "@tsconfig/svelte": "^5.0.4",
+        "svelte": "^5.19.0",
+        "svelte-check": "^4.1.4",
+        "tslib": "^2.8.1",
+        "typescript": "~5.7.2",
+        "vite": "^6.0.7"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sveltejs/acorn-typescript": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.10.tgz",
+      "integrity": "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8.9.0"
+      }
+    },
+    "node_modules/@sveltejs/load-config": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@sveltejs/load-config/-/load-config-0.2.0.tgz",
+      "integrity": "sha512-1LgZ/qUqSoq+QorD83lk2hka79Px0wXNW2q5V1nZlxGhQgw1jrsIbVz5YiCeucVLo4XvFLjXukUaQjIiqowkcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-5.1.1.tgz",
+      "integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
+        "debug": "^4.4.1",
+        "deepmerge": "^4.3.1",
+        "kleur": "^4.1.5",
+        "magic-string": "^0.30.17",
+        "vitefu": "^1.0.6"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22"
+      },
+      "peerDependencies": {
+        "svelte": "^5.0.0",
+        "vite": "^6.0.0"
+      }
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte-inspector": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-4.0.1.tgz",
+      "integrity": "sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.7"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22"
+      },
+      "peerDependencies": {
+        "@sveltejs/vite-plugin-svelte": "^5.0.0",
+        "svelte": "^5.0.0",
+        "vite": "^6.0.0"
+      }
+    },
+    "node_modules/@tsconfig/svelte": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-5.0.8.tgz",
+      "integrity": "sha512-UkNnw1/oFEfecR8ypyHIQuWYdkPvHiwcQ78sh+ymIiYoF+uc5H1UBetbjyqT+vgGJ3qQN6nhucJviX6HesWtKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
+      "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/devalue": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esrap": {
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.12.tgz",
+      "integrity": "sha512-On0QbLyaiAkVC4eXtgnXK9Kh2opit+3rcUSOc45DqJ2s/X2eXAHsGOKRSJ6IDagQEW5vPyivANfXUiqgXC67Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/types": "^8.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/is-reference": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.6"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/locate-character": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/svelte": {
+      "version": "5.56.4",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.4.tgz",
+      "integrity": "sha512-/d0QHehmRuJW8gVz395MTkPcPozxzdjBMBE8oEYGz8O3b9KTMzzQ9ZHJQLuFKOHOPQbU6kx/X4iid/EBBzH7iw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.4",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@sveltejs/acorn-typescript": "^1.0.10",
+        "@types/estree": "^1.0.5",
+        "@types/trusted-types": "^2.0.7",
+        "acorn": "^8.12.1",
+        "aria-query": "5.3.1",
+        "axobject-query": "^4.1.0",
+        "clsx": "^2.1.1",
+        "devalue": "^5.8.1",
+        "esm-env": "^1.2.1",
+        "esrap": "^2.2.12",
+        "is-reference": "^3.0.3",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.11",
+        "zimmerframe": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/svelte-check": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.7.1.tgz",
+      "integrity": "sha512-FGUOmAqxXdN/H9Zm8slrqO7SLtFisXRB7rfOsHNJ3MLTD2po/+Stg8XyErkpumPHbuUiYTcqrEIzxpVWKTLqtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "@sveltejs/load-config": "^0.2.0",
+        "chokidar": "^4.0.1",
+        "fdir": "^6.2.0",
+        "picocolors": "^1.0.0",
+        "sade": "^1.7.4"
+      },
+      "bin": {
+        "svelte-check": "bin/svelte-check"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "svelte": "^4.0.0 || ^5.0.0-next.0",
+        "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitefu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+      "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "tests/deps/*",
+        "tests/projects/*",
+        "tests/projects/workspace/packages/*"
+      ],
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zimmerframe": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
+      "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/frontend/connections/package.json
+++ b/frontend/connections/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "connections-island",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "check": "svelte-check --tsconfig ./tsconfig.json"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^5.0.3",
+    "@tsconfig/svelte": "^5.0.4",
+    "svelte": "^5.19.0",
+    "svelte-check": "^4.1.4",
+    "tslib": "^2.8.1",
+    "typescript": "~5.7.2",
+    "vite": "^6.0.7"
+  }
+}

--- a/frontend/connections/src/App.svelte
+++ b/frontend/connections/src/App.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  // Root of the connections island (#connections-root). Reads the ShellContext from
+  // the root data-attrs (passed by main.ts), loads the active invite + connected
+  // list ONCE, then drives the invite state machine via the shared store. No writes
+  // happen on load; no liveness/poll (parity — Connections.razor doesn't poll).
+  import { untrack } from 'svelte';
+  import type { ShellContext } from './lib/types';
+  import { connectionsStore as store } from './lib/connectionsStore.svelte';
+  import InviteShare from './lib/components/InviteShare.svelte';
+  import CodeEntry from './lib/components/CodeEntry.svelte';
+  import ConnectedList from './lib/components/ConnectedList.svelte';
+  import DisconnectDialog from './lib/components/DisconnectDialog.svelte';
+  import Toasts from './lib/components/Toasts.svelte';
+
+  let { ctx }: { ctx: ShellContext } = $props();
+
+  async function load(): Promise<void> {
+    await store.load();
+  }
+
+  // ⚠ Loop safety (memory svelte5-setup-effect-async-loader-loop): the one-time
+  // setup effect calls load(), whose sync prefix reads THEN writes store state.
+  // Wrapping the whole body in untrack() gives the effect zero reactive deps so it
+  // runs exactly once. There is no liveness here (parity — the page doesn't poll).
+  $effect(() => {
+    untrack(() => {
+      void ctx; // shell context available; the store calls /api directly (household resolved server-side)
+      void load();
+    });
+  });
+</script>
+
+<div class="con-page">
+  <h1 class="con-title">Family Connections</h1>
+
+  {#if !store.loaded && store.loading}
+    <div class="con-loading">Loading…</div>
+  {:else if !store.loaded && store.error}
+    <div class="con-inline-error" role="alert">
+      <span>{store.error}</span>
+      <button type="button" class="con-retry" onclick={() => void load()}>Retry</button>
+    </div>
+  {:else}
+    <InviteShare />
+    <CodeEntry />
+    <ConnectedList />
+  {/if}
+</div>
+
+<DisconnectDialog />
+<Toasts />

--- a/frontend/connections/src/lib/api.ts
+++ b/frontend/connections/src/lib/api.ts
@@ -1,0 +1,90 @@
+import type {
+  ConnectionsDto,
+  InviteDto,
+  ValidateResultDto,
+  AcceptResultDto,
+} from './types';
+
+const BASE = '/api/settings/connections';
+
+/**
+ * Thrown on any non-2xx response. `status` lets callers react to a rejection.
+ *
+ * ⚠ Carried from the other islands: the app re-executes empty-body API 4xx
+ * through a Blazor `/not-found` page, so a server-side "not found" can arrive
+ * as an empty 400 (a bare DELETE 404 even surfaces as 405). The connections
+ * endpoints return outcome envelopes (200) for the expected validate/accept flow
+ * results, so a 4xx here is a genuine error (or 401) — treat ANY 4xx as a
+ * non-retryable client rejection.
+ */
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+
+  /** A non-retryable client rejection (validation / not found / conflict). Any 4xx. */
+  get isClientRejection(): boolean {
+    return this.status >= 400 && this.status < 500;
+  }
+}
+
+async function request<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    credentials: 'include',
+    headers: { Accept: 'application/json', ...(init?.headers ?? {}) },
+    ...init,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    let message = text || res.statusText;
+    // The endpoints return { message } on 4xx — surface it for the toast.
+    try {
+      const parsed = JSON.parse(text);
+      if (parsed && typeof parsed.message === 'string') message = parsed.message;
+    } catch { /* not JSON — use the raw text */ }
+    throw new ApiError(res.status, message);
+  }
+  if (res.status === 204) return undefined as T;
+  return (await res.json()) as T;
+}
+
+function jsonBody(body: unknown): RequestInit {
+  return {
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  };
+}
+
+/** #1 The active invite (or null) + connected households, in one payload. */
+export async function getConnections(): Promise<ConnectionsDto> {
+  return request<ConnectionsDto>(`${BASE}/`);
+}
+
+/** #2 Generate a new invite (replaces any prior active one) → the code (201). */
+export async function generateInvite(): Promise<InviteDto> {
+  return request<InviteDto>(`${BASE}/invite`, { method: 'POST' });
+}
+
+/** #3 Cancel the active invite → 204 (idempotent). */
+export async function cancelInvite(): Promise<void> {
+  await request<void>(`${BASE}/invite`, { method: 'DELETE' });
+}
+
+/** #4 Validate a code WITHOUT connecting → 200 outcome envelope. */
+export async function validateCode(code: string): Promise<ValidateResultDto> {
+  return request<ValidateResultDto>(`${BASE}/validate`, { method: 'POST', ...jsonBody({ code }) });
+}
+
+/** #5 Accept a code (establish the connection) → 200 outcome envelope. */
+export async function acceptCode(code: string): Promise<AcceptResultDto> {
+  return request<AcceptResultDto>(`${BASE}/accept`, { method: 'POST', ...jsonBody({ code }) });
+}
+
+/** #6 Disconnect a connected household → 204 (idempotent; M1 enforced server-side). */
+export async function disconnect(householdId: number): Promise<void> {
+  await request<void>(`${BASE}/connected/${householdId}`, { method: 'DELETE' });
+}

--- a/frontend/connections/src/lib/components/CodeEntry.svelte
+++ b/frontend/connections/src/lib/components/CodeEntry.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+  // Enter-a-code section (parity Connections.razor:84-151): input (uppercase/strip/
+  // max-6) + Submit → validate; on valid, a pre-connection confirm → Connect/Cancel.
+  // On accept failure the store returns here with codeError (review R-B3).
+  import { connectionsStore as store } from '../connectionsStore.svelte';
+
+  function onInput(e: Event) {
+    store.setCode((e.currentTarget as HTMLInputElement).value);
+  }
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter' && store.canSubmit) void store.validate();
+  }
+</script>
+
+<section class="con-card">
+  <h2 class="con-card-title">Enter a Code</h2>
+  <p class="con-card-sub">Got a code from someone? Enter it below.</p>
+
+  {#if !store.showConfirm}
+    <div class="con-entry-row">
+      <input
+        class="con-code-input"
+        type="text"
+        autocomplete="off"
+        autocapitalize="characters"
+        spellcheck="false"
+        maxlength="6"
+        aria-label="Invite Code"
+        placeholder="ABC123"
+        value={store.enteredCode}
+        oninput={onInput}
+        onkeydown={onKeydown}
+        disabled={store.validating}
+      />
+      <button type="button" class="con-btn-primary" onclick={() => store.validate()} disabled={!store.canSubmit}>
+        {#if store.validating}<span class="con-spinner"></span>{/if}
+        Submit
+      </button>
+    </div>
+
+    {#if store.codeError}
+      <div class="con-alert con-alert-warning" role="alert" style="margin-top: 12px;">{store.codeError}</div>
+    {/if}
+  {:else}
+    <div class="con-alert con-alert-info" style="margin-bottom: 16px;">
+      Connecting with <strong>{store.pendingHouseholdName}</strong> lets both families browse each other's recipes.
+      They can see your recipes but can't change them. You can disconnect anytime.
+    </div>
+    <div class="con-actions">
+      <button type="button" class="con-btn-outline" onclick={() => store.cancelConfirm()} disabled={store.accepting}>
+        Cancel
+      </button>
+      <button type="button" class="con-btn-primary" onclick={() => store.accept()} disabled={store.accepting}>
+        {#if store.accepting}<span class="con-spinner"></span>{/if}
+        Connect
+      </button>
+    </div>
+  {/if}
+</section>

--- a/frontend/connections/src/lib/components/ConnectedList.svelte
+++ b/frontend/connections/src/lib/components/ConnectedList.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  // Connected-families section (parity Connections.razor:153-188): list each
+  // connected household with its connected-date + a Stop Sharing button (opens the
+  // disconnect-confirm dialog), or an empty hint.
+  import { connectionsStore as store } from '../connectionsStore.svelte';
+  import { formatConnectedDate } from '../dates';
+</script>
+
+<section class="con-card">
+  <h2 class="con-card-title">Your Connected Families</h2>
+
+  {#if store.connected.length === 0}
+    <p class="con-empty">
+      You haven't connected with any families yet. Create an invite code or enter one to get started.
+    </p>
+  {:else}
+    <ul class="con-list">
+      {#each store.connected as family (family.householdId)}
+        <li class="con-row">
+          <div>
+            <div class="con-row-name">{family.householdName}</div>
+            <div class="con-row-date">Connected {formatConnectedDate(family.connectedAt)}</div>
+          </div>
+          <button type="button" class="con-btn-danger" onclick={() => store.askDisconnect(family)}>
+            🔗 Stop Sharing
+          </button>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</section>

--- a/frontend/connections/src/lib/components/DisconnectDialog.svelte
+++ b/frontend/connections/src/lib/components/DisconnectDialog.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+  // Disconnect-confirm dialog (parity Connections.razor:192-220): the household name
+  // + 3 consequence bullets + a Stop Sharing (danger) action with a busy spinner.
+  // Driven by store.disconnectTarget (a native <dialog> showModal/close).
+  import { connectionsStore as store } from '../connectionsStore.svelte';
+
+  let dialogEl: HTMLDialogElement | null = $state(null);
+  const open = $derived(store.disconnectTarget !== null);
+
+  $effect(() => {
+    if (!dialogEl) return;
+    if (open && !dialogEl.open) {
+      dialogEl.showModal();
+    } else if (!open && dialogEl.open) {
+      dialogEl.close();
+    }
+  });
+</script>
+
+<dialog bind:this={dialogEl} onclose={() => store.cancelDisconnect()} class="con-dialog">
+  {#if store.disconnectTarget}
+    <div class="con-dialog-body">
+      <h2 class="con-dialog-title">Stop sharing with {store.disconnectTarget.householdName}?</h2>
+      <ul class="con-dialog-list">
+        <li><span class="con-mark con-mark-no">✕</span> You'll no longer be able to browse their recipes</li>
+        <li><span class="con-mark con-mark-no">✕</span> They'll no longer be able to browse yours</li>
+        <li><span class="con-mark con-mark-yes">✓</span> Recipes you've already copied will stay in your collection</li>
+      </ul>
+      <div class="con-actions con-dialog-actions">
+        <button type="button" class="con-btn-outline" onclick={() => store.cancelDisconnect()} disabled={store.disconnecting}>
+          Cancel
+        </button>
+        <button type="button" class="con-btn-danger-filled" onclick={() => store.confirmDisconnect()} disabled={store.disconnecting}>
+          {#if store.disconnecting}<span class="con-spinner"></span>{/if}
+          Stop Sharing
+        </button>
+      </div>
+    </div>
+  {/if}
+</dialog>
+
+<style>
+  .con-dialog[open] {
+    position: fixed;
+    inset: 0;
+    margin: auto;
+    border: none;
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text);
+    padding: 0;
+    width: min(420px, calc(100vw - 32px));
+    box-shadow: var(--shadow-4);
+  }
+  .con-dialog::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+  }
+  .con-dialog-body {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding: 24px;
+  }
+  .con-dialog-title {
+    margin: 0;
+    font-size: 1.125rem;
+    font-weight: 500;
+  }
+  .con-dialog-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    font-size: 0.9rem;
+    color: var(--color-text-muted);
+  }
+  .con-dialog-list li {
+    display: flex;
+    gap: 10px;
+    align-items: flex-start;
+  }
+  .con-mark {
+    flex-shrink: 0;
+    font-weight: 700;
+  }
+  .con-mark-no {
+    color: var(--color-error);
+  }
+  .con-mark-yes {
+    color: var(--color-success);
+  }
+  .con-dialog-actions {
+    justify-content: flex-end;
+    margin-top: 4px;
+  }
+</style>

--- a/frontend/connections/src/lib/components/InviteShare.svelte
+++ b/frontend/connections/src/lib/components/InviteShare.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  // Share section (parity Connections.razor:32-82): generate a code, show it with
+  // expiry + copy + cancel, or the "Create Invite Code" button when there's none.
+  import { connectionsStore as store } from '../connectionsStore.svelte';
+  import { formatExpiry } from '../dates';
+</script>
+
+<section class="con-card">
+  <h2 class="con-card-title">Share Your Recipes</h2>
+  <p class="con-card-sub">
+    Share this code with your family or friends — they'll enter it in their app to start sharing recipes together.
+  </p>
+
+  {#if store.generating}
+    <div class="con-share"><span class="con-spinner" aria-label="Creating invite"></span></div>
+  {:else if store.activeInvite}
+    <div class="con-share">
+      <div class="con-code">{store.activeInvite.code}</div>
+      <button type="button" class="con-btn-outline" onclick={() => store.copyCode()}>📋 Copy Code</button>
+      <div class="con-expiry">Expires {formatExpiry(store.activeInvite.expiresAt)}</div>
+      <button type="button" class="con-btn-danger" onclick={() => store.cancelActiveInvite()}>Cancel Invite</button>
+    </div>
+  {:else}
+    <button type="button" class="con-btn-primary" onclick={() => store.generate()}>Create Invite Code</button>
+  {/if}
+</section>

--- a/frontend/connections/src/lib/components/Toasts.svelte
+++ b/frontend/connections/src/lib/components/Toasts.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+  // The toast region. Mirrors the meal-plan island Toasts component, re-scoped
+  // to `con-`. Mounted once at the App root.
+  import { toasts, dismissToast } from '../toasts.svelte';
+</script>
+
+<div class="con-toast-region" role="status" aria-live="polite">
+  {#each toasts() as toast (toast.id)}
+    <div class="con-toast con-toast-{toast.kind}">
+      <span class="con-toast-msg">{toast.message}</span>
+      <button
+        type="button"
+        class="con-toast-close"
+        aria-label="Dismiss"
+        onclick={() => dismissToast(toast.id)}
+      >
+        ×
+      </button>
+    </div>
+  {/each}
+</div>
+
+<style>
+  .con-toast-region {
+    position: fixed;
+    left: 50%;
+    bottom: 24px;
+    transform: translateX(-50%);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    z-index: 1100;
+    pointer-events: none;
+    max-width: min(560px, calc(100vw - 32px));
+  }
+  /* Mobile: clear the MainLayout bottom nav so toasts aren't hidden behind it. */
+  @media (max-width: 960px) {
+    .con-toast-region {
+      bottom: calc(80px + env(safe-area-inset-bottom, 0px));
+    }
+  }
+  .con-toast {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 12px 10px 16px;
+    border-radius: var(--radius-sm);
+    color: #fff;
+    background: #323232;
+    box-shadow: var(--shadow-4);
+    font-size: 0.875rem;
+    pointer-events: auto;
+    animation: con-toast-in 0.2s ease-out;
+  }
+  .con-toast-success {
+    background: var(--color-success);
+  }
+  .con-toast-error {
+    background: var(--color-error);
+  }
+  .con-toast-msg {
+    flex: 1;
+    min-width: 0;
+  }
+  .con-toast-close {
+    background: transparent;
+    border: none;
+    color: rgba(255, 255, 255, 0.8);
+    font-size: 1.25rem;
+    line-height: 1;
+    padding: 0 4px;
+    cursor: pointer;
+  }
+  .con-toast-close:hover {
+    color: #fff;
+  }
+  @keyframes con-toast-in {
+    from {
+      opacity: 0;
+      transform: translateY(8px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+</style>

--- a/frontend/connections/src/lib/connectionsStore.svelte.ts
+++ b/frontend/connections/src/lib/connectionsStore.svelte.ts
@@ -1,0 +1,246 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Connections view store (#connections-root). Source of truth for the active
+// invite, the connected-households list, AND the invite-flow state machine
+// (generate → enter code → validate → pre-connection confirm → accept; plus the
+// disconnect-confirm flow). Faithful port of Connections.razor's @code block.
+//
+// ⚠ Svelte 5 rune rule (global CORRECTION): never `export` a reassigned `$state`.
+// We wrap the mutable state in a class instance and export the instance.
+//
+// Parity-first ⇒ versionless / last-write-wins. The page does NOT poll (no
+// liveness). Every mutation `await`s then refreshes; a `loadSeq` guard drops a
+// stale reload that resolves after a newer one (memory fca-island-async-race-guards).
+// There is no autosave/draft here (all actions are explicit buttons), so the
+// flush-before-delete guard from that memory does not apply.
+//
+// Error surfacing parity: validate failures + accept failures render INLINE as
+// codeError (a warning under the code input); generate/cancel/disconnect/copy
+// failures surface as toasts. The validate/accept endpoints return a 200 outcome
+// envelope, so a business "no" is `isValid:false` / `success:false`, not a throw.
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { InviteDto, ConnectedDto } from './types';
+import {
+  ApiError,
+  getConnections,
+  generateInvite,
+  cancelInvite,
+  validateCode,
+  acceptCode,
+  disconnect,
+} from './api';
+import { showToast } from './toasts.svelte';
+
+/**
+ * Faithful port of Connections.razor's MapValidationError (:403-415). The service
+ * returns prose error strings ("You cannot connect to your own household.") that
+ * don't match these code labels, so today this falls through to the default and
+ * passes the service message through — the port preserves that exact behavior.
+ */
+export function mapValidationError(error: string | null | undefined): string {
+  switch ((error ?? '').toLowerCase()) {
+    case 'self_connection':
+    case 'self-connection':
+    case 'self':
+      return 'This is your own invite code. Share it with another family to connect.';
+    case 'already_connected':
+    case 'already-connected':
+    case 'already connected':
+      return "You're already connected with this family!";
+    case 'expired':
+      return 'This code has expired. Ask them to create a new one.';
+    case 'invalid':
+    case 'not_found':
+    case 'not found':
+      return "We couldn't find that code. Check the code and try again.";
+    default:
+      return error || "We couldn't find that code. Check the code and try again.";
+  }
+}
+
+class ConnectionsStore {
+  // ── Loaded data ──
+  activeInvite = $state<InviteDto | null>(null);
+  connected = $state<ConnectedDto[]>([]);
+  loading = $state(true);
+  error = $state<string | null>(null);
+
+  // ── Share-section flow ──
+  generating = $state(false);
+
+  // ── Enter-a-code flow ──
+  enteredCode = $state('');
+  validating = $state(false);
+  codeError = $state<string | null>(null);
+  showConfirm = $state(false);
+  pendingHouseholdName = $state<string | null>(null);
+  accepting = $state(false);
+
+  // ── Disconnect flow ──
+  disconnectTarget = $state<ConnectedDto | null>(null);
+  disconnecting = $state(false);
+
+  /**
+   * True once the FIRST load resolved. Gates the skeleton so reloads don't reflash it, AND lets the App keep
+   * the sections mounted on a later reload error (a refresh failure must not swap the whole view back to the
+   * error state — the dashboard pattern).
+   */
+  loaded = $state(false);
+  /** Monotonic load id — a slower older response must not overwrite a newer one. */
+  private seq = 0;
+
+  /** Whether the Submit button is enabled (parity: exactly 6 chars + not mid-validate). */
+  get canSubmit(): boolean {
+    return this.enteredCode.length === 6 && !this.validating;
+  }
+
+  /** Load the active invite + connected list. Spinner only on the FIRST load; reloads refresh in place. */
+  async load(): Promise<void> {
+    const s = ++this.seq;
+    try {
+      if (!this.loaded) this.loading = true;
+      this.error = null;
+      const dto = await getConnections();
+      if (s !== this.seq) return; // a newer load superseded this one
+      this.activeInvite = dto.activeInvite;
+      this.connected = dto.connected;
+      this.loaded = true;
+    } catch (e) {
+      if (s !== this.seq) return;
+      this.error = describe(e, 'load connections');
+    } finally {
+      if (s === this.seq) this.loading = false;
+    }
+  }
+
+  // ── Share section ───────────────────────────────────────────────────────────
+
+  async generate(): Promise<void> {
+    this.generating = true;
+    try {
+      this.activeInvite = await generateInvite();
+    } catch (e) {
+      showToast({ message: describe(e, 'create invite'), kind: 'error' });
+    } finally {
+      this.generating = false;
+    }
+  }
+
+  async cancelActiveInvite(): Promise<void> {
+    try {
+      await cancelInvite();
+      this.activeInvite = null;
+    } catch (e) {
+      showToast({ message: describe(e, 'cancel invite'), kind: 'error' });
+    }
+  }
+
+  /** Copy the active code to the clipboard, with the parity "select manually" fallback. */
+  async copyCode(): Promise<void> {
+    const code = this.activeInvite?.code;
+    if (!code) return;
+    try {
+      await navigator.clipboard.writeText(code);
+      showToast({ message: 'Code copied to clipboard', kind: 'success' });
+    } catch {
+      showToast({ message: 'Unable to copy — please select the code manually', kind: 'error' });
+    }
+  }
+
+  // ── Enter-a-code section ──────────────────────────────────────────────────────
+
+  /** Port of OnCodeTextChanged (:361-370): uppercase, strip non-alphanumerics, cap at 6, clear the error. */
+  setCode(raw: string): void {
+    this.enteredCode = [...raw.toUpperCase()]
+      .filter((c) => /[A-Z0-9]/.test(c))
+      .slice(0, 6)
+      .join('');
+    this.codeError = null;
+  }
+
+  async validate(): Promise<void> {
+    if (this.enteredCode.length !== 6) return;
+    this.validating = true;
+    this.codeError = null;
+    try {
+      const res = await validateCode(this.enteredCode);
+      if (res.isValid) {
+        this.pendingHouseholdName = res.householdName;
+        this.showConfirm = true;
+      } else {
+        this.codeError = mapValidationError(res.error);
+      }
+    } catch (e) {
+      this.codeError = `Something went wrong. Please try again. (${describe(e, 'validate code')})`;
+    } finally {
+      this.validating = false;
+    }
+  }
+
+  cancelConfirm(): void {
+    this.showConfirm = false;
+    this.pendingHouseholdName = null;
+  }
+
+  async accept(): Promise<void> {
+    this.accepting = true;
+    try {
+      const res = await acceptCode(this.enteredCode);
+      if (res.success) {
+        showToast({
+          message: `You're now connected with ${res.connectedHouseholdName}! Browse their recipes from your Recipes page.`,
+          kind: 'success',
+        });
+        this.showConfirm = false;
+        this.pendingHouseholdName = null;
+        this.enteredCode = '';
+        await this.load(); // refresh the connected list
+      } else {
+        // Accept failure returns to the ENTRY view with the mapped error (review R-B3).
+        this.codeError = mapValidationError(res.error);
+        this.showConfirm = false;
+      }
+    } catch (e) {
+      showToast({ message: describe(e, 'connect'), kind: 'error' });
+      this.showConfirm = false;
+    } finally {
+      this.accepting = false;
+    }
+  }
+
+  // ── Disconnect section ────────────────────────────────────────────────────────
+
+  askDisconnect(household: ConnectedDto): void {
+    this.disconnectTarget = household;
+  }
+
+  cancelDisconnect(): void {
+    this.disconnectTarget = null;
+  }
+
+  async confirmDisconnect(): Promise<void> {
+    const target = this.disconnectTarget;
+    if (!target) return;
+    this.disconnecting = true;
+    try {
+      await disconnect(target.householdId);
+      showToast({ message: `Stopped sharing with ${target.householdName}`, kind: 'success' });
+      await this.load();
+    } catch (e) {
+      if (e instanceof ApiError) await this.load(); // reconcile to truth on a 4xx
+      showToast({ message: describe(e, 'disconnect'), kind: 'error' });
+    } finally {
+      this.disconnectTarget = null;
+      this.disconnecting = false;
+    }
+  }
+}
+
+function describe(e: unknown, action: string): string {
+  if (e instanceof ApiError) return e.message || `Couldn't ${action} (HTTP ${e.status}).`;
+  if (e instanceof Error) return e.message;
+  return `Couldn't ${action}.`;
+}
+
+/** The single shared connections-view store instance (export the instance, not the runes). */
+export const connectionsStore = new ConnectionsStore();

--- a/frontend/connections/src/lib/dates.ts
+++ b/frontend/connections/src/lib/dates.ts
@@ -1,0 +1,35 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Date helpers for the connections island. Both dates on the wire (invite
+// expiresAt, connected connectedAt) are FULL ISO-8601 instants (UTC) — review X5.
+// We parse the full instant (new Date(iso) handles the offset correctly) and
+// format in the user's local timezone. This is NOT the noon-UTC date-only case
+// (that trick is only for bare "YYYY-MM-DD"); never new Date('YYYY-MM-DD') here.
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Relative-until-or-absolute expiry text — a faithful port of Connections.razor's
+ * GetExpiryText (:350-357). Rendered as "Expires {this}" in the share card:
+ *   < 1 min   → "in less than a minute"
+ *   < 60 min  → "in N minutes"
+ *   < 24 hr   → "in N hours"
+ *   else      → "on Mon D, YYYY" (local)
+ * Integer truncation matches the C# (int) cast.
+ */
+export function formatExpiry(iso: string): string {
+  const expires = new Date(iso);
+  if (Number.isNaN(expires.getTime())) return '';
+  const remainingMs = expires.getTime() - Date.now();
+  const minutes = remainingMs / 60_000;
+  if (minutes < 1) return 'in less than a minute';
+  if (minutes < 60) return `in ${Math.floor(minutes)} minutes`;
+  const hours = remainingMs / 3_600_000;
+  if (hours < 24) return `in ${Math.floor(hours)} hours`;
+  return `on ${expires.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}`;
+}
+
+/** "Jun 20, 2026" connected-date — parity Connections.razor:173 ("MMM d, yyyy" local), or "" when invalid. */
+export function formatConnectedDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+}

--- a/frontend/connections/src/lib/toasts.svelte.ts
+++ b/frontend/connections/src/lib/toasts.svelte.ts
@@ -1,0 +1,47 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Transient toast notices for the connections island (mirrors the chores
+// island's toast store). Used for non-alarming 4xx/network surfacing and the
+// "someone changed this — refreshed" reconcile notice. Kept deliberately
+// small: a module-level `$state` list + helpers.
+//
+// ⚠ Svelte 5 rune rule: we never export a reassigned `$state` rune directly.
+// The list lives inside a module-private `$state` object; callers read it via
+// the `toasts()` accessor and mutate it only through the exported functions.
+// ─────────────────────────────────────────────────────────────────────────
+
+export type ToastKind = 'info' | 'success' | 'error';
+
+export interface Toast {
+  id: number;
+  message: string;
+  kind: ToastKind;
+  durationMs: number;
+}
+
+let nextId = 1;
+const store = $state<{ items: Toast[] }>({ items: [] });
+
+/** The live toast list (reactive — read inside markup). */
+export function toasts(): readonly Toast[] {
+  return store.items;
+}
+
+/** Push a toast. Auto-dismisses after `durationMs` (default 3.5s). */
+export function showToast(toast: { message: string; kind: ToastKind; durationMs?: number }): number {
+  const id = nextId++;
+  const full: Toast = {
+    id,
+    message: toast.message,
+    kind: toast.kind,
+    durationMs: toast.durationMs ?? 3500,
+  };
+  store.items = [...store.items, full];
+  if (full.durationMs > 0) {
+    setTimeout(() => dismissToast(id), full.durationMs);
+  }
+  return id;
+}
+
+export function dismissToast(id: number): void {
+  store.items = store.items.filter((t) => t.id !== id);
+}

--- a/frontend/connections/src/lib/types.ts
+++ b/frontend/connections/src/lib/types.ts
@@ -1,0 +1,54 @@
+// ─────────────────────────────────────────────────────────────────────────
+// TS mirror of the /api/settings/connections contract (M9 lockstep). Source of truth:
+//   - Services/Dtos/SettingsConnectionDtos.cs (the C# records — connection-scoped
+//     names there to avoid colliding with the recipes ConnectedHouseholdDto; here
+//     they are island-local)
+//   - tests/.../Fixtures/Settings/connections.json (byte-locked tripwire)
+//   - Endpoints/SettingsConnectionsEndpoints.cs (request DTOs)
+//
+// ⚠ CASING: all keys camelCase. No enums.
+// ⚠ DATES (review X5): `expiresAt` / `connectedAt` are FULL ISO-8601 instants (UTC) —
+//   render them local via new Date(iso) (NEVER new Date('YYYY-MM-DD')). See dates.ts.
+// ─────────────────────────────────────────────────────────────────────────
+
+/** The per-page context the Razor host hands the island via data- attributes. */
+export interface ShellContext {
+  householdId: number;
+  userId: number;
+  userName: string;
+}
+
+/** The household's single active invite. */
+export interface InviteDto {
+  code: string;
+  /** full ISO-8601 instant (UTC). */
+  expiresAt: string;
+}
+
+/** One connected household. */
+export interface ConnectedDto {
+  householdId: number;
+  householdName: string;
+  /** full ISO-8601 instant (UTC). */
+  connectedAt: string;
+}
+
+/** The Connections view aggregate (GET /). `activeInvite` is null when none. */
+export interface ConnectionsDto {
+  activeInvite: InviteDto | null;
+  connected: ConnectedDto[];
+}
+
+/** Validate outcome envelope (200, never a 4xx — review §8). */
+export interface ValidateResultDto {
+  isValid: boolean;
+  householdName: string | null;
+  error: string | null;
+}
+
+/** Accept outcome envelope (200). On failure the island returns to the entry view (review R-B3). */
+export interface AcceptResultDto {
+  success: boolean;
+  connectedHouseholdName: string | null;
+  error: string | null;
+}

--- a/frontend/connections/src/main.ts
+++ b/frontend/connections/src/main.ts
@@ -1,0 +1,204 @@
+import { mount as svelteMount, unmount } from 'svelte';
+import App from './App.svelte';
+import './styles/app.css';
+import type { ShellContext } from './lib/types';
+
+type MountedApp = ReturnType<typeof svelteMount>;
+
+interface Instance {
+  app: MountedApp;
+  /** The exact node we mounted into — lets us detect a Blazor resume that
+   *  replaced or emptied the root out from under us. */
+  el: HTMLElement;
+}
+
+// Blazor Server inserts component output via DOM diff, and inline <script>
+// tags in that output are NOT executed by the browser. The Razor shell
+// (Connections.razor) uses IJSRuntime.InvokeAsync("import", ...) to load this
+// module, then calls the global mounter below. Exposing a named entry on
+// window is the simplest way to survive enhanced-nav round-trips.
+declare global {
+  interface Window {
+    ConnectionsIsland?: {
+      mount(rootId: string): void;
+      destroy(rootId: string): void;
+    };
+  }
+}
+
+const ROOT_ID = 'connections-root';
+
+const instances = new Map<string, Instance>();
+
+// Roots the Razor shell has asked us to mount. We re-assert these when the page
+// is restored so a Blazor circuit resume / enhanced-nav merge that wiped our
+// content can't leave the island permanently blank (see reassertMounts below).
+const desiredRoots = new Set<string>();
+
+function readContext(el: HTMLElement): ShellContext {
+  const householdId = Number(el.dataset.householdId ?? '0');
+  const userId = Number(el.dataset.userId ?? '0');
+  const userName = el.dataset.userName ?? '';
+  if (!householdId || !userId) {
+    throw new Error('connections: missing data-household-id / data-user-id');
+  }
+  return { householdId, userId, userName };
+}
+
+// Track dark-mode state and mirror it as a class on the island root so the
+// CSS override wins even when MudBlazor's runtime toggle doesn't propagate
+// the class down to us (we've seen it stay on <html> at load but go missing
+// after runtime toggles, leaving the island stuck in light mode).
+const darkObservers = new Map<string, () => void>();
+
+function isDarkActive(): boolean {
+  if (document.documentElement.classList.contains('mud-theme-dark')) return true;
+  if (document.body?.classList.contains('mud-theme-dark')) return true;
+  try {
+    if (localStorage.getItem('darkMode') === 'true') return true;
+  } catch { /* storage blocked */ }
+  return false;
+}
+
+function syncDarkClass(el: HTMLElement) {
+  el.classList.toggle('con-dark-mode', isDarkActive());
+}
+
+function installDarkObserver(rootId: string, el: HTMLElement) {
+  syncDarkClass(el);
+  const htmlObs = new MutationObserver(() => syncDarkClass(el));
+  htmlObs.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
+  const bodyObs = new MutationObserver(() => syncDarkClass(el));
+  if (document.body) bodyObs.observe(document.body, { attributes: true, attributeFilter: ['class'] });
+  const storageHandler = (e: StorageEvent) => {
+    if (e.key === 'darkMode') syncDarkClass(el);
+  };
+  window.addEventListener('storage', storageHandler);
+  darkObservers.set(rootId, () => {
+    htmlObs.disconnect();
+    bodyObs.disconnect();
+    window.removeEventListener('storage', storageHandler);
+  });
+}
+
+/**
+ * A mount is healthy only if the CURRENT root element is the exact node we
+ * mounted into, it's still in the document, and it still holds our rendered
+ * children. Blazor's .NET 10 circuit resume (the path that fires on a mobile
+ * background→return) REPLACES the root node and re-runs the host component's
+ * lifecycle — a fresh firstRender re-calls mount(). The old mount-once guard
+ * (`instances.has`) refused to re-mount into that new node, leaving the board
+ * blank until a full reload. Comparing the live node to the one we mounted into
+ * lets the re-invoked mount() rebuild instead of no-op.
+ */
+function isHealthy(rootId: string): boolean {
+  const inst = instances.get(rootId);
+  if (!inst) return false;
+  const el = document.getElementById(rootId);
+  return el != null && el === inst.el && el.isConnected && el.childElementCount > 0;
+}
+
+function mountRoot(rootId: string) {
+  desiredRoots.add(rootId);
+  // Already mounted AND still intact — nothing to do.
+  if (isHealthy(rootId)) return;
+  // A stale prior mount (root emptied / replaced / detached): tear it down first
+  // so we don't leak the Svelte instance or its observers before remounting.
+  if (instances.has(rootId)) destroyRoot(rootId, /* internal */ true);
+  const el = document.getElementById(rootId) as HTMLElement | null;
+  if (!el) {
+    console.warn('[connections-island] root element not found:', rootId);
+    return;
+  }
+  installDarkObserver(rootId, el);
+  const app = svelteMount(App, { target: el, props: { ctx: readContext(el) } });
+  instances.set(rootId, { app, el });
+  ensureHealObserver();
+}
+
+function destroyRoot(rootId: string, internal = false) {
+  const inst = instances.get(rootId);
+  if (!inst) {
+    if (!internal) desiredRoots.delete(rootId);
+    return;
+  }
+  // Blazor's circuit resume disposes the OLD page component AFTER it has already
+  // re-initialised the new one — whose firstRender re-calls mount(), which we use
+  // to rebuild into the freshly-replaced root. That trailing destroy() targets a
+  // SUPERSEDED component and would otherwise tear our live island back down.
+  // Ignore an external destroy while the current mount is healthy; a genuine
+  // navigation-away leaves no healthy root (the page is gone), so real teardown
+  // still runs then. `internal` is our own self-heal replacing a stale mount — it
+  // must always proceed.
+  if (!internal && isHealthy(rootId)) return;
+  if (!internal) desiredRoots.delete(rootId);
+  unmount(inst.app);
+  instances.delete(rootId);
+  const disposer = darkObservers.get(rootId);
+  if (disposer) {
+    disposer();
+    darkObservers.delete(rootId);
+  }
+}
+
+window.ConnectionsIsland = { mount: mountRoot, destroy: destroyRoot };
+
+// ── Resilience: self-heal after a Blazor circuit resume ────────────────────
+// Mobile browsers background the tab on an app/tab switch; Blazor Server's .NET
+// 10 circuit pause/resume then reconciles the DOM on return and can REPLACE the
+// island root — sometimes re-invoking our mount() (handled in mountRoot), and
+// sometimes NOT (observed: nondeterministic). Either way the swap is a DOM
+// mutation, so we watch a STABLE anchor (document.body — Blazor replaces a chunk
+// of the island's ancestors, so observing the root or its parent misses it) and
+// rebuild any desired root that has gone unhealthy.
+//
+// The heal runs SYNCHRONOUSLY in the observer microtask — NOT via
+// requestAnimationFrame, which is paused while the tab is hidden (the wipe can
+// land a beat after the tab is technically still settling). `healing` guards
+// re-entrancy (mountRoot mutates the DOM, which re-queues this callback); once
+// the root is healthy again the next pass no-ops, so it can't loop. The cost on
+// every unrelated DOM change is one getElementById + isHealthy per desired root
+// (normally one), which is negligible.
+let healObserver: MutationObserver | null = null;
+let healing = false;
+function runHeal() {
+  if (healing) return;
+  healing = true;
+  try {
+    for (const rootId of desiredRoots) {
+      // Only rebuild when the root EXISTS but is stale/empty. A missing root is
+      // a navigation-away (or mid-reconcile) — not ours to remount; the next
+      // mutation re-checks once the fresh root lands.
+      if (document.getElementById(rootId) && !isHealthy(rootId)) mountRoot(rootId);
+    }
+  } finally {
+    healing = false;
+  }
+}
+function ensureHealObserver() {
+  if (healObserver || !document.body) return;
+  healObserver = new MutationObserver(runHeal);
+  healObserver.observe(document.body, { childList: true, subtree: true });
+}
+
+// bfcache restore re-attaches the frozen DOM without any mutation, so the body
+// observer won't fire — re-assert directly on pageshow as a cheap belt.
+window.addEventListener('pageshow', () => {
+  ensureHealObserver();
+  for (const rootId of desiredRoots) {
+    if (document.getElementById(rootId) && !isHealthy(rootId)) mountRoot(rootId);
+  }
+});
+
+// Standalone dev auto-mount: if the root is already on the page when the
+// module loads (Vite's index.html), mount immediately. In production the
+// Razor shell calls window.ConnectionsIsland.mount() explicitly via JS interop.
+function autoMountIfReady() {
+  const el = document.getElementById(ROOT_ID);
+  if (el) mountRoot(ROOT_ID);
+}
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', autoMountIfReady);
+} else {
+  autoMountIfReady();
+}

--- a/frontend/connections/src/styles/app.css
+++ b/frontend/connections/src/styles/app.css
@@ -1,0 +1,290 @@
+@import './tokens.css';
+
+/*
+ * The island renders inside the host page, which also loads Bootstrap + MudBlazor.
+ * Bootstrap defines .row / .container globally, and those names collide with
+ * ambient island styles. We avoid the collision by prefixing all island class
+ * names with `con-` (connections) rather than overriding globals here.
+ */
+
+#connections-root {
+  font-family: var(--font-family);
+  color: var(--color-text);
+  background: var(--color-background);
+  min-height: 100%;
+}
+
+#connections-root,
+#connections-root *,
+#connections-root *::before,
+#connections-root *::after {
+  box-sizing: border-box;
+}
+
+/*
+ * Suppress the outer Blazor ReconnectModal while the island is on the page.
+ * It's a showModal() <dialog>, which blocks all interaction behind it —
+ * including our HTTP-driven island that doesn't need the circuit to work.
+ * This CSS only ships on the connections page (via <HeadContent>), so other
+ * pages still get the normal reconnect UX.
+ */
+#components-reconnect-modal {
+  display: none !important;
+}
+
+/* ───────────────────────────────────────────────────────────────────────────
+ * Connections layout — ported from Connections.razor's MudContainer/MudPaper
+ * structure, re-scoped to `con-`. Kept in app.css (not a component <style>) so
+ * Svelte's unused-selector pruning can't drop a shared class.
+ * ─────────────────────────────────────────────────────────────────────────── */
+
+.con-page {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 24px 16px 96px;
+}
+.con-title {
+  margin: 0 0 24px;
+  font-size: 1.5rem;
+  font-weight: 500;
+}
+
+/* Section card (MudPaper Elevation=2 / pa-6 mb-6) */
+.con-card {
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-2);
+  padding: 24px;
+  margin-bottom: 24px;
+}
+.con-card:last-child {
+  margin-bottom: 0;
+}
+.con-card-title {
+  margin: 0 0 8px;
+  font-size: 1.25rem;
+  font-weight: 500;
+}
+.con-card-sub {
+  margin: 0 0 16px;
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
+}
+
+/* ── Share section ── */
+.con-share {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+.con-code {
+  font-family: 'Courier New', monospace;
+  font-size: 2.25rem;
+  font-weight: 700;
+  letter-spacing: 0.4em;
+  /* the trailing letter-spacing pushes the glyph block right; pad back so it reads centered */
+  padding-left: 0.4em;
+}
+.con-expiry {
+  color: var(--color-text-muted);
+  font-size: 0.8125rem;
+}
+
+/* ── Enter-a-code section ── */
+.con-entry-row {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.con-code-input {
+  font-family: 'Courier New', monospace;
+  font-size: 1.25rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  width: 220px;
+  max-width: 100%;
+  padding: 12px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-line-strong);
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+.con-code-input:focus {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -1px;
+}
+.con-code-input:disabled {
+  opacity: 0.6;
+}
+
+/* ── Connected-families list ── */
+.con-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.con-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding: 12px 4px;
+  border-bottom: 1px solid var(--color-divider);
+}
+.con-row:last-child {
+  border-bottom: none;
+}
+.con-row-name {
+  font-weight: 500;
+}
+.con-row-date {
+  margin-top: 2px;
+  color: var(--color-text-muted);
+  font-size: 0.8125rem;
+}
+
+/* ── Alerts (MudAlert Warning / Info) ── */
+.con-alert {
+  padding: 12px 16px;
+  border-radius: var(--radius-sm);
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+.con-alert-warning {
+  background: color-mix(in srgb, var(--color-warning) 14%, transparent);
+  border-left: 4px solid var(--color-warning);
+  color: var(--color-text);
+}
+.con-alert-info {
+  background: color-mix(in srgb, var(--color-info) 12%, transparent);
+  border-left: 4px solid var(--color-info);
+  color: var(--color-text);
+}
+.con-alert-error {
+  background: color-mix(in srgb, var(--color-error) 12%, transparent);
+  border-left: 4px solid var(--color-error);
+  color: var(--color-text);
+}
+
+/* ── Buttons ── */
+.con-btn-primary,
+.con-btn-outline,
+.con-btn-text,
+.con-btn-danger,
+.con-btn-danger-filled {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  font: inherit;
+  font-weight: 500;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  min-height: 40px;
+  padding: 8px 18px;
+  border: 1px solid transparent;
+}
+.con-btn-primary {
+  background: var(--color-primary);
+  color: #fff;
+}
+.con-btn-primary:hover {
+  background: var(--color-primary-hover);
+}
+.con-btn-outline {
+  background: transparent;
+  color: var(--color-primary);
+  border-color: var(--color-line-strong);
+}
+.con-btn-outline:hover {
+  background: var(--color-action-hover);
+}
+.con-btn-text {
+  background: transparent;
+  color: var(--color-primary);
+  min-height: 36px;
+  padding: 6px 12px;
+}
+.con-btn-text:hover {
+  background: var(--color-action-hover);
+}
+.con-btn-danger {
+  background: transparent;
+  color: var(--color-error);
+  min-height: 36px;
+  padding: 6px 12px;
+}
+.con-btn-danger:hover {
+  background: color-mix(in srgb, var(--color-error) 10%, transparent);
+}
+.con-btn-danger-filled {
+  background: var(--color-error);
+  color: #fff;
+}
+.con-btn-danger-filled:hover {
+  filter: brightness(0.95);
+}
+.con-btn-primary:disabled,
+.con-btn-outline:disabled,
+.con-btn-text:disabled,
+.con-btn-danger:disabled,
+.con-btn-danger-filled:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.con-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+/* ── Spinner (MudProgressCircular Indeterminate) ── */
+.con-spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: con-spin 0.7s linear infinite;
+}
+@keyframes con-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* ── States ── */
+.con-empty {
+  color: var(--color-text-muted);
+}
+.con-loading {
+  padding: 48px 0;
+  text-align: center;
+  color: var(--color-text-muted);
+}
+.con-inline-error {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+  padding: 10px 14px;
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--color-error) 12%, transparent);
+  color: var(--color-error);
+}
+.con-retry {
+  margin-left: auto;
+  padding: 4px 12px;
+  border: 1px solid currentColor;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}

--- a/frontend/connections/src/styles/tokens.css
+++ b/frontend/connections/src/styles/tokens.css
@@ -1,0 +1,95 @@
+/*
+ * Design tokens mirrored from the MudBlazor theme used elsewhere in the app
+ * (kept in sync with frontend/dashboard/src/styles/tokens.css).
+ * Light mode = :root. Dark mode = html.mud-theme-dark (set by App.razor)
+ * plus #connections-root.con-dark-mode (mirrored by main.ts's dark observer).
+ */
+
+:root {
+  /* brand */
+  --color-primary: rgb(46, 125, 50);
+  --color-primary-hover: rgb(36, 97, 39);
+  --color-primary-soft: rgb(58, 156, 63);
+  --color-secondary: rgb(255, 111, 0);
+
+  /* surfaces */
+  --color-surface: rgb(255, 255, 255);
+  --color-background: rgb(250, 250, 250);
+  --color-appbar: rgb(46, 125, 50);
+  --color-drawer: rgb(245, 245, 245);
+
+  /* text */
+  --color-text: rgb(66, 66, 66);
+  --color-text-muted: rgba(0, 0, 0, 0.54);
+  --color-text-disabled: rgba(0, 0, 0, 0.38);
+
+  /* structure */
+  --color-line: rgba(0, 0, 0, 0.12);
+  --color-line-strong: rgb(189, 189, 189);
+  --color-divider: rgb(224, 224, 224);
+  --color-action-hover: rgba(0, 0, 0, 0.06);
+  --color-action-disabled: rgba(0, 0, 0, 0.26);
+
+  /* semantic */
+  --color-success: rgb(67, 160, 71);
+  --color-error: rgb(229, 57, 53);
+  --color-warning: rgb(251, 140, 0);
+  --color-info: rgb(30, 136, 229);
+
+  /* typography */
+  --font-family: Roboto, Helvetica, Arial, sans-serif;
+
+  /* shape */
+  --radius-sm: 4px;
+  --radius-md: 4px;
+
+  /* elevation (MudBlazor 1, 2, 4) */
+  --shadow-1:
+    0 2px 1px -1px rgba(0, 0, 0, 0.2),
+    0 1px 1px 0 rgba(0, 0, 0, 0.14),
+    0 1px 3px 0 rgba(0, 0, 0, 0.12);
+  --shadow-2:
+    0 3px 1px -2px rgba(0, 0, 0, 0.2),
+    0 2px 2px 0 rgba(0, 0, 0, 0.14),
+    0 1px 5px 0 rgba(0, 0, 0, 0.12);
+  --shadow-4:
+    0 2px 4px -1px rgba(0, 0, 0, 0.2),
+    0 4px 5px 0 rgba(0, 0, 0, 0.14),
+    0 1px 10px 0 rgba(0, 0, 0, 0.12);
+}
+
+/*
+ * Dark-mode override. MudBlazor v8 + the App.razor bootstrap script both
+ * toggle `mud-theme-dark` on <html>, but runtime theme toggles sometimes
+ * land on <body> or deeper. Matching the bare class is a superset that
+ * works regardless of where the ancestor lives.
+ */
+.mud-theme-dark,
+html.mud-theme-dark,
+body.mud-theme-dark,
+#connections-root.con-dark-mode {
+  --color-primary: rgb(102, 187, 106);
+  --color-primary-hover: rgb(77, 172, 82);
+  --color-primary-soft: rgb(128, 198, 132);
+  --color-secondary: rgb(255, 183, 77);
+
+  --color-surface: rgb(30, 30, 30);
+  --color-background: rgb(18, 18, 18);
+  --color-appbar: rgb(26, 26, 26);
+  --color-drawer: rgb(26, 26, 26);
+
+  --color-text: rgba(255, 255, 255, 0.87);
+  --color-text-muted: rgba(255, 255, 255, 0.6);
+  --color-text-disabled: rgba(255, 255, 255, 0.2);
+
+  --color-line: rgba(255, 255, 255, 0.12);
+  --color-line-strong: rgba(255, 255, 255, 0.3);
+  --color-divider: rgba(255, 255, 255, 0.12);
+  --color-action-hover: rgba(173, 173, 177, 0.06);
+  --color-action-disabled: rgba(255, 255, 255, 0.26);
+
+  --color-success: rgb(102, 187, 106);
+  --color-error: rgb(239, 83, 80);
+  --color-warning: rgb(255, 167, 38);
+  --color-info: rgb(66, 165, 245);
+}

--- a/frontend/connections/src/vite-env.d.ts
+++ b/frontend/connections/src/vite-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="svelte" />
+/// <reference types="vite/client" />

--- a/frontend/connections/svelte.config.js
+++ b/frontend/connections/svelte.config.js
@@ -1,0 +1,8 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+export default {
+  preprocess: vitePreprocess(),
+  compilerOptions: {
+    runes: true,
+  },
+};

--- a/frontend/connections/tsconfig.json
+++ b/frontend/connections/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "@tsconfig/svelte/tsconfig.json",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowJs": false,
+    "checkJs": false,
+    "isolatedModules": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitAny": true,
+    "skipLibCheck": true,
+    "types": ["svelte", "vite/client"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.svelte", "src/vite-env.d.ts"]
+}

--- a/frontend/connections/vite.config.ts
+++ b/frontend/connections/vite.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+
+// The connections island (settings cluster B) is embedded into a Razor shell at
+// /settings/connections. Build output goes to ./dist/ — the CopyConnectionsIsland
+// MSBuild target in FamilyCoordinationApp.csproj copies this into
+// wwwroot/islands/connections/. The connections-node-build Docker stage emits dist/,
+// the .NET stage reads it via COPY --from. Mirrors frontend/dashboard/vite.config.ts.
+export default defineConfig({
+  plugins: [svelte()],
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    rollupOptions: {
+      input: 'src/main.ts',
+      output: {
+        entryFileNames: 'index.js',
+        chunkFileNames: 'chunks/[name]-[hash].js',
+        assetFileNames: (info) =>
+          info.name?.endsWith('.css') ? 'index.css' : 'assets/[name]-[hash][extname]',
+      },
+    },
+    sourcemap: true,
+  },
+  server: {
+    port: 5179,
+    // Dev server proxies /api to the running .NET app so `npm run dev` works
+    // standalone against a locally-running Blazor host on :5000.
+    proxy: {
+      '/api': {
+        target: 'http://localhost:5000',
+        changeOrigin: false,
+      },
+    },
+  },
+});

--- a/src/FamilyCoordinationApp/Components/Pages/Settings/Connections.razor
+++ b/src/FamilyCoordinationApp/Components/Pages/Settings/Connections.razor
@@ -1,497 +1,128 @@
 @page "/settings/connections"
-@rendermode InteractiveServer
 @attribute [Authorize]
-@using System.Security.Claims
 @using FamilyCoordinationApp.Data
-@using FamilyCoordinationApp.Data.Entities
-@using FamilyCoordinationApp.Services.Interfaces
+@using Microsoft.AspNetCore.Components.Web
 @using Microsoft.EntityFrameworkCore
+@using Microsoft.JSInterop
+@using System.Security.Claims
+@implements IAsyncDisposable
 
-@inject IHouseholdConnectionService ConnectionService
+@inject IConfiguration Config
+@inject AuthenticationStateProvider AuthStateProvider
 @inject IDbContextFactory<ApplicationDbContext> DbFactory
-@inject ISnackbar Snackbar
-@inject IJSRuntime JSRuntime
+@inject IJSRuntime JS
+@inject IWebHostEnvironment HostEnv
 
-<PageTitle>Connections - Family Kitchen</PageTitle>
+@*
+    Thin island host (strangler, settings cluster B). Flag ON (SETTINGS_CONNECTIONS_USE_ISLAND=true) → mount the
+    Svelte connections island; flag OFF → the existing Blazor page (<ConnectionsBlazor/>) as the zero-regression
+    fallback. Mirrors Categories.razor (single-route, single root). The global <Routes @@rendermode="InteractiveServer">
+    supplies interactivity (the old explicit @@rendermode on this page was redundant).
+*@
 
-<MudContainer MaxWidth="MaxWidth.Medium" Class="py-4">
-    <MudText Typo="Typo.h4" Class="mb-6">Family Connections</MudText>
-
-    @if (_loading)
+@* When the flag is ON we never render the Blazor fallback — not even during the brief async gap before _shell
+   resolves — to avoid momentarily mounting (then disposing) the Blazor page under the island flag (memory
+   fca-island-host-prerender-fallback-race). The island-div condition is unchanged, so mounting is unaffected. *@
+@if (_useIsland)
+{
+    @if (_shell is not null)
     {
-        <MudProgressLinear Indeterminate="true" Class="mb-4" />
+        <PageTitle>Connections - Family Kitchen</PageTitle>
+
+        <HeadContent>
+            <link rel="stylesheet" href="/islands/connections/index.css?v=@IslandVersion" />
+        </HeadContent>
+
+        <div id="connections-root"
+             data-household-id="@_shell.HouseholdId"
+             data-user-id="@_shell.UserId"
+             data-user-name="@_shell.UserName"></div>
     }
-    else if (HouseholdId == 0)
-    {
-        <MudAlert Severity="Severity.Error">
-            Unable to load household information. Please try refreshing the page.
-        </MudAlert>
-    }
-    else
-    {
-        @* Section 1: Invite a Family *@
-        <MudPaper Class="pa-6 mb-6" Elevation="2">
-            <MudText Typo="Typo.h5" Class="mb-2">Share Your Recipes</MudText>
-            <MudText Typo="Typo.body1" Color="Color.Secondary" Class="mb-4">
-                Share this code with your family or friends — they'll enter it in their app to start sharing recipes together.
-            </MudText>
-
-            @if (_generatingInvite)
-            {
-                <div class="d-flex justify-center py-4">
-                    <MudProgressCircular Indeterminate="true" Size="Size.Medium" />
-                </div>
-            }
-            else if (_activeInvite != null)
-            {
-                <div class="d-flex flex-column align-center gap-3">
-                    <MudText Typo="Typo.h3" Style="font-family: 'Courier New', monospace; letter-spacing: 0.4em; font-weight: 700;">
-                        @_activeInvite.InviteCode
-                    </MudText>
-
-                    <MudButton StartIcon="@Icons.Material.Filled.ContentCopy"
-                               Color="Color.Primary"
-                               Variant="Variant.Outlined"
-                               Size="Size.Small"
-                               OnClick="CopyInviteCode">
-                        Copy Code
-                    </MudButton>
-
-                    <MudText Typo="Typo.caption" Color="Color.Secondary">
-                        Expires @GetExpiryText(_activeInvite.ExpiresAt)
-                    </MudText>
-
-                    <MudButton StartIcon="@Icons.Material.Filled.Cancel"
-                               Color="Color.Error"
-                               Variant="Variant.Text"
-                               Size="Size.Small"
-                               OnClick="CancelInvite">
-                        Cancel Invite
-                    </MudButton>
-                </div>
-            }
-            else
-            {
-                <MudButton StartIcon="@Icons.Material.Filled.Share"
-                           Color="Color.Primary"
-                           Variant="Variant.Filled"
-                           OnClick="GenerateInvite">
-                    Create Invite Code
-                </MudButton>
-            }
-        </MudPaper>
-
-        @* Section 2: Enter a Code *@
-        <MudPaper Class="pa-6 mb-6" Elevation="2">
-            <MudText Typo="Typo.h5" Class="mb-2">Enter a Code</MudText>
-            <MudText Typo="Typo.body1" Color="Color.Secondary" Class="mb-4">
-                Got a code from someone? Enter it below.
-            </MudText>
-
-            @if (!_showConfirmation)
-            {
-                <div class="d-flex gap-3 align-center flex-wrap">
-                    <MudTextField @bind-Value="_enteredCode"
-                                  Label="Invite Code"
-                                  Variant="Variant.Outlined"
-                                  MaxLength="6"
-                                  Style="max-width: 220px; font-family: 'Courier New', monospace; font-size: 1.25rem; letter-spacing: 0.2em;"
-                                  Immediate="true"
-                                  TextChanged="OnCodeTextChanged"
-                                  Disabled="_validatingCode" />
-
-                    <MudButton Color="Color.Primary"
-                               Variant="Variant.Filled"
-                               OnClick="ValidateCode"
-                               Disabled="@(_enteredCode?.Length != 6 || _validatingCode)">
-                        @if (_validatingCode)
-                        {
-                            <MudProgressCircular Indeterminate="true" Size="Size.Small" Class="mr-2" />
-                        }
-                        Submit
-                    </MudButton>
-                </div>
-
-                @if (!string.IsNullOrEmpty(_codeError))
-                {
-                    <MudAlert Severity="Severity.Warning" Class="mt-3" Dense="true">
-                        @_codeError
-                    </MudAlert>
-                }
-            }
-            else
-            {
-                @* Pre-connection confirmation *@
-                <MudAlert Severity="Severity.Info" Class="mb-4">
-                    <MudText Typo="Typo.body1" Class="mb-2">
-                        Connecting with <strong>@_pendingHouseholdName</strong> lets both families browse each other's recipes.
-                        They can see your recipes but can't change them. You can disconnect anytime.
-                    </MudText>
-                </MudAlert>
-
-                <div class="d-flex gap-2">
-                    <MudButton Color="Color.Default"
-                               Variant="Variant.Outlined"
-                               OnClick="CancelConnect"
-                               Disabled="_acceptingInvite">
-                        Cancel
-                    </MudButton>
-                    <MudButton Color="Color.Primary"
-                               Variant="Variant.Filled"
-                               OnClick="AcceptConnection"
-                               Disabled="_acceptingInvite">
-                        @if (_acceptingInvite)
-                        {
-                            <MudProgressCircular Indeterminate="true" Size="Size.Small" Class="mr-2" />
-                        }
-                        Connect
-                    </MudButton>
-                </div>
-            }
-        </MudPaper>
-
-        @* Section 3: Connected Families *@
-        <MudPaper Class="pa-6" Elevation="2">
-            <MudText Typo="Typo.h5" Class="mb-4">Your Connected Families</MudText>
-
-            @if (_connectedHouseholds.Count == 0)
-            {
-                <MudText Typo="Typo.body1" Color="Color.Secondary">
-                    You haven't connected with any families yet. Create an invite code or enter one to get started.
-                </MudText>
-            }
-            else
-            {
-                <MudList T="ConnectedHouseholdInfo" Dense="false">
-                    @foreach (var household in _connectedHouseholds)
-                    {
-                        <MudListItem T="ConnectedHouseholdInfo">
-                            <div class="d-flex justify-space-between align-center flex-wrap gap-2" style="width: 100%;">
-                                <div>
-                                    <MudText Typo="Typo.body1"><strong>@household.HouseholdName</strong></MudText>
-                                    <MudText Typo="Typo.caption" Color="Color.Secondary">
-                                        Connected @household.ConnectedAt.ToLocalTime().ToString("MMM d, yyyy")
-                                    </MudText>
-                                </div>
-                                <MudButton StartIcon="@Icons.Material.Filled.LinkOff"
-                                           Color="Color.Error"
-                                           Variant="Variant.Text"
-                                           Size="Size.Small"
-                                           OnClick="@(() => ConfirmDisconnect(household))">
-                                    Stop Sharing
-                                </MudButton>
-                            </div>
-                        </MudListItem>
-                    }
-                </MudList>
-            }
-        </MudPaper>
-    }
-</MudContainer>
-
-@* Disconnect confirmation dialog *@
-<MudDialog @bind-Visible="_showDisconnectDialog" Options="_dialogOptions">
-    <TitleContent>
-        <MudText Typo="Typo.h6">Stop sharing with @_householdToDisconnect?.HouseholdName?</MudText>
-    </TitleContent>
-    <DialogContent>
-        <MudList T="string" Dense="true">
-            <MudListItem T="string" Icon="@Icons.Material.Filled.VisibilityOff" IconSize="Size.Small">
-                You'll no longer be able to browse their recipes
-            </MudListItem>
-            <MudListItem T="string" Icon="@Icons.Material.Filled.VisibilityOff" IconSize="Size.Small">
-                They'll no longer be able to browse yours
-            </MudListItem>
-            <MudListItem T="string" Icon="@Icons.Material.Filled.CheckCircle" IconSize="Size.Small" IconColor="Color.Success">
-                Recipes you've already copied will stay in your collection
-            </MudListItem>
-        </MudList>
-    </DialogContent>
-    <DialogActions>
-        <MudButton OnClick="CancelDisconnect" Color="Color.Default" Disabled="_disconnecting">Cancel</MudButton>
-        <MudButton OnClick="ConfirmDisconnectAction" Color="Color.Error" Variant="Variant.Filled" Disabled="_disconnecting">
-            @if (_disconnecting)
-            {
-                <MudProgressCircular Indeterminate="true" Size="Size.Small" Class="mr-2" />
-            }
-            Stop Sharing
-        </MudButton>
-    </DialogActions>
-</MudDialog>
+}
+else
+{
+    <ConnectionsBlazor />
+}
 
 @code {
-    [CascadingParameter] private Task<AuthenticationState>? AuthState { get; set; }
+    private bool _useIsland;
+    private ShellData? _shell;
+    private IJSObjectReference? _islandModule;
 
-    private int HouseholdId;
-    private int UserId;
-    private bool _loading = true;
-
-    // Invite generation
-    private HouseholdInvite? _activeInvite;
-    private bool _generatingInvite;
-
-    // Code entry
-    private string _enteredCode = string.Empty;
-    private string? _codeError;
-    private bool _validatingCode;
-    private bool _showConfirmation;
-    private string? _pendingHouseholdName;
-    private bool _acceptingInvite;
-
-    // Connected households
-    private List<ConnectedHouseholdInfo> _connectedHouseholds = new();
-
-    // Disconnect
-    private bool _showDisconnectDialog;
-    private ConnectedHouseholdInfo? _householdToDisconnect;
-    private bool _disconnecting;
-
-    private DialogOptions _dialogOptions = new()
-    {
-        CloseOnEscapeKey = true,
-        MaxWidth = MaxWidth.Small
-    };
+    private const string RootId = "connections-root";
 
     protected override async Task OnInitializedAsync()
     {
-        await LoadUserContext();
-        if (HouseholdId > 0)
-        {
-            await LoadData();
-        }
-        _loading = false;
-    }
+        _useIsland = IsIslandEnabled();
+        if (!_useIsland) return;
 
-    private async Task LoadUserContext()
-    {
-        if (AuthState == null) return;
-
-        var authState = await AuthState;
-        var email = authState.User.FindFirstValue(ClaimTypes.Email);
-
-        if (string.IsNullOrEmpty(email)) return;
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        var email = authState.User.FindFirst(ClaimTypes.Email)?.Value;
+        var userName = authState.User.FindFirst(ClaimTypes.Name)?.Value ?? string.Empty;
 
         await using var context = await DbFactory.CreateDbContextAsync();
-        var user = await context.Users
-            .FirstOrDefaultAsync(u => u.Email == email);
-
-        if (user != null)
+        var user = await context.Users.FirstOrDefaultAsync(u => u.Email == email);
+        if (user is null)
         {
-            HouseholdId = user.HouseholdId;
-            UserId = user.Id;
+            throw new InvalidOperationException("User not found. Please log in again.");
         }
+
+        _shell = new ShellData(user.HouseholdId, user.Id, userName);
     }
 
-    private async Task LoadData()
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender || !_useIsland || _shell is null) return;
+
+        await JS.InvokeVoidAsync("ensureIslandStylesheet", $"/islands/connections/index.css?v={IslandVersion}");
+
+        _islandModule = await JS.InvokeAsync<IJSObjectReference>(
+            "import", $"/islands/connections/index.js?v={IslandVersion}");
+        await JS.InvokeVoidAsync("ConnectionsIsland.mount", RootId);
+    }
+
+    // Cache-bust the island URLs per deploy via the published bundle's mtime (mirrors Categories.razor).
+    private static string? _islandVersion;
+    private string IslandVersion => _islandVersion ??= ComputeIslandVersion();
+
+    private string ComputeIslandVersion()
     {
         try
         {
-            var inviteTask = ConnectionService.GetActiveInviteAsync(HouseholdId);
-            var connectionsTask = ConnectionService.GetConnectedHouseholdsAsync(HouseholdId);
-
-            await Task.WhenAll(inviteTask, connectionsTask);
-
-            _activeInvite = await inviteTask;
-            _connectedHouseholds = await connectionsTask;
-        }
-        catch (Exception ex)
-        {
-            Snackbar.Add($"Error loading connection data: {ex.Message}", Severity.Error);
-        }
-    }
-
-    // --- Invite Generation ---
-
-    private async Task GenerateInvite()
-    {
-        _generatingInvite = true;
-        try
-        {
-            _activeInvite = await ConnectionService.GenerateInviteAsync(HouseholdId, UserId);
-        }
-        catch (Exception ex)
-        {
-            Snackbar.Add($"Error creating invite: {ex.Message}", Severity.Error);
-        }
-        finally
-        {
-            _generatingInvite = false;
-        }
-    }
-
-    private async Task CancelInvite()
-    {
-        try
-        {
-            await ConnectionService.InvalidateInviteAsync(HouseholdId);
-            _activeInvite = null;
-        }
-        catch (Exception ex)
-        {
-            Snackbar.Add($"Error cancelling invite: {ex.Message}", Severity.Error);
-        }
-    }
-
-    private async Task CopyInviteCode()
-    {
-        if (_activeInvite == null) return;
-
-        try
-        {
-            await JSRuntime.InvokeVoidAsync("navigator.clipboard.writeText", _activeInvite.InviteCode);
-            Snackbar.Add("Code copied to clipboard", Severity.Success);
+            var path = Path.Combine(HostEnv.WebRootPath, "islands", "connections", "index.js");
+            return new DateTimeOffset(File.GetLastWriteTimeUtc(path)).ToUnixTimeSeconds().ToString();
         }
         catch
         {
-            Snackbar.Add("Unable to copy — please select the code manually", Severity.Warning);
+            return "0";
         }
     }
 
-    private static string GetExpiryText(DateTime expiresAt)
+    private bool IsIslandEnabled()
     {
-        var remaining = expiresAt - DateTime.UtcNow;
-        if (remaining.TotalMinutes < 1) return "in less than a minute";
-        if (remaining.TotalMinutes < 60) return $"in {(int)remaining.TotalMinutes} minutes";
-        if (remaining.TotalHours < 24) return $"in {(int)remaining.TotalHours} hours";
-        return $"on {expiresAt.ToLocalTime():MMM d, yyyy}";
+        var configValue = Config["SETTINGS_CONNECTIONS_USE_ISLAND"];
+        if (!string.IsNullOrEmpty(configValue))
+        {
+            return configValue.Equals("true", StringComparison.OrdinalIgnoreCase);
+        }
+
+        var envValue = Environment.GetEnvironmentVariable("SETTINGS_CONNECTIONS_USE_ISLAND");
+        return string.Equals(envValue, "true", StringComparison.OrdinalIgnoreCase);
     }
 
-    // --- Code Entry ---
-
-    private void OnCodeTextChanged(string value)
+    public async ValueTask DisposeAsync()
     {
-        // Auto-uppercase and strip whitespace/dashes
-        _enteredCode = new string(value
-            .ToUpperInvariant()
-            .Where(c => char.IsLetterOrDigit(c))
-            .Take(6)
-            .ToArray());
-        _codeError = null;
-    }
-
-    private async Task ValidateCode()
-    {
-        if (string.IsNullOrWhiteSpace(_enteredCode) || _enteredCode.Length != 6) return;
-
-        _validatingCode = true;
-        _codeError = null;
-
+        if (_islandModule is null) return;
         try
         {
-            var (isValid, householdName, error) = await ConnectionService.ValidateInviteCodeAsync(_enteredCode, HouseholdId);
-
-            if (isValid)
-            {
-                _pendingHouseholdName = householdName;
-                _showConfirmation = true;
-            }
-            else
-            {
-                _codeError = MapValidationError(error);
-            }
+            await JS.InvokeVoidAsync("ConnectionsIsland.destroy", RootId);
+            await _islandModule.DisposeAsync();
         }
-        catch (Exception ex)
+        catch (JSDisconnectedException)
         {
-            _codeError = $"Something went wrong. Please try again. ({ex.Message})";
-        }
-        finally
-        {
-            _validatingCode = false;
+            // Circuit already gone (user navigated away after disconnect) — nothing to clean up.
         }
     }
 
-    private static string MapValidationError(string? error) => error?.ToLowerInvariant() switch
-    {
-        "self_connection" or "self-connection" or "self" =>
-            "This is your own invite code. Share it with another family to connect.",
-        "already_connected" or "already-connected" or "already connected" =>
-            "You're already connected with this family!",
-        "expired" =>
-            "This code has expired. Ask them to create a new one.",
-        "invalid" or "not_found" or "not found" =>
-            "We couldn't find that code. Check the code and try again.",
-        _ =>
-            error ?? "We couldn't find that code. Check the code and try again."
-    };
-
-    private void CancelConnect()
-    {
-        _showConfirmation = false;
-        _pendingHouseholdName = null;
-    }
-
-    private async Task AcceptConnection()
-    {
-        _acceptingInvite = true;
-
-        try
-        {
-            var (success, connectedName, error) = await ConnectionService.AcceptInviteAsync(
-                _enteredCode, HouseholdId, UserId);
-
-            if (success)
-            {
-                Snackbar.Add($"You're now connected with {connectedName}! Browse their recipes from your Recipes page.", Severity.Success);
-                _showConfirmation = false;
-                _pendingHouseholdName = null;
-                _enteredCode = string.Empty;
-
-                // Refresh connected households
-                _connectedHouseholds = await ConnectionService.GetConnectedHouseholdsAsync(HouseholdId);
-            }
-            else
-            {
-                _codeError = MapValidationError(error);
-                _showConfirmation = false;
-            }
-        }
-        catch (Exception ex)
-        {
-            Snackbar.Add($"Error connecting: {ex.Message}", Severity.Error);
-            _showConfirmation = false;
-        }
-        finally
-        {
-            _acceptingInvite = false;
-        }
-    }
-
-    // --- Disconnect ---
-
-    private void ConfirmDisconnect(ConnectedHouseholdInfo household)
-    {
-        _householdToDisconnect = household;
-        _showDisconnectDialog = true;
-    }
-
-    private void CancelDisconnect()
-    {
-        _showDisconnectDialog = false;
-        _householdToDisconnect = null;
-    }
-
-    private async Task ConfirmDisconnectAction()
-    {
-        if (_householdToDisconnect == null) return;
-
-        _disconnecting = true;
-
-        try
-        {
-            await ConnectionService.DisconnectHouseholdsAsync(HouseholdId, _householdToDisconnect.HouseholdId);
-            Snackbar.Add($"Stopped sharing with {_householdToDisconnect.HouseholdName}", Severity.Success);
-
-            _connectedHouseholds = await ConnectionService.GetConnectedHouseholdsAsync(HouseholdId);
-        }
-        catch (Exception ex)
-        {
-            Snackbar.Add($"Error disconnecting: {ex.Message}", Severity.Error);
-        }
-        finally
-        {
-            _showDisconnectDialog = false;
-            _householdToDisconnect = null;
-            _disconnecting = false;
-        }
-    }
+    private sealed record ShellData(int HouseholdId, int UserId, string UserName);
 }

--- a/src/FamilyCoordinationApp/Components/Pages/Settings/ConnectionsBlazor.razor
+++ b/src/FamilyCoordinationApp/Components/Pages/Settings/ConnectionsBlazor.razor
@@ -1,0 +1,502 @@
+@using System.Security.Claims
+@using FamilyCoordinationApp.Data
+@using FamilyCoordinationApp.Data.Entities
+@using FamilyCoordinationApp.Services.Interfaces
+@using Microsoft.EntityFrameworkCore
+
+@inject IHouseholdConnectionService ConnectionService
+@inject IDbContextFactory<ApplicationDbContext> DbFactory
+@inject ISnackbar Snackbar
+@inject IJSRuntime JSRuntime
+
+@*
+    The original Blazor Connections body, extracted verbatim from Connections.razor as the zero-regression
+    fallback for the strangler (flag SETTINGS_CONNECTIONS_USE_ISLAND=false → this renders). NOT routable — the
+    @@page "/settings/connections" + [Authorize] live on the host Connections.razor (the global
+    <Routes @@rendermode="InteractiveServer"> covers interactivity, so the explicit @@rendermode is dropped).
+    Delete once the island is prod-stable.
+*@
+
+<PageTitle>Connections - Family Kitchen</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Medium" Class="py-4">
+    <MudText Typo="Typo.h4" Class="mb-6">Family Connections</MudText>
+
+    @if (_loading)
+    {
+        <MudProgressLinear Indeterminate="true" Class="mb-4" />
+    }
+    else if (HouseholdId == 0)
+    {
+        <MudAlert Severity="Severity.Error">
+            Unable to load household information. Please try refreshing the page.
+        </MudAlert>
+    }
+    else
+    {
+        @* Section 1: Invite a Family *@
+        <MudPaper Class="pa-6 mb-6" Elevation="2">
+            <MudText Typo="Typo.h5" Class="mb-2">Share Your Recipes</MudText>
+            <MudText Typo="Typo.body1" Color="Color.Secondary" Class="mb-4">
+                Share this code with your family or friends — they'll enter it in their app to start sharing recipes together.
+            </MudText>
+
+            @if (_generatingInvite)
+            {
+                <div class="d-flex justify-center py-4">
+                    <MudProgressCircular Indeterminate="true" Size="Size.Medium" />
+                </div>
+            }
+            else if (_activeInvite != null)
+            {
+                <div class="d-flex flex-column align-center gap-3">
+                    <MudText Typo="Typo.h3" Style="font-family: 'Courier New', monospace; letter-spacing: 0.4em; font-weight: 700;">
+                        @_activeInvite.InviteCode
+                    </MudText>
+
+                    <MudButton StartIcon="@Icons.Material.Filled.ContentCopy"
+                               Color="Color.Primary"
+                               Variant="Variant.Outlined"
+                               Size="Size.Small"
+                               OnClick="CopyInviteCode">
+                        Copy Code
+                    </MudButton>
+
+                    <MudText Typo="Typo.caption" Color="Color.Secondary">
+                        Expires @GetExpiryText(_activeInvite.ExpiresAt)
+                    </MudText>
+
+                    <MudButton StartIcon="@Icons.Material.Filled.Cancel"
+                               Color="Color.Error"
+                               Variant="Variant.Text"
+                               Size="Size.Small"
+                               OnClick="CancelInvite">
+                        Cancel Invite
+                    </MudButton>
+                </div>
+            }
+            else
+            {
+                <MudButton StartIcon="@Icons.Material.Filled.Share"
+                           Color="Color.Primary"
+                           Variant="Variant.Filled"
+                           OnClick="GenerateInvite">
+                    Create Invite Code
+                </MudButton>
+            }
+        </MudPaper>
+
+        @* Section 2: Enter a Code *@
+        <MudPaper Class="pa-6 mb-6" Elevation="2">
+            <MudText Typo="Typo.h5" Class="mb-2">Enter a Code</MudText>
+            <MudText Typo="Typo.body1" Color="Color.Secondary" Class="mb-4">
+                Got a code from someone? Enter it below.
+            </MudText>
+
+            @if (!_showConfirmation)
+            {
+                <div class="d-flex gap-3 align-center flex-wrap">
+                    <MudTextField @bind-Value="_enteredCode"
+                                  Label="Invite Code"
+                                  Variant="Variant.Outlined"
+                                  MaxLength="6"
+                                  Style="max-width: 220px; font-family: 'Courier New', monospace; font-size: 1.25rem; letter-spacing: 0.2em;"
+                                  Immediate="true"
+                                  TextChanged="OnCodeTextChanged"
+                                  Disabled="_validatingCode" />
+
+                    <MudButton Color="Color.Primary"
+                               Variant="Variant.Filled"
+                               OnClick="ValidateCode"
+                               Disabled="@(_enteredCode?.Length != 6 || _validatingCode)">
+                        @if (_validatingCode)
+                        {
+                            <MudProgressCircular Indeterminate="true" Size="Size.Small" Class="mr-2" />
+                        }
+                        Submit
+                    </MudButton>
+                </div>
+
+                @if (!string.IsNullOrEmpty(_codeError))
+                {
+                    <MudAlert Severity="Severity.Warning" Class="mt-3" Dense="true">
+                        @_codeError
+                    </MudAlert>
+                }
+            }
+            else
+            {
+                @* Pre-connection confirmation *@
+                <MudAlert Severity="Severity.Info" Class="mb-4">
+                    <MudText Typo="Typo.body1" Class="mb-2">
+                        Connecting with <strong>@_pendingHouseholdName</strong> lets both families browse each other's recipes.
+                        They can see your recipes but can't change them. You can disconnect anytime.
+                    </MudText>
+                </MudAlert>
+
+                <div class="d-flex gap-2">
+                    <MudButton Color="Color.Default"
+                               Variant="Variant.Outlined"
+                               OnClick="CancelConnect"
+                               Disabled="_acceptingInvite">
+                        Cancel
+                    </MudButton>
+                    <MudButton Color="Color.Primary"
+                               Variant="Variant.Filled"
+                               OnClick="AcceptConnection"
+                               Disabled="_acceptingInvite">
+                        @if (_acceptingInvite)
+                        {
+                            <MudProgressCircular Indeterminate="true" Size="Size.Small" Class="mr-2" />
+                        }
+                        Connect
+                    </MudButton>
+                </div>
+            }
+        </MudPaper>
+
+        @* Section 3: Connected Families *@
+        <MudPaper Class="pa-6" Elevation="2">
+            <MudText Typo="Typo.h5" Class="mb-4">Your Connected Families</MudText>
+
+            @if (_connectedHouseholds.Count == 0)
+            {
+                <MudText Typo="Typo.body1" Color="Color.Secondary">
+                    You haven't connected with any families yet. Create an invite code or enter one to get started.
+                </MudText>
+            }
+            else
+            {
+                <MudList T="ConnectedHouseholdInfo" Dense="false">
+                    @foreach (var household in _connectedHouseholds)
+                    {
+                        <MudListItem T="ConnectedHouseholdInfo">
+                            <div class="d-flex justify-space-between align-center flex-wrap gap-2" style="width: 100%;">
+                                <div>
+                                    <MudText Typo="Typo.body1"><strong>@household.HouseholdName</strong></MudText>
+                                    <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                        Connected @household.ConnectedAt.ToLocalTime().ToString("MMM d, yyyy")
+                                    </MudText>
+                                </div>
+                                <MudButton StartIcon="@Icons.Material.Filled.LinkOff"
+                                           Color="Color.Error"
+                                           Variant="Variant.Text"
+                                           Size="Size.Small"
+                                           OnClick="@(() => ConfirmDisconnect(household))">
+                                    Stop Sharing
+                                </MudButton>
+                            </div>
+                        </MudListItem>
+                    }
+                </MudList>
+            }
+        </MudPaper>
+    }
+</MudContainer>
+
+@* Disconnect confirmation dialog *@
+<MudDialog @bind-Visible="_showDisconnectDialog" Options="_dialogOptions">
+    <TitleContent>
+        <MudText Typo="Typo.h6">Stop sharing with @_householdToDisconnect?.HouseholdName?</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudList T="string" Dense="true">
+            <MudListItem T="string" Icon="@Icons.Material.Filled.VisibilityOff" IconSize="Size.Small">
+                You'll no longer be able to browse their recipes
+            </MudListItem>
+            <MudListItem T="string" Icon="@Icons.Material.Filled.VisibilityOff" IconSize="Size.Small">
+                They'll no longer be able to browse yours
+            </MudListItem>
+            <MudListItem T="string" Icon="@Icons.Material.Filled.CheckCircle" IconSize="Size.Small" IconColor="Color.Success">
+                Recipes you've already copied will stay in your collection
+            </MudListItem>
+        </MudList>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="CancelDisconnect" Color="Color.Default" Disabled="_disconnecting">Cancel</MudButton>
+        <MudButton OnClick="ConfirmDisconnectAction" Color="Color.Error" Variant="Variant.Filled" Disabled="_disconnecting">
+            @if (_disconnecting)
+            {
+                <MudProgressCircular Indeterminate="true" Size="Size.Small" Class="mr-2" />
+            }
+            Stop Sharing
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private Task<AuthenticationState>? AuthState { get; set; }
+
+    private int HouseholdId;
+    private int UserId;
+    private bool _loading = true;
+
+    // Invite generation
+    private HouseholdInvite? _activeInvite;
+    private bool _generatingInvite;
+
+    // Code entry
+    private string _enteredCode = string.Empty;
+    private string? _codeError;
+    private bool _validatingCode;
+    private bool _showConfirmation;
+    private string? _pendingHouseholdName;
+    private bool _acceptingInvite;
+
+    // Connected households
+    private List<ConnectedHouseholdInfo> _connectedHouseholds = new();
+
+    // Disconnect
+    private bool _showDisconnectDialog;
+    private ConnectedHouseholdInfo? _householdToDisconnect;
+    private bool _disconnecting;
+
+    private DialogOptions _dialogOptions = new()
+    {
+        CloseOnEscapeKey = true,
+        MaxWidth = MaxWidth.Small
+    };
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadUserContext();
+        if (HouseholdId > 0)
+        {
+            await LoadData();
+        }
+        _loading = false;
+    }
+
+    private async Task LoadUserContext()
+    {
+        if (AuthState == null) return;
+
+        var authState = await AuthState;
+        var email = authState.User.FindFirstValue(ClaimTypes.Email);
+
+        if (string.IsNullOrEmpty(email)) return;
+
+        await using var context = await DbFactory.CreateDbContextAsync();
+        var user = await context.Users
+            .FirstOrDefaultAsync(u => u.Email == email);
+
+        if (user != null)
+        {
+            HouseholdId = user.HouseholdId;
+            UserId = user.Id;
+        }
+    }
+
+    private async Task LoadData()
+    {
+        try
+        {
+            var inviteTask = ConnectionService.GetActiveInviteAsync(HouseholdId);
+            var connectionsTask = ConnectionService.GetConnectedHouseholdsAsync(HouseholdId);
+
+            await Task.WhenAll(inviteTask, connectionsTask);
+
+            _activeInvite = await inviteTask;
+            _connectedHouseholds = await connectionsTask;
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Error loading connection data: {ex.Message}", Severity.Error);
+        }
+    }
+
+    // --- Invite Generation ---
+
+    private async Task GenerateInvite()
+    {
+        _generatingInvite = true;
+        try
+        {
+            _activeInvite = await ConnectionService.GenerateInviteAsync(HouseholdId, UserId);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Error creating invite: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _generatingInvite = false;
+        }
+    }
+
+    private async Task CancelInvite()
+    {
+        try
+        {
+            await ConnectionService.InvalidateInviteAsync(HouseholdId);
+            _activeInvite = null;
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Error cancelling invite: {ex.Message}", Severity.Error);
+        }
+    }
+
+    private async Task CopyInviteCode()
+    {
+        if (_activeInvite == null) return;
+
+        try
+        {
+            await JSRuntime.InvokeVoidAsync("navigator.clipboard.writeText", _activeInvite.InviteCode);
+            Snackbar.Add("Code copied to clipboard", Severity.Success);
+        }
+        catch
+        {
+            Snackbar.Add("Unable to copy — please select the code manually", Severity.Warning);
+        }
+    }
+
+    private static string GetExpiryText(DateTime expiresAt)
+    {
+        var remaining = expiresAt - DateTime.UtcNow;
+        if (remaining.TotalMinutes < 1) return "in less than a minute";
+        if (remaining.TotalMinutes < 60) return $"in {(int)remaining.TotalMinutes} minutes";
+        if (remaining.TotalHours < 24) return $"in {(int)remaining.TotalHours} hours";
+        return $"on {expiresAt.ToLocalTime():MMM d, yyyy}";
+    }
+
+    // --- Code Entry ---
+
+    private void OnCodeTextChanged(string value)
+    {
+        // Auto-uppercase and strip whitespace/dashes
+        _enteredCode = new string(value
+            .ToUpperInvariant()
+            .Where(c => char.IsLetterOrDigit(c))
+            .Take(6)
+            .ToArray());
+        _codeError = null;
+    }
+
+    private async Task ValidateCode()
+    {
+        if (string.IsNullOrWhiteSpace(_enteredCode) || _enteredCode.Length != 6) return;
+
+        _validatingCode = true;
+        _codeError = null;
+
+        try
+        {
+            var (isValid, householdName, error) = await ConnectionService.ValidateInviteCodeAsync(_enteredCode, HouseholdId);
+
+            if (isValid)
+            {
+                _pendingHouseholdName = householdName;
+                _showConfirmation = true;
+            }
+            else
+            {
+                _codeError = MapValidationError(error);
+            }
+        }
+        catch (Exception ex)
+        {
+            _codeError = $"Something went wrong. Please try again. ({ex.Message})";
+        }
+        finally
+        {
+            _validatingCode = false;
+        }
+    }
+
+    private static string MapValidationError(string? error) => error?.ToLowerInvariant() switch
+    {
+        "self_connection" or "self-connection" or "self" =>
+            "This is your own invite code. Share it with another family to connect.",
+        "already_connected" or "already-connected" or "already connected" =>
+            "You're already connected with this family!",
+        "expired" =>
+            "This code has expired. Ask them to create a new one.",
+        "invalid" or "not_found" or "not found" =>
+            "We couldn't find that code. Check the code and try again.",
+        _ =>
+            error ?? "We couldn't find that code. Check the code and try again."
+    };
+
+    private void CancelConnect()
+    {
+        _showConfirmation = false;
+        _pendingHouseholdName = null;
+    }
+
+    private async Task AcceptConnection()
+    {
+        _acceptingInvite = true;
+
+        try
+        {
+            var (success, connectedName, error) = await ConnectionService.AcceptInviteAsync(
+                _enteredCode, HouseholdId, UserId);
+
+            if (success)
+            {
+                Snackbar.Add($"You're now connected with {connectedName}! Browse their recipes from your Recipes page.", Severity.Success);
+                _showConfirmation = false;
+                _pendingHouseholdName = null;
+                _enteredCode = string.Empty;
+
+                // Refresh connected households
+                _connectedHouseholds = await ConnectionService.GetConnectedHouseholdsAsync(HouseholdId);
+            }
+            else
+            {
+                _codeError = MapValidationError(error);
+                _showConfirmation = false;
+            }
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Error connecting: {ex.Message}", Severity.Error);
+            _showConfirmation = false;
+        }
+        finally
+        {
+            _acceptingInvite = false;
+        }
+    }
+
+    // --- Disconnect ---
+
+    private void ConfirmDisconnect(ConnectedHouseholdInfo household)
+    {
+        _householdToDisconnect = household;
+        _showDisconnectDialog = true;
+    }
+
+    private void CancelDisconnect()
+    {
+        _showDisconnectDialog = false;
+        _householdToDisconnect = null;
+    }
+
+    private async Task ConfirmDisconnectAction()
+    {
+        if (_householdToDisconnect == null) return;
+
+        _disconnecting = true;
+
+        try
+        {
+            await ConnectionService.DisconnectHouseholdsAsync(HouseholdId, _householdToDisconnect.HouseholdId);
+            Snackbar.Add($"Stopped sharing with {_householdToDisconnect.HouseholdName}", Severity.Success);
+
+            _connectedHouseholds = await ConnectionService.GetConnectedHouseholdsAsync(HouseholdId);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Error disconnecting: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _showDisconnectDialog = false;
+            _householdToDisconnect = null;
+            _disconnecting = false;
+        }
+    }
+}

--- a/src/FamilyCoordinationApp/Endpoints/SettingsConnectionsEndpoints.cs
+++ b/src/FamilyCoordinationApp/Endpoints/SettingsConnectionsEndpoints.cs
@@ -1,0 +1,160 @@
+using System.Security.Claims;
+using FamilyCoordinationApp.Data;
+using FamilyCoordinationApp.Services.Dtos;
+using FamilyCoordinationApp.Services.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace FamilyCoordinationApp.Endpoints;
+
+/// <summary>
+/// Minimal-API surface for Settings island B (Connections, strangler — mirrors <see cref="SettingsEndpoints"/>):
+/// an <c>/api/settings/connections</c> group behind <c>.RequireAuthorization().DisableAntiforgery()</c>, every
+/// handler resolving the HouseholdId/UserId from the authenticated caller (M1, never client-supplied) via
+/// <see cref="UserContextResolver"/>. Thin over the existing <see cref="IHouseholdConnectionService"/> — the real
+/// work is the island's client-side invite state machine, not this surface.
+///
+/// <para><b>200-with-outcome (review §8):</b> validate / accept return <c>200</c> with an outcome envelope
+/// (<c>{ isValid, … }</c> / <c>{ success, … }</c>), NOT a 4xx — an invalid / expired / self / already-connected
+/// code is an expected user-flow result, rendered inline as a warning today. This keeps the island's api.ts on
+/// the happy path and the error-mapping client-side (parity <c>MapValidationError</c>).</para>
+///
+/// <para><b>Non-empty 4xx (review R-B4):</b> the only genuine 4xx here is <c>401</c> (unresolved caller). The
+/// app-global <c>UseStatusCodePagesWithReExecute</c> turns an empty-body non-GET 4xx into a 405, so any 4xx we
+/// add later must carry a body — see <see cref="SettingsEndpoints"/>.</para>
+///
+/// <para><b>Disconnect M1 + idempotency (review R-B2):</b> <c>DELETE /connected/{householdId}</c> →
+/// <c>DisconnectHouseholdsAsync(callerHh, householdId)</c>. M1 holds because one arg is ALWAYS the server-resolved
+/// caller household — a caller can only affect a pairing involving their own household (passing a stranger's id
+/// just no-ops). The service no-ops to nothing when the pairing is already gone, so the endpoint stays a clean
+/// idempotent <c>204</c> (double-click safe).</para>
+/// </summary>
+public static class SettingsConnectionsEndpoints
+{
+    public static IEndpointRouteBuilder MapSettingsConnectionsEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/settings/connections")
+            .RequireAuthorization()
+            .DisableAntiforgery();
+
+        group.MapGet("/", GetConnections);
+        group.MapPost("/invite", GenerateInvite);
+        group.MapDelete("/invite", CancelInvite);
+        group.MapPost("/validate", ValidateCode);
+        group.MapPost("/accept", AcceptCode);
+        group.MapDelete("/connected/{householdId:int}", Disconnect);
+
+        return app;
+    }
+
+    /// <summary>#1 GET / — the active invite (null when none) + connected households, in one payload (parity LoadData).</summary>
+    private static async Task<IResult> GetConnections(
+        ClaimsPrincipal principal,
+        IHouseholdConnectionService connectionService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        var invite = await connectionService.GetActiveInviteAsync(user.HouseholdId, ct);
+        var connected = await connectionService.GetConnectedHouseholdsAsync(user.HouseholdId, ct);
+
+        return Results.Ok(new ConnectionsDto(
+            invite is null ? null : new ConnectionInviteDto(invite.InviteCode, invite.ExpiresAt),
+            connected.Select(c => new ConnectedFamilyDto(c.HouseholdId, c.HouseholdName, c.ConnectedAt)).ToList()));
+    }
+
+    /// <summary>#2 POST /invite — generate (replaces any existing active invite) → the new code (201).</summary>
+    private static async Task<IResult> GenerateInvite(
+        ClaimsPrincipal principal,
+        IHouseholdConnectionService connectionService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        var invite = await connectionService.GenerateInviteAsync(user.HouseholdId, user.UserId, cancellationToken: ct);
+        return Results.Created(
+            "/api/settings/connections",
+            new ConnectionInviteDto(invite.InviteCode, invite.ExpiresAt));
+    }
+
+    /// <summary>#3 DELETE /invite — cancel the household's active invite → 204 (idempotent; no active invite is a no-op).</summary>
+    private static async Task<IResult> CancelInvite(
+        ClaimsPrincipal principal,
+        IHouseholdConnectionService connectionService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        await connectionService.InvalidateInviteAsync(user.HouseholdId, ct);
+        return Results.NoContent();
+    }
+
+    /// <summary>#4 POST /validate — check a code WITHOUT connecting → 200 outcome envelope (parity: warning, never an HTTP error).</summary>
+    private static async Task<IResult> ValidateCode(
+        ValidateRequest req,
+        ClaimsPrincipal principal,
+        IHouseholdConnectionService connectionService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        // An empty/whitespace code is treated as invalid (the island guards length===6, but stay on the 200
+        // envelope and never let a null code reach the service's .Trim()).
+        if (string.IsNullOrWhiteSpace(req.Code))
+        {
+            return Results.Ok(new ValidateInviteResultDto(false, null, "Invalid invite code."));
+        }
+
+        var (isValid, householdName, error) = await connectionService.ValidateInviteCodeAsync(req.Code, user.HouseholdId, ct);
+        return Results.Ok(new ValidateInviteResultDto(isValid, householdName, error));
+    }
+
+    /// <summary>#5 POST /accept — establish the connection → 200 outcome envelope (failure returns to the entry view, review R-B3).</summary>
+    private static async Task<IResult> AcceptCode(
+        AcceptRequest req,
+        ClaimsPrincipal principal,
+        IHouseholdConnectionService connectionService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        if (string.IsNullOrWhiteSpace(req.Code))
+        {
+            return Results.Ok(new AcceptInviteResultDto(false, null, "Invalid invite code."));
+        }
+
+        var (success, connectedName, error) = await connectionService.AcceptInviteAsync(req.Code, user.HouseholdId, user.UserId, ct);
+        return Results.Ok(new AcceptInviteResultDto(success, connectedName, error));
+    }
+
+    /// <summary>#6 DELETE /connected/{householdId} — stop sharing with a connected household → 204 (M1 + idempotent, review R-B2).</summary>
+    private static async Task<IResult> Disconnect(
+        int householdId,
+        ClaimsPrincipal principal,
+        IHouseholdConnectionService connectionService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        // M1: one arg is always the resolved caller household, so this can only drop a pairing involving the
+        // caller. A stranger id (or an already-gone pairing) no-ops → still 204.
+        await connectionService.DisconnectHouseholdsAsync(user.HouseholdId, householdId, ct);
+        return Results.NoContent();
+    }
+}
+
+// ─── Request DTOs ───────────────────────────────────────────────────────────────
+
+public sealed record ValidateRequest(string Code);
+public sealed record AcceptRequest(string Code);

--- a/src/FamilyCoordinationApp/FamilyCoordinationApp.csproj
+++ b/src/FamilyCoordinationApp/FamilyCoordinationApp.csproj
@@ -123,6 +123,24 @@
           SkipUnchangedFiles="true" />
   </Target>
 
+  <!--
+    Copy the built connections island (cluster B: the household-connection invite flow) into wwwroot before build
+    (strangler). Run `npm run build` in frontend/connections/ first (or let the Docker build do it via the
+    connections-node-build stage). If dist/ doesn't exist, the target is skipped silently and the island endpoint
+    404s — Connections.razor renders the Blazor fallback via the SETTINGS_CONNECTIONS_USE_ISLAND toggle. Parallel
+    to CopySettingsIsland.
+  -->
+  <Target Name="CopyConnectionsIsland"
+          BeforeTargets="AssignTargetPaths"
+          Condition="Exists('$(MSBuildThisFileDirectory)..\..\frontend\connections\dist')">
+    <ItemGroup>
+      <_ConnectionsIslandFiles Include="$(MSBuildThisFileDirectory)..\..\frontend\connections\dist\**\*.*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_ConnectionsIslandFiles)"
+          DestinationFiles="@(_ConnectionsIslandFiles->'$(MSBuildThisFileDirectory)wwwroot\islands\connections\%(RecursiveDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true" />
+  </Target>
+
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.4.0" />
     <PackageReference Include="blazor-dragdrop" Version="2.6.1" />

--- a/src/FamilyCoordinationApp/Program.cs
+++ b/src/FamilyCoordinationApp/Program.cs
@@ -409,6 +409,7 @@ app.MapMealPlanEndpoints();
 app.MapRecipesEndpoints();
 app.MapDashboardEndpoints();
 app.MapSettingsEndpoints();
+app.MapSettingsConnectionsEndpoints();
 
 // Health check endpoint for Docker
 app.MapGet("/health", () => Results.Ok("healthy"));

--- a/src/FamilyCoordinationApp/Services/Dtos/SettingsConnectionDtos.cs
+++ b/src/FamilyCoordinationApp/Services/Dtos/SettingsConnectionDtos.cs
@@ -1,0 +1,65 @@
+namespace FamilyCoordinationApp.Services.Dtos;
+
+// ─────────────────────────────────────────────────────────────────────────
+// Settings island B (Connections) DTOs — the household-connection invite flow
+// (strangler; mirrors the cluster-A SettingsDtos lockstep). Source of truth for
+// the island TS contract:
+//   tests/.../Fixtures/Settings/connections.json + frontend/connections/src/lib/types.ts.
+// A shape/casing change updates THIS file, that fixture, and types.ts in
+// lockstep (ConnectionsDtoContractTests is the tripwire).
+//
+// ⚠ CASING: all keys camelCase (JsonSerializerDefaults.Web).
+// ⚠ DATES (review X5): ExpiresAt / ConnectedAt are FULL INSTANTS (DateTime, UTC) —
+//   they serialize as round-trip ISO-8601 strings ("2026-06-26T12:00:00Z"), NOT
+//   bare "YYYY-MM-DD". The island renders them local via new Date(iso) (relative
+//   "expires in N hours" for the invite, absolute "Jun 26, 2026" for connected-at).
+//   These are NOT the noon-UTC date-only case. No enums here ⇒ plain camelCase.
+//
+// Type names are connection-scoped (ConnectionInviteDto / ConnectedFamilyDto) to
+// stay collision-free in the shared Dtos namespace — RecipeDtos already owns a
+// ConnectedHouseholdDto(id, name) (no ConnectedAt), so this view uses its own. The
+// JSON property names (code/expiresAt/…) are what the wire contract + types.ts
+// mirror, not the C# type names.
+// ─────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// The Connections view aggregate (parity <c>Connections.razor</c> LoadData): the household's single active
+/// invite (null when none) + the list of connected households. One GET payload over
+/// <c>GetActiveInviteAsync</c> + <c>GetConnectedHouseholdsAsync</c>.
+/// </summary>
+public sealed record ConnectionsDto(
+    ConnectionInviteDto? ActiveInvite,
+    IReadOnlyList<ConnectedFamilyDto> Connected);
+
+/// <summary>An active share code. <see cref="Code"/> is the entity's <c>InviteCode</c> (review R-B1, NOT a bare
+/// <c>Code</c>); <see cref="ExpiresAt"/> is a UTC instant the island renders as relative "expires in …" text.</summary>
+public sealed record ConnectionInviteDto(
+    string Code,
+    DateTime ExpiresAt);
+
+/// <summary>One connected household. <see cref="ConnectedAt"/> is a UTC instant rendered as an absolute local date.</summary>
+public sealed record ConnectedFamilyDto(
+    int HouseholdId,
+    string HouseholdName,
+    DateTime ConnectedAt);
+
+/// <summary>
+/// The outcome of a validate call (200-with-outcome envelope, NOT a 4xx — review §8). An invalid / expired /
+/// self / already-connected code is an expected user-flow result: <see cref="IsValid"/> is false and
+/// <see cref="Error"/> carries the service's message (the island maps it to copy via mapValidationError, a
+/// parity port that today passes the message through).
+/// </summary>
+public sealed record ValidateInviteResultDto(
+    bool IsValid,
+    string? HouseholdName,
+    string? Error);
+
+/// <summary>
+/// The outcome of an accept call (200-with-outcome envelope). On success the island toasts
+/// <see cref="ConnectedHouseholdName"/> and refreshes the connected list; on failure it returns to the entry
+/// view showing <see cref="Error"/> (review R-B3).
+/// </summary>
+public sealed record AcceptInviteResultDto(
+    bool Success,
+    string? ConnectedHouseholdName,
+    string? Error);

--- a/tests/FamilyCoordinationApp.Tests/Fixtures/Settings/connections.json
+++ b/tests/FamilyCoordinationApp.Tests/Fixtures/Settings/connections.json
@@ -1,0 +1,13 @@
+{
+  "activeInvite": {
+    "code": "ABC234",
+    "expiresAt": "2026-06-26T12:00:00Z"
+  },
+  "connected": [
+    {
+      "householdId": 2,
+      "householdName": "The Smiths",
+      "connectedAt": "2026-06-20T14:30:00Z"
+    }
+  ]
+}

--- a/tests/FamilyCoordinationApp.Tests/Integration/SettingsConnectionsEndpointTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Integration/SettingsConnectionsEndpointTests.cs
@@ -1,0 +1,266 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FamilyCoordinationApp.Data;
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Services;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FamilyCoordinationApp.Tests.Integration;
+
+/// <summary>
+/// End-to-end coverage of the Settings island B endpoints (<c>/api/settings/connections</c>) through the real
+/// HTTP pipeline against real Postgres (reuses <see cref="ChoresWebAppFactory"/>'s two-household seed — household
+/// A id=1 with alice + amy, household B id=2 with bob). Each test method gets its OWN freshly-seeded database, so
+/// mutations are isolated. Proves: the generate→get→cancel invite lifecycle; the validate outcome envelope
+/// (valid / self / already-connected / bad code, all 200 — review §8); accept connects both sides symmetrically;
+/// disconnect removes it both sides and is idempotent; the 401 gate; and the M1 invariant that a third household
+/// cannot sever a pairing it isn't part of (review R-B2).
+/// </summary>
+[Collection(IntegrationCollection.Name)]
+[Trait("kind", "integration")]
+public sealed class SettingsConnectionsEndpointTests(PostgresContainerFixture postgres) : IAsyncLifetime
+{
+    private readonly ChoresWebAppFactory _factory = new(postgres);
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    public async Task InitializeAsync()
+    {
+        await _factory.EnsureSeededAsync();
+        // The connection service's rate-limiter is a process-static dictionary keyed by household id (shared
+        // across every integration test in the process). Clear it so a prior test's validate-failures can't
+        // rate-limit this one (the seed household ids 1/2 are reused across methods).
+        HouseholdConnectionService.ClearRateLimitState();
+    }
+
+    public async Task DisposeAsync() => await _factory.DisposeAsync();
+
+    private HttpClient ClientA => _factory.CreateClientAs(ChoresWebAppFactory.UserAEmail);
+    private HttpClient ClientB => _factory.CreateClientAs(ChoresWebAppFactory.UserBEmail);
+
+    private const string Url = "/api/settings/connections";
+
+    // Wire shapes (camelCase via JsonSerializerDefaults.Web).
+    private sealed record InviteDto(string code, string expiresAt);
+    private sealed record ConnectedDto(int householdId, string householdName, string connectedAt);
+    private sealed record ConnectionsDto(InviteDto? activeInvite, List<ConnectedDto> connected);
+    private sealed record ValidateResult(bool isValid, string? householdName, string? error);
+    private sealed record AcceptResult(bool success, string? connectedHouseholdName, string? error);
+
+    private async Task<InviteDto> GenerateInviteAsync(HttpClient client)
+    {
+        var resp = await client.PostAsync($"{Url}/invite", content: null);
+        resp.StatusCode.Should().Be(HttpStatusCode.Created);
+        return (await resp.Content.ReadFromJsonAsync<InviteDto>(Json))!;
+    }
+
+    private async Task<ConnectionsDto> GetConnectionsAsync(HttpClient client) =>
+        (await client.GetFromJsonAsync<ConnectionsDto>($"{Url}/", Json))!;
+
+    // ─── Gate + load ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Connections_Unauthenticated_Returns401()
+    {
+        var resp = await _factory.CreateAnonymousClient().GetAsync($"{Url}/");
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Connections_Empty_HasNoActiveInvite_AndNoConnections()
+    {
+        var dto = await GetConnectionsAsync(ClientA);
+        dto.activeInvite.Should().BeNull();
+        dto.connected.Should().BeEmpty();
+    }
+
+    // ─── Invite lifecycle ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Invite_GenerateGetCancel_RoundTrips_AndCancelIsIdempotent()
+    {
+        var invite = await GenerateInviteAsync(ClientA);
+        invite.code.Should().HaveLength(6);
+        DateTime.Parse(invite.expiresAt).ToUniversalTime().Should().BeAfter(DateTime.UtcNow);
+
+        // GET reflects the active invite.
+        var after = await GetConnectionsAsync(ClientA);
+        after.activeInvite.Should().NotBeNull();
+        after.activeInvite!.code.Should().Be(invite.code);
+
+        // Cancel → 204 → no active invite.
+        var del = await ClientA.DeleteAsync($"{Url}/invite");
+        del.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        (await GetConnectionsAsync(ClientA)).activeInvite.Should().BeNull();
+
+        // Cancel again with no active invite is an idempotent 204 (double-click safe).
+        (await ClientA.DeleteAsync($"{Url}/invite")).StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task Invite_Generate_ReplacesPriorActiveInvite()
+    {
+        var first = await GenerateInviteAsync(ClientA);
+        var second = await GenerateInviteAsync(ClientA);
+
+        // Only the latest is active (parity: generate invalidates any prior — GetActiveInvite returns one).
+        var dto = await GetConnectionsAsync(ClientA);
+        dto.activeInvite!.code.Should().Be(second.code);
+
+        // The superseded code no longer validates for another household.
+        var v = await ClientB.PostAsJsonAsync($"{Url}/validate", new { code = first.code }, Json);
+        (await v.Content.ReadFromJsonAsync<ValidateResult>(Json))!.isValid.Should().BeFalse();
+    }
+
+    // ─── Validate (200 outcome envelope) ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task Validate_SelfCode_IsInvalid_WithNonEmptyError()
+    {
+        var invite = await GenerateInviteAsync(ClientA);
+
+        var resp = await ClientA.PostAsJsonAsync($"{Url}/validate", new { code = invite.code }, Json);
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var v = (await resp.Content.ReadFromJsonAsync<ValidateResult>(Json))!;
+        v.isValid.Should().BeFalse("a household can't connect to its own code (self-connection)");
+        v.error.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task Validate_BadCode_IsInvalid_WithNonEmptyError()
+    {
+        var resp = await ClientB.PostAsJsonAsync($"{Url}/validate", new { code = "ZZZ999" }, Json);
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var v = (await resp.Content.ReadFromJsonAsync<ValidateResult>(Json))!;
+        v.isValid.Should().BeFalse();
+        v.error.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task Validate_ValidCode_ReturnsValid_WithInvitingHouseholdName()
+    {
+        var invite = await GenerateInviteAsync(ClientA);
+
+        var resp = await ClientB.PostAsJsonAsync($"{Url}/validate", new { code = invite.code }, Json);
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var v = (await resp.Content.ReadFromJsonAsync<ValidateResult>(Json))!;
+        v.isValid.Should().BeTrue();
+        v.householdName.Should().Be("Household A");
+        v.error.Should().BeNull();
+    }
+
+    // ─── Accept + connected list + disconnect ─────────────────────────────────────────
+
+    [Fact]
+    public async Task Accept_Connects_BothHouseholdsSeeEachOther_ThenDisconnectRemovesBothSides()
+    {
+        var invite = await GenerateInviteAsync(ClientA);
+
+        var acc = await ClientB.PostAsJsonAsync($"{Url}/accept", new { code = invite.code }, Json);
+        acc.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = (await acc.Content.ReadFromJsonAsync<AcceptResult>(Json))!;
+        result.success.Should().BeTrue();
+        result.connectedHouseholdName.Should().Be("Household A");
+
+        // B sees A; A sees B (the connection is symmetric).
+        var bConn = await GetConnectionsAsync(ClientB);
+        bConn.connected.Should().ContainSingle()
+            .Which.Should().Match<ConnectedDto>(c => c.householdId == ChoresWebAppFactory.HouseholdAId && c.householdName == "Household A");
+
+        var aConn = await GetConnectionsAsync(ClientA);
+        aConn.connected.Should().ContainSingle()
+            .Which.householdId.Should().Be(ChoresWebAppFactory.HouseholdBId);
+
+        // B disconnects from A → 204 → gone on BOTH sides.
+        var dis = await ClientB.DeleteAsync($"{Url}/connected/{ChoresWebAppFactory.HouseholdAId}");
+        dis.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        (await GetConnectionsAsync(ClientB)).connected.Should().BeEmpty();
+        (await GetConnectionsAsync(ClientA)).connected.Should().BeEmpty();
+
+        // Disconnecting an already-gone pairing is an idempotent 204.
+        (await ClientB.DeleteAsync($"{Url}/connected/{ChoresWebAppFactory.HouseholdAId}"))
+            .StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task Accept_BadCode_ReturnsFailureEnvelope()
+    {
+        var acc = await ClientB.PostAsJsonAsync($"{Url}/accept", new { code = "ZZZ999" }, Json);
+        acc.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = (await acc.Content.ReadFromJsonAsync<AcceptResult>(Json))!;
+        result.success.Should().BeFalse();
+        result.error.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task Validate_And_Accept_AlreadyConnected_AreRejected()
+    {
+        // Connect A ↔ B first.
+        var invite = await GenerateInviteAsync(ClientA);
+        var acc = await ClientB.PostAsJsonAsync($"{Url}/accept", new { code = invite.code }, Json);
+        (await acc.Content.ReadFromJsonAsync<AcceptResult>(Json))!.success.Should().BeTrue();
+
+        // A fresh code now reads as already-connected for B (validate + accept both refuse).
+        var invite2 = await GenerateInviteAsync(ClientA);
+
+        var v = await ClientB.PostAsJsonAsync($"{Url}/validate", new { code = invite2.code }, Json);
+        (await v.Content.ReadFromJsonAsync<ValidateResult>(Json))!.isValid.Should().BeFalse();
+
+        var acc2 = await ClientB.PostAsJsonAsync($"{Url}/accept", new { code = invite2.code }, Json);
+        (await acc2.Content.ReadFromJsonAsync<AcceptResult>(Json))!.success.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Disconnect_ThirdParty_CannotSeverAPairingItIsNotPartOf_M1()
+    {
+        // Connect A ↔ B.
+        var invite = await GenerateInviteAsync(ClientA);
+        (await (await ClientB.PostAsJsonAsync($"{Url}/accept", new { code = invite.code }, Json))
+            .Content.ReadFromJsonAsync<AcceptResult>(Json))!.success.Should().BeTrue();
+
+        // Seed a third household + whitelisted user, authenticate as them.
+        var carolEmail = await SeedThirdHouseholdAsync();
+        var clientC = _factory.CreateClientAs(carolEmail);
+
+        // C asks to disconnect A and B — the service only acts on a pairing involving the CALLER's household, so
+        // these no-op to 204 and leave the A↔B connection intact (M1; one arg is always the resolved caller).
+        (await clientC.DeleteAsync($"{Url}/connected/{ChoresWebAppFactory.HouseholdAId}"))
+            .StatusCode.Should().Be(HttpStatusCode.NoContent);
+        (await clientC.DeleteAsync($"{Url}/connected/{ChoresWebAppFactory.HouseholdBId}"))
+            .StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        (await GetConnectionsAsync(ClientA)).connected.Select(c => c.householdId)
+            .Should().Contain(ChoresWebAppFactory.HouseholdBId, "a stranger cannot sever the A↔B pairing");
+    }
+
+    /// <summary>
+    /// Insert a third household + a whitelisted user directly (the seed resynced the Households/Users identity
+    /// sequences past the explicit-id seed, so generated ids continue past 2/3 with no PK collision). Returns the
+    /// new user's email for <see cref="ChoresWebAppFactory.CreateClientAs"/>.
+    /// </summary>
+    private async Task<string> SeedThirdHouseholdAsync()
+    {
+        var dbFactory = _factory.Services.GetRequiredService<IDbContextFactory<ApplicationDbContext>>();
+        await using var ctx = await dbFactory.CreateDbContextAsync();
+
+        var household = new Household { Name = "Household C", CreatedAt = DateTime.UtcNow };
+        ctx.Households.Add(household);
+        await ctx.SaveChangesAsync();
+
+        var user = new User
+        {
+            HouseholdId = household.Id,
+            Email = "carol@household-c.test",
+            DisplayName = "Carol C",
+            Initials = "CC",
+            IsWhitelisted = true,
+            CreatedAt = DateTime.UtcNow
+        };
+        ctx.Users.Add(user);
+        await ctx.SaveChangesAsync();
+
+        return user.Email;
+    }
+}

--- a/tests/FamilyCoordinationApp.Tests/Services/SettingsConnectionsDtoContractTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/SettingsConnectionsDtoContractTests.cs
@@ -1,0 +1,83 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using FamilyCoordinationApp.Services.Dtos;
+
+namespace FamilyCoordinationApp.Tests.Services;
+
+/// <summary>
+/// Contract / consumer-audit test for the Settings island B aggregate DTO (M9 — mirrors
+/// <see cref="SettingsDtoContractTests"/>). Serializes a representative <see cref="ConnectionsDto"/> with the SAME
+/// options the app registers globally (camelCase, Web defaults) and asserts byte-equality with the checked-in
+/// <c>Fixtures/Settings/connections.json</c>. The island's <c>types.ts</c> mirrors this fixture; any DTO
+/// shape/casing change breaks this test → forcing the island contract to update in lockstep (M9).
+///
+/// <para>⚠ DATES (review X5): <see cref="ConnectionInviteDto.ExpiresAt"/> and
+/// <see cref="ConnectedFamilyDto.ConnectedAt"/> are FULL INSTANTS (DateTime, UTC) → serialize as round-trip
+/// ISO-8601 strings ("2026-06-26T12:00:00Z"), NOT bare "YYYY-MM-DD". The island renders them local via
+/// new Date(iso).</para>
+/// </summary>
+public class SettingsConnectionsDtoContractTests
+{
+    /// <summary>Web defaults (camelCase) — equivalent to the app's global Minimal-API JSON config for these (enum-free) DTOs.</summary>
+    public static readonly JsonSerializerOptions ConnectionsJsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+    };
+
+    private static string FixturePath(string file) =>
+        Path.Combine(AppContext.BaseDirectory, "Fixtures", "Settings", file);
+
+    public static ConnectionsDto BuildRepresentativeConnections() => new(
+        ActiveInvite: new ConnectionInviteDto(
+            Code: "ABC234",
+            ExpiresAt: new DateTime(2026, 6, 26, 12, 0, 0, DateTimeKind.Utc)),
+        Connected: new List<ConnectedFamilyDto>
+        {
+            new(HouseholdId: 2, HouseholdName: "The Smiths",
+                ConnectedAt: new DateTime(2026, 6, 20, 14, 30, 0, DateTimeKind.Utc)),
+        });
+
+    [Fact]
+    public void SerializedConnections_MatchesContractFixture()
+    {
+        var json = JsonSerializer.Serialize(BuildRepresentativeConnections(), ConnectionsJsonOptions);
+        File.Exists(FixturePath("connections.json")).Should().BeTrue();
+        Normalize(json).Should().Be(Normalize(File.ReadAllText(FixturePath("connections.json"))),
+            "the serialized ConnectionsDto must match connections.json; update the fixture AND types.ts in lockstep (M9)");
+    }
+
+    [Fact]
+    public void Connections_UseCamelCaseKeys_AndIsoInstantDates()
+    {
+        var json = JsonSerializer.Serialize(BuildRepresentativeConnections(), ConnectionsJsonOptions);
+        var root = JsonNode.Parse(json)!.AsObject();
+        root.Select(kvp => kvp.Key).Should().BeEquivalentTo("activeInvite", "connected");
+
+        var invite = root["activeInvite"]!.AsObject();
+        invite.Select(kvp => kvp.Key).Should().BeEquivalentTo("code", "expiresAt");
+        // ExpiresAt is a full ISO-8601 instant (NOT a bare date) — review X5.
+        invite["expiresAt"]!.GetValue<string>().Should().Be("2026-06-26T12:00:00Z");
+
+        var connected = root["connected"]!.AsArray()[0]!.AsObject();
+        connected.Select(kvp => kvp.Key).Should().BeEquivalentTo("householdId", "householdName", "connectedAt");
+        connected["connectedAt"]!.GetValue<string>().Should().Be("2026-06-20T14:30:00Z");
+    }
+
+    [Fact]
+    public void ActiveInvite_IsNullable()
+    {
+        // Parity: a household with no active invite serializes activeInvite: null (the island shows the
+        // "Create Invite Code" button, not a code).
+        var dto = new ConnectionsDto(ActiveInvite: null, Connected: new List<ConnectedFamilyDto>());
+        var json = JsonSerializer.Serialize(dto, ConnectionsJsonOptions);
+        var root = JsonNode.Parse(json)!.AsObject();
+        root["activeInvite"].Should().BeNull("a JSON null property reads back as a null JsonNode");
+        root["connected"]!.AsArray().Should().BeEmpty();
+    }
+
+    private static string Normalize(string json) =>
+        JsonNode.Parse(json)!.ToJsonString(new JsonSerializerOptions { WriteIndented = false });
+}


### PR DESCRIPTION
## Settings strangler — cluster B (Connections)

Replaces the `Connections.razor` invite ceremony (498 L, `@rendermode InteractiveServer`) with a **Svelte 5 island** over a thin `/api/settings/connections` surface. **Ships OFF** behind `SETTINGS_CONNECTIONS_USE_ISLAND` (compose default `:-false`) — flag OFF renders the verbatim Blazor fallback, so this is a zero-regression merge. Sequenced after cluster A (#55, merged).

Parity-first: today's behavior migrated 1:1, no new UX.

### Backend
- **`SettingsConnectionsEndpoints.cs`** — thin group over the existing `IHouseholdConnectionService`, household/user resolved server-side via `UserContextResolver` (M1, never client-supplied).
  - `validate` / `accept` return **200 outcome envelopes** (`{ isValid, … }` / `{ success, … }`), not 4xx — an invalid/expired/self/already-connected code is an expected flow result, not an HTTP error (review §8).
  - `DELETE /connected/{id}` is **M1-scoped + idempotent** — one arg is always the resolved caller household, so a caller can only sever a pairing involving their own household; an already-gone pairing no-ops to 204 (review R-B2).
  - 4xx carry non-empty bodies (the `UseStatusCodePagesWithReExecute` 405 gotcha).
- **`SettingsConnectionDtos.cs`** — `ConnectionsDto` aggregate (camelCase; `expiresAt`/`connectedAt` are full ISO-8601 instants per review X5). Registered in `Program.cs`.

### Island — `frontend/connections/` (port 5179, `con-` prefix; copied from the dashboard single-root scaffold)
- **`connectionsStore.svelte.ts`** — the invite state machine: generate → validate → pre-connection confirm → accept; plus the disconnect-confirm flow. `loadSeq` guard + `untrack` one-time load (no fetch loop); no liveness (parity — the page doesn't poll).
- **`InviteShare` / `CodeEntry` / `ConnectedList` / `DisconnectDialog` / `Toasts`** components.
- Faithful ports of `MapValidationError` (passthrough today) + `GetExpiryText` + the connected-date format.

### Host + wiring
- Thin flag-gated **`Connections.razor`** host — the fallback renders **only when the flag is OFF** (`@if (_useIsland) { @if (_shell) {…} } else {<ConnectionsBlazor/>}`), per the prerender-race pattern A established; verbatim **`ConnectionsBlazor.razor`** fallback.
- `CopyConnectionsIsland` MSBuild target, `connections-node-build` Docker stage + COPY, `docker-build.sh` entry, compose flag.

### Tests — all green
- **3 contract** (`ConnectionsDto` byte-locks `connections.json` ↔ `types.ts`) + **11 real-PG integration** (generate/get/cancel + idempotent; validate self/bad/valid/already-connected; accept connects both sides symmetrically; disconnect removes both sides + idempotent; **third-party cannot sever a pairing it isn't part of**; 401 gate).
- Full suite **756 passed / 0 failed**; `svelte-check` 0/0; `vite build` clean; no new format violations.

### Browser-verified at `:8080` (two-household ceremony)
Seeded a second household + active invite, then drove the real island: generate (6-char code + expiry) → cancel → code-normalize (`"tes t-24x"` → `TEST24`) → validate → confirm ("Connecting with The Testers…") → **accept** (connected list + success toast, DB connection 1↔2) → **disconnect** (3-bullet dialog → removed both sides, DB empty) → bad-code inline warning. Flag-OFF Blazor fallback renders clean (no prerender 500). **Exactly 1 GET on load** (no runaway fetch); **no console errors**.

https://claude.ai/code/session_01MHJbyCChh3jkrcjQgaMcaN
