### PR TITLE
feat(settings): strangle Admin (Household requests + Feedback) into a Svelte island (cluster C)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,15 @@ RUN if [ -f package-lock.json ]; then npm ci; else npm install --no-audit --no-f
 COPY frontend/connections/ ./
 RUN npm run build
 
+# Stage 1h: Build the Svelte admin island (settings cluster C; parallel to the others).
+# Emits ./dist/ which the .NET stage copies into wwwroot/islands/admin/.
+FROM node:20-alpine AS admin-node-build
+WORKDIR /frontend
+COPY frontend/admin/package.json frontend/admin/package-lock.json* ./
+RUN if [ -f package-lock.json ]; then npm ci; else npm install --no-audit --no-fund; fi
+COPY frontend/admin/ ./
+RUN npm run build
+
 # Stage 2: Build the .NET app.
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
@@ -79,6 +88,7 @@ COPY --from=recipes-node-build /frontend/dist/ ./FamilyCoordinationApp/wwwroot/i
 COPY --from=dashboard-node-build /frontend/dist/ ./FamilyCoordinationApp/wwwroot/islands/dashboard/
 COPY --from=settings-node-build /frontend/dist/ ./FamilyCoordinationApp/wwwroot/islands/settings/
 COPY --from=connections-node-build /frontend/dist/ ./FamilyCoordinationApp/wwwroot/islands/connections/
+COPY --from=admin-node-build /frontend/dist/ ./FamilyCoordinationApp/wwwroot/islands/admin/
 
 # Explicitly set working directory to project folder before publish
 WORKDIR /src/FamilyCoordinationApp

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -65,6 +65,7 @@ build_island "./frontend/recipes" "recipes"
 build_island "./frontend/dashboard" "dashboard"
 build_island "./frontend/settings" "settings"
 build_island "./frontend/connections" "connections"
+build_island "./frontend/admin" "admin"
 echo ""
 
 # Step 3: Publish locally

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,12 @@ services:
       DASHBOARD_USE_ISLAND: ${DASHBOARD_USE_ISLAND:-false}
       SETTINGS_HOUSEHOLD_USE_ISLAND: ${SETTINGS_HOUSEHOLD_USE_ISLAND:-false}
       SETTINGS_CONNECTIONS_USE_ISLAND: ${SETTINGS_CONNECTIONS_USE_ISLAND:-false}
+      SETTINGS_ADMIN_USE_ISLAND: ${SETTINGS_ADMIN_USE_ISLAND:-false}
+      # Site-admin allowlist (comma-separated emails) — gates the household-requests + feedback admin views
+      # (SiteAdminService). MUST be mapped here: .env is only used for ${VAR} substitution, not auto-injected,
+      # so the documented SITE_ADMIN_EMAILS go-live value is inert in the container without this line (same
+      # gotcha as CHORES_DIGEST_TRIGGER_TOKEN below). Cluster C is the first feature to exercise it end-to-end.
+      SITE_ADMIN_EMAILS: ${SITE_ADMIN_EMAILS:-}
       # Chores v1.1 digest. The token gates POST /api/chores/digest/run (cron trigger); unset ⇒ endpoint
       # returns 503 (feature off). MUST be mapped here — .env is only used for ${VAR} substitution, not
       # auto-injected, so the documented go-live step (set CHORES_DIGEST_TRIGGER_TOKEN) is inert without this.

--- a/frontend/admin/.gitignore
+++ b/frontend/admin/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.log
+.DS_Store

--- a/frontend/admin/index.html
+++ b/frontend/admin/index.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Admin (dev)</title>
+  </head>
+  <body>
+    <!--
+      Dev-only host. In production the Razor shells (HouseholdAdmin.razor / FeedbackAdmin.razor)
+      provide these attrs. main.ts mounts whichever root id is present (spec D1):
+      #admin-households-root (data-view="households") or #admin-feedback-root (data-view="feedback").
+      Swap the block below to test the feedback view standalone.
+    -->
+    <div
+      id="admin-households-root"
+      data-household-id="1"
+      data-user-id="1"
+      data-user-name="Dev User"
+      data-view="households"
+    ></div>
+    <!--
+    <div
+      id="admin-feedback-root"
+      data-household-id="1"
+      data-user-id="1"
+      data-user-name="Dev User"
+      data-view="feedback"
+    ></div>
+    -->
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/frontend/admin/package-lock.json
+++ b/frontend/admin/package-lock.json
@@ -1,0 +1,1541 @@
+{
+  "name": "admin-island",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "admin-island",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@sveltejs/vite-plugin-svelte": "^5.0.3",
+        "@tsconfig/svelte": "^5.0.4",
+        "svelte": "^5.19.0",
+        "svelte-check": "^4.1.4",
+        "tslib": "^2.8.1",
+        "typescript": "~5.7.2",
+        "vite": "^6.0.7"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sveltejs/acorn-typescript": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.10.tgz",
+      "integrity": "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8.9.0"
+      }
+    },
+    "node_modules/@sveltejs/load-config": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@sveltejs/load-config/-/load-config-0.2.0.tgz",
+      "integrity": "sha512-1LgZ/qUqSoq+QorD83lk2hka79Px0wXNW2q5V1nZlxGhQgw1jrsIbVz5YiCeucVLo4XvFLjXukUaQjIiqowkcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-5.1.1.tgz",
+      "integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
+        "debug": "^4.4.1",
+        "deepmerge": "^4.3.1",
+        "kleur": "^4.1.5",
+        "magic-string": "^0.30.17",
+        "vitefu": "^1.0.6"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22"
+      },
+      "peerDependencies": {
+        "svelte": "^5.0.0",
+        "vite": "^6.0.0"
+      }
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte-inspector": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-4.0.1.tgz",
+      "integrity": "sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.7"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22"
+      },
+      "peerDependencies": {
+        "@sveltejs/vite-plugin-svelte": "^5.0.0",
+        "svelte": "^5.0.0",
+        "vite": "^6.0.0"
+      }
+    },
+    "node_modules/@tsconfig/svelte": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-5.0.8.tgz",
+      "integrity": "sha512-UkNnw1/oFEfecR8ypyHIQuWYdkPvHiwcQ78sh+ymIiYoF+uc5H1UBetbjyqT+vgGJ3qQN6nhucJviX6HesWtKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
+      "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/devalue": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esrap": {
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.12.tgz",
+      "integrity": "sha512-On0QbLyaiAkVC4eXtgnXK9Kh2opit+3rcUSOc45DqJ2s/X2eXAHsGOKRSJ6IDagQEW5vPyivANfXUiqgXC67Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/types": "^8.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/is-reference": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.6"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/locate-character": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/svelte": {
+      "version": "5.56.4",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.4.tgz",
+      "integrity": "sha512-/d0QHehmRuJW8gVz395MTkPcPozxzdjBMBE8oEYGz8O3b9KTMzzQ9ZHJQLuFKOHOPQbU6kx/X4iid/EBBzH7iw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.4",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@sveltejs/acorn-typescript": "^1.0.10",
+        "@types/estree": "^1.0.5",
+        "@types/trusted-types": "^2.0.7",
+        "acorn": "^8.12.1",
+        "aria-query": "5.3.1",
+        "axobject-query": "^4.1.0",
+        "clsx": "^2.1.1",
+        "devalue": "^5.8.1",
+        "esm-env": "^1.2.1",
+        "esrap": "^2.2.12",
+        "is-reference": "^3.0.3",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.11",
+        "zimmerframe": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/svelte-check": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.7.1.tgz",
+      "integrity": "sha512-FGUOmAqxXdN/H9Zm8slrqO7SLtFisXRB7rfOsHNJ3MLTD2po/+Stg8XyErkpumPHbuUiYTcqrEIzxpVWKTLqtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "@sveltejs/load-config": "^0.2.0",
+        "chokidar": "^4.0.1",
+        "fdir": "^6.2.0",
+        "picocolors": "^1.0.0",
+        "sade": "^1.7.4"
+      },
+      "bin": {
+        "svelte-check": "bin/svelte-check"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "svelte": "^4.0.0 || ^5.0.0-next.0",
+        "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitefu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+      "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "tests/deps/*",
+        "tests/projects/*",
+        "tests/projects/workspace/packages/*"
+      ],
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zimmerframe": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
+      "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/frontend/admin/package.json
+++ b/frontend/admin/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "admin-island",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "check": "svelte-check --tsconfig ./tsconfig.json"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^5.0.3",
+    "@tsconfig/svelte": "^5.0.4",
+    "svelte": "^5.19.0",
+    "svelte-check": "^4.1.4",
+    "tslib": "^2.8.1",
+    "typescript": "~5.7.2",
+    "vite": "^6.0.7"
+  }
+}

--- a/frontend/admin/src/FeedbackApp.svelte
+++ b/frontend/admin/src/FeedbackApp.svelte
@@ -1,0 +1,275 @@
+<script lang="ts">
+  // Feedback view (#admin-feedback-root). Parity with FeedbackAdmin.razor: DUAL-MODE
+  // (the server scopes the list — admin sees all, a regular user sees own household, R-C1),
+  // an all/unread/open filter, type chip + New/Resolved chips + author line, and per-item
+  // mark-read / resolve / reopen. Polls at 15s while visible (R-C9).
+  import { onMount } from 'svelte';
+  import type { ShellContext, FeedbackDto, FeedbackType } from './lib/types';
+  import { feedbackStore } from './lib/feedbackStore.svelte';
+  import { formatDateTime } from './lib/dates';
+  import { startLiveness } from './lib/liveness';
+  import Toasts from './lib/components/Toasts.svelte';
+
+  let { ctx }: { ctx: ShellContext } = $props();
+  const store = feedbackStore;
+
+  // Feedback type label/icon/color map (R-C10 — the enum is camelCase on the wire; the chip
+  // shows a friendly label, not the raw value).
+  const TYPE_META: Record<FeedbackType, { label: string; icon: string; cls: string }> = {
+    bug: { label: 'Bug', icon: '🐛', cls: 'adm-type-bug' },
+    featureRequest: { label: 'Feature Request', icon: '💡', cls: 'adm-type-feature' },
+    general: { label: 'General', icon: '💬', cls: 'adm-type-general' },
+  };
+  function typeMeta(t: FeedbackType) {
+    return TYPE_META[t] ?? { label: t, icon: '💬', cls: 'adm-type-general' };
+  }
+
+  let filter = $state<'all' | 'unread' | 'open'>('all');
+  const filtered = $derived(
+    filter === 'unread'
+      ? store.items.filter((i) => !i.isRead)
+      : filter === 'open'
+        ? store.items.filter((i) => !i.isResolved)
+        : store.items,
+  );
+
+  onMount(() => {
+    void ctx;
+    void store.load();
+    const handle = startLiveness(() => store.load(), 15_000);
+    return () => handle.stop();
+  });
+
+  /** Author suffix (R-C6): live user → name; deleted → "Deleted user"; anonymous → nothing. */
+  function authorSuffix(item: FeedbackDto): string {
+    if (item.authorName) return ` — ${item.authorName}`;
+    if (item.authorDeleted) return ' — Deleted user';
+    return '';
+  }
+</script>
+
+<div class="adm-page">
+  <div class="adm-header">
+    <h1 class="adm-title">Feedback &amp; Requests</h1>
+    <div class="adm-toggle" role="group" aria-label="Filter feedback">
+      <button type="button" class:adm-toggle-on={filter === 'all'} onclick={() => (filter = 'all')}>All</button>
+      <button type="button" class:adm-toggle-on={filter === 'unread'} onclick={() => (filter = 'unread')}>Unread</button>
+      <button type="button" class:adm-toggle-on={filter === 'open'} onclick={() => (filter = 'open')}>Open</button>
+    </div>
+  </div>
+
+  {#if store.loading}
+    <div class="adm-skeleton">Loading…</div>
+  {:else if store.error}
+    <div class="adm-error">{store.error}</div>
+  {:else if filtered.length === 0}
+    <div class="adm-info">
+      No feedback yet. The feedback button appears in the bottom-left corner of every page.
+    </div>
+  {:else}
+    <div class="adm-cards">
+      {#each filtered as item (item.id)}
+        {@const meta = typeMeta(item.type)}
+        <div class="adm-card" class:adm-card-unread={!item.isRead}>
+          <div class="adm-card-head">
+            <span class="adm-avatar {meta.cls}" aria-hidden="true">{meta.icon}</span>
+            <div class="adm-card-main">
+              <div class="adm-card-line">
+                <span class="adm-chip {meta.cls}">{meta.label}</span>
+                {#if !item.isRead}
+                  <span class="adm-chip adm-chip-new">New</span>
+                {/if}
+                {#if item.isResolved}
+                  <span class="adm-chip adm-chip-resolved">Resolved</span>
+                {/if}
+              </div>
+              <div class="adm-card-meta">{formatDateTime(item.createdAt)}{authorSuffix(item)}</div>
+            </div>
+            <div class="adm-card-actions">
+              {#if !item.isRead}
+                <button type="button" class="adm-btn-text" onclick={() => store.markRead(item.id)}>Mark read</button>
+              {/if}
+              {#if !item.isResolved}
+                <button type="button" class="adm-btn-text adm-ok" onclick={() => store.markResolved(item.id)}>Resolve</button>
+              {:else}
+                <button type="button" class="adm-btn-text" onclick={() => store.reopen(item.id)}>Reopen</button>
+              {/if}
+            </div>
+          </div>
+          <div class="adm-card-body">{item.message}</div>
+          {#if item.currentPage}
+            <div class="adm-card-page">🔗 {item.currentPage}</div>
+          {/if}
+        </div>
+      {/each}
+    </div>
+  {/if}
+</div>
+
+<Toasts />
+
+<style>
+  .adm-page {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 24px 16px 96px;
+  }
+  .adm-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-bottom: 20px;
+  }
+  .adm-title {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 500;
+  }
+  .adm-toggle {
+    display: inline-flex;
+    border: 1px solid var(--color-line-strong);
+    border-radius: 999px;
+    overflow: hidden;
+  }
+  .adm-toggle button {
+    font: inherit;
+    font-weight: 500;
+    border: none;
+    background: transparent;
+    color: var(--color-text);
+    padding: 6px 16px;
+    cursor: pointer;
+  }
+  .adm-toggle button.adm-toggle-on {
+    background: var(--color-primary);
+    color: #fff;
+  }
+  .adm-cards {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .adm-card {
+    background: var(--color-surface);
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-1);
+    padding: 14px 16px;
+  }
+  .adm-card-unread {
+    border-left: 4px solid var(--color-info);
+  }
+  .adm-card-head {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+  }
+  .adm-avatar {
+    flex-shrink: 0;
+    width: 38px;
+    height: 38px;
+    display: grid;
+    place-items: center;
+    border-radius: 50%;
+    border: 1px solid var(--color-line-strong);
+    font-size: 1.1rem;
+  }
+  .adm-card-main {
+    flex: 1;
+    min-width: 0;
+  }
+  .adm-card-line {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .adm-card-meta {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    margin-top: 4px;
+  }
+  .adm-card-body {
+    margin-top: 10px;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    font-size: 0.9375rem;
+  }
+  .adm-card-page {
+    margin-top: 8px;
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    overflow-wrap: anywhere;
+  }
+  .adm-card-actions {
+    display: flex;
+    align-items: flex-start;
+    gap: 4px;
+    flex-shrink: 0;
+  }
+  .adm-chip {
+    font-size: 0.6875rem;
+    font-weight: 500;
+    padding: 2px 10px;
+    border-radius: 12px;
+    white-space: nowrap;
+    border: 1px solid var(--color-line-strong);
+    color: var(--color-text-muted);
+  }
+  .adm-type-bug {
+    border-color: var(--color-error);
+    color: var(--color-error);
+  }
+  .adm-type-feature {
+    border-color: var(--color-info);
+    color: var(--color-info);
+  }
+  .adm-type-general {
+    border-color: var(--color-line-strong);
+    color: var(--color-text-muted);
+  }
+  .adm-chip-new {
+    border-color: var(--color-info);
+    color: var(--color-info);
+  }
+  .adm-chip-resolved {
+    border-color: var(--color-success);
+    color: var(--color-success);
+  }
+  .adm-btn-text {
+    font: inherit;
+    font-weight: 500;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 6px 10px;
+    border-radius: var(--radius-sm);
+    color: var(--color-primary);
+  }
+  .adm-btn-text:hover {
+    background: var(--color-action-hover);
+  }
+  .adm-ok {
+    color: var(--color-success);
+  }
+  .adm-skeleton,
+  .adm-info,
+  .adm-error {
+    padding: 16px;
+    border-radius: var(--radius-sm);
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+  .adm-error {
+    background: rgba(229, 57, 53, 0.08);
+    border-left: 4px solid var(--color-error);
+    color: var(--color-text);
+  }
+  .adm-info {
+    background: rgba(30, 136, 229, 0.08);
+    border-left: 4px solid var(--color-info);
+    color: var(--color-text);
+  }
+</style>

--- a/frontend/admin/src/HouseholdsApp.svelte
+++ b/frontend/admin/src/HouseholdsApp.svelte
@@ -1,0 +1,358 @@
+<script lang="ts">
+  // Household Requests view (#admin-households-root). Parity with HouseholdAdmin.razor:
+  // SITE-ADMIN ONLY (a 403 on load → "Access denied", R-C4), a pending/all filter, request
+  // cards with approve (confirm) / reject (reason dialog), and an existing-households table.
+  // The approve transaction / already-reviewed 409 / member counts are SERVER-side (R-C2/3/8);
+  // this view just renders + drives them. Polls at 30s while visible (R-C9).
+  import { onMount } from 'svelte';
+  import type { ShellContext, HouseholdRequestDto } from './lib/types';
+  import { householdRequestsStore } from './lib/householdRequestsStore.svelte';
+  import { formatDateTime, formatDate } from './lib/dates';
+  import { startLiveness, type LivenessHandle } from './lib/liveness';
+  import ConfirmDialog from './lib/components/ConfirmDialog.svelte';
+  import RejectReasonDialog from './lib/components/RejectReasonDialog.svelte';
+  import Toasts from './lib/components/Toasts.svelte';
+
+  let { ctx }: { ctx: ShellContext } = $props();
+  const store = householdRequestsStore;
+
+  let filter = $state<'pending' | 'all'>('pending');
+  const filtered = $derived(
+    filter === 'pending' ? store.requests.filter((r) => r.status === 'pending') : store.requests,
+  );
+
+  onMount(() => {
+    void ctx; // host context available; not needed by the store
+    let handle: LivenessHandle | null = null;
+    void (async () => {
+      await store.load();
+      // Only poll once we know the caller is a site admin (parity: the timer started inside the
+      // _isSiteAdmin branch). A non-admin's 403 view stays static.
+      if (!store.accessDenied) {
+        handle = startLiveness(() => store.load(), 30_000);
+      }
+    })();
+    return () => handle?.stop();
+  });
+
+  function statusIcon(status: HouseholdRequestDto['status']): string {
+    return status === 'approved' ? '✅' : status === 'rejected' ? '❌' : '⏳';
+  }
+  function statusLabel(status: HouseholdRequestDto['status']): string {
+    return status === 'approved' ? 'Approved' : status === 'rejected' ? 'Rejected' : 'Pending';
+  }
+
+  // Approve confirm.
+  let confirmRequest = $state<HouseholdRequestDto | null>(null);
+  const approveMessage = $derived(
+    confirmRequest ? `Create household “${confirmRequest.householdName}” for ${confirmRequest.displayName}?` : '',
+  );
+  async function confirmApprove() {
+    const r = confirmRequest;
+    confirmRequest = null;
+    if (r) await store.approve(r.id, r.householdName);
+  }
+
+  // Reject reason dialog.
+  let rejectTarget = $state<HouseholdRequestDto | null>(null);
+  async function confirmReject(reason: string) {
+    const r = rejectTarget;
+    rejectTarget = null;
+    if (r) await store.reject(r.id, reason, r.displayName);
+  }
+</script>
+
+<div class="adm-page">
+  <div class="adm-header">
+    <h1 class="adm-title">Household Requests</h1>
+    {#if !store.accessDenied}
+      <div class="adm-toggle" role="group" aria-label="Filter requests">
+        <button type="button" class:adm-toggle-on={filter === 'pending'} onclick={() => (filter = 'pending')}>Pending</button>
+        <button type="button" class:adm-toggle-on={filter === 'all'} onclick={() => (filter = 'all')}>All</button>
+      </div>
+    {/if}
+  </div>
+
+  {#if store.accessDenied}
+    <div class="adm-denied">Access denied. Only site administrators can manage household requests.</div>
+  {:else if store.loading}
+    <div class="adm-skeleton">Loading…</div>
+  {:else if store.error}
+    <div class="adm-error">{store.error}</div>
+  {:else}
+    {#if filtered.length === 0}
+      <div class="adm-info">
+        {filter === 'pending' ? 'No pending household requests.' : 'No household requests yet.'}
+      </div>
+    {:else}
+      <div class="adm-cards">
+        {#each filtered as r (r.id)}
+          <div class="adm-card" class:adm-card-pending={r.status === 'pending'}>
+            <div class="adm-card-head">
+              <span class="adm-avatar adm-status-{r.status}" aria-hidden="true">{statusIcon(r.status)}</span>
+              <div class="adm-card-main">
+                <div class="adm-card-line">
+                  <span class="adm-card-name">{r.householdName}</span>
+                  <span class="adm-chip adm-chip-{r.status}">{statusLabel(r.status)}</span>
+                </div>
+                <div class="adm-card-sub"><strong>{r.displayName}</strong> ({r.email})</div>
+                <div class="adm-card-meta">
+                  Requested: {formatDateTime(r.requestedAt)}
+                  {#if r.reviewedAt}
+                    • Reviewed: {formatDate(r.reviewedAt)}{#if r.reviewedBy} by {r.reviewedBy}{/if}
+                  {/if}
+                </div>
+              </div>
+              {#if r.status === 'pending'}
+                <div class="adm-card-actions">
+                  <button type="button" class="adm-btn-text adm-ok" onclick={() => (confirmRequest = r)}>Approve</button>
+                  <button type="button" class="adm-btn-text adm-danger-text" onclick={() => (rejectTarget = r)}>Reject</button>
+                </div>
+              {/if}
+            </div>
+            {#if r.status === 'rejected' && r.rejectionReason}
+              <div class="adm-card-reason"><strong>Rejection reason:</strong> {r.rejectionReason}</div>
+            {/if}
+          </div>
+        {/each}
+      </div>
+    {/if}
+
+    <h2 class="adm-subtitle">Existing Households</h2>
+    {#if store.households.length === 0}
+      <div class="adm-info">No households exist yet.</div>
+    {:else}
+      <div class="adm-table-wrap">
+        <table class="adm-table">
+          <thead>
+            <tr><th>Household</th><th>Members</th><th>Created</th></tr>
+          </thead>
+          <tbody>
+            {#each store.households as h (h.householdId)}
+              <tr>
+                <td>{h.name}</td>
+                <td>{h.memberCount}</td>
+                <td>{formatDate(h.createdAt)}</td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      </div>
+    {/if}
+  {/if}
+</div>
+
+<ConfirmDialog
+  open={confirmRequest != null}
+  title="Approve Request"
+  message={approveMessage}
+  confirmLabel="Approve"
+  tone="primary"
+  onCancel={() => (confirmRequest = null)}
+  onConfirm={confirmApprove}
+/>
+<RejectReasonDialog
+  open={rejectTarget != null}
+  requestorName={rejectTarget?.displayName ?? ''}
+  householdName={rejectTarget?.householdName ?? ''}
+  onCancel={() => (rejectTarget = null)}
+  onConfirm={confirmReject}
+/>
+<Toasts />
+
+<style>
+  .adm-page {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 24px 16px 96px;
+  }
+  .adm-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-bottom: 20px;
+  }
+  .adm-title {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 500;
+  }
+  .adm-subtitle {
+    margin: 28px 0 12px;
+    font-size: 1.125rem;
+    font-weight: 500;
+  }
+  .adm-toggle {
+    display: inline-flex;
+    border: 1px solid var(--color-line-strong);
+    border-radius: 999px;
+    overflow: hidden;
+  }
+  .adm-toggle button {
+    font: inherit;
+    font-weight: 500;
+    border: none;
+    background: transparent;
+    color: var(--color-text);
+    padding: 6px 16px;
+    cursor: pointer;
+  }
+  .adm-toggle button.adm-toggle-on {
+    background: var(--color-primary);
+    color: #fff;
+  }
+  .adm-cards {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .adm-card {
+    background: var(--color-surface);
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-1);
+    padding: 14px 16px;
+  }
+  .adm-card-pending {
+    border-left: 4px solid var(--color-info);
+  }
+  .adm-card-head {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+  }
+  .adm-avatar {
+    flex-shrink: 0;
+    width: 38px;
+    height: 38px;
+    display: grid;
+    place-items: center;
+    border-radius: 50%;
+    border: 1px solid var(--color-line-strong);
+    font-size: 1.1rem;
+  }
+  .adm-card-main {
+    flex: 1;
+    min-width: 0;
+  }
+  .adm-card-line {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .adm-card-name {
+    font-size: 1.0625rem;
+    font-weight: 500;
+  }
+  .adm-card-sub {
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+    margin-top: 2px;
+    overflow-wrap: anywhere;
+  }
+  .adm-card-meta {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    margin-top: 4px;
+  }
+  .adm-card-actions {
+    display: flex;
+    align-items: flex-start;
+    gap: 4px;
+    flex-shrink: 0;
+  }
+  .adm-card-reason {
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+    margin-top: 10px;
+    padding-top: 10px;
+    border-top: 1px solid var(--color-line);
+  }
+  .adm-chip {
+    font-size: 0.6875rem;
+    font-weight: 500;
+    padding: 2px 10px;
+    border-radius: 12px;
+    white-space: nowrap;
+    border: 1px solid var(--color-line-strong);
+    color: var(--color-text-muted);
+  }
+  .adm-chip-pending {
+    border-color: var(--color-info);
+    color: var(--color-info);
+  }
+  .adm-chip-approved {
+    border-color: var(--color-success);
+    color: var(--color-success);
+  }
+  .adm-chip-rejected {
+    border-color: var(--color-error);
+    color: var(--color-error);
+  }
+  .adm-btn-text {
+    font: inherit;
+    font-weight: 500;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 6px 10px;
+    border-radius: var(--radius-sm);
+    color: var(--color-primary);
+  }
+  .adm-btn-text:hover {
+    background: var(--color-action-hover);
+  }
+  .adm-ok {
+    color: var(--color-success);
+  }
+  .adm-danger-text {
+    color: var(--color-error);
+  }
+  .adm-table-wrap {
+    overflow-x: auto;
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-md);
+  }
+  .adm-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9375rem;
+  }
+  .adm-table th,
+  .adm-table td {
+    text-align: left;
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--color-line);
+  }
+  .adm-table th {
+    font-weight: 500;
+    color: var(--color-text-muted);
+    font-size: 0.8125rem;
+  }
+  .adm-table tbody tr:last-child td {
+    border-bottom: none;
+  }
+  .adm-skeleton,
+  .adm-info,
+  .adm-denied,
+  .adm-error {
+    padding: 16px;
+    border-radius: var(--radius-sm);
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+  .adm-denied,
+  .adm-error {
+    background: rgba(229, 57, 53, 0.08);
+    border-left: 4px solid var(--color-error);
+    color: var(--color-text);
+  }
+  .adm-info {
+    background: rgba(30, 136, 229, 0.08);
+    border-left: 4px solid var(--color-info);
+    color: var(--color-text);
+  }
+</style>

--- a/frontend/admin/src/lib/api.ts
+++ b/frontend/admin/src/lib/api.ts
@@ -1,0 +1,96 @@
+import type { HouseholdRequestsDto, HouseholdSummaryDto, FeedbackListDto } from './types';
+
+const REQUESTS = '/api/settings/household-requests';
+const FEEDBACK = '/api/settings/feedback';
+
+/**
+ * Thrown on any non-2xx response. `status` lets callers react to a rejection.
+ *
+ * ⚠ Carried from the other islands: the app re-executes empty-body API 4xx
+ * through a Blazor `/not-found` page, so a server-side "not found" can arrive
+ * as an empty 400 (a bare DELETE 404 even surfaces as 405). Every admin endpoint
+ * returns a NON-EMPTY body on 4xx, and the island treats ANY 4xx as a
+ * non-retryable client rejection → reconcile (refetch) + a calm toast. The
+ * 403 on the households GET is special-cased by the store as the access-denied
+ * signal (R-C4 — the 403 IS the signal; no /context endpoint).
+ */
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+
+  /** A non-retryable client rejection (validation / not found / conflict). Any 4xx. */
+  get isClientRejection(): boolean {
+    return this.status >= 400 && this.status < 500;
+  }
+}
+
+async function request<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    credentials: 'include',
+    headers: { Accept: 'application/json', ...(init?.headers ?? {}) },
+    ...init,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    let message = text || res.statusText;
+    // The endpoints return { message } on 4xx — surface it for the toast.
+    try {
+      const parsed = JSON.parse(text);
+      if (parsed && typeof parsed.message === 'string') message = parsed.message;
+    } catch { /* not JSON — use the raw text */ }
+    throw new ApiError(res.status, message);
+  }
+  if (res.status === 204) return undefined as T;
+  return (await res.json()) as T;
+}
+
+function jsonBody(body: unknown): RequestInit {
+  return {
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  };
+}
+
+// ─── Household requests (site-admin only) ───────────────────────────────────
+
+/** #1 Requests (pending-first) + existing households. 403 (ApiError) for a non-admin → access denied. */
+export async function getHouseholdRequests(): Promise<HouseholdRequestsDto> {
+  return request<HouseholdRequestsDto>(`${REQUESTS}/`);
+}
+
+/** #2 Approve → the new household summary (201). Already-reviewed ⇒ 409 (ApiError); unknown ⇒ 404. */
+export async function approveRequest(id: number): Promise<HouseholdSummaryDto> {
+  return request<HouseholdSummaryDto>(`${REQUESTS}/${id}/approve`, { method: 'POST' });
+}
+
+/** #3 Reject with an OPTIONAL reason → 204. Already-reviewed ⇒ 409 (ApiError); unknown ⇒ 404. */
+export async function rejectRequest(id: number, reason: string): Promise<void> {
+  await request<void>(`${REQUESTS}/${id}/reject`, { method: 'POST', ...jsonBody({ reason }) });
+}
+
+// ─── Feedback (dual-mode) ───────────────────────────────────────────────────
+
+/** #4 Feedback for the caller (admin: all; regular: own household) + the isSiteAdmin signal. */
+export async function getFeedback(): Promise<FeedbackListDto> {
+  return request<FeedbackListDto>(`${FEEDBACK}/`);
+}
+
+/** #5 Mark read → 204. Not visible to a non-admin ⇒ 404 (R-C1). */
+export async function markFeedbackRead(id: number): Promise<void> {
+  await request<void>(`${FEEDBACK}/${id}/read`, { method: 'POST' });
+}
+
+/** #6 Mark resolved (also read) → 204. Not visible ⇒ 404 (R-C1). */
+export async function markFeedbackResolved(id: number): Promise<void> {
+  await request<void>(`${FEEDBACK}/${id}/resolve`, { method: 'POST' });
+}
+
+/** #7 Reopen → 204. Not visible ⇒ 404 (R-C1). */
+export async function reopenFeedback(id: number): Promise<void> {
+  await request<void>(`${FEEDBACK}/${id}/reopen`, { method: 'POST' });
+}

--- a/frontend/admin/src/lib/components/ConfirmDialog.svelte
+++ b/frontend/admin/src/lib/components/ConfirmDialog.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+  // A tiny confirm dialog — replaces the Blazor delete-confirm MudDialog.
+  // Hosted in ListApp; opened with a message + a confirm callback.
+  interface Props {
+    open: boolean;
+    title: string;
+    message: string;
+    confirmLabel?: string;
+    cancelLabel?: string;
+    /** 'danger' (default, red) for destructive confirms; 'primary' (green) for approve. */
+    tone?: 'danger' | 'primary';
+    onCancel: () => void;
+    onConfirm: () => void;
+  }
+
+  let {
+    open,
+    title,
+    message,
+    confirmLabel = 'Delete',
+    cancelLabel = 'Cancel',
+    tone = 'danger',
+    onCancel,
+    onConfirm,
+  }: Props = $props();
+
+  let dialogEl: HTMLDialogElement | null = $state(null);
+
+  $effect(() => {
+    if (!dialogEl) return;
+    if (open && !dialogEl.open) {
+      dialogEl.showModal();
+    } else if (!open && dialogEl.open) {
+      dialogEl.close();
+    }
+  });
+</script>
+
+<dialog bind:this={dialogEl} onclose={onCancel} class="rc-confirm">
+  {#if open}
+    <div class="rc-confirm-body">
+      <h2>{title}</h2>
+      <p class="rc-confirm-msg">{message}</p>
+      <div class="rc-confirm-actions">
+        <button type="button" class="rc-btn-ghost" onclick={onCancel}>{cancelLabel}</button>
+        <button
+          type="button"
+          class={tone === 'primary' ? 'rc-btn-confirm-primary' : 'rc-btn-danger'}
+          onclick={onConfirm}
+        >{confirmLabel}</button>
+      </div>
+    </div>
+  {/if}
+</dialog>
+
+<style>
+  .rc-confirm[open] {
+    position: fixed;
+    inset: 0;
+    margin: auto;
+    border: none;
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text);
+    padding: 0;
+    width: min(400px, calc(100vw - 32px));
+    box-shadow: var(--shadow-4);
+  }
+  .rc-confirm::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+  }
+  .rc-confirm-body {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 24px;
+  }
+  .rc-confirm h2 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 500;
+  }
+  .rc-confirm-msg {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+  .rc-confirm-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 8px;
+  }
+  .rc-btn-ghost,
+  .rc-btn-danger,
+  .rc-btn-confirm-primary {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    border: none;
+    cursor: pointer;
+    min-height: 40px;
+    font-weight: 500;
+  }
+  .rc-btn-ghost {
+    background: transparent;
+    color: var(--color-text-muted);
+  }
+  .rc-btn-ghost:hover {
+    background: var(--color-action-hover);
+  }
+  .rc-btn-danger {
+    background: var(--color-error);
+    color: #fff;
+  }
+  .rc-btn-danger:hover {
+    filter: brightness(0.95);
+  }
+  .rc-btn-confirm-primary {
+    background: var(--color-primary);
+    color: #fff;
+  }
+  .rc-btn-confirm-primary:hover {
+    background: var(--color-primary-hover);
+  }
+</style>

--- a/frontend/admin/src/lib/components/RejectReasonDialog.svelte
+++ b/frontend/admin/src/lib/components/RejectReasonDialog.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+  // Reject-with-reason dialog (parity RejectReasonDialog.razor). The reason is
+  // OPTIONAL (R-C7) — submitting with an empty box is allowed (the server does
+  // not 400). MaxLength 500, mirroring the MudTextField.
+  interface Props {
+    open: boolean;
+    requestorName: string;
+    householdName: string;
+    onCancel: () => void;
+    onConfirm: (reason: string) => void;
+  }
+
+  let { open, requestorName, householdName, onCancel, onConfirm }: Props = $props();
+
+  let dialogEl: HTMLDialogElement | null = $state(null);
+  let reason = $state('');
+
+  $effect(() => {
+    if (!dialogEl) return;
+    if (open && !dialogEl.open) {
+      reason = ''; // fresh each time it opens
+      dialogEl.showModal();
+    } else if (!open && dialogEl.open) {
+      dialogEl.close();
+    }
+  });
+
+  function submit() {
+    onConfirm(reason.trim());
+  }
+</script>
+
+<dialog bind:this={dialogEl} onclose={onCancel} class="adm-reject">
+  {#if open}
+    <div class="adm-reject-body">
+      <h2>Reject Request</h2>
+      <p class="adm-reject-msg">
+        Reject household request “<strong>{householdName}</strong>” from <strong>{requestorName}</strong>?
+      </p>
+      <label class="adm-field">
+        <span class="adm-field-label">Reason (optional)</span>
+        <textarea
+          class="adm-textarea"
+          rows="3"
+          maxlength="500"
+          placeholder="Why is this request being rejected?"
+          bind:value={reason}
+        ></textarea>
+      </label>
+      <div class="adm-reject-actions">
+        <button type="button" class="adm-btn-ghost" onclick={onCancel}>Cancel</button>
+        <button type="button" class="adm-btn-danger" onclick={submit}>Reject</button>
+      </div>
+    </div>
+  {/if}
+</dialog>
+
+<style>
+  .adm-reject[open] {
+    position: fixed;
+    inset: 0;
+    margin: auto;
+    border: none;
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text);
+    padding: 0;
+    width: min(440px, calc(100vw - 32px));
+    box-shadow: var(--shadow-4);
+  }
+  .adm-reject::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+  }
+  .adm-reject-body {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 24px;
+  }
+  .adm-reject h2 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 500;
+  }
+  .adm-reject-msg {
+    margin: 0;
+    font-size: 0.9375rem;
+  }
+  .adm-field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .adm-field-label {
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+  }
+  .adm-textarea {
+    font: inherit;
+    padding: 10px 12px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--color-line-strong);
+    background: var(--color-surface);
+    color: var(--color-text);
+    resize: vertical;
+    min-height: 72px;
+  }
+  .adm-textarea:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -1px;
+  }
+  .adm-reject-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 4px;
+  }
+  .adm-btn-ghost,
+  .adm-btn-danger {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    border: none;
+    cursor: pointer;
+    min-height: 40px;
+    font-weight: 500;
+  }
+  .adm-btn-ghost {
+    background: transparent;
+    color: var(--color-text-muted);
+  }
+  .adm-btn-ghost:hover {
+    background: var(--color-action-hover);
+  }
+  .adm-btn-danger {
+    background: var(--color-error);
+    color: #fff;
+  }
+  .adm-btn-danger:hover {
+    filter: brightness(0.95);
+  }
+</style>

--- a/frontend/admin/src/lib/components/Toasts.svelte
+++ b/frontend/admin/src/lib/components/Toasts.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+  // The toast region. Mirrors the meal-plan island's Toasts component, re-scoped
+  // to `rc-`. Mounted once at each App root (ListApp / EditApp).
+  import { toasts, dismissToast } from '../toasts.svelte';
+</script>
+
+<div class="rc-toast-region" role="status" aria-live="polite">
+  {#each toasts() as toast (toast.id)}
+    <div class="rc-toast rc-toast-{toast.kind}">
+      <span class="rc-toast-msg">{toast.message}</span>
+      {#if toast.action}
+        <button
+          type="button"
+          class="rc-toast-action"
+          onclick={() => {
+            toast.action?.onClick();
+            dismissToast(toast.id);
+          }}
+        >
+          {toast.action.label}
+        </button>
+      {/if}
+      <button
+        type="button"
+        class="rc-toast-close"
+        aria-label="Dismiss"
+        onclick={() => dismissToast(toast.id)}
+      >
+        ×
+      </button>
+    </div>
+  {/each}
+</div>
+
+<style>
+  .rc-toast-region {
+    position: fixed;
+    left: 50%;
+    bottom: 24px;
+    transform: translateX(-50%);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    z-index: 1100;
+    pointer-events: none;
+    max-width: min(560px, calc(100vw - 32px));
+  }
+  /* Mobile: clear the MainLayout bottom nav so toasts aren't hidden behind it. */
+  @media (max-width: 960px) {
+    .rc-toast-region {
+      bottom: calc(80px + env(safe-area-inset-bottom, 0px));
+    }
+  }
+  .rc-toast {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 12px 10px 16px;
+    border-radius: var(--radius-sm);
+    color: #fff;
+    background: #323232;
+    box-shadow: var(--shadow-4);
+    font-size: 0.875rem;
+    pointer-events: auto;
+    animation: rc-toast-in 0.2s ease-out;
+  }
+  .rc-toast-success {
+    background: var(--color-success);
+  }
+  .rc-toast-error {
+    background: var(--color-error);
+  }
+  .rc-toast-msg {
+    flex: 1;
+    min-width: 0;
+  }
+  .rc-toast-action {
+    background: transparent;
+    border: none;
+    color: #fff;
+    font: inherit;
+    font-weight: 600;
+    text-transform: uppercase;
+    font-size: 0.8125rem;
+    cursor: pointer;
+    padding: 0 4px;
+    flex-shrink: 0;
+  }
+  .rc-toast-action:hover {
+    text-decoration: underline;
+  }
+  .rc-toast-close {
+    background: transparent;
+    border: none;
+    color: rgba(255, 255, 255, 0.8);
+    font-size: 1.25rem;
+    line-height: 1;
+    padding: 0 4px;
+    cursor: pointer;
+  }
+  .rc-toast-close:hover {
+    color: #fff;
+  }
+  @keyframes rc-toast-in {
+    from {
+      opacity: 0;
+      transform: translateY(8px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+</style>

--- a/frontend/admin/src/lib/dates.ts
+++ b/frontend/admin/src/lib/dates.ts
@@ -1,0 +1,21 @@
+// Date helpers for the admin island. Every date on the wire (requestedAt /
+// reviewedAt / createdAt) is a FULL ISO-8601 instant WITH time-of-day (UTC,
+// review X5) — NOT the noon-UTC date-only case. We parse the full instant
+// (new Date(iso) handles the offset correctly) and format it in the user's
+// local timezone. Never use new Date('YYYY-MM-DD') here.
+
+/** Full local date+time ("Jun 24, 2026, 1:30 PM"), or "" when absent/invalid. Parity: ToLocalTime + date/time. */
+export function formatDateTime(iso: string | null): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleString();
+}
+
+/** Local date only ("Jun 24, 2026"), or "" when absent/invalid (the reviewed/created short form). */
+export function formatDate(iso: string | null): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+}

--- a/frontend/admin/src/lib/feedbackStore.svelte.ts
+++ b/frontend/admin/src/lib/feedbackStore.svelte.ts
@@ -1,0 +1,80 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Feedback view store (#admin-feedback-root). Source of truth for the feedback
+// list + the caller's isSiteAdmin flag. DUAL-MODE: the server scopes the list
+// (admin → all households; regular → own household, R-C1), so the store just
+// renders whatever it's handed and uses `isSiteAdmin` for affordances/copy.
+//
+// Discipline: onMount one-time load, `loadSeq` guard on every load (this view
+// POLLS at 15s), await-then-reload mutations, reconcile on any 4xx. The IDOR
+// scope (a non-admin's mutation of another household's item ⇒ 404) is enforced
+// SERVER-side; here a 404 just reconciles + toasts.
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { FeedbackDto } from './types';
+import {
+  ApiError,
+  getFeedback,
+  markFeedbackRead,
+  markFeedbackResolved,
+  reopenFeedback,
+} from './api';
+import { showToast } from './toasts.svelte';
+
+class FeedbackStore {
+  items = $state<FeedbackDto[]>([]);
+  isSiteAdmin = $state(false);
+  loading = $state(true);
+  error = $state<string | null>(null);
+
+  private hasLoaded = false;
+  private seq = 0;
+
+  async load(): Promise<void> {
+    const s = ++this.seq;
+    try {
+      if (!this.hasLoaded) this.loading = true;
+      this.error = null;
+      const dto = await getFeedback();
+      if (s !== this.seq) return; // stale poll — drop
+      this.items = dto.items;
+      this.isSiteAdmin = dto.isSiteAdmin;
+      this.hasLoaded = true;
+    } catch (e) {
+      if (s !== this.seq) return;
+      this.error = describe(e, 'load feedback');
+    } finally {
+      if (s === this.seq) this.loading = false;
+    }
+  }
+
+  async markRead(id: number): Promise<void> {
+    await this.mutate(() => markFeedbackRead(id), 'mark read');
+  }
+
+  async markResolved(id: number): Promise<void> {
+    await this.mutate(() => markFeedbackResolved(id), 'resolve', 'Marked as resolved.');
+  }
+
+  async reopen(id: number): Promise<void> {
+    await this.mutate(() => reopenFeedback(id), 'reopen');
+  }
+
+  private async mutate(action: () => Promise<void>, label: string, successMessage?: string): Promise<void> {
+    try {
+      await action();
+      await this.load();
+      if (successMessage) showToast({ message: successMessage, kind: 'success' });
+    } catch (e) {
+      if (e instanceof ApiError) await this.load();
+      showToast({ message: describe(e, label), kind: 'error' });
+    }
+  }
+}
+
+function describe(e: unknown, action: string): string {
+  if (e instanceof ApiError) return e.message || `Couldn't ${action} (HTTP ${e.status}).`;
+  if (e instanceof Error) return e.message;
+  return `Couldn't ${action}.`;
+}
+
+export const feedbackStore = new FeedbackStore();

--- a/frontend/admin/src/lib/householdRequestsStore.svelte.ts
+++ b/frontend/admin/src/lib/householdRequestsStore.svelte.ts
@@ -1,0 +1,83 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Household-requests view store (#admin-households-root). Source of truth for
+// the request list + the existing-households table. SITE-ADMIN ONLY: a 403 on
+// the list GET sets `accessDenied` (the 403 IS the signal — R-C4, no /context
+// endpoint), and the App renders "Access denied".
+//
+// Discipline (memories svelte5-setup-effect-async-loader-loop + fca-island-async-
+// race-guards): onMount one-time load, `loadSeq` monotonic guard on every load
+// (this view POLLS at 30s, so a stale poll response must never clobber a newer
+// one), await-then-reload mutations, reconcile (refetch) on any 4xx. The approve
+// transaction / 409 already-reviewed guard / IDOR live SERVER-side (the source of
+// truth); the client just reflects them.
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { HouseholdRequestDto, HouseholdSummaryDto } from './types';
+import { ApiError, getHouseholdRequests, approveRequest, rejectRequest } from './api';
+import { showToast } from './toasts.svelte';
+
+class HouseholdRequestsStore {
+  requests = $state<HouseholdRequestDto[]>([]);
+  households = $state<HouseholdSummaryDto[]>([]);
+  loading = $state(true);
+  error = $state<string | null>(null);
+  /** True after a 403 on the list GET — the caller is not a site admin (R-C4). */
+  accessDenied = $state(false);
+
+  private hasLoaded = false;
+  private seq = 0;
+
+  async load(): Promise<void> {
+    const s = ++this.seq;
+    try {
+      if (!this.hasLoaded) this.loading = true;
+      this.error = null;
+      const dto = await getHouseholdRequests();
+      if (s !== this.seq) return; // a newer load already applied — drop this stale one
+      this.requests = dto.requests;
+      this.households = dto.households;
+      this.accessDenied = false;
+      this.hasLoaded = true;
+    } catch (e) {
+      if (s !== this.seq) return;
+      if (e instanceof ApiError && e.status === 403) {
+        this.accessDenied = true; // the 403 IS the access-denied signal (R-C4)
+      } else {
+        this.error = describe(e, 'load household requests');
+      }
+    } finally {
+      if (s === this.seq) this.loading = false;
+    }
+  }
+
+  async approve(id: number, householdName: string): Promise<void> {
+    try {
+      const summary = await approveRequest(id);
+      await this.load();
+      showToast({ message: `Approved — created “${summary.name}”.`, kind: 'success' });
+    } catch (e) {
+      // A 409 (already reviewed by another admin / a stale poll) reconciles to the truth, R-C3.
+      if (e instanceof ApiError) await this.load();
+      showToast({ message: describe(e, `approve “${householdName}”`), kind: 'error' });
+    }
+  }
+
+  async reject(id: number, reason: string, requestorName: string): Promise<void> {
+    try {
+      await rejectRequest(id, reason);
+      await this.load();
+      showToast({ message: `Rejected request from ${requestorName}.`, kind: 'info' });
+    } catch (e) {
+      if (e instanceof ApiError) await this.load();
+      showToast({ message: describe(e, 'reject request'), kind: 'error' });
+    }
+  }
+}
+
+function describe(e: unknown, action: string): string {
+  if (e instanceof ApiError) return e.message || `Couldn't ${action} (HTTP ${e.status}).`;
+  if (e instanceof Error) return e.message;
+  return `Couldn't ${action}.`;
+}
+
+export const householdRequestsStore = new HouseholdRequestsStore();

--- a/frontend/admin/src/lib/liveness.ts
+++ b/frontend/admin/src/lib/liveness.ts
@@ -1,0 +1,78 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Liveness — lightweight collaboration refresh for the admin island (the one
+// settings cluster that polls, review R-C9). Per-view cadence: households 30s,
+// feedback 15s (parity with the old Blazor timers).
+//
+// A change made by another admin/household member should appear within the
+// interval while the tab is VISIBLE, and immediately when the tab regains focus.
+// We do this with a plain interval + `visibilitychange`, NOT Blazor's
+// DataNotifier / PresenceService / PollingService (those are SignalR-circuit-bound).
+//
+// The poll PAUSES while the tab is hidden (visible-only, R-C9): no interval ticks
+// fire when `document.hidden` is true, and on re-show we refetch once immediately,
+// then resume the interval. This keeps background tabs quiet (a tiny, strictly-
+// better behaviour change vs the old always-on timer). The caller's loader carries
+// the loadSeq guard, so a stale poll response can never clobber a newer one.
+// ─────────────────────────────────────────────────────────────────────────
+
+const DEFAULT_INTERVAL_MS = 20_000;
+
+export interface LivenessHandle {
+  /** Tear down the interval + visibility listener. Call on unmount. */
+  stop(): void;
+}
+
+/**
+ * Start polling. `refresh` is the view reload (App.svelte's loader). It is
+ * only invoked while the document is visible. `intervalMs` sets the cadence
+ * (households 30s, feedback 15s). Returns a handle whose `stop()` removes the
+ * interval + listener.
+ */
+export function startLiveness(refresh: () => void, intervalMs: number = DEFAULT_INTERVAL_MS): LivenessHandle {
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  function tick() {
+    // Guard: never poll while hidden (the interval is cleared on hide, but this
+    // is belt-and-suspenders in case a tick is queued at the moment of hiding).
+    if (document.visibilityState === 'visible') {
+      refresh();
+    }
+  }
+
+  function startInterval() {
+    if (timer != null) return;
+    timer = setInterval(tick, intervalMs);
+  }
+
+  function stopInterval() {
+    if (timer != null) {
+      clearInterval(timer);
+      timer = null;
+    }
+  }
+
+  function handleVisibility() {
+    if (document.visibilityState === 'visible') {
+      // Re-show: refetch immediately, then resume the interval.
+      refresh();
+      startInterval();
+    } else {
+      // Hidden: pause polling entirely.
+      stopInterval();
+    }
+  }
+
+  document.addEventListener('visibilitychange', handleVisibility);
+
+  // Begin polling only if we start visible.
+  if (document.visibilityState === 'visible') {
+    startInterval();
+  }
+
+  return {
+    stop() {
+      stopInterval();
+      document.removeEventListener('visibilitychange', handleVisibility);
+    },
+  };
+}

--- a/frontend/admin/src/lib/toasts.svelte.ts
+++ b/frontend/admin/src/lib/toasts.svelte.ts
@@ -1,0 +1,60 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Transient toast notices for the recipes island (mirrors the meal-plan/chores
+// toast store). Used for non-alarming 4xx/network surfacing, the "someone
+// changed this — refreshed" reconcile notice, and edit-form save outcomes. Kept
+// deliberately small: a module-level `$state` list + helpers.
+//
+// ⚠ Svelte 5 rune rule: we never export a reassigned `$state` rune directly.
+// The list lives inside a module-private `$state` object; callers read it via
+// the `toasts()` accessor and mutate it only through the exported functions.
+// ─────────────────────────────────────────────────────────────────────────
+
+export type ToastKind = 'info' | 'success' | 'error';
+
+/** Optional inline action (e.g. the ingredient delete-with-undo). */
+export interface ToastAction {
+  label: string;
+  onClick: () => void;
+}
+
+export interface Toast {
+  id: number;
+  message: string;
+  kind: ToastKind;
+  durationMs: number;
+  action?: ToastAction;
+}
+
+let nextId = 1;
+const store = $state<{ items: Toast[] }>({ items: [] });
+
+/** The live toast list (reactive — read inside markup). */
+export function toasts(): readonly Toast[] {
+  return store.items;
+}
+
+/** Push a toast. Auto-dismisses after `durationMs` (default 3.5s). */
+export function showToast(toast: {
+  message: string;
+  kind: ToastKind;
+  durationMs?: number;
+  action?: ToastAction;
+}): number {
+  const id = nextId++;
+  const full: Toast = {
+    id,
+    message: toast.message,
+    kind: toast.kind,
+    durationMs: toast.durationMs ?? 3500,
+    action: toast.action,
+  };
+  store.items = [...store.items, full];
+  if (full.durationMs > 0) {
+    setTimeout(() => dismissToast(id), full.durationMs);
+  }
+  return id;
+}
+
+export function dismissToast(id: number): void {
+  store.items = store.items.filter((t) => t.id !== id);
+}

--- a/frontend/admin/src/lib/types.ts
+++ b/frontend/admin/src/lib/types.ts
@@ -1,0 +1,74 @@
+// ─────────────────────────────────────────────────────────────────────────
+// TS mirror of the /api/settings admin contract (M9 lockstep). Source of truth:
+//   - Services/Dtos/SettingsAdminDtos.cs (the C# records — admin-scoped names)
+//   - tests/.../Fixtures/Settings/{household-requests,feedback}.json (byte-locked tripwires)
+//   - Endpoints/SettingsAdminEndpoints.cs (request DTOs + the 403/IDOR contract)
+//
+// ⚠ CASING: all keys camelCase.
+// ⚠ ENUMS (R-C10): status / type are string unions matching the camelCase wire
+//   values the global JsonStringEnumConverter emits.
+// ⚠ DATES (X5): requestedAt / reviewedAt / createdAt are FULL ISO-8601 instants
+//   (UTC, "…Z") — render local via new Date(iso).toLocaleString() (NOT noon-UTC).
+// ─────────────────────────────────────────────────────────────────────────
+
+/** The per-page context the Razor host hands the island via data- attributes. */
+export interface ShellContext {
+  householdId: number;
+  userId: number;
+  userName: string;
+  view: 'households' | 'feedback';
+}
+
+// ── Household requests (Fixtures/Settings/household-requests.json) ───────────
+
+export type HouseholdRequestStatus = 'pending' | 'approved' | 'rejected';
+
+export interface HouseholdRequestDto {
+  id: number;
+  householdName: string;
+  displayName: string;
+  email: string;
+  status: HouseholdRequestStatus;
+  /** full ISO-8601 instant (UTC). */
+  requestedAt: string;
+  /** full ISO-8601 instant (UTC), or null until reviewed. */
+  reviewedAt: string | null;
+  reviewedBy: string | null;
+  rejectionReason: string | null;
+}
+
+export interface HouseholdSummaryDto {
+  householdId: number;
+  name: string;
+  memberCount: number;
+  /** full ISO-8601 instant (UTC). */
+  createdAt: string;
+}
+
+export interface HouseholdRequestsDto {
+  requests: HouseholdRequestDto[];
+  households: HouseholdSummaryDto[];
+}
+
+// ── Feedback (Fixtures/Settings/feedback.json) ──────────────────────────────
+
+export type FeedbackType = 'bug' | 'featureRequest' | 'general';
+
+export interface FeedbackDto {
+  id: number;
+  type: FeedbackType;
+  message: string;
+  currentPage: string | null;
+  isRead: boolean;
+  isResolved: boolean;
+  /** full ISO-8601 instant (UTC). */
+  createdAt: string;
+  /** Author 3-way (R-C6): live user → name; deleted user → null + authorDeleted; anonymous → null + !authorDeleted. */
+  authorName: string | null;
+  authorDeleted: boolean;
+}
+
+export interface FeedbackListDto {
+  isSiteAdmin: boolean;
+  items: FeedbackDto[];
+}

--- a/frontend/admin/src/main.ts
+++ b/frontend/admin/src/main.ts
@@ -1,0 +1,196 @@
+import { mount as svelteMount, unmount } from 'svelte';
+import type { Component } from 'svelte';
+import HouseholdsApp from './HouseholdsApp.svelte';
+import FeedbackApp from './FeedbackApp.svelte';
+import './styles/app.css';
+import type { ShellContext } from './lib/types';
+
+type MountedApp = ReturnType<typeof svelteMount>;
+
+interface Instance {
+  app: MountedApp;
+  /** The exact node we mounted into — lets us detect a Blazor resume that
+   *  replaced or emptied the root out from under us. */
+  el: HTMLElement;
+}
+
+// Blazor Server inserts component output via DOM diff, and inline <script>
+// tags in that output are NOT executed by the browser. The Razor shells
+// (HouseholdAdmin.razor / FeedbackAdmin.razor) use IJSRuntime.InvokeAsync("import", …)
+// to load this module, then call the global mounter below. Exposing a named
+// entry on window is the simplest way to survive enhanced-nav round-trips.
+declare global {
+  interface Window {
+    AdminIsland?: {
+      mount(rootId: string): void;
+      destroy(rootId: string): void;
+    };
+  }
+}
+
+// One bundle serves BOTH admin routes (spec D1): /settings/households mounts the
+// households root, /settings/feedback mounts the feedback root. The root's
+// `data-view` attr picks the component; only one root is present per page.
+const HOUSEHOLDS_ROOT_ID = 'admin-households-root';
+const FEEDBACK_ROOT_ID = 'admin-feedback-root';
+const ALL_ROOT_IDS = [HOUSEHOLDS_ROOT_ID, FEEDBACK_ROOT_ID];
+
+const instances = new Map<string, Instance>();
+
+// Roots the Razor shell has asked us to mount. We re-assert these when the page
+// is restored so a Blazor circuit resume / enhanced-nav merge that wiped our
+// content can't leave the island permanently blank (see runHeal below).
+const desiredRoots = new Set<string>();
+
+function readContext(el: HTMLElement): ShellContext {
+  const householdId = Number(el.dataset.householdId ?? '0');
+  const userId = Number(el.dataset.userId ?? '0');
+  const userName = el.dataset.userName ?? '';
+  const view = el.dataset.view === 'feedback' ? 'feedback' : 'households';
+  if (!householdId || !userId) {
+    throw new Error('admin: missing data-household-id / data-user-id');
+  }
+  return { householdId, userId, userName, view };
+}
+
+function componentForView(view: ShellContext['view']): Component<{ ctx: ShellContext }> {
+  return (view === 'feedback' ? FeedbackApp : HouseholdsApp) as Component<{ ctx: ShellContext }>;
+}
+
+// Track dark-mode state and mirror it as a class on the island root so the
+// CSS override wins even when MudBlazor's runtime toggle doesn't propagate
+// the class down to us (we've seen it stay on <html> at load but go missing
+// after runtime toggles, leaving the island stuck in light mode).
+const darkObservers = new Map<string, () => void>();
+
+function isDarkActive(): boolean {
+  if (document.documentElement.classList.contains('mud-theme-dark')) return true;
+  if (document.body?.classList.contains('mud-theme-dark')) return true;
+  try {
+    if (localStorage.getItem('darkMode') === 'true') return true;
+  } catch { /* storage blocked */ }
+  return false;
+}
+
+function syncDarkClass(el: HTMLElement) {
+  el.classList.toggle('adm-dark-mode', isDarkActive());
+}
+
+function installDarkObserver(rootId: string, el: HTMLElement) {
+  syncDarkClass(el);
+  const htmlObs = new MutationObserver(() => syncDarkClass(el));
+  htmlObs.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
+  const bodyObs = new MutationObserver(() => syncDarkClass(el));
+  if (document.body) bodyObs.observe(document.body, { attributes: true, attributeFilter: ['class'] });
+  const storageHandler = (e: StorageEvent) => {
+    if (e.key === 'darkMode') syncDarkClass(el);
+  };
+  window.addEventListener('storage', storageHandler);
+  darkObservers.set(rootId, () => {
+    htmlObs.disconnect();
+    bodyObs.disconnect();
+    window.removeEventListener('storage', storageHandler);
+  });
+}
+
+/**
+ * A mount is healthy only if the CURRENT root element is the exact node we
+ * mounted into, it's still in the document, and it still holds our rendered
+ * children. Blazor's .NET 10 circuit resume REPLACES the root node and re-runs
+ * the host component's lifecycle — a fresh firstRender re-calls mount().
+ * Comparing the live node to the one we mounted into lets the re-invoked
+ * mount() rebuild instead of no-op.
+ */
+function isHealthy(rootId: string): boolean {
+  const inst = instances.get(rootId);
+  if (!inst) return false;
+  const el = document.getElementById(rootId);
+  return el != null && el === inst.el && el.isConnected && el.childElementCount > 0;
+}
+
+function mountRoot(rootId: string) {
+  desiredRoots.add(rootId);
+  if (isHealthy(rootId)) return;
+  if (instances.has(rootId)) destroyRoot(rootId, /* internal */ true);
+  const el = document.getElementById(rootId) as HTMLElement | null;
+  if (!el) {
+    console.warn('[admin-island] root element not found:', rootId);
+    return;
+  }
+  installDarkObserver(rootId, el);
+  const ctx = readContext(el);
+  const app = svelteMount(componentForView(ctx.view), { target: el, props: { ctx } });
+  instances.set(rootId, { app, el });
+  ensureHealObserver();
+}
+
+function destroyRoot(rootId: string, internal = false) {
+  const inst = instances.get(rootId);
+  if (!inst) {
+    if (!internal) desiredRoots.delete(rootId);
+    return;
+  }
+  // Blazor's circuit resume disposes the OLD page component AFTER re-initialising
+  // the new one (whose firstRender re-calls mount()). Ignore an external destroy
+  // while the current mount is healthy; a genuine navigation-away leaves no healthy
+  // root, so real teardown still runs then. `internal` (self-heal) always proceeds.
+  if (!internal && isHealthy(rootId)) return;
+  if (!internal) desiredRoots.delete(rootId);
+  unmount(inst.app);
+  instances.delete(rootId);
+  const disposer = darkObservers.get(rootId);
+  if (disposer) {
+    disposer();
+    darkObservers.delete(rootId);
+  }
+}
+
+window.AdminIsland = { mount: mountRoot, destroy: destroyRoot };
+
+// ── Resilience: self-heal after a Blazor circuit resume ────────────────────
+// Mobile browsers background the tab on an app/tab switch; Blazor Server's .NET
+// 10 circuit pause/resume then reconciles the DOM on return and can REPLACE the
+// island root. We watch a STABLE anchor (document.body) and rebuild any desired
+// root that has gone unhealthy. `healing` guards re-entrancy; once the root is
+// healthy again the next pass no-ops, so it can't loop.
+let healObserver: MutationObserver | null = null;
+let healing = false;
+function runHeal() {
+  if (healing) return;
+  healing = true;
+  try {
+    for (const rootId of desiredRoots) {
+      if (document.getElementById(rootId) && !isHealthy(rootId)) mountRoot(rootId);
+    }
+  } finally {
+    healing = false;
+  }
+}
+function ensureHealObserver() {
+  if (healObserver || !document.body) return;
+  healObserver = new MutationObserver(runHeal);
+  healObserver.observe(document.body, { childList: true, subtree: true });
+}
+
+// bfcache restore re-attaches the frozen DOM without any mutation, so the body
+// observer won't fire — re-assert directly on pageshow as a cheap belt.
+window.addEventListener('pageshow', () => {
+  ensureHealObserver();
+  for (const rootId of desiredRoots) {
+    if (document.getElementById(rootId) && !isHealthy(rootId)) mountRoot(rootId);
+  }
+});
+
+// Standalone dev auto-mount: if a known root is already on the page when the
+// module loads (Vite's index.html), mount it immediately. In production the
+// Razor shell calls window.AdminIsland.mount() explicitly via JS interop.
+function autoMountIfReady() {
+  for (const rootId of ALL_ROOT_IDS) {
+    if (document.getElementById(rootId)) mountRoot(rootId);
+  }
+}
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', autoMountIfReady);
+} else {
+  autoMountIfReady();
+}

--- a/frontend/admin/src/styles/app.css
+++ b/frontend/admin/src/styles/app.css
@@ -1,0 +1,39 @@
+@import './tokens.css';
+
+/*
+ * The island renders inside the host page, which also loads Bootstrap + MudBlazor.
+ * Bootstrap defines .row / .container globally, and those names collide with
+ * ambient island styles. We avoid the collision by prefixing all island class
+ * names (`adm-` for layout, `rc-` for the shared dialog/toast components) rather
+ * than overriding globals here.
+ */
+
+#admin-households-root,
+#admin-feedback-root {
+  font-family: var(--font-family);
+  color: var(--color-text);
+  background: var(--color-background);
+  min-height: 100%;
+}
+
+#admin-households-root,
+#admin-households-root *,
+#admin-households-root *::before,
+#admin-households-root *::after,
+#admin-feedback-root,
+#admin-feedback-root *,
+#admin-feedback-root *::before,
+#admin-feedback-root *::after {
+  box-sizing: border-box;
+}
+
+/*
+ * Suppress the outer Blazor ReconnectModal while the island is on the page.
+ * It's a showModal() <dialog>, which blocks all interaction behind it —
+ * including our HTTP-driven island that doesn't need the circuit to work.
+ * This CSS only ships on the admin pages (via <HeadContent>), so other
+ * pages still get the normal reconnect UX.
+ */
+#components-reconnect-modal {
+  display: none !important;
+}

--- a/frontend/admin/src/styles/tokens.css
+++ b/frontend/admin/src/styles/tokens.css
@@ -1,0 +1,97 @@
+/*
+ * Design tokens mirrored from the MudBlazor theme used elsewhere in the app
+ * (kept in sync with frontend/meal-plan/src/styles/tokens.css).
+ * Light mode = :root. Dark mode = html.mud-theme-dark (set by App.razor)
+ * plus #admin-households-root.adm-dark-mode / #admin-feedback-root.adm-dark-mode
+ * (mirrored by main.ts's dark observer).
+ */
+
+:root {
+  /* brand */
+  --color-primary: rgb(46, 125, 50);
+  --color-primary-hover: rgb(36, 97, 39);
+  --color-primary-soft: rgb(58, 156, 63);
+  --color-secondary: rgb(255, 111, 0);
+
+  /* surfaces */
+  --color-surface: rgb(255, 255, 255);
+  --color-background: rgb(250, 250, 250);
+  --color-appbar: rgb(46, 125, 50);
+  --color-drawer: rgb(245, 245, 245);
+
+  /* text */
+  --color-text: rgb(66, 66, 66);
+  --color-text-muted: rgba(0, 0, 0, 0.54);
+  --color-text-disabled: rgba(0, 0, 0, 0.38);
+
+  /* structure */
+  --color-line: rgba(0, 0, 0, 0.12);
+  --color-line-strong: rgb(189, 189, 189);
+  --color-divider: rgb(224, 224, 224);
+  --color-action-hover: rgba(0, 0, 0, 0.06);
+  --color-action-disabled: rgba(0, 0, 0, 0.26);
+
+  /* semantic */
+  --color-success: rgb(67, 160, 71);
+  --color-error: rgb(229, 57, 53);
+  --color-warning: rgb(251, 140, 0);
+  --color-info: rgb(30, 136, 229);
+
+  /* typography */
+  --font-family: Roboto, Helvetica, Arial, sans-serif;
+
+  /* shape */
+  --radius-sm: 4px;
+  --radius-md: 4px;
+
+  /* elevation (MudBlazor 1, 2, 4) */
+  --shadow-1:
+    0 2px 1px -1px rgba(0, 0, 0, 0.2),
+    0 1px 1px 0 rgba(0, 0, 0, 0.14),
+    0 1px 3px 0 rgba(0, 0, 0, 0.12);
+  --shadow-2:
+    0 3px 1px -2px rgba(0, 0, 0, 0.2),
+    0 2px 2px 0 rgba(0, 0, 0, 0.14),
+    0 1px 5px 0 rgba(0, 0, 0, 0.12);
+  --shadow-4:
+    0 2px 4px -1px rgba(0, 0, 0, 0.2),
+    0 4px 5px 0 rgba(0, 0, 0, 0.14),
+    0 1px 10px 0 rgba(0, 0, 0, 0.12);
+}
+
+/*
+ * Dark-mode override. MudBlazor v8 + the App.razor bootstrap script both
+ * toggle `mud-theme-dark` on <html>, but runtime theme toggles sometimes
+ * land on <body> or deeper. Matching the bare class is a superset that
+ * works regardless of where the ancestor lives.
+ */
+.mud-theme-dark,
+html.mud-theme-dark,
+body.mud-theme-dark,
+#admin-households-root.adm-dark-mode,
+#admin-feedback-root.adm-dark-mode {
+  --color-primary: rgb(102, 187, 106);
+  --color-primary-hover: rgb(77, 172, 82);
+  --color-primary-soft: rgb(128, 198, 132);
+  --color-secondary: rgb(255, 183, 77);
+
+  --color-surface: rgb(30, 30, 30);
+  --color-background: rgb(18, 18, 18);
+  --color-appbar: rgb(26, 26, 26);
+  --color-drawer: rgb(26, 26, 26);
+
+  --color-text: rgba(255, 255, 255, 0.87);
+  --color-text-muted: rgba(255, 255, 255, 0.6);
+  --color-text-disabled: rgba(255, 255, 255, 0.2);
+
+  --color-line: rgba(255, 255, 255, 0.12);
+  --color-line-strong: rgba(255, 255, 255, 0.3);
+  --color-divider: rgba(255, 255, 255, 0.12);
+  --color-action-hover: rgba(173, 173, 177, 0.06);
+  --color-action-disabled: rgba(255, 255, 255, 0.26);
+
+  --color-success: rgb(102, 187, 106);
+  --color-error: rgb(239, 83, 80);
+  --color-warning: rgb(255, 167, 38);
+  --color-info: rgb(66, 165, 245);
+}

--- a/frontend/admin/src/vite-env.d.ts
+++ b/frontend/admin/src/vite-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="svelte" />
+/// <reference types="vite/client" />

--- a/frontend/admin/svelte.config.js
+++ b/frontend/admin/svelte.config.js
@@ -1,0 +1,8 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+export default {
+  preprocess: vitePreprocess(),
+  compilerOptions: {
+    runes: true,
+  },
+};

--- a/frontend/admin/tsconfig.json
+++ b/frontend/admin/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "@tsconfig/svelte/tsconfig.json",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowJs": false,
+    "checkJs": false,
+    "isolatedModules": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitAny": true,
+    "skipLibCheck": true,
+    "types": ["svelte", "vite/client"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.svelte", "src/vite-env.d.ts"]
+}

--- a/frontend/admin/vite.config.ts
+++ b/frontend/admin/vite.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+
+// The admin island (cluster C) is embedded into two Razor shells (HouseholdAdmin.razor
+// at /settings/households and FeedbackAdmin.razor at /settings/feedback). Both host pages
+// load this single bundle and mount the matching root by a data-view attr (spec D1).
+// Build output goes to ./dist/ — the CopyAdminIsland MSBuild target in
+// FamilyCoordinationApp.csproj copies this into wwwroot/islands/admin/.
+// The admin-node-build Docker stage emits dist/; the .NET stage reads it via COPY --from.
+// Mirrors frontend/settings/vite.config.ts (output index.js + index.css).
+export default defineConfig({
+  plugins: [svelte()],
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    rollupOptions: {
+      input: 'src/main.ts',
+      output: {
+        entryFileNames: 'index.js',
+        chunkFileNames: 'chunks/[name]-[hash].js',
+        assetFileNames: (info) =>
+          info.name?.endsWith('.css') ? 'index.css' : 'assets/[name]-[hash][extname]',
+      },
+    },
+    sourcemap: true,
+  },
+  server: {
+    port: 5180,
+    // Dev server proxies /api to the running .NET app so `npm run dev` works
+    // standalone against a locally-running Blazor host on :5000.
+    proxy: {
+      '/api': {
+        target: 'http://localhost:5000',
+        changeOrigin: false,
+      },
+    },
+  },
+});

--- a/src/FamilyCoordinationApp/Components/Pages/Settings/FeedbackAdmin.razor
+++ b/src/FamilyCoordinationApp/Components/Pages/Settings/FeedbackAdmin.razor
@@ -1,288 +1,129 @@
 @page "/settings/feedback"
 @attribute [Authorize]
 @using FamilyCoordinationApp.Data
-@using FamilyCoordinationApp.Data.Entities
-@using FamilyCoordinationApp.Services
+@using Microsoft.AspNetCore.Components.Web
 @using Microsoft.EntityFrameworkCore
+@using Microsoft.JSInterop
 @using System.Security.Claims
+@implements IAsyncDisposable
 
+@inject IConfiguration Config
+@inject AuthenticationStateProvider AuthStateProvider
 @inject IDbContextFactory<ApplicationDbContext> DbFactory
-@inject ISnackbar Snackbar
-@inject ISiteAdminService SiteAdminService
+@inject IJSRuntime JS
+@inject IWebHostEnvironment HostEnv
 
-<PageTitle>Feedback - Family Kitchen</PageTitle>
+@*
+    Thin island host (strangler, cluster C). Flag ON (SETTINGS_ADMIN_USE_ISLAND=true) → mount the Svelte admin
+    island (feedback view); flag OFF → the existing Blazor page (<FeedbackAdminBlazor/>) as the zero-regression
+    fallback. Mirrors Categories.razor. One bundle (/islands/admin) serves both this and HouseholdAdmin.razor; the
+    data-view attr picks the view. Feedback is DUAL-MODE — the server scopes the list (admin: all; regular: own
+    household, R-C1), so this host mounts the island for everyone.
+*@
 
-<MudContainer MaxWidth="MaxWidth.Large" Class="py-4">
-    <div class="d-flex justify-space-between align-center mb-4">
-        <MudText Typo="Typo.h4">Feedback & Requests</MudText>
-        <MudToggleGroup T="string" @bind-Value="_filter" Color="Color.Primary" Rounded="true">
-            <MudToggleItem Value="@("all")">All</MudToggleItem>
-            <MudToggleItem Value="@("unread")">Unread</MudToggleItem>
-            <MudToggleItem Value="@("open")">Open</MudToggleItem>
-        </MudToggleGroup>
-    </div>
-
-    @if (_loading)
+@* Flag ON → never render the Blazor fallback, even in the async gap before _shell resolves
+   (memory fca-island-host-prerender-fallback-race). *@
+@if (_useIsland)
+{
+    @if (_shell is not null)
     {
-        <MudProgressLinear Indeterminate="true" />
-    }
-    else if (!_feedbackItems.Any())
-    {
-        <MudAlert Severity="Severity.Info">
-            No feedback yet. The feedback button appears in the bottom-left corner of every page.
-        </MudAlert>
-    }
-    else
-    {
-        <MudStack Spacing="3">
-            @foreach (var item in FilteredItems)
-            {
-                <MudCard Elevation="2" Class="@(item.IsRead ? "" : "unread-card")">
-                    <MudCardHeader>
-                        <CardHeaderAvatar>
-                            <MudAvatar Color="@GetTypeColor(item.Type)" Variant="Variant.Outlined">
-                                <MudIcon Icon="@GetTypeIcon(item.Type)" />
-                            </MudAvatar>
-                        </CardHeaderAvatar>
-                        <CardHeaderContent>
-                            <div class="d-flex align-center gap-2">
-                                <MudChip T="string" Size="Size.Small" Color="@GetTypeColor(item.Type)">
-                                    @item.Type
-                                </MudChip>
-                                @if (!item.IsRead)
-                                {
-                                    <MudChip T="string" Size="Size.Small" Color="Color.Info">New</MudChip>
-                                }
-                                @if (item.IsResolved)
-                                {
-                                    <MudChip T="string" Size="Size.Small" Color="Color.Success">Resolved</MudChip>
-                                }
-                            </div>
-                            <MudText Typo="Typo.caption" Color="Color.Secondary">
-                                @item.CreatedAt.ToLocalTime().ToString("MMM d, yyyy h:mm tt")
-                                @if (item.User != null)
-                                {
-                                    @: — @item.User.DisplayName
-                                }
-                                else if (item.UserId.HasValue)
-                                {
-                                    @: — <em>Deleted user</em>
-                                }
-                            </MudText>
-                        </CardHeaderContent>
-                        <CardHeaderActions>
-                            <MudMenu Icon="@Icons.Material.Filled.MoreVert">
-                                @if (!item.IsRead)
-                                {
-                                    <MudMenuItem OnClick="@(() => MarkAsRead(item))">
-                                        Mark as Read
-                                    </MudMenuItem>
-                                }
-                                @if (!item.IsResolved)
-                                {
-                                    <MudMenuItem OnClick="@(() => MarkAsResolved(item))">
-                                        Mark as Resolved
-                                    </MudMenuItem>
-                                }
-                                else
-                                {
-                                    <MudMenuItem OnClick="@(() => ReopenItem(item))">
-                                        Reopen
-                                    </MudMenuItem>
-                                }
-                            </MudMenu>
-                        </CardHeaderActions>
-                    </MudCardHeader>
-                    <MudCardContent>
-                        <MudText Style="white-space: pre-wrap;">@item.Message</MudText>
-                        
-                        @if (!string.IsNullOrEmpty(item.CurrentPage))
-                        {
-                            <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mt-2">
-                                <MudIcon Icon="@Icons.Material.Filled.Link" Size="Size.Small" Class="mr-1" />
-                                @item.CurrentPage
-                            </MudText>
-                        }
-                    </MudCardContent>
-                </MudCard>
-            }
-        </MudStack>
-    }
-</MudContainer>
+        <PageTitle>Feedback - Family Kitchen</PageTitle>
 
-<style>
-    .unread-card {
-        border-left: 4px solid var(--mud-palette-info);
-    }
-</style>
+        <HeadContent>
+            <link rel="stylesheet" href="/islands/admin/index.css?v=@IslandVersion" />
+        </HeadContent>
 
-@implements IDisposable
+        <div id="admin-feedback-root"
+             data-household-id="@_shell.HouseholdId"
+             data-user-id="@_shell.UserId"
+             data-user-name="@_shell.UserName"
+             data-view="feedback"></div>
+    }
+}
+else
+{
+    <FeedbackAdminBlazor />
+}
 
 @code {
-    [CascadingParameter]
-    private Task<AuthenticationState>? AuthStateTask { get; set; }
+    private bool _useIsland;
+    private ShellData? _shell;
+    private IJSObjectReference? _islandModule;
 
-    private List<Feedback> _feedbackItems = new();
-    private bool _loading = true;
-    private string _filter = "all";
-    private System.Timers.Timer? _refreshTimer;
-    private int _lastCount = 0;
-    private bool _isSiteAdmin = false;
-    private int? _currentHouseholdId;
-
-    private IEnumerable<Feedback> FilteredItems => _filter switch
-    {
-        "unread" => _feedbackItems.Where(f => !f.IsRead),
-        "open" => _feedbackItems.Where(f => !f.IsResolved),
-        _ => _feedbackItems
-    };
+    private const string RootId = "admin-feedback-root";
 
     protected override async Task OnInitializedAsync()
     {
-        await LoadCurrentUser();
-        await LoadFeedback();
-        
-        // Auto-refresh every 15 seconds
-        _refreshTimer = new System.Timers.Timer(15000);
-        _refreshTimer.Elapsed += async (_, _) => await InvokeAsync(RefreshIfChanged);
-        _refreshTimer.Start();
-    }
+        _useIsland = IsIslandEnabled();
+        if (!_useIsland) return;
 
-    private async Task LoadCurrentUser()
-    {
-        if (AuthStateTask == null) return;
-
-        var authState = await AuthStateTask;
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
         var email = authState.User.FindFirst(ClaimTypes.Email)?.Value;
+        var userName = authState.User.FindFirst(ClaimTypes.Name)?.Value ?? string.Empty;
 
-        if (!string.IsNullOrEmpty(email))
+        await using var context = await DbFactory.CreateDbContextAsync();
+        var user = await context.Users.FirstOrDefaultAsync(u => u.Email == email);
+        if (user is null)
         {
-            _isSiteAdmin = SiteAdminService.IsSiteAdmin(email);
-
-            if (!_isSiteAdmin)
-            {
-                await using var context = await DbFactory.CreateDbContextAsync();
-                var user = await context.Users.FirstOrDefaultAsync(u => u.Email == email);
-                _currentHouseholdId = user?.HouseholdId;
-            }
+            throw new InvalidOperationException("User not found. Please log in again.");
         }
+
+        _shell = new ShellData(user.HouseholdId, user.Id, userName);
     }
-    
-    private async Task RefreshIfChanged()
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender || !_useIsland || _shell is null) return;
+
+        await JS.InvokeVoidAsync("ensureIslandStylesheet", $"/islands/admin/index.css?v={IslandVersion}");
+
+        _islandModule = await JS.InvokeAsync<IJSObjectReference>(
+            "import", $"/islands/admin/index.js?v={IslandVersion}");
+        await JS.InvokeVoidAsync("AdminIsland.mount", RootId);
+    }
+
+    // Cache-bust the island URLs per deploy via the published bundle's mtime (mirrors Categories.razor).
+    private static string? _islandVersion;
+    private string IslandVersion => _islandVersion ??= ComputeIslandVersion();
+
+    private string ComputeIslandVersion()
     {
         try
         {
-            await using var context = await DbFactory.CreateDbContextAsync();
-            
-            IQueryable<Feedback> query = context.Feedbacks;
-            if (!_isSiteAdmin && _currentHouseholdId.HasValue)
-            {
-                query = query.Where(f => f.HouseholdId == _currentHouseholdId);
-            }
-            
-            var count = await query.CountAsync();
-            
-            if (count != _lastCount)
-            {
-                await LoadFeedback();
-            }
+            var path = Path.Combine(HostEnv.WebRootPath, "islands", "admin", "index.js");
+            return new DateTimeOffset(File.GetLastWriteTimeUtc(path)).ToUnixTimeSeconds().ToString();
         }
         catch
         {
-            // Ignore refresh errors
+            return "0";
         }
     }
 
-    private async Task LoadFeedback()
+    private bool IsIslandEnabled()
     {
-        _loading = true;
-        StateHasChanged();
+        var configValue = Config["SETTINGS_ADMIN_USE_ISLAND"];
+        if (!string.IsNullOrEmpty(configValue))
+        {
+            return configValue.Equals("true", StringComparison.OrdinalIgnoreCase);
+        }
 
+        var envValue = Environment.GetEnvironmentVariable("SETTINGS_ADMIN_USE_ISLAND");
+        return string.Equals(envValue, "true", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_islandModule is null) return;
         try
         {
-            await using var context = await DbFactory.CreateDbContextAsync();
-            
-            IQueryable<Feedback> query = context.Feedbacks
-                .Include(f => f.User)
-                .Include(f => f.Household);
-
-            // Site admins see all feedback; regular users see only their household's
-            if (!_isSiteAdmin && _currentHouseholdId.HasValue)
-            {
-                query = query.Where(f => f.HouseholdId == _currentHouseholdId);
-            }
-
-            _feedbackItems = await query
-                .OrderByDescending(f => f.CreatedAt)
-                .ToListAsync();
-            _lastCount = _feedbackItems.Count;
+            await JS.InvokeVoidAsync("AdminIsland.destroy", RootId);
+            await _islandModule.DisposeAsync();
         }
-        finally
+        catch (JSDisconnectedException)
         {
-            _loading = false;
-            StateHasChanged();
+            // Circuit already gone (user navigated away after disconnect) — nothing to clean up.
         }
     }
 
-    private async Task MarkAsRead(Feedback item)
-    {
-        await using var context = await DbFactory.CreateDbContextAsync();
-        var feedback = await context.Feedbacks.FindAsync(item.Id);
-        if (feedback != null)
-        {
-            feedback.IsRead = true;
-            await context.SaveChangesAsync();
-            item.IsRead = true;
-            StateHasChanged();
-        }
-    }
-
-    private async Task MarkAsResolved(Feedback item)
-    {
-        await using var context = await DbFactory.CreateDbContextAsync();
-        var feedback = await context.Feedbacks.FindAsync(item.Id);
-        if (feedback != null)
-        {
-            feedback.IsRead = true;
-            feedback.IsResolved = true;
-            await context.SaveChangesAsync();
-            item.IsRead = true;
-            item.IsResolved = true;
-            Snackbar.Add("Marked as resolved", Severity.Success);
-            StateHasChanged();
-        }
-    }
-
-    private async Task ReopenItem(Feedback item)
-    {
-        await using var context = await DbFactory.CreateDbContextAsync();
-        var feedback = await context.Feedbacks.FindAsync(item.Id);
-        if (feedback != null)
-        {
-            feedback.IsResolved = false;
-            await context.SaveChangesAsync();
-            item.IsResolved = false;
-            StateHasChanged();
-        }
-    }
-
-    private static Color GetTypeColor(FeedbackType type) => type switch
-    {
-        FeedbackType.Bug => Color.Error,
-        FeedbackType.FeatureRequest => Color.Info,
-        _ => Color.Default
-    };
-
-    private static string GetTypeIcon(FeedbackType type) => type switch
-    {
-        FeedbackType.Bug => Icons.Material.Filled.BugReport,
-        FeedbackType.FeatureRequest => Icons.Material.Filled.Lightbulb,
-        _ => Icons.Material.Filled.Chat
-    };
-    
-    public void Dispose()
-    {
-        _refreshTimer?.Stop();
-        _refreshTimer?.Dispose();
-    }
+    private sealed record ShellData(int HouseholdId, int UserId, string UserName);
 }

--- a/src/FamilyCoordinationApp/Components/Pages/Settings/FeedbackAdminBlazor.razor
+++ b/src/FamilyCoordinationApp/Components/Pages/Settings/FeedbackAdminBlazor.razor
@@ -1,0 +1,293 @@
+@using FamilyCoordinationApp.Data
+@using FamilyCoordinationApp.Data.Entities
+@using FamilyCoordinationApp.Services
+@using Microsoft.EntityFrameworkCore
+@using System.Security.Claims
+
+@inject IDbContextFactory<ApplicationDbContext> DbFactory
+@inject ISnackbar Snackbar
+@inject ISiteAdminService SiteAdminService
+
+@*
+    The original Blazor feedback body, extracted verbatim from FeedbackAdmin.razor as the zero-regression
+    fallback for the strangler (flag SETTINGS_ADMIN_USE_ISLAND=false → this renders). NOT routable — the
+    @@page "/settings/feedback" + [Authorize] live on the host FeedbackAdmin.razor. Delete once the island is
+    prod-stable.
+*@
+
+<PageTitle>Feedback - Family Kitchen</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Large" Class="py-4">
+    <div class="d-flex justify-space-between align-center mb-4">
+        <MudText Typo="Typo.h4">Feedback & Requests</MudText>
+        <MudToggleGroup T="string" @bind-Value="_filter" Color="Color.Primary" Rounded="true">
+            <MudToggleItem Value="@("all")">All</MudToggleItem>
+            <MudToggleItem Value="@("unread")">Unread</MudToggleItem>
+            <MudToggleItem Value="@("open")">Open</MudToggleItem>
+        </MudToggleGroup>
+    </div>
+
+    @if (_loading)
+    {
+        <MudProgressLinear Indeterminate="true" />
+    }
+    else if (!_feedbackItems.Any())
+    {
+        <MudAlert Severity="Severity.Info">
+            No feedback yet. The feedback button appears in the bottom-left corner of every page.
+        </MudAlert>
+    }
+    else
+    {
+        <MudStack Spacing="3">
+            @foreach (var item in FilteredItems)
+            {
+                <MudCard Elevation="2" Class="@(item.IsRead ? "" : "unread-card")">
+                    <MudCardHeader>
+                        <CardHeaderAvatar>
+                            <MudAvatar Color="@GetTypeColor(item.Type)" Variant="Variant.Outlined">
+                                <MudIcon Icon="@GetTypeIcon(item.Type)" />
+                            </MudAvatar>
+                        </CardHeaderAvatar>
+                        <CardHeaderContent>
+                            <div class="d-flex align-center gap-2">
+                                <MudChip T="string" Size="Size.Small" Color="@GetTypeColor(item.Type)">
+                                    @item.Type
+                                </MudChip>
+                                @if (!item.IsRead)
+                                {
+                                    <MudChip T="string" Size="Size.Small" Color="Color.Info">New</MudChip>
+                                }
+                                @if (item.IsResolved)
+                                {
+                                    <MudChip T="string" Size="Size.Small" Color="Color.Success">Resolved</MudChip>
+                                }
+                            </div>
+                            <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                @item.CreatedAt.ToLocalTime().ToString("MMM d, yyyy h:mm tt")
+                                @if (item.User != null)
+                                {
+                                    @: — @item.User.DisplayName
+                                }
+                                else if (item.UserId.HasValue)
+                                {
+                                    @: — <em>Deleted user</em>
+                                }
+                            </MudText>
+                        </CardHeaderContent>
+                        <CardHeaderActions>
+                            <MudMenu Icon="@Icons.Material.Filled.MoreVert">
+                                @if (!item.IsRead)
+                                {
+                                    <MudMenuItem OnClick="@(() => MarkAsRead(item))">
+                                        Mark as Read
+                                    </MudMenuItem>
+                                }
+                                @if (!item.IsResolved)
+                                {
+                                    <MudMenuItem OnClick="@(() => MarkAsResolved(item))">
+                                        Mark as Resolved
+                                    </MudMenuItem>
+                                }
+                                else
+                                {
+                                    <MudMenuItem OnClick="@(() => ReopenItem(item))">
+                                        Reopen
+                                    </MudMenuItem>
+                                }
+                            </MudMenu>
+                        </CardHeaderActions>
+                    </MudCardHeader>
+                    <MudCardContent>
+                        <MudText Style="white-space: pre-wrap;">@item.Message</MudText>
+                        
+                        @if (!string.IsNullOrEmpty(item.CurrentPage))
+                        {
+                            <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mt-2">
+                                <MudIcon Icon="@Icons.Material.Filled.Link" Size="Size.Small" Class="mr-1" />
+                                @item.CurrentPage
+                            </MudText>
+                        }
+                    </MudCardContent>
+                </MudCard>
+            }
+        </MudStack>
+    }
+</MudContainer>
+
+<style>
+    .unread-card {
+        border-left: 4px solid var(--mud-palette-info);
+    }
+</style>
+
+@implements IDisposable
+
+@code {
+    [CascadingParameter]
+    private Task<AuthenticationState>? AuthStateTask { get; set; }
+
+    private List<Feedback> _feedbackItems = new();
+    private bool _loading = true;
+    private string _filter = "all";
+    private System.Timers.Timer? _refreshTimer;
+    private int _lastCount = 0;
+    private bool _isSiteAdmin = false;
+    private int? _currentHouseholdId;
+
+    private IEnumerable<Feedback> FilteredItems => _filter switch
+    {
+        "unread" => _feedbackItems.Where(f => !f.IsRead),
+        "open" => _feedbackItems.Where(f => !f.IsResolved),
+        _ => _feedbackItems
+    };
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadCurrentUser();
+        await LoadFeedback();
+        
+        // Auto-refresh every 15 seconds
+        _refreshTimer = new System.Timers.Timer(15000);
+        _refreshTimer.Elapsed += async (_, _) => await InvokeAsync(RefreshIfChanged);
+        _refreshTimer.Start();
+    }
+
+    private async Task LoadCurrentUser()
+    {
+        if (AuthStateTask == null) return;
+
+        var authState = await AuthStateTask;
+        var email = authState.User.FindFirst(ClaimTypes.Email)?.Value;
+
+        if (!string.IsNullOrEmpty(email))
+        {
+            _isSiteAdmin = SiteAdminService.IsSiteAdmin(email);
+
+            if (!_isSiteAdmin)
+            {
+                await using var context = await DbFactory.CreateDbContextAsync();
+                var user = await context.Users.FirstOrDefaultAsync(u => u.Email == email);
+                _currentHouseholdId = user?.HouseholdId;
+            }
+        }
+    }
+    
+    private async Task RefreshIfChanged()
+    {
+        try
+        {
+            await using var context = await DbFactory.CreateDbContextAsync();
+            
+            IQueryable<Feedback> query = context.Feedbacks;
+            if (!_isSiteAdmin && _currentHouseholdId.HasValue)
+            {
+                query = query.Where(f => f.HouseholdId == _currentHouseholdId);
+            }
+            
+            var count = await query.CountAsync();
+            
+            if (count != _lastCount)
+            {
+                await LoadFeedback();
+            }
+        }
+        catch
+        {
+            // Ignore refresh errors
+        }
+    }
+
+    private async Task LoadFeedback()
+    {
+        _loading = true;
+        StateHasChanged();
+
+        try
+        {
+            await using var context = await DbFactory.CreateDbContextAsync();
+            
+            IQueryable<Feedback> query = context.Feedbacks
+                .Include(f => f.User)
+                .Include(f => f.Household);
+
+            // Site admins see all feedback; regular users see only their household's
+            if (!_isSiteAdmin && _currentHouseholdId.HasValue)
+            {
+                query = query.Where(f => f.HouseholdId == _currentHouseholdId);
+            }
+
+            _feedbackItems = await query
+                .OrderByDescending(f => f.CreatedAt)
+                .ToListAsync();
+            _lastCount = _feedbackItems.Count;
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task MarkAsRead(Feedback item)
+    {
+        await using var context = await DbFactory.CreateDbContextAsync();
+        var feedback = await context.Feedbacks.FindAsync(item.Id);
+        if (feedback != null)
+        {
+            feedback.IsRead = true;
+            await context.SaveChangesAsync();
+            item.IsRead = true;
+            StateHasChanged();
+        }
+    }
+
+    private async Task MarkAsResolved(Feedback item)
+    {
+        await using var context = await DbFactory.CreateDbContextAsync();
+        var feedback = await context.Feedbacks.FindAsync(item.Id);
+        if (feedback != null)
+        {
+            feedback.IsRead = true;
+            feedback.IsResolved = true;
+            await context.SaveChangesAsync();
+            item.IsRead = true;
+            item.IsResolved = true;
+            Snackbar.Add("Marked as resolved", Severity.Success);
+            StateHasChanged();
+        }
+    }
+
+    private async Task ReopenItem(Feedback item)
+    {
+        await using var context = await DbFactory.CreateDbContextAsync();
+        var feedback = await context.Feedbacks.FindAsync(item.Id);
+        if (feedback != null)
+        {
+            feedback.IsResolved = false;
+            await context.SaveChangesAsync();
+            item.IsResolved = false;
+            StateHasChanged();
+        }
+    }
+
+    private static Color GetTypeColor(FeedbackType type) => type switch
+    {
+        FeedbackType.Bug => Color.Error,
+        FeedbackType.FeatureRequest => Color.Info,
+        _ => Color.Default
+    };
+
+    private static string GetTypeIcon(FeedbackType type) => type switch
+    {
+        FeedbackType.Bug => Icons.Material.Filled.BugReport,
+        FeedbackType.FeatureRequest => Icons.Material.Filled.Lightbulb,
+        _ => Icons.Material.Filled.Chat
+    };
+    
+    public void Dispose()
+    {
+        _refreshTimer?.Stop();
+        _refreshTimer?.Dispose();
+    }
+}

--- a/src/FamilyCoordinationApp/Components/Pages/Settings/HouseholdAdmin.razor
+++ b/src/FamilyCoordinationApp/Components/Pages/Settings/HouseholdAdmin.razor
@@ -1,352 +1,130 @@
 @page "/settings/households"
 @attribute [Authorize]
 @using FamilyCoordinationApp.Data
-@using FamilyCoordinationApp.Data.Entities
-@using FamilyCoordinationApp.Services
+@using Microsoft.AspNetCore.Components.Web
 @using Microsoft.EntityFrameworkCore
+@using Microsoft.JSInterop
 @using System.Security.Claims
+@implements IAsyncDisposable
 
+@inject IConfiguration Config
+@inject AuthenticationStateProvider AuthStateProvider
 @inject IDbContextFactory<ApplicationDbContext> DbFactory
-@inject ISnackbar Snackbar
-@inject ISiteAdminService SiteAdminService
-@inject IDialogService DialogService
-@inject NavigationManager Navigation
-@inject ILogger<HouseholdAdmin> Logger
+@inject IJSRuntime JS
+@inject IWebHostEnvironment HostEnv
 
-<PageTitle>Household Requests - Family Kitchen</PageTitle>
+@*
+    Thin island host (strangler, cluster C). Flag ON (SETTINGS_ADMIN_USE_ISLAND=true) → mount the Svelte admin
+    island (households view); flag OFF → the existing Blazor page (<HouseholdAdminBlazor/>) as the zero-regression
+    fallback. Mirrors Categories.razor. One bundle (/islands/admin) serves both this and FeedbackAdmin.razor; the
+    data-view attr picks the view. The island enforces the site-admin gate via the 403 on its list GET — the host
+    mounts it for everyone and the island renders "Access denied" for a non-admin (R-C4).
+*@
 
-<MudContainer MaxWidth="MaxWidth.Large" Class="py-4">
-    @if (!_isSiteAdmin)
+@* When the flag is ON we never render the Blazor fallback — not even during the brief async gap before
+   _shell resolves — to avoid momentarily mounting (then disposing) the Blazor page under the island flag
+   (memory fca-island-host-prerender-fallback-race). *@
+@if (_useIsland)
+{
+    @if (_shell is not null)
     {
-        <MudAlert Severity="Severity.Error">
-            Access denied. Only site administrators can manage household requests.
-        </MudAlert>
+        <PageTitle>Household Requests - Family Kitchen</PageTitle>
+
+        <HeadContent>
+            <link rel="stylesheet" href="/islands/admin/index.css?v=@IslandVersion" />
+        </HeadContent>
+
+        <div id="admin-households-root"
+             data-household-id="@_shell.HouseholdId"
+             data-user-id="@_shell.UserId"
+             data-user-name="@_shell.UserName"
+             data-view="households"></div>
     }
-    else
-    {
-        <div class="d-flex justify-space-between align-center mb-4">
-            <MudText Typo="Typo.h4">Household Requests</MudText>
-            <MudToggleGroup T="string" @bind-Value="_filter" Color="Color.Primary" Rounded="true">
-                <MudToggleItem Value="@("pending")">Pending</MudToggleItem>
-                <MudToggleItem Value="@("all")">All</MudToggleItem>
-            </MudToggleGroup>
-        </div>
-
-        @if (_loading)
-        {
-            <MudProgressLinear Indeterminate="true" />
-        }
-        else if (!FilteredRequests.Any())
-        {
-            <MudAlert Severity="Severity.Info">
-                @if (_filter == "pending")
-                {
-                    <span>No pending household requests.</span>
-                }
-                else
-                {
-                    <span>No household requests yet.</span>
-                }
-            </MudAlert>
-        }
-        else
-        {
-            <MudStack Spacing="3">
-                @foreach (var request in FilteredRequests)
-                {
-                    <MudCard Elevation="2" Class="@GetCardClass(request)">
-                        <MudCardHeader>
-                            <CardHeaderAvatar>
-                                <MudAvatar Color="@GetStatusColor(request.Status)" Variant="Variant.Outlined">
-                                    <MudIcon Icon="@GetStatusIcon(request.Status)" />
-                                </MudAvatar>
-                            </CardHeaderAvatar>
-                            <CardHeaderContent>
-                                <div class="d-flex align-center gap-2 flex-wrap">
-                                    <MudText Typo="Typo.h6">@request.HouseholdName</MudText>
-                                    <MudChip T="string" Size="Size.Small" Color="@GetStatusColor(request.Status)">
-                                        @request.Status
-                                    </MudChip>
-                                </div>
-                                <MudText Typo="Typo.body2" Color="Color.Secondary">
-                                    <strong>@request.DisplayName</strong> (@request.Email)
-                                </MudText>
-                                <MudText Typo="Typo.caption" Color="Color.Secondary">
-                                    Requested: @request.RequestedAt.ToLocalTime().ToString("MMM d, yyyy h:mm tt")
-                                    @if (request.ReviewedAt.HasValue)
-                                    {
-                                        <span> • Reviewed: @request.ReviewedAt.Value.ToLocalTime().ToString("MMM d, yyyy")</span>
-                                        @if (!string.IsNullOrEmpty(request.ReviewedBy))
-                                        {
-                                            <span> by @request.ReviewedBy</span>
-                                        }
-                                    }
-                                </MudText>
-                            </CardHeaderContent>
-                            <CardHeaderActions>
-                                @if (request.Status == HouseholdRequestStatus.Pending)
-                                {
-                                    <MudButtonGroup Variant="Variant.Outlined" Size="Size.Small">
-                                        <MudButton Color="Color.Success" 
-                                                   StartIcon="@Icons.Material.Filled.Check"
-                                                   OnClick="@(() => ApproveRequest(request))">
-                                            Approve
-                                        </MudButton>
-                                        <MudButton Color="Color.Error"
-                                                   StartIcon="@Icons.Material.Filled.Close"
-                                                   OnClick="@(() => RejectRequest(request))">
-                                            Reject
-                                        </MudButton>
-                                    </MudButtonGroup>
-                                }
-                            </CardHeaderActions>
-                        </MudCardHeader>
-                        @if (request.Status == HouseholdRequestStatus.Rejected && !string.IsNullOrEmpty(request.RejectionReason))
-                        {
-                            <MudCardContent Class="pt-0">
-                                <MudText Typo="Typo.body2" Color="Color.Secondary">
-                                    <strong>Rejection reason:</strong> @request.RejectionReason
-                                </MudText>
-                            </MudCardContent>
-                        }
-                    </MudCard>
-                }
-            </MudStack>
-        }
-
-        <MudDivider Class="my-6" />
-
-        <MudText Typo="Typo.h5" Class="mb-4">Existing Households</MudText>
-        
-        @if (_households.Any())
-        {
-            <MudTable Items="_households" Hover="true" Breakpoint="Breakpoint.Sm">
-                <HeaderContent>
-                    <MudTh>Household</MudTh>
-                    <MudTh>Members</MudTh>
-                    <MudTh>Created</MudTh>
-                </HeaderContent>
-                <RowTemplate>
-                    <MudTd DataLabel="Household">@context.Name</MudTd>
-                    <MudTd DataLabel="Members">@context.Users.Count</MudTd>
-                    <MudTd DataLabel="Created">@context.CreatedAt.ToLocalTime().ToString("MMM d, yyyy")</MudTd>
-                </RowTemplate>
-            </MudTable>
-        }
-        else
-        {
-            <MudAlert Severity="Severity.Info">No households exist yet.</MudAlert>
-        }
-    }
-</MudContainer>
-
-@implements IDisposable
+}
+else
+{
+    <HouseholdAdminBlazor />
+}
 
 @code {
-    [CascadingParameter]
-    private Task<AuthenticationState>? AuthStateTask { get; set; }
+    private bool _useIsland;
+    private ShellData? _shell;
+    private IJSObjectReference? _islandModule;
 
-    private List<HouseholdRequest> _requests = new();
-    private List<Household> _households = new();
-    private bool _loading = true;
-    private string _filter = "pending";
-    private bool _isSiteAdmin = false;
-    private string _currentEmail = "";
-    private System.Timers.Timer? _refreshTimer;
-
-    private IEnumerable<HouseholdRequest> FilteredRequests => _filter switch
-    {
-        "pending" => _requests.Where(r => r.Status == HouseholdRequestStatus.Pending),
-        _ => _requests
-    };
+    private const string RootId = "admin-households-root";
 
     protected override async Task OnInitializedAsync()
     {
-        await LoadCurrentUser();
-        
-        if (_isSiteAdmin)
+        _useIsland = IsIslandEnabled();
+        if (!_useIsland) return;
+
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+        var email = authState.User.FindFirst(ClaimTypes.Email)?.Value;
+        var userName = authState.User.FindFirst(ClaimTypes.Name)?.Value ?? string.Empty;
+
+        await using var context = await DbFactory.CreateDbContextAsync();
+        var user = await context.Users.FirstOrDefaultAsync(u => u.Email == email);
+        if (user is null)
         {
-            await LoadData();
-            
-            // Auto-refresh every 30 seconds
-            _refreshTimer = new System.Timers.Timer(30000);
-            _refreshTimer.Elapsed += async (_, _) => await InvokeAsync(LoadData);
-            _refreshTimer.Start();
+            throw new InvalidOperationException("User not found. Please log in again.");
         }
+
+        _shell = new ShellData(user.HouseholdId, user.Id, userName);
     }
 
-    private async Task LoadCurrentUser()
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (AuthStateTask == null) return;
+        if (!firstRender || !_useIsland || _shell is null) return;
 
-        var authState = await AuthStateTask;
-        _currentEmail = authState.User.FindFirst(ClaimTypes.Email)?.Value ?? "";
-        _isSiteAdmin = SiteAdminService.IsSiteAdmin(_currentEmail);
+        await JS.InvokeVoidAsync("ensureIslandStylesheet", $"/islands/admin/index.css?v={IslandVersion}");
+
+        _islandModule = await JS.InvokeAsync<IJSObjectReference>(
+            "import", $"/islands/admin/index.js?v={IslandVersion}");
+        await JS.InvokeVoidAsync("AdminIsland.mount", RootId);
     }
 
-    private async Task LoadData()
-    {
-        _loading = true;
-        StateHasChanged();
+    // Cache-bust the island URLs per deploy via the published bundle's mtime (mirrors Categories.razor).
+    private static string? _islandVersion;
+    private string IslandVersion => _islandVersion ??= ComputeIslandVersion();
 
+    private string ComputeIslandVersion()
+    {
         try
         {
-            await using var context = await DbFactory.CreateDbContextAsync();
-
-            _requests = await context.HouseholdRequests
-                .OrderByDescending(r => r.Status == HouseholdRequestStatus.Pending)
-                .ThenByDescending(r => r.RequestedAt)
-                .ToListAsync();
-
-            _households = await context.Households
-                .Include(h => h.Users)
-                .OrderBy(h => h.Name)
-                .ToListAsync();
+            var path = Path.Combine(HostEnv.WebRootPath, "islands", "admin", "index.js");
+            return new DateTimeOffset(File.GetLastWriteTimeUtc(path)).ToUnixTimeSeconds().ToString();
         }
-        finally
+        catch
         {
-            _loading = false;
-            StateHasChanged();
+            return "0";
         }
     }
 
-    private async Task ApproveRequest(HouseholdRequest request)
+    private bool IsIslandEnabled()
     {
-        var confirm = await DialogService.ShowMessageBox(
-            "Approve Request",
-            $"Create household '{request.HouseholdName}' for {request.DisplayName}?",
-            yesText: "Approve",
-            cancelText: "Cancel");
+        var configValue = Config["SETTINGS_ADMIN_USE_ISLAND"];
+        if (!string.IsNullOrEmpty(configValue))
+        {
+            return configValue.Equals("true", StringComparison.OrdinalIgnoreCase);
+        }
 
-        if (confirm != true) return;
+        var envValue = Environment.GetEnvironmentVariable("SETTINGS_ADMIN_USE_ISLAND");
+        return string.Equals(envValue, "true", StringComparison.OrdinalIgnoreCase);
+    }
 
+    public async ValueTask DisposeAsync()
+    {
+        if (_islandModule is null) return;
         try
         {
-            await using var context = await DbFactory.CreateDbContextAsync();
-
-            // Create household
-            var household = new Household
-            {
-                Name = request.HouseholdName,
-                CreatedAt = DateTime.UtcNow
-            };
-            context.Households.Add(household);
-            await context.SaveChangesAsync();
-
-            // Create user in household
-            var user = new User
-            {
-                HouseholdId = household.Id,
-                Email = request.Email,
-                DisplayName = request.DisplayName,
-                GoogleId = request.GoogleId,
-                IsWhitelisted = true,
-                CreatedAt = DateTime.UtcNow
-            };
-            context.Users.Add(user);
-
-            // Update request status
-            var dbRequest = await context.HouseholdRequests.FindAsync(request.Id);
-            if (dbRequest != null)
-            {
-                dbRequest.Status = HouseholdRequestStatus.Approved;
-                dbRequest.ReviewedAt = DateTime.UtcNow;
-                dbRequest.ReviewedBy = _currentEmail;
-            }
-
-            await context.SaveChangesAsync();
-
-            // Seed default categories for new household
-            await SeedData.SeedDefaultCategoriesAsync(DbFactory, household.Id);
-
-            Logger.LogInformation(
-                "Approved household request: {HouseholdName} for {Email} by {Admin}",
-                request.HouseholdName, request.Email, _currentEmail);
-
-            Snackbar.Add($"Approved: Created '{request.HouseholdName}' for {request.DisplayName}", Severity.Success);
-            await LoadData();
+            await JS.InvokeVoidAsync("AdminIsland.destroy", RootId);
+            await _islandModule.DisposeAsync();
         }
-        catch (Exception ex)
+        catch (JSDisconnectedException)
         {
-            Logger.LogError(ex, "Failed to approve household request {RequestId}", request.Id);
-            Snackbar.Add($"Failed to approve: {ex.Message}", Severity.Error);
+            // Circuit already gone (user navigated away after disconnect) — nothing to clean up.
         }
     }
 
-    private async Task RejectRequest(HouseholdRequest request)
-    {
-        var parameters = new DialogParameters<RejectReasonDialog>
-        {
-            { x => x.RequestorName, request.DisplayName },
-            { x => x.HouseholdName, request.HouseholdName }
-        };
-        var options = new DialogOptions { CloseButton = true, MaxWidth = MaxWidth.Small };
-        var dialog = await DialogService.ShowAsync<RejectReasonDialog>("Reject Request", parameters, options);
-        var result = await dialog.Result;
-
-        if (result.Canceled) return;
-
-        var reason = result.Data as string;
-
-        try
-        {
-            await using var context = await DbFactory.CreateDbContextAsync();
-
-            var dbRequest = await context.HouseholdRequests.FindAsync(request.Id);
-            if (dbRequest != null)
-            {
-                dbRequest.Status = HouseholdRequestStatus.Rejected;
-                dbRequest.ReviewedAt = DateTime.UtcNow;
-                dbRequest.ReviewedBy = _currentEmail;
-                dbRequest.RejectionReason = reason;
-                await context.SaveChangesAsync();
-            }
-
-            Logger.LogInformation(
-                "Rejected household request: {HouseholdName} for {Email} by {Admin}. Reason: {Reason}",
-                request.HouseholdName, request.Email, _currentEmail, reason);
-
-            Snackbar.Add($"Rejected request from {request.DisplayName}", Severity.Warning);
-            await LoadData();
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Failed to reject household request {RequestId}", request.Id);
-            Snackbar.Add($"Failed to reject: {ex.Message}", Severity.Error);
-        }
-    }
-
-    private static Color GetStatusColor(HouseholdRequestStatus status) => status switch
-    {
-        HouseholdRequestStatus.Pending => Color.Info,
-        HouseholdRequestStatus.Approved => Color.Success,
-        HouseholdRequestStatus.Rejected => Color.Error,
-        _ => Color.Default
-    };
-
-    private static string GetStatusIcon(HouseholdRequestStatus status) => status switch
-    {
-        HouseholdRequestStatus.Pending => Icons.Material.Filled.HourglassTop,
-        HouseholdRequestStatus.Approved => Icons.Material.Filled.CheckCircle,
-        HouseholdRequestStatus.Rejected => Icons.Material.Filled.Cancel,
-        _ => Icons.Material.Filled.Home
-    };
-
-    private static string GetCardClass(HouseholdRequest request) => request.Status switch
-    {
-        HouseholdRequestStatus.Pending => "pending-card",
-        _ => ""
-    };
-
-    public void Dispose()
-    {
-        _refreshTimer?.Stop();
-        _refreshTimer?.Dispose();
-    }
+    private sealed record ShellData(int HouseholdId, int UserId, string UserName);
 }
-
-<style>
-    .pending-card {
-        border-left: 4px solid var(--mud-palette-info);
-    }
-</style>

--- a/src/FamilyCoordinationApp/Components/Pages/Settings/HouseholdAdminBlazor.razor
+++ b/src/FamilyCoordinationApp/Components/Pages/Settings/HouseholdAdminBlazor.razor
@@ -1,0 +1,357 @@
+@using FamilyCoordinationApp.Data
+@using FamilyCoordinationApp.Data.Entities
+@using FamilyCoordinationApp.Services
+@using Microsoft.EntityFrameworkCore
+@using System.Security.Claims
+
+@inject IDbContextFactory<ApplicationDbContext> DbFactory
+@inject ISnackbar Snackbar
+@inject ISiteAdminService SiteAdminService
+@inject IDialogService DialogService
+@inject NavigationManager Navigation
+@inject ILogger<HouseholdAdminBlazor> Logger
+
+@*
+    The original Blazor household-requests body, extracted verbatim from HouseholdAdmin.razor as the
+    zero-regression fallback for the strangler (flag SETTINGS_ADMIN_USE_ISLAND=false → this renders). NOT
+    routable — the @@page "/settings/households" + [Authorize] live on the host HouseholdAdmin.razor. Delete
+    once the island is prod-stable.
+*@
+
+<PageTitle>Household Requests - Family Kitchen</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Large" Class="py-4">
+    @if (!_isSiteAdmin)
+    {
+        <MudAlert Severity="Severity.Error">
+            Access denied. Only site administrators can manage household requests.
+        </MudAlert>
+    }
+    else
+    {
+        <div class="d-flex justify-space-between align-center mb-4">
+            <MudText Typo="Typo.h4">Household Requests</MudText>
+            <MudToggleGroup T="string" @bind-Value="_filter" Color="Color.Primary" Rounded="true">
+                <MudToggleItem Value="@("pending")">Pending</MudToggleItem>
+                <MudToggleItem Value="@("all")">All</MudToggleItem>
+            </MudToggleGroup>
+        </div>
+
+        @if (_loading)
+        {
+            <MudProgressLinear Indeterminate="true" />
+        }
+        else if (!FilteredRequests.Any())
+        {
+            <MudAlert Severity="Severity.Info">
+                @if (_filter == "pending")
+                {
+                    <span>No pending household requests.</span>
+                }
+                else
+                {
+                    <span>No household requests yet.</span>
+                }
+            </MudAlert>
+        }
+        else
+        {
+            <MudStack Spacing="3">
+                @foreach (var request in FilteredRequests)
+                {
+                    <MudCard Elevation="2" Class="@GetCardClass(request)">
+                        <MudCardHeader>
+                            <CardHeaderAvatar>
+                                <MudAvatar Color="@GetStatusColor(request.Status)" Variant="Variant.Outlined">
+                                    <MudIcon Icon="@GetStatusIcon(request.Status)" />
+                                </MudAvatar>
+                            </CardHeaderAvatar>
+                            <CardHeaderContent>
+                                <div class="d-flex align-center gap-2 flex-wrap">
+                                    <MudText Typo="Typo.h6">@request.HouseholdName</MudText>
+                                    <MudChip T="string" Size="Size.Small" Color="@GetStatusColor(request.Status)">
+                                        @request.Status
+                                    </MudChip>
+                                </div>
+                                <MudText Typo="Typo.body2" Color="Color.Secondary">
+                                    <strong>@request.DisplayName</strong> (@request.Email)
+                                </MudText>
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                    Requested: @request.RequestedAt.ToLocalTime().ToString("MMM d, yyyy h:mm tt")
+                                    @if (request.ReviewedAt.HasValue)
+                                    {
+                                        <span> • Reviewed: @request.ReviewedAt.Value.ToLocalTime().ToString("MMM d, yyyy")</span>
+                                        @if (!string.IsNullOrEmpty(request.ReviewedBy))
+                                        {
+                                            <span> by @request.ReviewedBy</span>
+                                        }
+                                    }
+                                </MudText>
+                            </CardHeaderContent>
+                            <CardHeaderActions>
+                                @if (request.Status == HouseholdRequestStatus.Pending)
+                                {
+                                    <MudButtonGroup Variant="Variant.Outlined" Size="Size.Small">
+                                        <MudButton Color="Color.Success" 
+                                                   StartIcon="@Icons.Material.Filled.Check"
+                                                   OnClick="@(() => ApproveRequest(request))">
+                                            Approve
+                                        </MudButton>
+                                        <MudButton Color="Color.Error"
+                                                   StartIcon="@Icons.Material.Filled.Close"
+                                                   OnClick="@(() => RejectRequest(request))">
+                                            Reject
+                                        </MudButton>
+                                    </MudButtonGroup>
+                                }
+                            </CardHeaderActions>
+                        </MudCardHeader>
+                        @if (request.Status == HouseholdRequestStatus.Rejected && !string.IsNullOrEmpty(request.RejectionReason))
+                        {
+                            <MudCardContent Class="pt-0">
+                                <MudText Typo="Typo.body2" Color="Color.Secondary">
+                                    <strong>Rejection reason:</strong> @request.RejectionReason
+                                </MudText>
+                            </MudCardContent>
+                        }
+                    </MudCard>
+                }
+            </MudStack>
+        }
+
+        <MudDivider Class="my-6" />
+
+        <MudText Typo="Typo.h5" Class="mb-4">Existing Households</MudText>
+        
+        @if (_households.Any())
+        {
+            <MudTable Items="_households" Hover="true" Breakpoint="Breakpoint.Sm">
+                <HeaderContent>
+                    <MudTh>Household</MudTh>
+                    <MudTh>Members</MudTh>
+                    <MudTh>Created</MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd DataLabel="Household">@context.Name</MudTd>
+                    <MudTd DataLabel="Members">@context.Users.Count</MudTd>
+                    <MudTd DataLabel="Created">@context.CreatedAt.ToLocalTime().ToString("MMM d, yyyy")</MudTd>
+                </RowTemplate>
+            </MudTable>
+        }
+        else
+        {
+            <MudAlert Severity="Severity.Info">No households exist yet.</MudAlert>
+        }
+    }
+</MudContainer>
+
+@implements IDisposable
+
+@code {
+    [CascadingParameter]
+    private Task<AuthenticationState>? AuthStateTask { get; set; }
+
+    private List<HouseholdRequest> _requests = new();
+    private List<Household> _households = new();
+    private bool _loading = true;
+    private string _filter = "pending";
+    private bool _isSiteAdmin = false;
+    private string _currentEmail = "";
+    private System.Timers.Timer? _refreshTimer;
+
+    private IEnumerable<HouseholdRequest> FilteredRequests => _filter switch
+    {
+        "pending" => _requests.Where(r => r.Status == HouseholdRequestStatus.Pending),
+        _ => _requests
+    };
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadCurrentUser();
+        
+        if (_isSiteAdmin)
+        {
+            await LoadData();
+            
+            // Auto-refresh every 30 seconds
+            _refreshTimer = new System.Timers.Timer(30000);
+            _refreshTimer.Elapsed += async (_, _) => await InvokeAsync(LoadData);
+            _refreshTimer.Start();
+        }
+    }
+
+    private async Task LoadCurrentUser()
+    {
+        if (AuthStateTask == null) return;
+
+        var authState = await AuthStateTask;
+        _currentEmail = authState.User.FindFirst(ClaimTypes.Email)?.Value ?? "";
+        _isSiteAdmin = SiteAdminService.IsSiteAdmin(_currentEmail);
+    }
+
+    private async Task LoadData()
+    {
+        _loading = true;
+        StateHasChanged();
+
+        try
+        {
+            await using var context = await DbFactory.CreateDbContextAsync();
+
+            _requests = await context.HouseholdRequests
+                .OrderByDescending(r => r.Status == HouseholdRequestStatus.Pending)
+                .ThenByDescending(r => r.RequestedAt)
+                .ToListAsync();
+
+            _households = await context.Households
+                .Include(h => h.Users)
+                .OrderBy(h => h.Name)
+                .ToListAsync();
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task ApproveRequest(HouseholdRequest request)
+    {
+        var confirm = await DialogService.ShowMessageBox(
+            "Approve Request",
+            $"Create household '{request.HouseholdName}' for {request.DisplayName}?",
+            yesText: "Approve",
+            cancelText: "Cancel");
+
+        if (confirm != true) return;
+
+        try
+        {
+            await using var context = await DbFactory.CreateDbContextAsync();
+
+            // Create household
+            var household = new Household
+            {
+                Name = request.HouseholdName,
+                CreatedAt = DateTime.UtcNow
+            };
+            context.Households.Add(household);
+            await context.SaveChangesAsync();
+
+            // Create user in household
+            var user = new User
+            {
+                HouseholdId = household.Id,
+                Email = request.Email,
+                DisplayName = request.DisplayName,
+                GoogleId = request.GoogleId,
+                IsWhitelisted = true,
+                CreatedAt = DateTime.UtcNow
+            };
+            context.Users.Add(user);
+
+            // Update request status
+            var dbRequest = await context.HouseholdRequests.FindAsync(request.Id);
+            if (dbRequest != null)
+            {
+                dbRequest.Status = HouseholdRequestStatus.Approved;
+                dbRequest.ReviewedAt = DateTime.UtcNow;
+                dbRequest.ReviewedBy = _currentEmail;
+            }
+
+            await context.SaveChangesAsync();
+
+            // Seed default categories for new household
+            await SeedData.SeedDefaultCategoriesAsync(DbFactory, household.Id);
+
+            Logger.LogInformation(
+                "Approved household request: {HouseholdName} for {Email} by {Admin}",
+                request.HouseholdName, request.Email, _currentEmail);
+
+            Snackbar.Add($"Approved: Created '{request.HouseholdName}' for {request.DisplayName}", Severity.Success);
+            await LoadData();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to approve household request {RequestId}", request.Id);
+            Snackbar.Add($"Failed to approve: {ex.Message}", Severity.Error);
+        }
+    }
+
+    private async Task RejectRequest(HouseholdRequest request)
+    {
+        var parameters = new DialogParameters<RejectReasonDialog>
+        {
+            { x => x.RequestorName, request.DisplayName },
+            { x => x.HouseholdName, request.HouseholdName }
+        };
+        var options = new DialogOptions { CloseButton = true, MaxWidth = MaxWidth.Small };
+        var dialog = await DialogService.ShowAsync<RejectReasonDialog>("Reject Request", parameters, options);
+        var result = await dialog.Result;
+
+        if (result.Canceled) return;
+
+        var reason = result.Data as string;
+
+        try
+        {
+            await using var context = await DbFactory.CreateDbContextAsync();
+
+            var dbRequest = await context.HouseholdRequests.FindAsync(request.Id);
+            if (dbRequest != null)
+            {
+                dbRequest.Status = HouseholdRequestStatus.Rejected;
+                dbRequest.ReviewedAt = DateTime.UtcNow;
+                dbRequest.ReviewedBy = _currentEmail;
+                dbRequest.RejectionReason = reason;
+                await context.SaveChangesAsync();
+            }
+
+            Logger.LogInformation(
+                "Rejected household request: {HouseholdName} for {Email} by {Admin}. Reason: {Reason}",
+                request.HouseholdName, request.Email, _currentEmail, reason);
+
+            Snackbar.Add($"Rejected request from {request.DisplayName}", Severity.Warning);
+            await LoadData();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to reject household request {RequestId}", request.Id);
+            Snackbar.Add($"Failed to reject: {ex.Message}", Severity.Error);
+        }
+    }
+
+    private static Color GetStatusColor(HouseholdRequestStatus status) => status switch
+    {
+        HouseholdRequestStatus.Pending => Color.Info,
+        HouseholdRequestStatus.Approved => Color.Success,
+        HouseholdRequestStatus.Rejected => Color.Error,
+        _ => Color.Default
+    };
+
+    private static string GetStatusIcon(HouseholdRequestStatus status) => status switch
+    {
+        HouseholdRequestStatus.Pending => Icons.Material.Filled.HourglassTop,
+        HouseholdRequestStatus.Approved => Icons.Material.Filled.CheckCircle,
+        HouseholdRequestStatus.Rejected => Icons.Material.Filled.Cancel,
+        _ => Icons.Material.Filled.Home
+    };
+
+    private static string GetCardClass(HouseholdRequest request) => request.Status switch
+    {
+        HouseholdRequestStatus.Pending => "pending-card",
+        _ => ""
+    };
+
+    public void Dispose()
+    {
+        _refreshTimer?.Stop();
+        _refreshTimer?.Dispose();
+    }
+}
+
+<style>
+    .pending-card {
+        border-left: 4px solid var(--mud-palette-info);
+    }
+</style>

--- a/src/FamilyCoordinationApp/Data/SeedData.cs
+++ b/src/FamilyCoordinationApp/Data/SeedData.cs
@@ -455,8 +455,19 @@ public static class SeedData
 
         if (existingCount > 0) return;
 
-        var defaultCategories = new[]
-        {
+        AddDefaultCategories(context, householdId);
+        await context.SaveChangesAsync();
+    }
+
+    /// <summary>
+    /// Stages the nine default categories for a household on the GIVEN context, WITHOUT saving — so a caller can
+    /// fold them into a larger unit of work (cluster-C's atomic household-approval transaction, review R-C2:
+    /// household + user + request-status + categories must commit or roll back together). The household is assumed
+    /// brand-new/empty here; the "already seeded?" guard lives in <see cref="SeedDefaultCategoriesAsync"/>.
+    /// </summary>
+    public static void AddDefaultCategories(ApplicationDbContext context, int householdId)
+    {
+        context.Categories.AddRange(
             new Category { HouseholdId = householdId, CategoryId = 1, Name = "Meat", IconEmoji = "meat_on_bone", Color = "#b71c1c", SortOrder = 1, IsDefault = true },
             new Category { HouseholdId = householdId, CategoryId = 2, Name = "Produce", IconEmoji = "leafy_green", Color = "#2e7d32", SortOrder = 2, IsDefault = true },
             new Category { HouseholdId = householdId, CategoryId = 3, Name = "Dairy", IconEmoji = "cheese_wedge", Color = "#ffc107", SortOrder = 3, IsDefault = true },
@@ -465,10 +476,6 @@ public static class SeedData
             new Category { HouseholdId = householdId, CategoryId = 6, Name = "Frozen", IconEmoji = "snowflake", Color = "#03a9f4", SortOrder = 6, IsDefault = true },
             new Category { HouseholdId = householdId, CategoryId = 7, Name = "Bakery", IconEmoji = "bread", Color = "#8d6e63", SortOrder = 7, IsDefault = true },
             new Category { HouseholdId = householdId, CategoryId = 8, Name = "Beverages", IconEmoji = "cup_with_straw", Color = "#9c27b0", SortOrder = 8, IsDefault = true },
-            new Category { HouseholdId = householdId, CategoryId = 9, Name = "Other", IconEmoji = "package", Color = "#607d8b", SortOrder = 9, IsDefault = true }
-        };
-
-        context.Categories.AddRange(defaultCategories);
-        await context.SaveChangesAsync();
+            new Category { HouseholdId = householdId, CategoryId = 9, Name = "Other", IconEmoji = "package", Color = "#607d8b", SortOrder = 9, IsDefault = true });
     }
 }

--- a/src/FamilyCoordinationApp/Endpoints/SettingsAdminEndpoints.cs
+++ b/src/FamilyCoordinationApp/Endpoints/SettingsAdminEndpoints.cs
@@ -1,0 +1,249 @@
+using System.Globalization;
+using System.Security.Claims;
+using FamilyCoordinationApp.Data;
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Services;
+using FamilyCoordinationApp.Services.Dtos;
+using FamilyCoordinationApp.Services.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace FamilyCoordinationApp.Endpoints;
+
+/// <summary>
+/// Minimal-API surface for Settings island C (Admin, strangler — the heaviest, most auth-sensitive cluster).
+/// Two groups under one file (review X2), both behind <c>.RequireAuthorization().DisableAntiforgery()</c>:
+/// <list type="bullet">
+/// <item><c>/api/settings/household-requests</c> — <b>SITE-ADMIN ONLY</b>. A per-handler 403 gate reads the
+/// caller's email from claims and checks <see cref="ISiteAdminService"/> (3 routes don't justify a filter, R-C5).
+/// These are GLOBAL reads/writes — no HouseholdId, gated by the 403, not by M1 (R-C8).</item>
+/// <item><c>/api/settings/feedback</c> — <b>DUAL-MODE</b>. A site admin sees/acts on all households' feedback; a
+/// regular user only their own household's (server-scoped, R-C1 — the circuit→REST lift would otherwise be an
+/// IDOR). The <c>isSiteAdmin</c> flag rides in the list payload for the island's affordances.</item>
+/// </list>
+///
+/// <para><b>Email plumbing (R-C5):</b> <see cref="UserContextResolver"/> intentionally drops the email (returns
+/// only HouseholdId/UserId), so the site-admin check reads <c>ClaimTypes.Email</c> from the principal DIRECTLY,
+/// and the resolver is called separately only for the household scope. <b>Non-empty 4xx (R-C5 / memory
+/// fca-empty-404-surfaces-as-405-on-delete):</b> the 403 and the IDOR 404 both carry a JSON body, else the global
+/// <c>UseStatusCodePagesWithReExecute</c> re-executes an empty non-GET 4xx as a 405.</para>
+///
+/// <para><b>Dates (X5):</b> RequestedAt/ReviewedAt/CreatedAt are full UTC instants → projected to explicit
+/// ISO-8601 <c>Z</c> strings (<see cref="ToIso"/>) so the wire format is unambiguous and the island renders local
+/// via <c>new Date(iso).toLocaleString()</c>.</para>
+/// </summary>
+public static class SettingsAdminEndpoints
+{
+    public static IEndpointRouteBuilder MapSettingsAdminEndpoints(this IEndpointRouteBuilder app)
+    {
+        // ── Household requests (site-admin only) ──────────────────────────────────
+        var requests = app.MapGroup("/api/settings/household-requests")
+            .RequireAuthorization()
+            .DisableAntiforgery();
+        requests.MapGet("/", GetHouseholdRequests);
+        requests.MapPost("/{id:int}/approve", ApproveRequest);
+        requests.MapPost("/{id:int}/reject", RejectRequest);
+
+        // ── Feedback (dual-mode) ──────────────────────────────────────────────────
+        var feedback = app.MapGroup("/api/settings/feedback")
+            .RequireAuthorization()
+            .DisableAntiforgery();
+        feedback.MapGet("/", GetFeedback);
+        feedback.MapPost("/{id:int}/read", MarkFeedbackRead);
+        feedback.MapPost("/{id:int}/resolve", MarkFeedbackResolved);
+        feedback.MapPost("/{id:int}/reopen", ReopenFeedback);
+
+        return app;
+    }
+
+    // ─── Household requests (site-admin only) ─────────────────────────────────────
+
+    /// <summary>#1 GET / — every request (pending-first) + every household with member count (403 if not site-admin).</summary>
+    private static async Task<IResult> GetHouseholdRequests(
+        ClaimsPrincipal principal,
+        ISiteAdminService siteAdmin,
+        IHouseholdRequestService requestService,
+        CancellationToken ct)
+    {
+        if (RequireSiteAdmin(principal, siteAdmin) is { } forbidden) return forbidden;
+
+        var data = await requestService.GetDataAsync(ct);
+        return Results.Ok(new HouseholdRequestsDto(
+            data.Requests.Select(ToRequestDto).ToList(),
+            data.Households.Select(ToSummaryDto).ToList()));
+    }
+
+    /// <summary>#2 POST /{id}/approve — the atomic household-creation transaction (201). 403 / 404 / 409 (already reviewed, R-C3).</summary>
+    private static async Task<IResult> ApproveRequest(
+        int id,
+        ClaimsPrincipal principal,
+        ISiteAdminService siteAdmin,
+        IHouseholdRequestService requestService,
+        CancellationToken ct)
+    {
+        if (RequireSiteAdmin(principal, siteAdmin) is { } forbidden) return forbidden;
+
+        var reviewerEmail = principal.FindFirst(ClaimTypes.Email)?.Value ?? "";
+        var result = await requestService.ApproveAsync(id, reviewerEmail, ct);
+        return result.Outcome switch
+        {
+            ReviewOutcome.NotFound => Results.NotFound(new { message = "Household request not found." }),
+            ReviewOutcome.AlreadyReviewed => Results.Conflict(new { message = "This request has already been reviewed." }),
+            // Member count is exactly 1 (the request's user, just created in the transaction).
+            _ => Results.Created("/api/settings/household-requests", new HouseholdSummaryDto(
+                result.CreatedHousehold!.Id, result.CreatedHousehold.Name, 1, ToIso(result.CreatedHousehold.CreatedAt))),
+        };
+    }
+
+    /// <summary>#3 POST /{id}/reject — reason OPTIONAL (R-C7). 403 / 404 / 409 (already reviewed, R-C3) / else 204.</summary>
+    private static async Task<IResult> RejectRequest(
+        int id,
+        RejectReasonRequest? req,
+        ClaimsPrincipal principal,
+        ISiteAdminService siteAdmin,
+        IHouseholdRequestService requestService,
+        CancellationToken ct)
+    {
+        if (RequireSiteAdmin(principal, siteAdmin) is { } forbidden) return forbidden;
+
+        var reviewerEmail = principal.FindFirst(ClaimTypes.Email)?.Value ?? "";
+        // Reason is optional: a missing body (req null) or empty/whitespace reason is fine — do NOT 400 (R-C7).
+        var outcome = await requestService.RejectAsync(id, req?.Reason, reviewerEmail, ct);
+        return outcome switch
+        {
+            ReviewOutcome.NotFound => Results.NotFound(new { message = "Household request not found." }),
+            ReviewOutcome.AlreadyReviewed => Results.Conflict(new { message = "This request has already been reviewed." }),
+            _ => Results.NoContent(),
+        };
+    }
+
+    // ─── Feedback (dual-mode) ─────────────────────────────────────────────────────
+
+    /// <summary>#4 GET / — feedback for the caller (admin: all; regular: own household), + the isSiteAdmin signal.</summary>
+    private static async Task<IResult> GetFeedback(
+        ClaimsPrincipal principal,
+        ISiteAdminService siteAdmin,
+        IFeedbackService feedbackService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var (isSiteAdmin, householdId, authorized) = await ResolveFeedbackScopeAsync(principal, siteAdmin, dbFactory, ct);
+        if (!authorized) return Results.Unauthorized();
+
+        var items = await feedbackService.GetFeedbackAsync(isSiteAdmin, householdId, ct);
+        return Results.Ok(new FeedbackListDto(isSiteAdmin, items.Select(ToFeedbackDto).ToList()));
+    }
+
+    /// <summary>#5 POST /{id}/read — scoped (R-C1): admin any; non-admin own-household only, else 404 (no leak).</summary>
+    private static async Task<IResult> MarkFeedbackRead(
+        int id, ClaimsPrincipal principal, ISiteAdminService siteAdmin,
+        IFeedbackService feedbackService, IDbContextFactory<ApplicationDbContext> dbFactory, CancellationToken ct)
+    {
+        var (isSiteAdmin, householdId, authorized) = await ResolveFeedbackScopeAsync(principal, siteAdmin, dbFactory, ct);
+        if (!authorized) return Results.Unauthorized();
+
+        return await feedbackService.MarkReadAsync(id, isSiteAdmin, householdId, ct)
+            ? Results.NoContent()
+            : NotFoundFeedback();
+    }
+
+    /// <summary>#6 POST /{id}/resolve — sets read+resolved (parity). Same scoping (R-C1).</summary>
+    private static async Task<IResult> MarkFeedbackResolved(
+        int id, ClaimsPrincipal principal, ISiteAdminService siteAdmin,
+        IFeedbackService feedbackService, IDbContextFactory<ApplicationDbContext> dbFactory, CancellationToken ct)
+    {
+        var (isSiteAdmin, householdId, authorized) = await ResolveFeedbackScopeAsync(principal, siteAdmin, dbFactory, ct);
+        if (!authorized) return Results.Unauthorized();
+
+        return await feedbackService.MarkResolvedAsync(id, isSiteAdmin, householdId, ct)
+            ? Results.NoContent()
+            : NotFoundFeedback();
+    }
+
+    /// <summary>#7 POST /{id}/reopen — clears resolved. Same scoping (R-C1).</summary>
+    private static async Task<IResult> ReopenFeedback(
+        int id, ClaimsPrincipal principal, ISiteAdminService siteAdmin,
+        IFeedbackService feedbackService, IDbContextFactory<ApplicationDbContext> dbFactory, CancellationToken ct)
+    {
+        var (isSiteAdmin, householdId, authorized) = await ResolveFeedbackScopeAsync(principal, siteAdmin, dbFactory, ct);
+        if (!authorized) return Results.Unauthorized();
+
+        return await feedbackService.ReopenAsync(id, isSiteAdmin, householdId, ct)
+            ? Results.NoContent()
+            : NotFoundFeedback();
+    }
+
+    // ─── Auth helpers ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The site-admin 403 gate (R-C5). Reads the email from claims directly (the resolver drops it) and returns a
+    /// NON-EMPTY-body 403 when the caller isn't a site admin, or null to proceed.
+    /// </summary>
+    private static IResult? RequireSiteAdmin(ClaimsPrincipal principal, ISiteAdminService siteAdmin)
+    {
+        var email = principal.FindFirst(ClaimTypes.Email)?.Value;
+        return siteAdmin.IsSiteAdmin(email)
+            ? null
+            : Results.Json(new { message = "Site admin access required." }, statusCode: StatusCodes.Status403Forbidden);
+    }
+
+    /// <summary>
+    /// Resolve the feedback caller's scope (R-C5): isSiteAdmin from the claim email DIRECTLY + householdId from the
+    /// resolver (for a non-admin's M1 scope). A site admin is authorized even without a resolved user row; a
+    /// non-admin must resolve to a household (else 401).
+    /// </summary>
+    private static async Task<(bool IsSiteAdmin, int? HouseholdId, bool Authorized)> ResolveFeedbackScopeAsync(
+        ClaimsPrincipal principal,
+        ISiteAdminService siteAdmin,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var email = principal.FindFirst(ClaimTypes.Email)?.Value;
+        var isSiteAdmin = siteAdmin.IsSiteAdmin(email);
+        var caller = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        var authorized = isSiteAdmin || caller is not null;
+        return (isSiteAdmin, caller?.HouseholdId, authorized);
+    }
+
+    private static IResult NotFoundFeedback() => Results.NotFound(new { message = "Feedback not found." });
+
+    // ─── Projection ───────────────────────────────────────────────────────────────
+
+    private static HouseholdRequestDto ToRequestDto(HouseholdRequest r) => new(
+        r.Id,
+        r.HouseholdName,
+        r.DisplayName,
+        r.Email,
+        r.Status,
+        ToIso(r.RequestedAt),
+        r.ReviewedAt is { } reviewed ? ToIso(reviewed) : null,
+        r.ReviewedBy,
+        r.RejectionReason);
+
+    private static HouseholdSummaryDto ToSummaryDto(Household h) => new(
+        h.Id, h.Name, h.Users.Count, ToIso(h.CreatedAt));
+
+    private static FeedbackDto ToFeedbackDto(Feedback f) => new(
+        f.Id,
+        f.Type,
+        f.Message,
+        string.IsNullOrEmpty(f.CurrentPage) ? null : f.CurrentPage,
+        f.IsRead,
+        f.IsResolved,
+        ToIso(f.CreatedAt),
+        // R-C6 author 3-way: live user → DisplayName; deleted user (UserId set, no row) → null+deleted; anon → null+not-deleted.
+        f.User is not null ? f.User.DisplayName : null,
+        f.User is null && f.UserId is not null);
+
+    /// <summary>
+    /// Format a stored UTC instant as an explicit ISO-8601 <c>Z</c> string (X5). The values are written as
+    /// <c>DateTime.UtcNow</c>; <see cref="DateTime.SpecifyKind(DateTime, DateTimeKind)"/> asserts UTC without
+    /// shifting (robust whether Npgsql returns Kind=Utc or Unspecified), so the island parses an unambiguous instant.
+    /// </summary>
+    private static string ToIso(DateTime dt) =>
+        DateTime.SpecifyKind(dt, DateTimeKind.Utc).ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+}
+
+// ─── Request DTOs ───────────────────────────────────────────────────────────────
+
+/// <summary>Reject body — <see cref="Reason"/> is OPTIONAL (nullable; empty allowed, R-C7).</summary>
+public sealed record RejectReasonRequest(string? Reason);

--- a/src/FamilyCoordinationApp/Endpoints/SettingsAdminEndpoints.cs
+++ b/src/FamilyCoordinationApp/Endpoints/SettingsAdminEndpoints.cs
@@ -88,6 +88,8 @@ public static class SettingsAdminEndpoints
         {
             ReviewOutcome.NotFound => Results.NotFound(new { message = "Household request not found." }),
             ReviewOutcome.AlreadyReviewed => Results.Conflict(new { message = "This request has already been reviewed." }),
+            // Email already a user (stale data / concurrent approve) — a clean 409, not a 500 (council R1).
+            ReviewOutcome.EmailInUse => Results.Conflict(new { message = "Could not approve — a user with that email already exists." }),
             // Member count is exactly 1 (the request's user, just created in the transaction).
             _ => Results.Created("/api/settings/household-requests", new HouseholdSummaryDto(
                 result.CreatedHousehold!.Id, result.CreatedHousehold.Name, 1, ToIso(result.CreatedHousehold.CreatedAt))),
@@ -105,8 +107,14 @@ public static class SettingsAdminEndpoints
     {
         if (RequireSiteAdmin(principal, siteAdmin) is { } forbidden) return forbidden;
 
+        // Reason is optional (R-C7): a missing body / empty reason is fine. But guard the column's 500-char limit
+        // server-side so an oversized direct-API reason is a clean 400, not a varchar-overflow 500 (council R4).
+        if (req?.Reason is { Length: > 500 })
+        {
+            return Results.BadRequest(new { message = "Rejection reason must be 500 characters or fewer." });
+        }
+
         var reviewerEmail = principal.FindFirst(ClaimTypes.Email)?.Value ?? "";
-        // Reason is optional: a missing body (req null) or empty/whitespace reason is fine — do NOT 400 (R-C7).
         var outcome = await requestService.RejectAsync(id, req?.Reason, reviewerEmail, ct);
         return outcome switch
         {

--- a/src/FamilyCoordinationApp/FamilyCoordinationApp.csproj
+++ b/src/FamilyCoordinationApp/FamilyCoordinationApp.csproj
@@ -141,6 +141,24 @@
           SkipUnchangedFiles="true" />
   </Target>
 
+  <!--
+    Copy the built admin island (cluster C: Household requests + Feedback) into wwwroot before build (strangler).
+    Run `npm run build` in frontend/admin/ first (or let the Docker build do it via the admin-node-build stage).
+    If dist/ doesn't exist, the target is skipped silently and the island endpoint 404s — HouseholdAdmin.razor /
+    FeedbackAdmin.razor render the Blazor fallback via the SETTINGS_ADMIN_USE_ISLAND toggle. Parallel to
+    CopySettingsIsland (one bundle serves both host pages).
+  -->
+  <Target Name="CopyAdminIsland"
+          BeforeTargets="AssignTargetPaths"
+          Condition="Exists('$(MSBuildThisFileDirectory)..\..\frontend\admin\dist')">
+    <ItemGroup>
+      <_AdminIslandFiles Include="$(MSBuildThisFileDirectory)..\..\frontend\admin\dist\**\*.*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_AdminIslandFiles)"
+          DestinationFiles="@(_AdminIslandFiles->'$(MSBuildThisFileDirectory)wwwroot\islands\admin\%(RecursiveDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true" />
+  </Target>
+
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.4.0" />
     <PackageReference Include="blazor-dragdrop" Version="2.6.1" />

--- a/src/FamilyCoordinationApp/Program.cs
+++ b/src/FamilyCoordinationApp/Program.cs
@@ -100,6 +100,11 @@ builder.Services.AddScoped<IHouseholdConnectionService, HouseholdConnectionServi
 // Settings island A (strangler): household member management lifted out of WhitelistAdmin.razor's direct EF
 // (the self / last-active / last-user guards are enforced here, server-side, and unit-testable).
 builder.Services.AddScoped<IHouseholdMemberService, HouseholdMemberService>();
+// Settings island C (strangler): household-request + feedback administration lifted out of HouseholdAdmin.razor /
+// FeedbackAdmin.razor's direct EF. The load-bearing parts are server-enforced here: the atomic approval
+// transaction (R-C2), the already-reviewed 409 guard (R-C3), and the feedback IDOR scope (R-C1).
+builder.Services.AddScoped<IHouseholdRequestService, HouseholdRequestService>();
+builder.Services.AddScoped<IFeedbackService, FeedbackService>();
 
 // Chores (Phase 10): room CRUD, chore writes/state-machine, and the board read model. Date math is
 // timezone-aware: the calculator is a stateless singleton; the household timezone (default America/Chicago,
@@ -410,6 +415,7 @@ app.MapRecipesEndpoints();
 app.MapDashboardEndpoints();
 app.MapSettingsEndpoints();
 app.MapSettingsConnectionsEndpoints();
+app.MapSettingsAdminEndpoints();
 
 // Health check endpoint for Docker
 app.MapGet("/health", () => Results.Ok("healthy"));

--- a/src/FamilyCoordinationApp/Services/Dtos/SettingsAdminDtos.cs
+++ b/src/FamilyCoordinationApp/Services/Dtos/SettingsAdminDtos.cs
@@ -1,0 +1,92 @@
+namespace FamilyCoordinationApp.Services.Dtos;
+
+using FamilyCoordinationApp.Data.Entities;
+
+// ─────────────────────────────────────────────────────────────────────────
+// Settings island C (Admin) DTOs — Household requests (site-admin-only) + Feedback
+// (dual-mode) (strangler; mirrors the cluster-A/B M9 lockstep). Source of truth for
+// the island TS contract:
+//   tests/.../Fixtures/Settings/{household-requests,feedback}.json
+//   + frontend/admin/src/lib/types.ts.
+// A shape/casing change updates THIS file, those fixtures, and types.ts in lockstep
+// (HouseholdRequestsDtoContractTests / FeedbackListDtoContractTests are the tripwires).
+//
+// ⚠ CASING: all keys camelCase (JsonSerializerDefaults.Web).
+// ⚠ ENUMS (review R-C10): HouseholdRequestStatus + FeedbackType are REAL enums → the
+//   app's global JsonStringEnumConverter(CamelCase) serializes them as camelCase
+//   strings on the wire ("pending"/"approved"/"rejected", "bug"/"featureRequest"/
+//   "general"). The island carries matching string-union types + a label/icon/color map.
+// ⚠ DATES (review X5): RequestedAt / ReviewedAt / CreatedAt are FULL INSTANTS WITH
+//   time-of-day (NOT the noon-UTC date-only case). They are projected server-side to
+//   round-trip ISO-8601 UTC strings ("2026-06-24T18:30:00Z") and the island renders
+//   them local via new Date(iso).toLocaleString(). Carried as `string` (not DateTime)
+//   so the wire format is pinned explicitly and unambiguously UTC — see
+//   SettingsAdminEndpoints.ToIso.
+//
+// Type names are admin-scoped and were grepped collision-free in the shared Dtos
+// namespace (cluster-B hit ConnectedHouseholdDto already living in RecipeDtos.cs).
+// ─────────────────────────────────────────────────────────────────────────
+
+// ─── Household requests (site-admin-only) ───────────────────────────────────────
+
+/// <summary>
+/// The Household-requests view aggregate (parity <c>HouseholdAdmin.razor</c> LoadData): every household-creation
+/// request (pending-first ordering) + every existing household with its member count. These are SITE-ADMIN GLOBAL
+/// reads — <see cref="HouseholdRequest"/> has no HouseholdId and the list spans all tenants, gated by the 403
+/// site-admin check, not by M1 (review R-C8).
+/// </summary>
+public sealed record HouseholdRequestsDto(
+    IReadOnlyList<HouseholdRequestDto> Requests,
+    IReadOnlyList<HouseholdSummaryDto> Households);
+
+/// <summary>
+/// One household-creation request. <see cref="Status"/> is a real enum → camelCase string on the wire.
+/// <see cref="RequestedAt"/> is always present; <see cref="ReviewedAt"/>/<see cref="ReviewedBy"/>/
+/// <see cref="RejectionReason"/> are null until a request is approved/rejected.
+/// </summary>
+public sealed record HouseholdRequestDto(
+    int Id,
+    string HouseholdName,
+    string DisplayName,
+    string Email,
+    HouseholdRequestStatus Status,
+    string RequestedAt,
+    string? ReviewedAt,
+    string? ReviewedBy,
+    string? RejectionReason);
+
+/// <summary>One existing household + its member count (parity: the "Existing Households" table; review R-C8 —
+/// <see cref="MemberCount"/> = Households.Include(Users) → Users.Count).</summary>
+public sealed record HouseholdSummaryDto(
+    int HouseholdId,
+    string Name,
+    int MemberCount,
+    string CreatedAt);
+
+// ─── Feedback (dual-mode) ───────────────────────────────────────────────────────
+
+/// <summary>
+/// The Feedback view payload. <see cref="IsSiteAdmin"/> is the island's visibility signal (review R-C4): a site
+/// admin sees ALL households' feedback; a regular user sees only their own household's (server-scoped, M1). The
+/// island uses the flag for copy/affordances, NOT to decide what to fetch — the server already scoped it.
+/// </summary>
+public sealed record FeedbackListDto(
+    bool IsSiteAdmin,
+    IReadOnlyList<FeedbackDto> Items);
+
+/// <summary>
+/// One feedback item. <see cref="Type"/> is a real enum → camelCase string on the wire (review R-C10). Author is
+/// a 3-way mapping (review R-C6): a live user → (<see cref="AuthorName"/>=DisplayName, <see cref="AuthorDeleted"/>
+/// =false); a deleted user (UserId set, no row) → (null, true) → the island renders "Deleted user"; anonymous
+/// (no UserId) → (null, false) → no author line at all.
+/// </summary>
+public sealed record FeedbackDto(
+    int Id,
+    FeedbackType Type,
+    string Message,
+    string? CurrentPage,
+    bool IsRead,
+    bool IsResolved,
+    string CreatedAt,
+    string? AuthorName,
+    bool AuthorDeleted);

--- a/src/FamilyCoordinationApp/Services/FeedbackService.cs
+++ b/src/FamilyCoordinationApp/Services/FeedbackService.cs
@@ -1,0 +1,70 @@
+using FamilyCoordinationApp.Data;
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Services.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace FamilyCoordinationApp.Services;
+
+/// <summary>
+/// Feedback administration (strangler — lifts <c>FeedbackAdmin.razor</c>'s direct-EF logic into a testable,
+/// dual-mode service). Short-lived contexts via the factory. Every read and mutation is household-scoped for a
+/// non-admin (R-C1, the IDOR fix): the scope is part of the query, so a non-admin posting another household's id
+/// finds nothing → the endpoint 404s with no existence leak. A site admin is unscoped (sees/acts on any item).
+/// </summary>
+public sealed class FeedbackService(
+    IDbContextFactory<ApplicationDbContext> dbFactory,
+    ILogger<FeedbackService> logger) : IFeedbackService
+{
+    public async Task<IReadOnlyList<Feedback>> GetFeedbackAsync(bool isSiteAdmin, int? householdId, CancellationToken cancellationToken = default)
+    {
+        await using var context = await dbFactory.CreateDbContextAsync(cancellationToken);
+
+        IQueryable<Feedback> query = context.Feedbacks.Include(f => f.User);
+
+        // Dual-mode: site admin → all households; regular user → own household only (R-C1, server-scoped). A
+        // non-admin with no resolved household sees nothing rather than everything.
+        if (!isSiteAdmin)
+        {
+            if (householdId is null) return [];
+            query = query.Where(f => f.HouseholdId == householdId);
+        }
+
+        return await query
+            .OrderByDescending(f => f.CreatedAt)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<bool> MarkReadAsync(int id, bool isSiteAdmin, int? householdId, CancellationToken cancellationToken = default)
+        => await MutateAsync(id, isSiteAdmin, householdId, f => f.IsRead = true, cancellationToken);
+
+    public async Task<bool> MarkResolvedAsync(int id, bool isSiteAdmin, int? householdId, CancellationToken cancellationToken = default)
+        => await MutateAsync(id, isSiteAdmin, householdId, f => { f.IsRead = true; f.IsResolved = true; }, cancellationToken);
+
+    public async Task<bool> ReopenAsync(int id, bool isSiteAdmin, int? householdId, CancellationToken cancellationToken = default)
+        => await MutateAsync(id, isSiteAdmin, householdId, f => f.IsResolved = false, cancellationToken);
+
+    /// <summary>
+    /// Find the item WITHIN the caller's visibility (R-C1) and apply <paramref name="mutate"/>. Returns false (⇒
+    /// the endpoint 404s) when the item doesn't exist or isn't visible to a non-admin — the household scope is in
+    /// the WHERE, so a cross-household id is indistinguishable from a missing one (no existence leak).
+    /// </summary>
+    private async Task<bool> MutateAsync(int id, bool isSiteAdmin, int? householdId, Action<Feedback> mutate, CancellationToken cancellationToken)
+    {
+        await using var context = await dbFactory.CreateDbContextAsync(cancellationToken);
+
+        IQueryable<Feedback> query = context.Feedbacks.Where(f => f.Id == id);
+        if (!isSiteAdmin)
+        {
+            if (householdId is null) return false;
+            query = query.Where(f => f.HouseholdId == householdId);
+        }
+
+        var feedback = await query.FirstOrDefaultAsync(cancellationToken);
+        if (feedback is null) return false;
+
+        mutate(feedback);
+        await context.SaveChangesAsync(cancellationToken);
+        logger.LogInformation("Mutated feedback {FeedbackId} (siteAdmin={IsSiteAdmin})", id, isSiteAdmin);
+        return true;
+    }
+}

--- a/src/FamilyCoordinationApp/Services/FeedbackService.cs
+++ b/src/FamilyCoordinationApp/Services/FeedbackService.cs
@@ -19,7 +19,8 @@ public sealed class FeedbackService(
     {
         await using var context = await dbFactory.CreateDbContextAsync(cancellationToken);
 
-        IQueryable<Feedback> query = context.Feedbacks.Include(f => f.User);
+        // Read-only projection ⇒ AsNoTracking (council R6).
+        IQueryable<Feedback> query = context.Feedbacks.AsNoTracking().Include(f => f.User);
 
         // Dual-mode: site admin → all households; regular user → own household only (R-C1, server-scoped). A
         // non-admin with no resolved household sees nothing rather than everything.

--- a/src/FamilyCoordinationApp/Services/HouseholdRequestService.cs
+++ b/src/FamilyCoordinationApp/Services/HouseholdRequestService.cs
@@ -1,0 +1,129 @@
+using FamilyCoordinationApp.Data;
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Services.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace FamilyCoordinationApp.Services;
+
+/// <summary>
+/// Household-creation request administration (strangler — lifts <c>HouseholdAdmin.razor</c>'s direct-EF logic into
+/// a testable service). Short-lived contexts via the factory. The site-admin 403 gate is the endpoint's job (these
+/// are global, not M1-scoped — review R-C8); the correctness-load-bearing parts live HERE: the atomic approval
+/// transaction (R-C2) and the already-reviewed guard (R-C3).
+/// </summary>
+public sealed class HouseholdRequestService(
+    IDbContextFactory<ApplicationDbContext> dbFactory,
+    ILogger<HouseholdRequestService> logger) : IHouseholdRequestService
+{
+    public async Task<HouseholdAdminData> GetDataAsync(CancellationToken cancellationToken = default)
+    {
+        await using var context = await dbFactory.CreateDbContextAsync(cancellationToken);
+
+        // Pending-first, then newest (parity HouseholdAdmin.LoadData :196-199). Global read — no HouseholdId on the
+        // entity, gated by the endpoint's site-admin 403 (R-C8).
+        var requests = await context.HouseholdRequests
+            .OrderByDescending(r => r.Status == HouseholdRequestStatus.Pending)
+            .ThenByDescending(r => r.RequestedAt)
+            .ToListAsync(cancellationToken);
+
+        // Include Users so the endpoint can project MemberCount = Users.Count (R-C8).
+        var households = await context.Households
+            .Include(h => h.Users)
+            .OrderBy(h => h.Name)
+            .ToListAsync(cancellationToken);
+
+        return new HouseholdAdminData(requests, households);
+    }
+
+    public async Task<ApproveResult> ApproveAsync(int requestId, string reviewerEmail, CancellationToken cancellationToken = default)
+    {
+        await using var context = await dbFactory.CreateDbContextAsync(cancellationToken);
+
+        // R-C2: ONE transaction over household + user + request-status + categories. Multiple SaveChanges inside it
+        // (the User FK needs household.Id, so the household must flush first), committed once at the end. A failure
+        // anywhere — including the User unique-email constraint — rolls the whole thing back, so we never leave an
+        // orphan household or a household with no categories. (Replaces the page's three separate commits.)
+        await using var transaction = await context.Database.BeginTransactionAsync(cancellationToken);
+
+        var request = await context.HouseholdRequests
+            .FirstOrDefaultAsync(r => r.Id == requestId, cancellationToken);
+        if (request is null)
+        {
+            return new ApproveResult(ReviewOutcome.NotFound, null);
+        }
+
+        // R-C3: only a still-pending request can be approved. A non-pending one (already approved/rejected, or just
+        // approved by another admin on a stale view) is refused — this closes the duplicate-household race.
+        if (request.Status != HouseholdRequestStatus.Pending)
+        {
+            return new ApproveResult(ReviewOutcome.AlreadyReviewed, null);
+        }
+
+        var now = DateTime.UtcNow;
+
+        var household = new Household
+        {
+            Name = request.HouseholdName,
+            CreatedAt = now,
+        };
+        context.Households.Add(household);
+        await context.SaveChangesAsync(cancellationToken); // assign household.Id for the user FK below
+
+        context.Users.Add(new User
+        {
+            HouseholdId = household.Id,
+            Email = request.Email,
+            DisplayName = request.DisplayName,
+            GoogleId = request.GoogleId,
+            IsWhitelisted = true,
+            CreatedAt = now,
+        });
+
+        request.Status = HouseholdRequestStatus.Approved;
+        request.ReviewedAt = now;
+        request.ReviewedBy = reviewerEmail;
+
+        // Seed the nine default categories on THIS context, inside the same transaction (R-C2) — not the old
+        // separate-context SeedDefaultCategoriesAsync, which committed independently.
+        SeedData.AddDefaultCategories(context, household.Id);
+
+        await context.SaveChangesAsync(cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
+
+        logger.LogInformation(
+            "Approved household request {RequestId}: {HouseholdName} for {Email} by {Admin}",
+            requestId, request.HouseholdName, request.Email, reviewerEmail);
+
+        return new ApproveResult(ReviewOutcome.Ok, household);
+    }
+
+    public async Task<ReviewOutcome> RejectAsync(int requestId, string? reason, string reviewerEmail, CancellationToken cancellationToken = default)
+    {
+        await using var context = await dbFactory.CreateDbContextAsync(cancellationToken);
+
+        var request = await context.HouseholdRequests
+            .FirstOrDefaultAsync(r => r.Id == requestId, cancellationToken);
+        if (request is null)
+        {
+            return ReviewOutcome.NotFound;
+        }
+
+        // R-C3: don't re-review an already-decided request.
+        if (request.Status != HouseholdRequestStatus.Pending)
+        {
+            return ReviewOutcome.AlreadyReviewed;
+        }
+
+        request.Status = HouseholdRequestStatus.Rejected;
+        request.ReviewedAt = DateTime.UtcNow;
+        request.ReviewedBy = reviewerEmail;
+        request.RejectionReason = reason; // OPTIONAL — null/empty is allowed (R-C7)
+        await context.SaveChangesAsync(cancellationToken);
+
+        logger.LogInformation(
+            "Rejected household request {RequestId}: {HouseholdName} for {Email} by {Admin}. Reason: {Reason}",
+            requestId, request.HouseholdName, request.Email, reviewerEmail, reason);
+
+        return ReviewOutcome.Ok;
+    }
+}

--- a/src/FamilyCoordinationApp/Services/HouseholdRequestService.cs
+++ b/src/FamilyCoordinationApp/Services/HouseholdRequestService.cs
@@ -20,14 +20,16 @@ public sealed class HouseholdRequestService(
         await using var context = await dbFactory.CreateDbContextAsync(cancellationToken);
 
         // Pending-first, then newest (parity HouseholdAdmin.LoadData :196-199). Global read — no HouseholdId on the
-        // entity, gated by the endpoint's site-admin 403 (R-C8).
+        // entity, gated by the endpoint's site-admin 403 (R-C8). Read-only ⇒ AsNoTracking (council R6).
         var requests = await context.HouseholdRequests
+            .AsNoTracking()
             .OrderByDescending(r => r.Status == HouseholdRequestStatus.Pending)
             .ThenByDescending(r => r.RequestedAt)
             .ToListAsync(cancellationToken);
 
         // Include Users so the endpoint can project MemberCount = Users.Count (R-C8).
         var households = await context.Households
+            .AsNoTracking()
             .Include(h => h.Users)
             .OrderBy(h => h.Name)
             .ToListAsync(cancellationToken);
@@ -87,8 +89,21 @@ public sealed class HouseholdRequestService(
         // separate-context SeedDefaultCategoriesAsync, which committed independently.
         SeedData.AddDefaultCategories(context, household.Id);
 
-        await context.SaveChangesAsync(cancellationToken);
-        await transaction.CommitAsync(cancellationToken);
+        try
+        {
+            await context.SaveChangesAsync(cancellationToken);
+            await transaction.CommitAsync(cancellationToken);
+        }
+        catch (DbUpdateException ex) when (IsUniqueViolation(ex))
+        {
+            // The request's email is already a user (stale data, or a concurrent approve that created the user
+            // first). The transaction is NOT committed; returning here disposes `transaction` → full rollback (no
+            // orphan household), so the caller gets a clean 409 instead of an opaque 500 (council R1). The R-C3
+            // status guard already closes the common stale-poll race; this closes the true-concurrent-approve one.
+            logger.LogWarning(ex,
+                "Approve {RequestId} blocked: email {Email} already in use — rolled back", requestId, request.Email);
+            return new ApproveResult(ReviewOutcome.EmailInUse, null);
+        }
 
         logger.LogInformation(
             "Approved household request {RequestId}: {HouseholdName} for {Email} by {Admin}",
@@ -96,6 +111,10 @@ public sealed class HouseholdRequestService(
 
         return new ApproveResult(ReviewOutcome.Ok, household);
     }
+
+    /// <summary>True when an EF save failure is a PostgreSQL unique-constraint violation (SQLSTATE 23505).</summary>
+    private static bool IsUniqueViolation(DbUpdateException ex) =>
+        ex.InnerException is Npgsql.PostgresException { SqlState: "23505" };
 
     public async Task<ReviewOutcome> RejectAsync(int requestId, string? reason, string reviewerEmail, CancellationToken cancellationToken = default)
     {

--- a/src/FamilyCoordinationApp/Services/Interfaces/IFeedbackService.cs
+++ b/src/FamilyCoordinationApp/Services/Interfaces/IFeedbackService.cs
@@ -1,0 +1,32 @@
+using FamilyCoordinationApp.Data.Entities;
+
+namespace FamilyCoordinationApp.Services.Interfaces;
+
+/// <summary>
+/// Feedback administration — lifted out of the direct-EF <c>FeedbackAdmin.razor</c> (review: cluster C). DUAL-MODE
+/// visibility (parity): a site admin sees ALL households' feedback; a regular user sees only their own household's.
+/// <para><b>R-C1 (IDOR must-fix):</b> the old page did <c>Feedbacks.FindAsync(id)</c> with NO household scoping
+/// before flipping flags — safe ONLY because the Blazor list never rendered another household's ids to a
+/// non-admin. As a REST surface that becomes an IDOR (a non-admin could POST an arbitrary id). So EVERY read and
+/// mutation here is scoped: site admin → any item; non-admin → only an item in their OWN household, else treated
+/// as not-found (the endpoint returns 404 with no existence leak). The scope is enforced in the query, not after
+/// the fetch.</para>
+/// </summary>
+public interface IFeedbackService
+{
+    /// <summary>
+    /// Feedback for the caller, newest-first. <paramref name="isSiteAdmin"/> ⇒ all households; otherwise only
+    /// <paramref name="householdId"/>'s (a non-admin with no resolved household sees nothing). Includes the author
+    /// <see cref="Feedback.User"/> for the name mapping.
+    /// </summary>
+    Task<IReadOnlyList<Feedback>> GetFeedbackAsync(bool isSiteAdmin, int? householdId, CancellationToken cancellationToken = default);
+
+    /// <summary>Mark an item read. Scoped (R-C1): returns false (⇒ 404) when the item doesn't exist OR isn't visible to the caller.</summary>
+    Task<bool> MarkReadAsync(int id, bool isSiteAdmin, int? householdId, CancellationToken cancellationToken = default);
+
+    /// <summary>Mark an item resolved (also sets read, parity). Scoped (R-C1): false ⇒ 404 (not found / not visible).</summary>
+    Task<bool> MarkResolvedAsync(int id, bool isSiteAdmin, int? householdId, CancellationToken cancellationToken = default);
+
+    /// <summary>Reopen a resolved item. Scoped (R-C1): false ⇒ 404 (not found / not visible).</summary>
+    Task<bool> ReopenAsync(int id, bool isSiteAdmin, int? householdId, CancellationToken cancellationToken = default);
+}

--- a/src/FamilyCoordinationApp/Services/Interfaces/IHouseholdRequestService.cs
+++ b/src/FamilyCoordinationApp/Services/Interfaces/IHouseholdRequestService.cs
@@ -46,12 +46,20 @@ public sealed record HouseholdAdminData(
     IReadOnlyList<HouseholdRequest> Requests,
     IReadOnlyList<Household> Households);
 
-/// <summary>Outcome of an approve/reject — maps to HTTP in the endpoint (NotFound ⇒ 404, AlreadyReviewed ⇒ 409).</summary>
+/// <summary>Outcome of an approve/reject — maps to HTTP in the endpoint (NotFound ⇒ 404, AlreadyReviewed/EmailInUse ⇒ 409).</summary>
 public enum ReviewOutcome
 {
     Ok,
     NotFound,
     AlreadyReviewed,
+
+    /// <summary>
+    /// Approve hit the unique <c>Users.Email</c> constraint: the request's email is already a user (a stale
+    /// data state, or a concurrent approve that won the race and created the user first). The transaction rolled
+    /// back fully — no orphan household. Maps to a clean 409 rather than letting the <c>DbUpdateException</c>
+    /// surface as a 500 (council R1). Only approve can produce this.
+    /// </summary>
+    EmailInUse,
 }
 
 /// <summary>The result of an approve: the <see cref="Outcome"/> plus the created household (only when Ok).</summary>

--- a/src/FamilyCoordinationApp/Services/Interfaces/IHouseholdRequestService.cs
+++ b/src/FamilyCoordinationApp/Services/Interfaces/IHouseholdRequestService.cs
@@ -1,0 +1,58 @@
+using FamilyCoordinationApp.Data.Entities;
+
+namespace FamilyCoordinationApp.Services.Interfaces;
+
+/// <summary>
+/// Household-creation request administration — lifted out of the direct-EF <c>HouseholdAdmin.razor</c> so the
+/// load-bearing approval logic is testable (review: cluster C). These are SITE-ADMIN GLOBAL operations — the
+/// site-admin 403 gate lives in the endpoint, NOT here (review R-C8 — requests have no HouseholdId and span all
+/// tenants). Two correctness invariants are enforced HERE, server-side, not just hidden behind the page's buttons:
+/// <list type="bullet">
+/// <item><b>R-C2 (atomicity):</b> approve creates household + whitelisted user + marks the request approved +
+/// seeds default categories inside ONE transaction — all four commit or none do (the old page did three separate
+/// commits → a mid-failure left an orphan household or a household with no categories).</item>
+/// <item><b>R-C3 (already-reviewed guard):</b> approve/reject of a non-<see cref="HouseholdRequestStatus.Pending"/>
+/// request is refused (<see cref="ReviewOutcome.AlreadyReviewed"/> → 409), closing the latent duplicate-household
+/// race two admins (or one on a 30s-stale view) could otherwise hit.</item>
+/// </list>
+/// </summary>
+public interface IHouseholdRequestService
+{
+    /// <summary>
+    /// Every household request (pending-first, then newest — parity ordering) + every existing household with its
+    /// <see cref="Household.Users"/> populated (for the member count). A cross-tenant read, legitimately (R-C8).
+    /// </summary>
+    Task<HouseholdAdminData> GetDataAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Approve a pending request inside one transaction (R-C2): create the household, create its first whitelisted
+    /// user, mark the request Approved (ReviewedAt/ReviewedBy = now/<paramref name="reviewerEmail"/>), and seed the
+    /// nine default categories. Non-pending ⇒ <see cref="ReviewOutcome.AlreadyReviewed"/> (R-C3); unknown id ⇒
+    /// <see cref="ReviewOutcome.NotFound"/>. On success the created <see cref="Household"/> is returned (member
+    /// count = 1) for the 201 summary.
+    /// </summary>
+    Task<ApproveResult> ApproveAsync(int requestId, string reviewerEmail, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Reject a pending request: mark Rejected + ReviewedAt/ReviewedBy + <paramref name="reason"/> (OPTIONAL —
+    /// nullable/empty allowed, review R-C7). Non-pending ⇒ <see cref="ReviewOutcome.AlreadyReviewed"/> (R-C3);
+    /// unknown id ⇒ <see cref="ReviewOutcome.NotFound"/>.
+    /// </summary>
+    Task<ReviewOutcome> RejectAsync(int requestId, string? reason, string reviewerEmail, CancellationToken cancellationToken = default);
+}
+
+/// <summary>The Household-requests view data (raw entities; the endpoint projects to DTOs).</summary>
+public sealed record HouseholdAdminData(
+    IReadOnlyList<HouseholdRequest> Requests,
+    IReadOnlyList<Household> Households);
+
+/// <summary>Outcome of an approve/reject — maps to HTTP in the endpoint (NotFound ⇒ 404, AlreadyReviewed ⇒ 409).</summary>
+public enum ReviewOutcome
+{
+    Ok,
+    NotFound,
+    AlreadyReviewed,
+}
+
+/// <summary>The result of an approve: the <see cref="Outcome"/> plus the created household (only when Ok).</summary>
+public sealed record ApproveResult(ReviewOutcome Outcome, Household? CreatedHousehold);

--- a/tests/FamilyCoordinationApp.Tests/Fixtures/Settings/feedback.json
+++ b/tests/FamilyCoordinationApp.Tests/Fixtures/Settings/feedback.json
@@ -1,0 +1,38 @@
+{
+  "isSiteAdmin": true,
+  "items": [
+    {
+      "id": 5,
+      "type": "bug",
+      "message": "The button doesn't work.",
+      "currentPage": "/recipes",
+      "isRead": false,
+      "isResolved": false,
+      "createdAt": "2026-06-24T20:00:00Z",
+      "authorName": "Jamie",
+      "authorDeleted": false
+    },
+    {
+      "id": 4,
+      "type": "featureRequest",
+      "message": "Please add dark mode.",
+      "currentPage": null,
+      "isRead": true,
+      "isResolved": false,
+      "createdAt": "2026-06-23T14:30:00Z",
+      "authorName": null,
+      "authorDeleted": true
+    },
+    {
+      "id": 3,
+      "type": "general",
+      "message": "Love the app!",
+      "currentPage": "/",
+      "isRead": true,
+      "isResolved": true,
+      "createdAt": "2026-06-22T08:00:00Z",
+      "authorName": null,
+      "authorDeleted": false
+    }
+  ]
+}

--- a/tests/FamilyCoordinationApp.Tests/Fixtures/Settings/household-requests.json
+++ b/tests/FamilyCoordinationApp.Tests/Fixtures/Settings/household-requests.json
@@ -1,0 +1,51 @@
+{
+  "requests": [
+    {
+      "id": 3,
+      "householdName": "The Greens",
+      "displayName": "Pat Green",
+      "email": "pat@example.com",
+      "status": "pending",
+      "requestedAt": "2026-06-24T18:30:00Z",
+      "reviewedAt": null,
+      "reviewedBy": null,
+      "rejectionReason": null
+    },
+    {
+      "id": 2,
+      "householdName": "The Blues",
+      "displayName": "Sam Blue",
+      "email": "sam@example.com",
+      "status": "approved",
+      "requestedAt": "2026-06-20T09:15:00Z",
+      "reviewedAt": "2026-06-21T10:00:00Z",
+      "reviewedBy": "admin@example.com",
+      "rejectionReason": null
+    },
+    {
+      "id": 1,
+      "householdName": "The Reds",
+      "displayName": "Alex Red",
+      "email": "alex@example.com",
+      "status": "rejected",
+      "requestedAt": "2026-06-18T12:00:00Z",
+      "reviewedAt": "2026-06-19T08:30:00Z",
+      "reviewedBy": "admin@example.com",
+      "rejectionReason": "Duplicate of an existing household."
+    }
+  ],
+  "households": [
+    {
+      "householdId": 1,
+      "name": "La Familia",
+      "memberCount": 4,
+      "createdAt": "2026-01-15T00:00:00Z"
+    },
+    {
+      "householdId": 2,
+      "name": "The Blues",
+      "memberCount": 1,
+      "createdAt": "2026-06-21T10:00:00Z"
+    }
+  ]
+}

--- a/tests/FamilyCoordinationApp.Tests/Integration/ChoresWebAppFactory.cs
+++ b/tests/FamilyCoordinationApp.Tests/Integration/ChoresWebAppFactory.cs
@@ -118,6 +118,11 @@ public class ChoresWebAppFactory(PostgresContainerFixture postgres) : WebApplica
         builder.UseSetting("Authentication:Google:ClientId", "test-client-id");
         builder.UseSetting("Authentication:Google:ClientSecret", "test-client-secret");
 
+        // Settings island C: make Alice (household A) the site admin so the cluster-C tests can exercise the
+        // site-admin 403 gate (household-requests) + dual-mode feedback visibility. ISiteAdminService reads this
+        // from config; no existing test exercises site-admin behavior, so this is inert for everything else.
+        builder.UseSetting("SITE_ADMIN_EMAILS", UserAEmail);
+
         // The digest-run endpoint refuses (503) unless this is configured; tests assert valid/missing/wrong
         // token against this known value. The unconfigured-token (503) variant is exercised by
         // UnconfiguredDigestWebAppFactory, which overrides ConfiguredTriggerToken to "" (treated as unset).

--- a/tests/FamilyCoordinationApp.Tests/Integration/SettingsAdminEndpointTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Integration/SettingsAdminEndpointTests.cs
@@ -1,0 +1,338 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FamilyCoordinationApp.Data;
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Services.Interfaces;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FamilyCoordinationApp.Tests.Integration;
+
+/// <summary>
+/// End-to-end coverage of the Settings island C (Admin) endpoints (<c>/api/settings/household-requests</c> +
+/// <c>/api/settings/feedback</c>) through the real HTTP pipeline against real Postgres. Reuses
+/// <see cref="ChoresWebAppFactory"/>'s two-household seed (A id=1 alice+amy, B id=2 bob) and makes
+/// <c>alice@household-a.test</c> the SITE ADMIN (via <c>SITE_ADMIN_EMAILS</c>) so the role split is exercised.
+/// Each test method gets its OWN freshly-seeded database. Proves the three load-bearing findings each with its own
+/// test: R-C1 (feedback IDOR is blocked), R-C2 (approve is atomic — a forced mid-approve failure rolls back fully),
+/// R-C3 (an already-reviewed request is a 409, never a second household); plus the 403 site-admin gate and the
+/// dual-mode feedback visibility.
+/// </summary>
+[Collection(IntegrationCollection.Name)]
+[Trait("kind", "integration")]
+public sealed class SettingsAdminEndpointTests(PostgresContainerFixture postgres) : IAsyncLifetime
+{
+    private readonly ChoresWebAppFactory _factory = new(postgres);
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    public async Task InitializeAsync() => await _factory.EnsureSeededAsync();
+
+    public async Task DisposeAsync() => await _factory.DisposeAsync();
+
+    // alice = site admin (household A); bob = regular user (household B).
+    private HttpClient AdminClient => _factory.CreateClientAs(ChoresWebAppFactory.UserAEmail);
+    private HttpClient NonAdminClient => _factory.CreateClientAs(ChoresWebAppFactory.UserBEmail);
+
+    private const string RequestsUrl = "/api/settings/household-requests";
+    private const string FeedbackUrl = "/api/settings/feedback";
+
+    private IDbContextFactory<ApplicationDbContext> DbFactory =>
+        _factory.Services.GetRequiredService<IDbContextFactory<ApplicationDbContext>>();
+
+    // Wire shapes (camelCase via JsonSerializerDefaults.Web; enums as camelCase strings).
+    private sealed record RequestWire(int id, string householdName, string displayName, string email, string status,
+        string requestedAt, string? reviewedAt, string? reviewedBy, string? rejectionReason);
+    private sealed record SummaryWire(int householdId, string name, int memberCount, string createdAt);
+    private sealed record RequestsWire(List<RequestWire> requests, List<SummaryWire> households);
+    private sealed record FeedbackWire(int id, string type, string message, string? currentPage, bool isRead,
+        bool isResolved, string createdAt, string? authorName, bool authorDeleted);
+    private sealed record FeedbackListWire(bool isSiteAdmin, List<FeedbackWire> items);
+
+    // ─── Seed helpers ─────────────────────────────────────────────────────────────
+
+    private async Task<int> SeedRequestAsync(
+        string householdName, string email, string displayName,
+        HouseholdRequestStatus status = HouseholdRequestStatus.Pending)
+    {
+        await using var ctx = await DbFactory.CreateDbContextAsync();
+        var req = new HouseholdRequest
+        {
+            Email = email,
+            DisplayName = displayName,
+            HouseholdName = householdName,
+            GoogleId = null,
+            Status = status,
+            RequestedAt = DateTime.UtcNow,
+        };
+        ctx.HouseholdRequests.Add(req);
+        await ctx.SaveChangesAsync();
+        return req.Id;
+    }
+
+    private async Task<int> SeedFeedbackAsync(
+        int householdId, int? userId = null, FeedbackType type = FeedbackType.Bug,
+        bool isRead = false, bool isResolved = false)
+    {
+        await using var ctx = await DbFactory.CreateDbContextAsync();
+        var fb = new Feedback
+        {
+            HouseholdId = householdId,
+            UserId = userId,
+            Type = type,
+            Message = "test feedback",
+            CreatedAt = DateTime.UtcNow,
+            IsRead = isRead,
+            IsResolved = isResolved,
+        };
+        ctx.Feedbacks.Add(fb);
+        await ctx.SaveChangesAsync();
+        return fb.Id;
+    }
+
+    // ─── Site-admin 403 gate (R-C8 — the C test for these routes is the gate, not M1) ─────────────
+
+    [Fact]
+    public async Task HouseholdRequests_NonSiteAdmin_Gets403_OnEveryRoute()
+    {
+        var requestId = await SeedRequestAsync("The Greens", "pat@example.com", "Pat Green");
+
+        (await NonAdminClient.GetAsync($"{RequestsUrl}/"))
+            .StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        (await NonAdminClient.PostAsync($"{RequestsUrl}/{requestId}/approve", null))
+            .StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        var reject = await NonAdminClient.PostAsJsonAsync($"{RequestsUrl}/{requestId}/reject", new { reason = "no" }, Json);
+        reject.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+
+        // 403 carries a non-empty body (so the global re-execute doesn't turn it into a 405 on the POSTs).
+        (await reject.Content.ReadAsStringAsync()).Should().Contain("Site admin");
+
+        // The request was untouched by the rejected calls.
+        await using var ctx = await DbFactory.CreateDbContextAsync();
+        (await ctx.HouseholdRequests.FindAsync(requestId))!.Status.Should().Be(HouseholdRequestStatus.Pending);
+    }
+
+    [Fact]
+    public async Task HouseholdRequests_Unauthenticated_Returns401()
+    {
+        (await _factory.CreateAnonymousClient().GetAsync($"{RequestsUrl}/"))
+            .StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task HouseholdRequests_SiteAdmin_SeesRequestsPendingFirst_AndHouseholdsWithMemberCounts()
+    {
+        await SeedRequestAsync("Approved Co", "sam@example.com", "Sam", HouseholdRequestStatus.Approved);
+        await SeedRequestAsync("Pending Co", "pat@example.com", "Pat", HouseholdRequestStatus.Pending);
+
+        var dto = (await AdminClient.GetFromJsonAsync<RequestsWire>($"{RequestsUrl}/", Json))!;
+
+        dto.requests.Should().HaveCount(2);
+        dto.requests[0].status.Should().Be("pending", "pending requests sort first (parity)");
+
+        // The two seeded households (A id=1: alice+amy = 2 members; B id=2: bob = 1), member counts populated (R-C8).
+        dto.households.Should().Contain(h => h.householdId == ChoresWebAppFactory.HouseholdAId && h.memberCount == 2);
+        dto.households.Should().Contain(h => h.householdId == ChoresWebAppFactory.HouseholdBId && h.memberCount == 1);
+    }
+
+    // ─── Approve: the atomic transaction (R-C2) ───────────────────────────────────
+
+    [Fact]
+    public async Task Approve_CreatesHousehold_WhitelistedUser_AndSeedsNineCategories_MarksApproved()
+    {
+        var requestId = await SeedRequestAsync("The Approved", "newowner@example.com", "New Owner");
+
+        var resp = await AdminClient.PostAsync($"{RequestsUrl}/{requestId}/approve", null);
+        resp.StatusCode.Should().Be(HttpStatusCode.Created);
+        var summary = (await resp.Content.ReadFromJsonAsync<SummaryWire>(Json))!;
+        summary.name.Should().Be("The Approved");
+        summary.memberCount.Should().Be(1);
+
+        await using var ctx = await DbFactory.CreateDbContextAsync();
+        var household = await ctx.Households.Include(h => h.Users)
+            .FirstOrDefaultAsync(h => h.Name == "The Approved");
+        household.Should().NotBeNull();
+
+        household!.Users.Should().ContainSingle()
+            .Which.Should().Match<User>(u => u.Email == "newowner@example.com" && u.IsWhitelisted);
+
+        // Default categories were seeded inside the same transaction (R-C2).
+        var categoryCount = await ctx.Categories.IgnoreQueryFilters()
+            .CountAsync(c => c.HouseholdId == household.Id);
+        categoryCount.Should().Be(9);
+
+        var request = await ctx.HouseholdRequests.FindAsync(requestId);
+        request!.Status.Should().Be(HouseholdRequestStatus.Approved);
+        request.ReviewedBy.Should().Be(ChoresWebAppFactory.UserAEmail);
+        request.ReviewedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Approve_AlreadyReviewed_Returns409_AndDoesNotCreateASecondHousehold()
+    {
+        var requestId = await SeedRequestAsync("Once Only", "once@example.com", "Once Owner");
+
+        var first = await AdminClient.PostAsync($"{RequestsUrl}/{requestId}/approve", null);
+        first.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        // R-C3: a second approve (e.g. a stale 30s-poll view or a second admin) must NOT spin up a second household.
+        var second = await AdminClient.PostAsync($"{RequestsUrl}/{requestId}/approve", null);
+        second.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        (await second.Content.ReadAsStringAsync()).Should().Contain("already been reviewed");
+
+        await using var ctx = await DbFactory.CreateDbContextAsync();
+        (await ctx.Households.CountAsync(h => h.Name == "Once Only")).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Approve_ForcedMidTransactionFailure_RollsBackFully_NoOrphanHousehold(/* R-C2 */)
+    {
+        // Seed a pending request whose email is ALREADY a user (alice). Approve creates the household (1st
+        // SaveChanges) then the user — which violates the unique Users.Email index on the 2nd SaveChanges, inside
+        // the same transaction. The whole unit of work must roll back: no orphan household, request still pending.
+        var requestId = await SeedRequestAsync("Rollback Household", ChoresWebAppFactory.UserAEmail, "Dup Owner");
+
+        using var scope = _factory.Services.CreateScope();
+        var service = scope.ServiceProvider.GetRequiredService<IHouseholdRequestService>();
+
+        var act = async () => await service.ApproveAsync(requestId, ChoresWebAppFactory.UserAEmail);
+        await act.Should().ThrowAsync<DbUpdateException>("the duplicate email violates the unique index mid-transaction");
+
+        await using var ctx = await DbFactory.CreateDbContextAsync();
+        (await ctx.Households.AnyAsync(h => h.Name == "Rollback Household"))
+            .Should().BeFalse("the household INSERT must roll back with the failed user INSERT (R-C2 atomicity)");
+        (await ctx.HouseholdRequests.FindAsync(requestId))!.Status
+            .Should().Be(HouseholdRequestStatus.Pending, "a fully-rolled-back approve leaves the request pending");
+    }
+
+    [Fact]
+    public async Task Approve_UnknownRequest_Returns404()
+    {
+        (await AdminClient.PostAsync($"{RequestsUrl}/999999/approve", null))
+            .StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // ─── Reject (optional reason R-C7; already-reviewed 409 R-C3) ──────────────────
+
+    [Fact]
+    public async Task Reject_WithReason_MarksRejected_AndStoresReason()
+    {
+        var requestId = await SeedRequestAsync("Reject Co", "rej@example.com", "Rej Owner");
+
+        var resp = await AdminClient.PostAsJsonAsync($"{RequestsUrl}/{requestId}/reject",
+            new { reason = "Duplicate household." }, Json);
+        resp.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        await using var ctx = await DbFactory.CreateDbContextAsync();
+        var request = await ctx.HouseholdRequests.FindAsync(requestId);
+        request!.Status.Should().Be(HouseholdRequestStatus.Rejected);
+        request.RejectionReason.Should().Be("Duplicate household.");
+        request.ReviewedBy.Should().Be(ChoresWebAppFactory.UserAEmail);
+    }
+
+    [Fact]
+    public async Task Reject_WithEmptyReason_IsAccepted_NoBadRequest(/* R-C7: reason is optional */)
+    {
+        var requestId = await SeedRequestAsync("No Reason Co", "nr@example.com", "NR Owner");
+
+        var resp = await AdminClient.PostAsJsonAsync($"{RequestsUrl}/{requestId}/reject", new { reason = "" }, Json);
+        resp.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        await using var ctx = await DbFactory.CreateDbContextAsync();
+        (await ctx.HouseholdRequests.FindAsync(requestId))!.Status.Should().Be(HouseholdRequestStatus.Rejected);
+    }
+
+    [Fact]
+    public async Task Reject_AlreadyReviewed_Returns409()
+    {
+        var requestId = await SeedRequestAsync("Twice Co", "twice@example.com", "Twice Owner");
+
+        (await AdminClient.PostAsJsonAsync($"{RequestsUrl}/{requestId}/reject", new { reason = "first" }, Json))
+            .StatusCode.Should().Be(HttpStatusCode.NoContent);
+        (await AdminClient.PostAsJsonAsync($"{RequestsUrl}/{requestId}/reject", new { reason = "second" }, Json))
+            .StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    // ─── Feedback dual-mode visibility ────────────────────────────────────────────
+
+    [Fact]
+    public async Task Feedback_SiteAdmin_SeesAllHouseholds_NonAdmin_SeesOwnOnly()
+    {
+        await SeedFeedbackAsync(ChoresWebAppFactory.HouseholdAId);
+        await SeedFeedbackAsync(ChoresWebAppFactory.HouseholdBId);
+
+        var adminList = (await AdminClient.GetFromJsonAsync<FeedbackListWire>($"{FeedbackUrl}/", Json))!;
+        adminList.isSiteAdmin.Should().BeTrue();
+        adminList.items.Should().HaveCount(2, "a site admin sees feedback from every household");
+
+        var bobList = (await NonAdminClient.GetFromJsonAsync<FeedbackListWire>($"{FeedbackUrl}/", Json))!;
+        bobList.isSiteAdmin.Should().BeFalse();
+        bobList.items.Should().ContainSingle("a regular user sees only their own household's feedback (M1)");
+    }
+
+    // ─── Feedback mutation IDOR (R-C1 — the security must-fix) ─────────────────────
+
+    [Fact]
+    public async Task Feedback_NonAdmin_CannotMutateAnotherHouseholdsItem_Returns404_NoMutation()
+    {
+        // A feedback row in household A. Bob is in household B → it must be invisible + immutable to him, and the
+        // 404 must not leak that it exists (R-C1).
+        var foreignId = await SeedFeedbackAsync(ChoresWebAppFactory.HouseholdAId);
+
+        foreach (var verb in new[] { "read", "resolve", "reopen" })
+        {
+            var resp = await NonAdminClient.PostAsync($"{FeedbackUrl}/{foreignId}/{verb}", null);
+            resp.StatusCode.Should().Be(HttpStatusCode.NotFound, $"non-admin {verb} on another household's feedback is an IDOR → 404");
+        }
+
+        // Nothing was mutated.
+        await using var ctx = await DbFactory.CreateDbContextAsync();
+        var fb = await ctx.Feedbacks.FindAsync(foreignId);
+        fb!.IsRead.Should().BeFalse();
+        fb.IsResolved.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Feedback_NonAdmin_CanMutateOwnHouseholdsItem(/* positive control: the 404 above is authz, not a blanket block */)
+    {
+        var ownId = await SeedFeedbackAsync(ChoresWebAppFactory.HouseholdBId);
+
+        (await NonAdminClient.PostAsync($"{FeedbackUrl}/{ownId}/read", null))
+            .StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        await using var ctx = await DbFactory.CreateDbContextAsync();
+        (await ctx.Feedbacks.FindAsync(ownId))!.IsRead.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Feedback_SiteAdmin_CanResolveAndReopen_AnyHouseholdsItem()
+    {
+        var id = await SeedFeedbackAsync(ChoresWebAppFactory.HouseholdBId);
+
+        (await AdminClient.PostAsync($"{FeedbackUrl}/{id}/resolve", null))
+            .StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        await using (var ctx = await DbFactory.CreateDbContextAsync())
+        {
+            var fb = await ctx.Feedbacks.FindAsync(id);
+            fb!.IsResolved.Should().BeTrue();
+            fb.IsRead.Should().BeTrue("resolve also marks read (parity)");
+        }
+
+        (await AdminClient.PostAsync($"{FeedbackUrl}/{id}/reopen", null))
+            .StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        await using (var ctx = await DbFactory.CreateDbContextAsync())
+        {
+            (await ctx.Feedbacks.FindAsync(id))!.IsResolved.Should().BeFalse();
+        }
+    }
+
+    [Fact]
+    public async Task Feedback_Mutation_UnknownId_Returns404()
+    {
+        (await AdminClient.PostAsync($"{FeedbackUrl}/999999/read", null))
+            .StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/tests/FamilyCoordinationApp.Tests/Integration/SettingsAdminEndpointTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Integration/SettingsAdminEndpointTests.cs
@@ -186,24 +186,37 @@ public sealed class SettingsAdminEndpointTests(PostgresContainerFixture postgres
     }
 
     [Fact]
-    public async Task Approve_ForcedMidTransactionFailure_RollsBackFully_NoOrphanHousehold(/* R-C2 */)
+    public async Task Approve_ForcedMidTransactionFailure_RollsBackFully_NoOrphanHousehold_Returns409(/* R-C2 + council R1 */)
     {
         // Seed a pending request whose email is ALREADY a user (alice). Approve creates the household (1st
         // SaveChanges) then the user — which violates the unique Users.Email index on the 2nd SaveChanges, inside
-        // the same transaction. The whole unit of work must roll back: no orphan household, request still pending.
+        // the same transaction. The whole unit of work must roll back (R-C2 atomicity: no orphan household, request
+        // still pending) AND surface as a clean 409, not an opaque 500 (council R1).
         var requestId = await SeedRequestAsync("Rollback Household", ChoresWebAppFactory.UserAEmail, "Dup Owner");
 
-        using var scope = _factory.Services.CreateScope();
-        var service = scope.ServiceProvider.GetRequiredService<IHouseholdRequestService>();
-
-        var act = async () => await service.ApproveAsync(requestId, ChoresWebAppFactory.UserAEmail);
-        await act.Should().ThrowAsync<DbUpdateException>("the duplicate email violates the unique index mid-transaction");
+        var resp = await AdminClient.PostAsync($"{RequestsUrl}/{requestId}/approve", null);
+        resp.StatusCode.Should().Be(HttpStatusCode.Conflict, "a duplicate email is a clean 409, not a 500");
+        (await resp.Content.ReadAsStringAsync()).Should().Contain("already exists");
 
         await using var ctx = await DbFactory.CreateDbContextAsync();
         (await ctx.Households.AnyAsync(h => h.Name == "Rollback Household"))
             .Should().BeFalse("the household INSERT must roll back with the failed user INSERT (R-C2 atomicity)");
         (await ctx.HouseholdRequests.FindAsync(requestId))!.Status
             .Should().Be(HouseholdRequestStatus.Pending, "a fully-rolled-back approve leaves the request pending");
+    }
+
+    [Fact]
+    public async Task Reject_WithOversizedReason_Returns400(/* council R4: guard the 500-char column limit */)
+    {
+        var requestId = await SeedRequestAsync("Too Long Co", "tl@example.com", "TL Owner");
+
+        var resp = await AdminClient.PostAsJsonAsync($"{RequestsUrl}/{requestId}/reject",
+            new { reason = new string('x', 501) }, Json);
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        await using var ctx = await DbFactory.CreateDbContextAsync();
+        (await ctx.HouseholdRequests.FindAsync(requestId))!.Status
+            .Should().Be(HouseholdRequestStatus.Pending, "a rejected (400) reject must not change the request");
     }
 
     [Fact]

--- a/tests/FamilyCoordinationApp.Tests/Services/SettingsAdminDtoContractTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/SettingsAdminDtoContractTests.cs
@@ -1,0 +1,132 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Services.Dtos;
+using FluentAssertions;
+
+namespace FamilyCoordinationApp.Tests.Services;
+
+/// <summary>
+/// Contract / consumer-audit tests for the Settings island C (Admin) aggregate DTOs (M9 — mirrors
+/// <see cref="SettingsConnectionsDtoContractTests"/>). Serializes representative <see cref="HouseholdRequestsDto"/>
+/// and <see cref="FeedbackListDto"/> values with the SAME options the app registers globally (camelCase Web
+/// defaults + <see cref="JsonStringEnumConverter"/> camelCase) and asserts equality with the checked-in
+/// <c>Fixtures/Settings/{household-requests,feedback}.json</c>. The island's <c>types.ts</c> mirrors these
+/// fixtures; any DTO shape/casing change breaks these tests → forcing the island contract to update in lockstep.
+///
+/// <para>⚠ ENUMS (R-C10): <see cref="HouseholdRequestStatus"/> + <see cref="FeedbackType"/> serialize as camelCase
+/// strings ("pending"/"approved"/"rejected", "bug"/"featureRequest"/"general").</para>
+/// <para>⚠ DATES (X5): RequestedAt/ReviewedAt/CreatedAt are full ISO-8601 instants ("…Z"), carried as strings.</para>
+/// <para>⚠ AUTHOR (R-C6): the three author cases — live (name + !deleted), deleted (null + deleted), anonymous
+/// (null + !deleted).</para>
+/// </summary>
+public class SettingsAdminDtoContractTests
+{
+    /// <summary>camelCase Web defaults + the enum→camelCase converter — equivalent to the app's global Minimal-API JSON config.</summary>
+    public static readonly JsonSerializerOptions AdminJsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+    };
+
+    private static string FixturePath(string file) =>
+        Path.Combine(AppContext.BaseDirectory, "Fixtures", "Settings", file);
+
+    public static HouseholdRequestsDto BuildRepresentativeRequests() => new(
+        Requests:
+        [
+            new HouseholdRequestDto(3, "The Greens", "Pat Green", "pat@example.com",
+                HouseholdRequestStatus.Pending, "2026-06-24T18:30:00Z", null, null, null),
+            new HouseholdRequestDto(2, "The Blues", "Sam Blue", "sam@example.com",
+                HouseholdRequestStatus.Approved, "2026-06-20T09:15:00Z", "2026-06-21T10:00:00Z", "admin@example.com", null),
+            new HouseholdRequestDto(1, "The Reds", "Alex Red", "alex@example.com",
+                HouseholdRequestStatus.Rejected, "2026-06-18T12:00:00Z", "2026-06-19T08:30:00Z", "admin@example.com",
+                "Duplicate of an existing household."),
+        ],
+        Households:
+        [
+            new HouseholdSummaryDto(1, "La Familia", 4, "2026-01-15T00:00:00Z"),
+            new HouseholdSummaryDto(2, "The Blues", 1, "2026-06-21T10:00:00Z"),
+        ]);
+
+    public static FeedbackListDto BuildRepresentativeFeedback() => new(
+        IsSiteAdmin: true,
+        Items:
+        [
+            new FeedbackDto(5, FeedbackType.Bug, "The button doesn't work.", "/recipes",
+                false, false, "2026-06-24T20:00:00Z", "Jamie", false),       // live user → name, !deleted
+            new FeedbackDto(4, FeedbackType.FeatureRequest, "Please add dark mode.", null,
+                true, false, "2026-06-23T14:30:00Z", null, true),            // deleted user → null + deleted
+            new FeedbackDto(3, FeedbackType.General, "Love the app!", "/",
+                true, true, "2026-06-22T08:00:00Z", null, false),            // anonymous → null + !deleted
+        ]);
+
+    [Fact]
+    public void SerializedRequests_MatchesContractFixture()
+    {
+        var json = JsonSerializer.Serialize(BuildRepresentativeRequests(), AdminJsonOptions);
+        File.Exists(FixturePath("household-requests.json")).Should().BeTrue();
+        Normalize(json).Should().Be(Normalize(File.ReadAllText(FixturePath("household-requests.json"))),
+            "the serialized HouseholdRequestsDto must match household-requests.json; update the fixture AND types.ts in lockstep (M9)");
+    }
+
+    [Fact]
+    public void SerializedFeedback_MatchesContractFixture()
+    {
+        var json = JsonSerializer.Serialize(BuildRepresentativeFeedback(), AdminJsonOptions);
+        File.Exists(FixturePath("feedback.json")).Should().BeTrue();
+        Normalize(json).Should().Be(Normalize(File.ReadAllText(FixturePath("feedback.json"))),
+            "the serialized FeedbackListDto must match feedback.json; update the fixture AND types.ts in lockstep (M9)");
+    }
+
+    [Fact]
+    public void Requests_UseCamelCaseKeys_EnumStrings_AndIsoInstantDates()
+    {
+        var json = JsonSerializer.Serialize(BuildRepresentativeRequests(), AdminJsonOptions);
+        var root = JsonNode.Parse(json)!.AsObject();
+        root.Select(kvp => kvp.Key).Should().BeEquivalentTo("requests", "households");
+
+        var pending = root["requests"]!.AsArray()[0]!.AsObject();
+        pending.Select(kvp => kvp.Key).Should().BeEquivalentTo(
+            "id", "householdName", "displayName", "email", "status",
+            "requestedAt", "reviewedAt", "reviewedBy", "rejectionReason");
+        // Enum → camelCase string (R-C10); date → full ISO-8601 instant with Z (X5).
+        pending["status"]!.GetValue<string>().Should().Be("pending");
+        pending["requestedAt"]!.GetValue<string>().Should().Be("2026-06-24T18:30:00Z");
+        pending["reviewedAt"].Should().BeNull();
+
+        var household = root["households"]!.AsArray()[0]!.AsObject();
+        household.Select(kvp => kvp.Key).Should().BeEquivalentTo("householdId", "name", "memberCount", "createdAt");
+    }
+
+    [Fact]
+    public void Feedback_UseCamelCaseKeys_EnumStrings_AndThreeWayAuthor()
+    {
+        var json = JsonSerializer.Serialize(BuildRepresentativeFeedback(), AdminJsonOptions);
+        var root = JsonNode.Parse(json)!.AsObject();
+        root.Select(kvp => kvp.Key).Should().BeEquivalentTo("isSiteAdmin", "items");
+
+        var items = root["items"]!.AsArray();
+
+        var live = items[0]!.AsObject();
+        live.Select(kvp => kvp.Key).Should().BeEquivalentTo(
+            "id", "type", "message", "currentPage", "isRead", "isResolved", "createdAt", "authorName", "authorDeleted");
+        live["type"]!.GetValue<string>().Should().Be("bug");
+        live["authorName"]!.GetValue<string>().Should().Be("Jamie");
+        live["authorDeleted"]!.GetValue<bool>().Should().BeFalse();
+
+        // featureRequest enum serializes camelCase (R-C10).
+        items[1]!["type"]!.GetValue<string>().Should().Be("featureRequest");
+        // Deleted user → null name + deleted=true (R-C6).
+        items[1]!["authorName"].Should().BeNull();
+        items[1]!["authorDeleted"]!.GetValue<bool>().Should().BeTrue();
+
+        // Anonymous → null name + deleted=false (R-C6).
+        items[2]!["authorName"].Should().BeNull();
+        items[2]!["authorDeleted"]!.GetValue<bool>().Should().BeFalse();
+    }
+
+    private static string Normalize(string json) =>
+        JsonNode.Parse(json)!.ToJsonString(new JsonSerializerOptions { WriteIndented = false });
+}


### PR DESCRIPTION
## Settings strangler — cluster C (Admin: Household requests + Feedback)

The last + heaviest settings cluster. Replaces two **direct-EF (no service layer)** Blazor pages with one Svelte island over a thin `/api` JSON surface, lifting their logic into two new testable services. **Ships OFF** behind `SETTINGS_ADMIN_USE_ISLAND` (verbatim Blazor fallback when off). Mirrors clusters A (#55) + B (#56).

- `/settings/households` — **site-admin only**: approve/reject household-creation requests + existing-households table.
- `/settings/feedback` — **dual-mode**: a site admin sees all households' feedback; a regular user sees only their own household's.

### The three load-bearing findings (each with its own test + browser proof)
- **R-C1 — Feedback mutation IDOR (security must-fix).** The circuit→REST lift would expose `Feedbacks.FindAsync(id)`-then-flip with no household scoping. Every read + mutation is now scoped **in the query**: site admin → any item; non-admin → own-household only, else **404** (cross-household id is indistinguishable from missing — no existence leak).
- **R-C2 — Approve transaction atomicity.** The old page did three separate commits (household → user+status → categories on a separate context); a mid-failure left an orphan household or one with no categories. `ApproveAsync` now wraps household + whitelisted user + request-status + the nine default categories in **one** `BeginTransactionAsync` — all commit or none do.
- **R-C3 — Already-reviewed 409 guard.** Approve/reject of a non-`Pending` request is refused with **409**, closing a latent duplicate-household race (two admins, or one on a 30s-stale poll, could approve a request into two households). An intended behavior change under the strangler (operator-confirmed).

### Backend
- `SettingsAdminDtos.cs` — real enums → camelCase strings (R-C10); full-instant dates → explicit ISO-8601 `Z` (X5); 3-way feedback author mapping (R-C6).
- `IHouseholdRequestService` + `IFeedbackService` (lifted from `HouseholdAdmin.razor` / `FeedbackAdmin.razor`); `SettingsAdminEndpoints.cs` (7 routes, per-handler site-admin 403 gate reading the email from claims directly — the resolver drops it, R-C5; non-empty 4xx bodies).
- compose: adds the `SETTINGS_ADMIN_USE_ISLAND` flag **and** the previously-unmapped `SITE_ADMIN_EMAILS` (`.env` only does `${VAR}` substitution, so the prod value never reached the container — cluster C is the first feature to exercise it).

### Island (`frontend/admin`, two-route bundle, port 5180)
Copied + rescoped from cluster A. Households view (access-denied on the 403, R-C4; pending/all filter; approve confirm + optional-reason reject dialog, R-C7); feedback view (type label/icon/color map; 3-way author; read/resolve/reopen). The one polling cluster — `liveness.ts` kept, visible-only, households 30s / feedback 15s (R-C9). Stores carry the `loadSeq` monotonic guard + `untrack`/onMount one-time load.

### Tests (+19) — all green
- 4 contract (DTO ↔ fixture ↔ `types.ts` lockstep).
- 15 real-PG integration: the 403 gate, the approve transaction **including a forced mid-approve rollback** (R-C2), 409-on-already-reviewed (R-C3), dual-mode feedback visibility, and the **IDOR-404** with a positive control (R-C1).

### Gates + `:8080` two-role browser verify
`dotnet build` clean · full suite **775/775** · `svelte-check` 0/0 · `vite build` clean · no NEW format violations.

Verified at `:8080` by flipping `SITE_ADMIN_EMAILS` for the role split:
- **Admin** — households island mounts, approve drives the full transaction (new household + whitelisted user + **9 categories**, DB-confirmed), 409-on-repeat (no dup household), feedback shows both households + read/resolve work; loop-check 0 background GETs.
- **Non-admin** — households "Access denied" (403, non-empty body); feedback shows own household only (`isSiteAdmin:false`); **IDOR blocked** (POST to another household's feedback → 404, no mutation; own-household → 204).
- **Flag OFF** — both pages render the Blazor fallback with no prerender-race 500; no console errors.

After this, the strangler clusters are done; only the shell/header keystone remains (separate, later).

https://claude.ai/code/session_015KeoM5Z3BbtqYjHiLwnbLs
