### PR TITLE
docs: reconcile FCA docs with strangler reality (islands shipped)

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -9,7 +9,7 @@ paths:
 
 *Path-scoped rule — auto-loads when you open app source (`src/FamilyCoordinationApp/**`) or tests. The load-bearing invariants (multi-tenant `HouseholdId` filtering, `IDbContextFactory`) are summarized always-on in `CLAUDE.md`; the full layout + patterns live here. Deployment / env config is a separate rule (`deployment.md`).*
 
-**Stack**: .NET 10 / Blazor Server / PostgreSQL / MudBlazor / EF Core / Docker
+**Stack**: .NET 10 / Blazor Server / PostgreSQL / MudBlazor / EF Core / Docker — **plus Svelte 5 + Vite islands** under `frontend/*` (strangler in progress; see § Strangler / Svelte Islands). Anyone editing `Components/Pages/*.razor` today is editing a thin island *host*, not the primary UI — that's now the fallback path.
 
 ## Project Layout
 
@@ -57,6 +57,27 @@ tests/FamilyCoordinationApp.Tests/
 **Recipe import pipeline**: `RecipeScraperService` (HTTP + AngleSharp for HTML parsing) → `RecipeImportService` (JSON-LD schema.org extraction) → `IngredientParser` (natural language parsing). Polly resilience on HTTP calls.
 
 **Household connections**: Households can connect via invite codes to share recipes bidirectionally. `HouseholdConnectionService` manages invites, connections, and recipe copying.
+
+## Strangler / Svelte Islands
+
+The UI is mid-strangler: Blazor Server is now a **shell** hosting Svelte 5 islands. All 8 major interactive surfaces have shipped as islands on `master`, each behind a `*_USE_ISLAND` env flag (default `false` in `docker-compose.yml`, `true` in local `.env`). Flag on → the `.razor` page renders the island; flag off → the original Blazor UI is the fallback.
+
+| Surface | Flag | Island source | Blazor host |
+|---|---|---|---|
+| Shopping list | `SHOPPING_LIST_USE_ISLAND` | `frontend/shopping-list/` | `ShoppingList.razor` |
+| Chores | `CHORES_USE_ISLAND` | `frontend/chores/` | `Chores.razor` |
+| Meal plan | `MEAL_PLAN_USE_ISLAND` | `frontend/meal-plan/` | `MealPlan.razor` |
+| Recipes | `RECIPES_USE_ISLAND` | `frontend/recipes/` | `Recipes.razor` |
+| Dashboard / home | `DASHBOARD_USE_ISLAND` | `frontend/dashboard/` | `Home.razor` |
+| Settings A (categories, users) | `SETTINGS_HOUSEHOLD_USE_ISLAND` | `frontend/settings/` | `Categories.razor`, `WhitelistAdmin.razor` |
+| Settings B (connections) | `SETTINGS_CONNECTIONS_USE_ISLAND` | `frontend/connections/` | `Connections.razor` |
+| Settings C (admin) | `SETTINGS_ADMIN_USE_ISLAND` | `frontend/admin/` | `FeedbackAdmin.razor`, `HouseholdAdmin.razor` |
+
+**Island-host gate (load-bearing):** gate the Blazor fallback with the *nested*-conditional pattern (outer `@if (_useIsland)` chooses island-path vs fallback; inner `@if (_shell is not null)` gates the actual island render) — NOT a single `_useIsland && _shell` condition, which lets a long-lived-context Blazor fallback mount-then-dispose in the prerender gap → `ObjectDisposedException` 500. Backend tests can't catch it; only a live `:8080` browser check does. Full detail: CORRECTIONS.md `fca-island-host-prerender-fallback-race`.
+
+**Build:** each island is an independent Vite build (`frontend/<name>/`, `npm run build`) → `wwwroot/islands/<name>/`. In Docker, one `node:20-alpine` stage per island (see `.claude/rules/deployment.md`). Remaining Blazor-only surfaces (auth/setup/static, reasonably out of scope): Login, Landing, Household/Pending+Request, Setup/FirstRunSetup, Privacy, Terms, Error, NotFound.
+
+**Full de-Blazor (Option A):** an unmerged spike on branch `spike/sveltekit-shell` (`frontend/app/`, adapter-static SvelteKit SPA served over `/api`, `base=/app`) keeps the .NET backend but drops Blazor Server's UI runtime entirely. Spine keystone quest `ae67f7dc`; commit message flags it "not wired for a prod flip."
 
 ## EF Core Migrations
 

--- a/.claude/rules/deployment.md
+++ b/.claude/rules/deployment.md
@@ -24,6 +24,8 @@ There is a known .NET SDK 10.0 bug (MSB3552) that breaks multi-stage Docker buil
 ./docker-build.sh v1.0.0   # Build with specific tag
 ```
 
+The `Dockerfile` also has one `node:20-alpine` build stage per Svelte island (8 stages: shopping-list, chores, meal-plan, recipes, dashboard, settings, connections, admin) that compile `frontend/<name>/` into `wwwroot/islands/<name>/` before the .NET publish stage. See `.claude/rules/architecture.md` § Strangler / Svelte Islands.
+
 ## Deployment
 
 Push to `master` triggers GitHub Actions:
@@ -42,3 +44,4 @@ Required env vars (set via `.env` on the server, generated from a secrets manage
 - `Authentication__Google__ClientSecret` — Google OAuth client secret
 - `SITE_ADMIN_EMAILS` — comma-separated admin emails
 - `DATAPROTECTION_CERT` — optional base64 PFX for key encryption
+- **`*_USE_ISLAND` strangler toggles** (8 flags: `SHOPPING_LIST_USE_ISLAND`, `CHORES_USE_ISLAND`, `MEAL_PLAN_USE_ISLAND`, `RECIPES_USE_ISLAND`, `DASHBOARD_USE_ISLAND`, `SETTINGS_HOUSEHOLD_USE_ISLAND`, `SETTINGS_CONNECTIONS_USE_ISLAND`, `SETTINGS_ADMIN_USE_ISLAND`) — per-surface. Default `false` in `docker-compose.yml`; each `true` swaps the Blazor page for its Svelte island. These decide whether the app serves the island UI or the Blazor fallback, so they're effectively required config for the current UI. Full table: `.claude/rules/architecture.md` § Strangler / Svelte Islands.

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,5 +1,7 @@
 # Project State
 
+> ⚠️ **HISTORICAL — SUPERSEDED (do not use as current status).** This file describes the Jan-2026 v1.0 gap-closure position (Phase 8 of 9, ~78%) and has not been maintained since. For current status see `.planning/ROADMAP.md` + the repo `CLAUDE.md`; for live work-state see the Spine campaign **"Family Coordination App"** (`spine_map`). *(banner added 2026-07-01, doc-health reconciliation)*
+
 ## Project Reference
 
 See: .planning/PROJECT.md (updated 2026-01-22)

--- a/.planning/archive/home-dashboard-island-spec.md
+++ b/.planning/archive/home-dashboard-island-spec.md
@@ -2,7 +2,7 @@
 
 **Quest:** Spine `62fe9326-af6f-43c3-bc0c-ff3031b9d354` (campaign "Family Coordination App", horizon `next` → pull to `now` on build).
 **Decisions (this session, 2026-06-24):** spec-first **focused**; **parity-first** — migrate today's read-only dashboard as-is, no new UX. **One aggregate endpoint** (`GET /api/dashboard`), **Landing.razor stays Blazor**, **read-only island** (no writes). Rationale in §5.
-**Status:** spec (awaiting operator review gate).
+**Status:** SHIPPED — merged PR #54 (2026-06-24, commit ce9b851). Archived 2026-07-01 (doc-health reconciliation). Header below is the original spec.
 **Template:** mirrors the shipped **meal-plan island** (`frontend/meal-plan/`) + its focused spec (`.planning/meal-plan-island-spec.md`) — the closest precedent for a *light* island. Recipes (`frontend/recipes/`, `.planning/recipes-island-spec.md`) is the secondary reference for the freshest scaffold conventions.
 
 ---

--- a/.planning/archive/meal-plan-island-spec.md
+++ b/.planning/archive/meal-plan-island-spec.md
@@ -2,7 +2,7 @@
 
 **Quest:** Spine `773aac12-af21-4e9e-8788-f55c3170f10b` (campaign "Family Coordination App", horizon `now`).
 **Decisions (operator, 2026-06-23):** spec-first **focused**; **parity-first** — migrate the current click-slot→picker surface as-is. Drag-to-assign is deferred to quest `1656427f` (provisional, `later`).
-**Status:** spec → build.
+**Status:** SHIPPED — merged PR #51 (2026-06-23, commit 0340a84). Archived 2026-07-01 (doc-health reconciliation). Header below is the original spec.
 
 ---
 

--- a/.planning/archive/recipes-island-spec.md
+++ b/.planning/archive/recipes-island-spec.md
@@ -2,7 +2,7 @@
 
 **Quest:** Spine `10d187a0-3bce-43f8-bc09-ada75ac35b43` (campaign "Family Coordination App", horizon `now`).
 **Decisions (operator, 2026-06-23):** **spec-first (deep)**; **combined** — one island bundle serving both `/recipes` (list) and `/recipes/new` + `/recipes/edit/{id}` (edit), one PR, one `RECIPES_USE_ISLAND` flag; **parity-first** — migrate today's surface as-is, harvest enhancements as provisional quests.
-**Status:** spec (awaiting review gate).
+**Status:** SHIPPED — merged PR #53 (2026-06-24, commit 357d34a). Archived 2026-07-01 (doc-health reconciliation). Header below is the original spec.
 **Template:** mirrors the shipped meal-plan island (`frontend/meal-plan/`) + its spec (`.planning/meal-plan-island-spec.md`). The chores island is the secondary reference (it has the `svelte-dnd-action` drag pattern recipes re-uses).
 
 ---

--- a/.planning/archive/settings-admin-island-spec.md
+++ b/.planning/archive/settings-admin-island-spec.md
@@ -2,7 +2,7 @@
 
 **Quest:** Spine `fd629f11-ff18-4539-ace1-6bda47b72fe2` (campaign "Family Coordination App"). Cluster **C** of the settings strangler (sequenced last — most backend net-new).
 **Decisions (this session, 2026-06-25):** spec-first focused; parity-first; **one island, two routes** (`/settings/households` + `/settings/feedback`) via the recipes data-view pattern; prefix `adm-`, port 5180.
-**Status:** first-pass spec — **for the cross-plan review session** to harden alongside A and B. Open questions flagged inline — this cluster has the most net-new backend + a **new auth shape**, so it most needs the review.
+**Status:** SHIPPED — merged PR #57 (2026-06-25, commit a01fc26). Archived 2026-07-01 (doc-health reconciliation). Header below is the original first-pass spec.
 **Template:** scaffold mirrors recipes (two-route bundle) + dashboard; backend introduces **two new services** + a **site-admin authorization gate**.
 
 ---

--- a/.planning/archive/settings-connections-island-spec.md
+++ b/.planning/archive/settings-connections-island-spec.md
@@ -2,7 +2,7 @@
 
 **Quest:** Spine `b60c13cb-c5b3-4d7d-ac59-3d873ac0675d` (campaign "Family Coordination App"). Cluster **B** of the settings strangler (sequenced after A).
 **Decisions (this session, 2026-06-25):** spec-first focused; parity-first; **single-route island** (`/settings/connections` only); flag `SETTINGS_CONNECTIONS_USE_ISLAND` (or reuse a shared settings flag — see Open items); prefix `con-`, port 5179.
-**Status:** first-pass spec — **for the cross-plan review session** to harden alongside A and C. Open questions flagged inline.
+**Status:** SHIPPED — merged PR #56 (2026-06-24, commit 38824da). Archived 2026-07-01 (doc-health reconciliation). Header below is the original first-pass spec.
 **Template:** mirrors the **dashboard island** (single-route, single root) for the scaffold; backend mirrors `RecipesEndpoints.cs` (thin `/api` over the existing service, M1).
 
 ---

--- a/.planning/archive/settings-household-island-spec.md
+++ b/.planning/archive/settings-household-island-spec.md
@@ -2,7 +2,7 @@
 
 **Quest:** Spine `57544e66-65b7-4680-853b-74aed5b014f7` (campaign "Family Coordination App", horizon `now`). Cluster **A** of the 3-island settings strangler (`dbee5aea` decomposed 2026-06-25; operator chose cluster-into-islands).
 **Decisions (this session, 2026-06-25):** spec-first **focused**; parity-first; **one island, two routes** (`/settings/categories` + `/settings/users`) via the recipes data-view-one-bundle pattern; one flag `SETTINGS_USE_ISLAND`, one PR.
-**Status:** spec (awaiting operator review gate).
+**Status:** SHIPPED — merged PR #55 (2026-06-24, commit 14c3323). Archived 2026-07-01 (doc-health reconciliation). Header below is the original spec. (Note: shipped flag is `SETTINGS_HOUSEHOLD_USE_ISLAND`, not the `SETTINGS_USE_ISLAND` named below.)
 **Template:** mirrors the shipped **recipes island** (`frontend/recipes/`, multi-route bundle + `svelte-dnd-action` drag-reorder) and the **dashboard island** (`frontend/dashboard/`, the freshest light scaffold). Backend mirrors `RecipesEndpoints.cs` (greenfield `/api` over existing/new services, M1).
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-Family Coordination App — a Blazor Server application for household meal planning, recipe management, shopping lists, and multi-user collaboration. Deployed to a self-hosted Ubuntu server via GitHub Actions.
+Family Coordination App — a household coordination app (meal planning, recipe management, shopping lists, chores, multi-user collaboration) on a self-hosted Ubuntu server, deployed via GitHub Actions. Originally Blazor Server; now a **Blazor Server shell hosting Svelte 5 islands** (strangler migration in progress). All 8 major interactive surfaces (chores, shopping-list, meal-plan, recipes, dashboard, settings A/B/C) ship as Svelte islands on `master`, each gated by a `*_USE_ISLAND` env flag (default `false` in `docker-compose.yml`, `true` in the local `.env`); the Blazor page is the fallback path. Island-host pattern + full flag table: `.claude/rules/architecture.md`.
 
-**Status**: Production, actively used. A SvelteKit rewrite (`family-kitchen-svelte`) is planned but not yet prioritized.
+**Status**: Production, actively used. The strangler is the largest in-flight thread — the final step, dropping Blazor Server's UI runtime entirely, is Spine keystone quest `ae67f7dc` (spiked on branch `spike/sveltekit-shell`, not yet merged). The separate `family-kitchen-svelte` project is dormant/superseded — it was never the migration vehicle; the in-repo `frontend/{island}` approach was.
 
 ## Build & Test Commands
 
@@ -25,6 +25,10 @@ dotnet format src/FamilyCoordinationApp/FamilyCoordinationApp.csproj --verify-no
 
 # Run locally (requires PostgreSQL + Google OAuth credentials)
 dotnet run --project src/FamilyCoordinationApp/FamilyCoordinationApp.csproj
+
+# Build / watch a single Svelte island (name ∈ shopping-list, chores, meal-plan,
+# recipes, dashboard, settings, connections, admin) — output → wwwroot/islands/<name>/
+cd frontend/<name> && npm install && npm run build   # or: npm run dev
 ```
 
 > No `.sln` file — build/test the `.csproj` directly (the commands above do).
@@ -32,17 +36,18 @@ dotnet run --project src/FamilyCoordinationApp/FamilyCoordinationApp.csproj
 
 ## Architecture (keystones)
 
-**Stack**: .NET 10 / Blazor Server / PostgreSQL / MudBlazor / EF Core / Docker.
+**Stack**: .NET 10 / Blazor Server / PostgreSQL / MudBlazor / EF Core / Docker — **plus Svelte 5 + Vite islands** under `frontend/*` (strangler; see the island-host keystone below).
 
 Load-bearing invariants — the full project layout + architectural patterns auto-load via `.claude/rules/architecture.md` when you open app source (`src/FamilyCoordinationApp/**`):
 - **Multi-tenant isolation** — every entity has a composite key (`HouseholdId` + entity id) and **every query filters by `HouseholdId`**. It's a security boundary, not a convention.
 - **DbContextFactory** — Blazor Server circuits are long-lived, so inject `IDbContextFactory<ApplicationDbContext>` (never `DbContext`) and create short-lived contexts via `dbFactory.CreateDbContextAsync()`.
+- **Island-host pattern (strangler)** — `Components/Pages/*.razor` are now thin hosts that render a Svelte island when the surface's `*_USE_ISLAND` flag is on, else the original Blazor UI. Gate the fallback with the nested-conditional pattern or a long-lived Blazor component disposes in the prerender gap → `ObjectDisposedException` 500 (CORRECTIONS.md `fca-island-host-prerender-fallback-race`). Island source in `frontend/<name>/`; built assets in `wwwroot/islands/<name>/`.
 
 Deployment + environment configuration detail auto-loads via `.claude/rules/deployment.md` when you open CI / Docker / deploy files.
 
 ## Roadmap
 
-`.planning/ROADMAP.md` is the authoritative phase list + status. Forward (not-yet-built) work is also tracked in the Spine campaign **"Family Coordination App"** (`spine_map` to see the frontier). As of 2026-06-18 the open phases are **13 — multi-room chores (M:N)** and **15 — equity rework / invisible labor**, both spec-first and not started; core app Phases 1–7 and chores Phases 10–12 + 14 are shipped (8–9 deprecated).
+`.planning/ROADMAP.md` is the authoritative phase list + status; forward work is also in the Spine campaign **"Family Coordination App"** (`spine_map` for the live frontier — trust it over any snapshot here). As of 2026-06-25: core app Phases 1–7 and chores Phases 10–12 + 14 + 16 (Snooze) are shipped (8–9 deprecated); open phases are **13 — multi-room chores (M:N)** and **15 — equity rework / invisible labor**. Running in parallel and larger than either: the **strangler track** — the 8-island migration (see § What This Is) plus the de-Blazor keystone (Spine quest `ae67f7dc`) — which ROADMAP.md does not yet track as phases.
 
 ## Corrections
 <!-- Also see global corrections: D:\Development\data\memory\CORRECTIONS.md -->


### PR DESCRIPTION
Documentation Health audit reconciliation (consumes `fca-docs-audit.md`), part of the doc-health campaign. Branched off `master` (not the `spike/sveltekit-shell` checkout).

- `CLAUDE.md` **What This Is**: stop calling FCA "a Blazor Server application" with a "planned but not prioritized" SvelteKit rewrite — it's a Blazor Server **shell hosting 8 shipped Svelte 5 islands** (strangler), gated by `*_USE_ISLAND` flags. Fix the stack line + roadmap section; add a per-island build command.
- `.claude/rules/architecture.md`: add a **Strangler / Svelte Islands** section (flag/host/source table, island-host gate hazard, build layout, de-Blazor spike). Note `Components/Pages/*.razor` are now thin hosts.
- `.claude/rules/deployment.md`: document the 8 `node:20-alpine` island build stages + list the 8 `*_USE_ISLAND` flags in the env-var contract.
- `.planning/`: mark the 6 shipped island specs SHIPPED (PRs #51, #53–#57) and move them to `.planning/archive/`. Add a HISTORICAL-SUPERSEDED banner to `STATE.md` (it was silently misstating the Jan-2026 Phase 8/9 position).

Doc-only; no build impact.

https://claude.ai/code/session_01Frebo7texwmwUDskat2rK2
