### PR TITLE
De-Blazor Wave 3 — presence + island route fan-out (WP-02/05/06/07/08/09)

### DIFF
--- a/frontend/app/src/lib/admin/FeedbackApp.svelte
+++ b/frontend/app/src/lib/admin/FeedbackApp.svelte
@@ -1,0 +1,273 @@
+<script lang="ts">
+  // Feedback view (#admin-feedback-root). Parity with FeedbackAdmin.razor: DUAL-MODE
+  // (the server scopes the list — admin sees all, a regular user sees own household, R-C1),
+  // an all/unread/open filter, type chip + New/Resolved chips + author line, and per-item
+  // mark-read / resolve / reopen. Polls at 15s while visible (R-C9).
+  import { onMount } from 'svelte';
+  import type { ShellContext, FeedbackDto, FeedbackType } from './lib/types';
+  import { feedbackStore } from './lib/feedbackStore.svelte';
+  import { formatDateTime } from './lib/dates';
+  import { startLiveness } from './lib/liveness';
+
+  let { ctx }: { ctx: ShellContext } = $props();
+  const store = feedbackStore;
+
+  // Feedback type label/icon/color map (R-C10 — the enum is camelCase on the wire; the chip
+  // shows a friendly label, not the raw value).
+  const TYPE_META: Record<FeedbackType, { label: string; icon: string; cls: string }> = {
+    bug: { label: 'Bug', icon: '🐛', cls: 'adm-type-bug' },
+    featureRequest: { label: 'Feature Request', icon: '💡', cls: 'adm-type-feature' },
+    general: { label: 'General', icon: '💬', cls: 'adm-type-general' },
+  };
+  function typeMeta(t: FeedbackType) {
+    return TYPE_META[t] ?? { label: t, icon: '💬', cls: 'adm-type-general' };
+  }
+
+  let filter = $state<'all' | 'unread' | 'open'>('all');
+  const filtered = $derived(
+    filter === 'unread'
+      ? store.items.filter((i) => !i.isRead)
+      : filter === 'open'
+        ? store.items.filter((i) => !i.isResolved)
+        : store.items,
+  );
+
+  onMount(() => {
+    void ctx;
+    void store.load();
+    const handle = startLiveness(() => store.load(), 15_000);
+    return () => handle.stop();
+  });
+
+  /** Author suffix (R-C6): live user → name; deleted → "Deleted user"; anonymous → nothing. */
+  function authorSuffix(item: FeedbackDto): string {
+    if (item.authorName) return ` — ${item.authorName}`;
+    if (item.authorDeleted) return ' — Deleted user';
+    return '';
+  }
+</script>
+
+<div class="adm-page">
+  <div class="adm-header">
+    <h1 class="adm-title">Feedback &amp; Requests</h1>
+    <div class="adm-toggle" role="group" aria-label="Filter feedback">
+      <button type="button" class:adm-toggle-on={filter === 'all'} onclick={() => (filter = 'all')}>All</button>
+      <button type="button" class:adm-toggle-on={filter === 'unread'} onclick={() => (filter = 'unread')}>Unread</button>
+      <button type="button" class:adm-toggle-on={filter === 'open'} onclick={() => (filter = 'open')}>Open</button>
+    </div>
+  </div>
+
+  {#if store.loading}
+    <div class="adm-skeleton">Loading…</div>
+  {:else if store.error}
+    <div class="adm-error">{store.error}</div>
+  {:else if filtered.length === 0}
+    <div class="adm-info">
+      No feedback yet. The feedback button appears in the bottom-left corner of every page.
+    </div>
+  {:else}
+    <div class="adm-cards">
+      {#each filtered as item (item.id)}
+        {@const meta = typeMeta(item.type)}
+        <div class="adm-card" class:adm-card-unread={!item.isRead}>
+          <div class="adm-card-head">
+            <span class="adm-avatar {meta.cls}" aria-hidden="true">{meta.icon}</span>
+            <div class="adm-card-main">
+              <div class="adm-card-line">
+                <span class="adm-chip {meta.cls}">{meta.label}</span>
+                {#if !item.isRead}
+                  <span class="adm-chip adm-chip-new">New</span>
+                {/if}
+                {#if item.isResolved}
+                  <span class="adm-chip adm-chip-resolved">Resolved</span>
+                {/if}
+              </div>
+              <div class="adm-card-meta">{formatDateTime(item.createdAt)}{authorSuffix(item)}</div>
+            </div>
+            <div class="adm-card-actions">
+              {#if !item.isRead}
+                <button type="button" class="adm-btn-text" onclick={() => store.markRead(item.id)}>Mark read</button>
+              {/if}
+              {#if !item.isResolved}
+                <button type="button" class="adm-btn-text adm-ok" onclick={() => store.markResolved(item.id)}>Resolve</button>
+              {:else}
+                <button type="button" class="adm-btn-text" onclick={() => store.reopen(item.id)}>Reopen</button>
+              {/if}
+            </div>
+          </div>
+          <div class="adm-card-body">{item.message}</div>
+          {#if item.currentPage}
+            <div class="adm-card-page">🔗 {item.currentPage}</div>
+          {/if}
+        </div>
+      {/each}
+    </div>
+  {/if}
+</div>
+
+
+<style>
+  .adm-page {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 24px 16px 96px;
+  }
+  .adm-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-bottom: 20px;
+  }
+  .adm-title {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 500;
+  }
+  .adm-toggle {
+    display: inline-flex;
+    border: 1px solid var(--color-line-strong);
+    border-radius: 999px;
+    overflow: hidden;
+  }
+  .adm-toggle button {
+    font: inherit;
+    font-weight: 500;
+    border: none;
+    background: transparent;
+    color: var(--color-text);
+    padding: 6px 16px;
+    cursor: pointer;
+  }
+  .adm-toggle button.adm-toggle-on {
+    background: var(--color-primary);
+    color: #fff;
+  }
+  .adm-cards {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .adm-card {
+    background: var(--color-surface);
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-1);
+    padding: 14px 16px;
+  }
+  .adm-card-unread {
+    border-left: 4px solid var(--color-info);
+  }
+  .adm-card-head {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+  }
+  .adm-avatar {
+    flex-shrink: 0;
+    width: 38px;
+    height: 38px;
+    display: grid;
+    place-items: center;
+    border-radius: 50%;
+    border: 1px solid var(--color-line-strong);
+    font-size: 1.1rem;
+  }
+  .adm-card-main {
+    flex: 1;
+    min-width: 0;
+  }
+  .adm-card-line {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .adm-card-meta {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    margin-top: 4px;
+  }
+  .adm-card-body {
+    margin-top: 10px;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    font-size: 0.9375rem;
+  }
+  .adm-card-page {
+    margin-top: 8px;
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    overflow-wrap: anywhere;
+  }
+  .adm-card-actions {
+    display: flex;
+    align-items: flex-start;
+    gap: 4px;
+    flex-shrink: 0;
+  }
+  .adm-chip {
+    font-size: 0.6875rem;
+    font-weight: 500;
+    padding: 2px 10px;
+    border-radius: 12px;
+    white-space: nowrap;
+    border: 1px solid var(--color-line-strong);
+    color: var(--color-text-muted);
+  }
+  .adm-type-bug {
+    border-color: var(--color-error);
+    color: var(--color-error);
+  }
+  .adm-type-feature {
+    border-color: var(--color-info);
+    color: var(--color-info);
+  }
+  .adm-type-general {
+    border-color: var(--color-line-strong);
+    color: var(--color-text-muted);
+  }
+  .adm-chip-new {
+    border-color: var(--color-info);
+    color: var(--color-info);
+  }
+  .adm-chip-resolved {
+    border-color: var(--color-success);
+    color: var(--color-success);
+  }
+  .adm-btn-text {
+    font: inherit;
+    font-weight: 500;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 6px 10px;
+    border-radius: var(--radius-sm);
+    color: var(--color-primary);
+  }
+  .adm-btn-text:hover {
+    background: var(--color-action-hover);
+  }
+  .adm-ok {
+    color: var(--color-success);
+  }
+  .adm-skeleton,
+  .adm-info,
+  .adm-error {
+    padding: 16px;
+    border-radius: var(--radius-sm);
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+  .adm-error {
+    background: rgba(229, 57, 53, 0.08);
+    border-left: 4px solid var(--color-error);
+    color: var(--color-text);
+  }
+  .adm-info {
+    background: rgba(30, 136, 229, 0.08);
+    border-left: 4px solid var(--color-info);
+    color: var(--color-text);
+  }
+</style>

--- a/frontend/app/src/lib/admin/HouseholdsApp.svelte
+++ b/frontend/app/src/lib/admin/HouseholdsApp.svelte
@@ -1,0 +1,356 @@
+<script lang="ts">
+  // Household Requests view (#admin-households-root). Parity with HouseholdAdmin.razor:
+  // SITE-ADMIN ONLY (a 403 on load → "Access denied", R-C4), a pending/all filter, request
+  // cards with approve (confirm) / reject (reason dialog), and an existing-households table.
+  // The approve transaction / already-reviewed 409 / member counts are SERVER-side (R-C2/3/8);
+  // this view just renders + drives them. Polls at 30s while visible (R-C9).
+  import { onMount } from 'svelte';
+  import type { ShellContext, HouseholdRequestDto } from './lib/types';
+  import { householdRequestsStore } from './lib/householdRequestsStore.svelte';
+  import { formatDateTime, formatDate } from './lib/dates';
+  import { startLiveness, type LivenessHandle } from './lib/liveness';
+  import ConfirmDialog from '$lib/shared/ConfirmDialog.svelte';
+  import RejectReasonDialog from './lib/components/RejectReasonDialog.svelte';
+
+  let { ctx }: { ctx: ShellContext } = $props();
+  const store = householdRequestsStore;
+
+  let filter = $state<'pending' | 'all'>('pending');
+  const filtered = $derived(
+    filter === 'pending' ? store.requests.filter((r) => r.status === 'pending') : store.requests,
+  );
+
+  onMount(() => {
+    void ctx; // host context available; not needed by the store
+    let handle: LivenessHandle | null = null;
+    void (async () => {
+      await store.load();
+      // Only poll once we know the caller is a site admin (parity: the timer started inside the
+      // _isSiteAdmin branch). A non-admin's 403 view stays static.
+      if (!store.accessDenied) {
+        handle = startLiveness(() => store.load(), 30_000);
+      }
+    })();
+    return () => handle?.stop();
+  });
+
+  function statusIcon(status: HouseholdRequestDto['status']): string {
+    return status === 'approved' ? '✅' : status === 'rejected' ? '❌' : '⏳';
+  }
+  function statusLabel(status: HouseholdRequestDto['status']): string {
+    return status === 'approved' ? 'Approved' : status === 'rejected' ? 'Rejected' : 'Pending';
+  }
+
+  // Approve confirm.
+  let confirmRequest = $state<HouseholdRequestDto | null>(null);
+  const approveMessage = $derived(
+    confirmRequest ? `Create household “${confirmRequest.householdName}” for ${confirmRequest.displayName}?` : '',
+  );
+  async function confirmApprove() {
+    const r = confirmRequest;
+    confirmRequest = null;
+    if (r) await store.approve(r.id, r.householdName);
+  }
+
+  // Reject reason dialog.
+  let rejectTarget = $state<HouseholdRequestDto | null>(null);
+  async function confirmReject(reason: string) {
+    const r = rejectTarget;
+    rejectTarget = null;
+    if (r) await store.reject(r.id, reason, r.displayName);
+  }
+</script>
+
+<div class="adm-page">
+  <div class="adm-header">
+    <h1 class="adm-title">Household Requests</h1>
+    {#if !store.accessDenied}
+      <div class="adm-toggle" role="group" aria-label="Filter requests">
+        <button type="button" class:adm-toggle-on={filter === 'pending'} onclick={() => (filter = 'pending')}>Pending</button>
+        <button type="button" class:adm-toggle-on={filter === 'all'} onclick={() => (filter = 'all')}>All</button>
+      </div>
+    {/if}
+  </div>
+
+  {#if store.accessDenied}
+    <div class="adm-denied">Access denied. Only site administrators can manage household requests.</div>
+  {:else if store.loading}
+    <div class="adm-skeleton">Loading…</div>
+  {:else if store.error}
+    <div class="adm-error">{store.error}</div>
+  {:else}
+    {#if filtered.length === 0}
+      <div class="adm-info">
+        {filter === 'pending' ? 'No pending household requests.' : 'No household requests yet.'}
+      </div>
+    {:else}
+      <div class="adm-cards">
+        {#each filtered as r (r.id)}
+          <div class="adm-card" class:adm-card-pending={r.status === 'pending'}>
+            <div class="adm-card-head">
+              <span class="adm-avatar adm-status-{r.status}" aria-hidden="true">{statusIcon(r.status)}</span>
+              <div class="adm-card-main">
+                <div class="adm-card-line">
+                  <span class="adm-card-name">{r.householdName}</span>
+                  <span class="adm-chip adm-chip-{r.status}">{statusLabel(r.status)}</span>
+                </div>
+                <div class="adm-card-sub"><strong>{r.displayName}</strong> ({r.email})</div>
+                <div class="adm-card-meta">
+                  Requested: {formatDateTime(r.requestedAt)}
+                  {#if r.reviewedAt}
+                    • Reviewed: {formatDate(r.reviewedAt)}{#if r.reviewedBy} by {r.reviewedBy}{/if}
+                  {/if}
+                </div>
+              </div>
+              {#if r.status === 'pending'}
+                <div class="adm-card-actions">
+                  <button type="button" class="adm-btn-text adm-ok" onclick={() => (confirmRequest = r)}>Approve</button>
+                  <button type="button" class="adm-btn-text adm-danger-text" onclick={() => (rejectTarget = r)}>Reject</button>
+                </div>
+              {/if}
+            </div>
+            {#if r.status === 'rejected' && r.rejectionReason}
+              <div class="adm-card-reason"><strong>Rejection reason:</strong> {r.rejectionReason}</div>
+            {/if}
+          </div>
+        {/each}
+      </div>
+    {/if}
+
+    <h2 class="adm-subtitle">Existing Households</h2>
+    {#if store.households.length === 0}
+      <div class="adm-info">No households exist yet.</div>
+    {:else}
+      <div class="adm-table-wrap">
+        <table class="adm-table">
+          <thead>
+            <tr><th>Household</th><th>Members</th><th>Created</th></tr>
+          </thead>
+          <tbody>
+            {#each store.households as h (h.householdId)}
+              <tr>
+                <td>{h.name}</td>
+                <td>{h.memberCount}</td>
+                <td>{formatDate(h.createdAt)}</td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      </div>
+    {/if}
+  {/if}
+</div>
+
+<ConfirmDialog
+  open={confirmRequest != null}
+  title="Approve Request"
+  message={approveMessage}
+  confirmLabel="Approve"
+  tone="primary"
+  onCancel={() => (confirmRequest = null)}
+  onConfirm={confirmApprove}
+/>
+<RejectReasonDialog
+  open={rejectTarget != null}
+  requestorName={rejectTarget?.displayName ?? ''}
+  householdName={rejectTarget?.householdName ?? ''}
+  onCancel={() => (rejectTarget = null)}
+  onConfirm={confirmReject}
+/>
+
+<style>
+  .adm-page {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 24px 16px 96px;
+  }
+  .adm-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-bottom: 20px;
+  }
+  .adm-title {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 500;
+  }
+  .adm-subtitle {
+    margin: 28px 0 12px;
+    font-size: 1.125rem;
+    font-weight: 500;
+  }
+  .adm-toggle {
+    display: inline-flex;
+    border: 1px solid var(--color-line-strong);
+    border-radius: 999px;
+    overflow: hidden;
+  }
+  .adm-toggle button {
+    font: inherit;
+    font-weight: 500;
+    border: none;
+    background: transparent;
+    color: var(--color-text);
+    padding: 6px 16px;
+    cursor: pointer;
+  }
+  .adm-toggle button.adm-toggle-on {
+    background: var(--color-primary);
+    color: #fff;
+  }
+  .adm-cards {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .adm-card {
+    background: var(--color-surface);
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-1);
+    padding: 14px 16px;
+  }
+  .adm-card-pending {
+    border-left: 4px solid var(--color-info);
+  }
+  .adm-card-head {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+  }
+  .adm-avatar {
+    flex-shrink: 0;
+    width: 38px;
+    height: 38px;
+    display: grid;
+    place-items: center;
+    border-radius: 50%;
+    border: 1px solid var(--color-line-strong);
+    font-size: 1.1rem;
+  }
+  .adm-card-main {
+    flex: 1;
+    min-width: 0;
+  }
+  .adm-card-line {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .adm-card-name {
+    font-size: 1.0625rem;
+    font-weight: 500;
+  }
+  .adm-card-sub {
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+    margin-top: 2px;
+    overflow-wrap: anywhere;
+  }
+  .adm-card-meta {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    margin-top: 4px;
+  }
+  .adm-card-actions {
+    display: flex;
+    align-items: flex-start;
+    gap: 4px;
+    flex-shrink: 0;
+  }
+  .adm-card-reason {
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+    margin-top: 10px;
+    padding-top: 10px;
+    border-top: 1px solid var(--color-line);
+  }
+  .adm-chip {
+    font-size: 0.6875rem;
+    font-weight: 500;
+    padding: 2px 10px;
+    border-radius: 12px;
+    white-space: nowrap;
+    border: 1px solid var(--color-line-strong);
+    color: var(--color-text-muted);
+  }
+  .adm-chip-pending {
+    border-color: var(--color-info);
+    color: var(--color-info);
+  }
+  .adm-chip-approved {
+    border-color: var(--color-success);
+    color: var(--color-success);
+  }
+  .adm-chip-rejected {
+    border-color: var(--color-error);
+    color: var(--color-error);
+  }
+  .adm-btn-text {
+    font: inherit;
+    font-weight: 500;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 6px 10px;
+    border-radius: var(--radius-sm);
+    color: var(--color-primary);
+  }
+  .adm-btn-text:hover {
+    background: var(--color-action-hover);
+  }
+  .adm-ok {
+    color: var(--color-success);
+  }
+  .adm-danger-text {
+    color: var(--color-error);
+  }
+  .adm-table-wrap {
+    overflow-x: auto;
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-md);
+  }
+  .adm-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9375rem;
+  }
+  .adm-table th,
+  .adm-table td {
+    text-align: left;
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--color-line);
+  }
+  .adm-table th {
+    font-weight: 500;
+    color: var(--color-text-muted);
+    font-size: 0.8125rem;
+  }
+  .adm-table tbody tr:last-child td {
+    border-bottom: none;
+  }
+  .adm-skeleton,
+  .adm-info,
+  .adm-denied,
+  .adm-error {
+    padding: 16px;
+    border-radius: var(--radius-sm);
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+  .adm-denied,
+  .adm-error {
+    background: rgba(229, 57, 53, 0.08);
+    border-left: 4px solid var(--color-error);
+    color: var(--color-text);
+  }
+  .adm-info {
+    background: rgba(30, 136, 229, 0.08);
+    border-left: 4px solid var(--color-info);
+    color: var(--color-text);
+  }
+</style>

--- a/frontend/app/src/lib/admin/lib/api.ts
+++ b/frontend/app/src/lib/admin/lib/api.ts
@@ -1,0 +1,96 @@
+import type { HouseholdRequestsDto, HouseholdSummaryDto, FeedbackListDto } from './types';
+
+const REQUESTS = '/api/settings/household-requests';
+const FEEDBACK = '/api/settings/feedback';
+
+/**
+ * Thrown on any non-2xx response. `status` lets callers react to a rejection.
+ *
+ * ⚠ Carried from the other islands: the app re-executes empty-body API 4xx
+ * through a Blazor `/not-found` page, so a server-side "not found" can arrive
+ * as an empty 400 (a bare DELETE 404 even surfaces as 405). Every admin endpoint
+ * returns a NON-EMPTY body on 4xx, and the island treats ANY 4xx as a
+ * non-retryable client rejection → reconcile (refetch) + a calm toast. The
+ * 403 on the households GET is special-cased by the store as the access-denied
+ * signal (R-C4 — the 403 IS the signal; no /context endpoint).
+ */
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+
+  /** A non-retryable client rejection (validation / not found / conflict). Any 4xx. */
+  get isClientRejection(): boolean {
+    return this.status >= 400 && this.status < 500;
+  }
+}
+
+async function request<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    credentials: 'include',
+    headers: { Accept: 'application/json', ...(init?.headers ?? {}) },
+    ...init,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    let message = text || res.statusText;
+    // The endpoints return { message } on 4xx — surface it for the toast.
+    try {
+      const parsed = JSON.parse(text);
+      if (parsed && typeof parsed.message === 'string') message = parsed.message;
+    } catch { /* not JSON — use the raw text */ }
+    throw new ApiError(res.status, message);
+  }
+  if (res.status === 204) return undefined as T;
+  return (await res.json()) as T;
+}
+
+function jsonBody(body: unknown): RequestInit {
+  return {
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  };
+}
+
+// ─── Household requests (site-admin only) ───────────────────────────────────
+
+/** #1 Requests (pending-first) + existing households. 403 (ApiError) for a non-admin → access denied. */
+export async function getHouseholdRequests(): Promise<HouseholdRequestsDto> {
+  return request<HouseholdRequestsDto>(`${REQUESTS}/`);
+}
+
+/** #2 Approve → the new household summary (201). Already-reviewed ⇒ 409 (ApiError); unknown ⇒ 404. */
+export async function approveRequest(id: number): Promise<HouseholdSummaryDto> {
+  return request<HouseholdSummaryDto>(`${REQUESTS}/${id}/approve`, { method: 'POST' });
+}
+
+/** #3 Reject with an OPTIONAL reason → 204. Already-reviewed ⇒ 409 (ApiError); unknown ⇒ 404. */
+export async function rejectRequest(id: number, reason: string): Promise<void> {
+  await request<void>(`${REQUESTS}/${id}/reject`, { method: 'POST', ...jsonBody({ reason }) });
+}
+
+// ─── Feedback (dual-mode) ───────────────────────────────────────────────────
+
+/** #4 Feedback for the caller (admin: all; regular: own household) + the isSiteAdmin signal. */
+export async function getFeedback(): Promise<FeedbackListDto> {
+  return request<FeedbackListDto>(`${FEEDBACK}/`);
+}
+
+/** #5 Mark read → 204. Not visible to a non-admin ⇒ 404 (R-C1). */
+export async function markFeedbackRead(id: number): Promise<void> {
+  await request<void>(`${FEEDBACK}/${id}/read`, { method: 'POST' });
+}
+
+/** #6 Mark resolved (also read) → 204. Not visible ⇒ 404 (R-C1). */
+export async function markFeedbackResolved(id: number): Promise<void> {
+  await request<void>(`${FEEDBACK}/${id}/resolve`, { method: 'POST' });
+}
+
+/** #7 Reopen → 204. Not visible ⇒ 404 (R-C1). */
+export async function reopenFeedback(id: number): Promise<void> {
+  await request<void>(`${FEEDBACK}/${id}/reopen`, { method: 'POST' });
+}

--- a/frontend/app/src/lib/admin/lib/components/RejectReasonDialog.svelte
+++ b/frontend/app/src/lib/admin/lib/components/RejectReasonDialog.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+  // Reject-with-reason dialog (parity RejectReasonDialog.razor). The reason is
+  // OPTIONAL (R-C7) — submitting with an empty box is allowed (the server does
+  // not 400). MaxLength 500, mirroring the MudTextField.
+  interface Props {
+    open: boolean;
+    requestorName: string;
+    householdName: string;
+    onCancel: () => void;
+    onConfirm: (reason: string) => void;
+  }
+
+  let { open, requestorName, householdName, onCancel, onConfirm }: Props = $props();
+
+  let dialogEl: HTMLDialogElement | null = $state(null);
+  let reason = $state('');
+
+  $effect(() => {
+    if (!dialogEl) return;
+    if (open && !dialogEl.open) {
+      reason = ''; // fresh each time it opens
+      dialogEl.showModal();
+    } else if (!open && dialogEl.open) {
+      dialogEl.close();
+    }
+  });
+
+  function submit() {
+    onConfirm(reason.trim());
+  }
+</script>
+
+<dialog bind:this={dialogEl} onclose={onCancel} class="adm-reject">
+  {#if open}
+    <div class="adm-reject-body">
+      <h2>Reject Request</h2>
+      <p class="adm-reject-msg">
+        Reject household request “<strong>{householdName}</strong>” from <strong>{requestorName}</strong>?
+      </p>
+      <label class="adm-field">
+        <span class="adm-field-label">Reason (optional)</span>
+        <textarea
+          class="adm-textarea"
+          rows="3"
+          maxlength="500"
+          placeholder="Why is this request being rejected?"
+          bind:value={reason}
+        ></textarea>
+      </label>
+      <div class="adm-reject-actions">
+        <button type="button" class="adm-btn-ghost" onclick={onCancel}>Cancel</button>
+        <button type="button" class="adm-btn-danger" onclick={submit}>Reject</button>
+      </div>
+    </div>
+  {/if}
+</dialog>
+
+<style>
+  .adm-reject[open] {
+    position: fixed;
+    inset: 0;
+    margin: auto;
+    border: none;
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text);
+    padding: 0;
+    width: min(440px, calc(100vw - 32px));
+    box-shadow: var(--shadow-4);
+  }
+  .adm-reject::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+  }
+  .adm-reject-body {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 24px;
+  }
+  .adm-reject h2 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 500;
+  }
+  .adm-reject-msg {
+    margin: 0;
+    font-size: 0.9375rem;
+  }
+  .adm-field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .adm-field-label {
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+  }
+  .adm-textarea {
+    font: inherit;
+    padding: 10px 12px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--color-line-strong);
+    background: var(--color-surface);
+    color: var(--color-text);
+    resize: vertical;
+    min-height: 72px;
+  }
+  .adm-textarea:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -1px;
+  }
+  .adm-reject-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 4px;
+  }
+  .adm-btn-ghost,
+  .adm-btn-danger {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    border: none;
+    cursor: pointer;
+    min-height: 40px;
+    font-weight: 500;
+  }
+  .adm-btn-ghost {
+    background: transparent;
+    color: var(--color-text-muted);
+  }
+  .adm-btn-ghost:hover {
+    background: var(--color-action-hover);
+  }
+  .adm-btn-danger {
+    background: var(--color-error);
+    color: #fff;
+  }
+  .adm-btn-danger:hover {
+    filter: brightness(0.95);
+  }
+</style>

--- a/frontend/app/src/lib/admin/lib/dates.ts
+++ b/frontend/app/src/lib/admin/lib/dates.ts
@@ -1,0 +1,21 @@
+// Date helpers for the admin island. Every date on the wire (requestedAt /
+// reviewedAt / createdAt) is a FULL ISO-8601 instant WITH time-of-day (UTC,
+// review X5) — NOT the noon-UTC date-only case. We parse the full instant
+// (new Date(iso) handles the offset correctly) and format it in the user's
+// local timezone. Never use new Date('YYYY-MM-DD') here.
+
+/** Full local date+time ("Jun 24, 2026, 1:30 PM"), or "" when absent/invalid. Parity: ToLocalTime + date/time. */
+export function formatDateTime(iso: string | null): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleString();
+}
+
+/** Local date only ("Jun 24, 2026"), or "" when absent/invalid (the reviewed/created short form). */
+export function formatDate(iso: string | null): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+}

--- a/frontend/app/src/lib/admin/lib/feedbackStore.svelte.ts
+++ b/frontend/app/src/lib/admin/lib/feedbackStore.svelte.ts
@@ -1,0 +1,80 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Feedback view store (#admin-feedback-root). Source of truth for the feedback
+// list + the caller's isSiteAdmin flag. DUAL-MODE: the server scopes the list
+// (admin → all households; regular → own household, R-C1), so the store just
+// renders whatever it's handed and uses `isSiteAdmin` for affordances/copy.
+//
+// Discipline: onMount one-time load, `loadSeq` guard on every load (this view
+// POLLS at 15s), await-then-reload mutations, reconcile on any 4xx. The IDOR
+// scope (a non-admin's mutation of another household's item ⇒ 404) is enforced
+// SERVER-side; here a 404 just reconciles + toasts.
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { FeedbackDto } from './types';
+import {
+  ApiError,
+  getFeedback,
+  markFeedbackRead,
+  markFeedbackResolved,
+  reopenFeedback,
+} from './api';
+import { showToast } from '$lib/shared/toast-store.svelte';
+
+class FeedbackStore {
+  items = $state<FeedbackDto[]>([]);
+  isSiteAdmin = $state(false);
+  loading = $state(true);
+  error = $state<string | null>(null);
+
+  private hasLoaded = false;
+  private seq = 0;
+
+  async load(): Promise<void> {
+    const s = ++this.seq;
+    try {
+      if (!this.hasLoaded) this.loading = true;
+      this.error = null;
+      const dto = await getFeedback();
+      if (s !== this.seq) return; // stale poll — drop
+      this.items = dto.items;
+      this.isSiteAdmin = dto.isSiteAdmin;
+      this.hasLoaded = true;
+    } catch (e) {
+      if (s !== this.seq) return;
+      this.error = describe(e, 'load feedback');
+    } finally {
+      if (s === this.seq) this.loading = false;
+    }
+  }
+
+  async markRead(id: number): Promise<void> {
+    await this.mutate(() => markFeedbackRead(id), 'mark read');
+  }
+
+  async markResolved(id: number): Promise<void> {
+    await this.mutate(() => markFeedbackResolved(id), 'resolve', 'Marked as resolved.');
+  }
+
+  async reopen(id: number): Promise<void> {
+    await this.mutate(() => reopenFeedback(id), 'reopen');
+  }
+
+  private async mutate(action: () => Promise<void>, label: string, successMessage?: string): Promise<void> {
+    try {
+      await action();
+      await this.load();
+      if (successMessage) showToast({ message: successMessage, kind: 'success' });
+    } catch (e) {
+      if (e instanceof ApiError) await this.load();
+      showToast({ message: describe(e, label), kind: 'error' });
+    }
+  }
+}
+
+function describe(e: unknown, action: string): string {
+  if (e instanceof ApiError) return e.message || `Couldn't ${action} (HTTP ${e.status}).`;
+  if (e instanceof Error) return e.message;
+  return `Couldn't ${action}.`;
+}
+
+export const feedbackStore = new FeedbackStore();

--- a/frontend/app/src/lib/admin/lib/householdRequestsStore.svelte.ts
+++ b/frontend/app/src/lib/admin/lib/householdRequestsStore.svelte.ts
@@ -1,0 +1,83 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Household-requests view store (#admin-households-root). Source of truth for
+// the request list + the existing-households table. SITE-ADMIN ONLY: a 403 on
+// the list GET sets `accessDenied` (the 403 IS the signal — R-C4, no /context
+// endpoint), and the App renders "Access denied".
+//
+// Discipline (memories svelte5-setup-effect-async-loader-loop + fca-island-async-
+// race-guards): onMount one-time load, `loadSeq` monotonic guard on every load
+// (this view POLLS at 30s, so a stale poll response must never clobber a newer
+// one), await-then-reload mutations, reconcile (refetch) on any 4xx. The approve
+// transaction / 409 already-reviewed guard / IDOR live SERVER-side (the source of
+// truth); the client just reflects them.
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { HouseholdRequestDto, HouseholdSummaryDto } from './types';
+import { ApiError, getHouseholdRequests, approveRequest, rejectRequest } from './api';
+import { showToast } from '$lib/shared/toast-store.svelte';
+
+class HouseholdRequestsStore {
+  requests = $state<HouseholdRequestDto[]>([]);
+  households = $state<HouseholdSummaryDto[]>([]);
+  loading = $state(true);
+  error = $state<string | null>(null);
+  /** True after a 403 on the list GET — the caller is not a site admin (R-C4). */
+  accessDenied = $state(false);
+
+  private hasLoaded = false;
+  private seq = 0;
+
+  async load(): Promise<void> {
+    const s = ++this.seq;
+    try {
+      if (!this.hasLoaded) this.loading = true;
+      this.error = null;
+      const dto = await getHouseholdRequests();
+      if (s !== this.seq) return; // a newer load already applied — drop this stale one
+      this.requests = dto.requests;
+      this.households = dto.households;
+      this.accessDenied = false;
+      this.hasLoaded = true;
+    } catch (e) {
+      if (s !== this.seq) return;
+      if (e instanceof ApiError && e.status === 403) {
+        this.accessDenied = true; // the 403 IS the access-denied signal (R-C4)
+      } else {
+        this.error = describe(e, 'load household requests');
+      }
+    } finally {
+      if (s === this.seq) this.loading = false;
+    }
+  }
+
+  async approve(id: number, householdName: string): Promise<void> {
+    try {
+      const summary = await approveRequest(id);
+      await this.load();
+      showToast({ message: `Approved — created “${summary.name}”.`, kind: 'success' });
+    } catch (e) {
+      // A 409 (already reviewed by another admin / a stale poll) reconciles to the truth, R-C3.
+      if (e instanceof ApiError) await this.load();
+      showToast({ message: describe(e, `approve “${householdName}”`), kind: 'error' });
+    }
+  }
+
+  async reject(id: number, reason: string, requestorName: string): Promise<void> {
+    try {
+      await rejectRequest(id, reason);
+      await this.load();
+      showToast({ message: `Rejected request from ${requestorName}.`, kind: 'info' });
+    } catch (e) {
+      if (e instanceof ApiError) await this.load();
+      showToast({ message: describe(e, 'reject request'), kind: 'error' });
+    }
+  }
+}
+
+function describe(e: unknown, action: string): string {
+  if (e instanceof ApiError) return e.message || `Couldn't ${action} (HTTP ${e.status}).`;
+  if (e instanceof Error) return e.message;
+  return `Couldn't ${action}.`;
+}
+
+export const householdRequestsStore = new HouseholdRequestsStore();

--- a/frontend/app/src/lib/admin/lib/liveness.ts
+++ b/frontend/app/src/lib/admin/lib/liveness.ts
@@ -1,0 +1,78 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Liveness — lightweight collaboration refresh for the admin island (the one
+// settings cluster that polls, review R-C9). Per-view cadence: households 30s,
+// feedback 15s (parity with the old Blazor timers).
+//
+// A change made by another admin/household member should appear within the
+// interval while the tab is VISIBLE, and immediately when the tab regains focus.
+// We do this with a plain interval + `visibilitychange`, NOT Blazor's
+// DataNotifier / PresenceService / PollingService (those are SignalR-circuit-bound).
+//
+// The poll PAUSES while the tab is hidden (visible-only, R-C9): no interval ticks
+// fire when `document.hidden` is true, and on re-show we refetch once immediately,
+// then resume the interval. This keeps background tabs quiet (a tiny, strictly-
+// better behaviour change vs the old always-on timer). The caller's loader carries
+// the loadSeq guard, so a stale poll response can never clobber a newer one.
+// ─────────────────────────────────────────────────────────────────────────
+
+const DEFAULT_INTERVAL_MS = 20_000;
+
+export interface LivenessHandle {
+  /** Tear down the interval + visibility listener. Call on unmount. */
+  stop(): void;
+}
+
+/**
+ * Start polling. `refresh` is the view reload (App.svelte's loader). It is
+ * only invoked while the document is visible. `intervalMs` sets the cadence
+ * (households 30s, feedback 15s). Returns a handle whose `stop()` removes the
+ * interval + listener.
+ */
+export function startLiveness(refresh: () => void, intervalMs: number = DEFAULT_INTERVAL_MS): LivenessHandle {
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  function tick() {
+    // Guard: never poll while hidden (the interval is cleared on hide, but this
+    // is belt-and-suspenders in case a tick is queued at the moment of hiding).
+    if (document.visibilityState === 'visible') {
+      refresh();
+    }
+  }
+
+  function startInterval() {
+    if (timer != null) return;
+    timer = setInterval(tick, intervalMs);
+  }
+
+  function stopInterval() {
+    if (timer != null) {
+      clearInterval(timer);
+      timer = null;
+    }
+  }
+
+  function handleVisibility() {
+    if (document.visibilityState === 'visible') {
+      // Re-show: refetch immediately, then resume the interval.
+      refresh();
+      startInterval();
+    } else {
+      // Hidden: pause polling entirely.
+      stopInterval();
+    }
+  }
+
+  document.addEventListener('visibilitychange', handleVisibility);
+
+  // Begin polling only if we start visible.
+  if (document.visibilityState === 'visible') {
+    startInterval();
+  }
+
+  return {
+    stop() {
+      stopInterval();
+      document.removeEventListener('visibilitychange', handleVisibility);
+    },
+  };
+}

--- a/frontend/app/src/lib/admin/lib/types.ts
+++ b/frontend/app/src/lib/admin/lib/types.ts
@@ -1,0 +1,74 @@
+// ─────────────────────────────────────────────────────────────────────────
+// TS mirror of the /api/settings admin contract (M9 lockstep). Source of truth:
+//   - Services/Dtos/SettingsAdminDtos.cs (the C# records — admin-scoped names)
+//   - tests/.../Fixtures/Settings/{household-requests,feedback}.json (byte-locked tripwires)
+//   - Endpoints/SettingsAdminEndpoints.cs (request DTOs + the 403/IDOR contract)
+//
+// ⚠ CASING: all keys camelCase.
+// ⚠ ENUMS (R-C10): status / type are string unions matching the camelCase wire
+//   values the global JsonStringEnumConverter emits.
+// ⚠ DATES (X5): requestedAt / reviewedAt / createdAt are FULL ISO-8601 instants
+//   (UTC, "…Z") — render local via new Date(iso).toLocaleString() (NOT noon-UTC).
+// ─────────────────────────────────────────────────────────────────────────
+
+/** The per-page context the Razor host hands the island via data- attributes. */
+export interface ShellContext {
+  householdId: number;
+  userId: number;
+  userName: string;
+  view: 'households' | 'feedback';
+}
+
+// ── Household requests (Fixtures/Settings/household-requests.json) ───────────
+
+export type HouseholdRequestStatus = 'pending' | 'approved' | 'rejected';
+
+export interface HouseholdRequestDto {
+  id: number;
+  householdName: string;
+  displayName: string;
+  email: string;
+  status: HouseholdRequestStatus;
+  /** full ISO-8601 instant (UTC). */
+  requestedAt: string;
+  /** full ISO-8601 instant (UTC), or null until reviewed. */
+  reviewedAt: string | null;
+  reviewedBy: string | null;
+  rejectionReason: string | null;
+}
+
+export interface HouseholdSummaryDto {
+  householdId: number;
+  name: string;
+  memberCount: number;
+  /** full ISO-8601 instant (UTC). */
+  createdAt: string;
+}
+
+export interface HouseholdRequestsDto {
+  requests: HouseholdRequestDto[];
+  households: HouseholdSummaryDto[];
+}
+
+// ── Feedback (Fixtures/Settings/feedback.json) ──────────────────────────────
+
+export type FeedbackType = 'bug' | 'featureRequest' | 'general';
+
+export interface FeedbackDto {
+  id: number;
+  type: FeedbackType;
+  message: string;
+  currentPage: string | null;
+  isRead: boolean;
+  isResolved: boolean;
+  /** full ISO-8601 instant (UTC). */
+  createdAt: string;
+  /** Author 3-way (R-C6): live user → name; deleted user → null + authorDeleted; anonymous → null + !authorDeleted. */
+  authorName: string | null;
+  authorDeleted: boolean;
+}
+
+export interface FeedbackListDto {
+  isSiteAdmin: boolean;
+  items: FeedbackDto[];
+}

--- a/frontend/app/src/lib/chores/App.svelte
+++ b/frontend/app/src/lib/chores/App.svelte
@@ -1,0 +1,612 @@
+<script lang="ts">
+  import { untrack } from 'svelte';
+  import type { ChoreDto, ShellContext } from './lib/types';
+  import { getBoard, uploadChorePhoto, createSubtask, ApiError } from './lib/api';
+  import { boardStore } from './lib/state.svelte';
+  import { startLiveness, type LivenessHandle } from './lib/liveness';
+  import { showToast } from '$lib/shared/toast-store.svelte';
+  import ViewSwitcher from './lib/components/ViewSwitcher.svelte';
+  import NeedsAttentionBoard from './lib/components/NeedsAttentionBoard.svelte';
+  import RoomsDashboard from './lib/components/RoomsDashboard.svelte';
+  import EquityBoard from './lib/components/EquityBoard.svelte';
+  import RecapBoard from './lib/components/RecapBoard.svelte';
+  import QuickAddSheet, { type QuickAddValue } from './lib/components/QuickAddSheet.svelte';
+  import EditChoreSheet from './lib/components/EditChoreSheet.svelte';
+  import HandOffPicker from './lib/components/HandOffPicker.svelte';
+  import CompleteDialog from './lib/components/CompleteDialog.svelte';
+  import DigestSettings from './lib/components/DigestSettings.svelte';
+  import PhotoLightbox from './lib/components/PhotoLightbox.svelte';
+
+  // ───────────────────────────────────────────────────────────────────────
+  // Root of the chores island. Fetches the ONE board payload into the shared
+  // store, then renders the view control + the active view. Model A board IA
+  // (Phase 14): a single attention-sectioned board with a PRIMARY filter
+  // (Up for grabs / Mine / All — lens ids up-for-grabs / mine / needs-attention)
+  // plus two on-demand ORGANIZERS (Rooms / Equity). Every view is a CLIENT-SIDE
+  // grouping of that one payload (M11) — switching never refetches. All
+  // dueness/decay is SERVER-computed (M5/M6): this component never derives
+  // dueness and never builds a Date from 'YYYY-MM-DD'.
+  //
+  // WP-11 wired the mutation handlers (shared by every view via ChoreCard).
+  // The roaming per-user default view: the store opens onto `board.userDefaultView`
+  // on first load (null ⇒ Up for grabs) and persists changes via PATCH
+  // /api/chores/me/default-view (server-stored on User.ChoresDefaultView so it
+  // roams across devices — NOT localStorage).
+  // ───────────────────────────────────────────────────────────────────────
+
+  interface Props {
+    ctx: ShellContext;
+  }
+
+  let { ctx }: Props = $props();
+
+  const store = boardStore;
+
+  let liveness: LivenessHandle | null = null;
+
+  // ── Quick-add + hand-off + edit + digest-settings dialog state ───────────
+  let quickAddOpen = $state(false);
+  let quickAddSubmitting = $state(false);
+  let handOffOpen = $state(false);
+  let handOffChore = $state<ChoreDto | null>(null);
+  // The shared member picker serves both "hand off / reassign" (held chores) and
+  // "assign" (up-for-grabs chores). The mode only changes copy + whether the
+  // "Leave for anyone" pile row shows — both call store.handOff on select.
+  let pickerMode = $state<'handoff' | 'assign'>('handoff');
+  let completeOpen = $state(false);
+  let completeChore = $state<ChoreDto | null>(null);
+  let editOpen = $state(false);
+  let editChore = $state<ChoreDto | null>(null);
+  let digestSettingsOpen = $state(false);
+
+  async function loadBoard() {
+    try {
+      // Keep the spinner only for the FIRST load; liveness refreshes are silent.
+      if (store.board == null) store.loading = true;
+      store.error = null;
+      store.setBoard(await getBoard());
+    } catch (e) {
+      if (e instanceof ApiError) {
+        store.error = `Failed to load the chore board (HTTP ${e.status}).`;
+      } else {
+        store.error = e instanceof Error ? e.message : String(e);
+      }
+    } finally {
+      store.loading = false;
+    }
+  }
+
+  // ── Card action handlers (optimistic mutations live in the store) ─────────
+  // The store owns the optimistic update + xmin-409 reconciliation; these are
+  // thin pass-throughs so any lens (WP-12) can reuse the same handlers.
+  function handleClaim(chore: ChoreDto) {
+    store.claim(chore.id);
+  }
+  function handleDrop(chore: ChoreDto) {
+    store.drop(chore.id);
+  }
+  function handleCommit(chore: ChoreDto) {
+    store.commit(chore.id);
+  }
+  function handleLeave(chore: ChoreDto) {
+    store.leave(chore.id);
+  }
+  function handleComplete(chore: ChoreDto) {
+    // Multi-person (co-sign) chore → open the participant dialog so the present
+    // member can record who's marking it done (D7). Single-person chore → keep
+    // the exact one-tap Done (unchanged): complete immediately, no dialog.
+    if (chore.requiredCount > 1) {
+      completeChore = chore;
+      completeOpen = true;
+    } else {
+      store.complete(chore.id);
+    }
+  }
+  function handleCompleteSubmit(participantUserIds: number[]) {
+    const chore = completeChore;
+    completeOpen = false;
+    completeChore = null;
+    if (chore) store.complete(chore.id, { participantUserIds });
+  }
+  function handleHandOff(chore: ChoreDto) {
+    pickerMode = 'handoff';
+    handOffChore = chore;
+    handOffOpen = true;
+  }
+  /**
+   * Assign an up-for-grabs chore to a chosen member. Opens the SAME member picker
+   * in "assign" mode; selecting a member runs store.handOff (a member target lands
+   * a deliberate Assigned server-side — see ChoreService.HandOffAsync). No new
+   * endpoint: assigning from the pile is just a hand-off with no current holder.
+   */
+  function handleAssign(chore: ChoreDto) {
+    pickerMode = 'assign';
+    handOffChore = chore;
+    handOffOpen = true;
+  }
+  function handleHandOffSelect(targetUserId: number | null) {
+    const chore = handOffChore;
+    handOffOpen = false;
+    handOffChore = null;
+    if (chore) store.handOff(chore.id, targetUserId);
+  }
+  function handleTake(chore: ChoreDto) {
+    // Take a chore currently held by someone else — grab it as a self-claim in
+    // one tap (covering for someone out/sick). No coordination with the holder
+    // needed; lands a Claimed (not a sticky assignment), so a recurring chore
+    // returns to the pile after this user completes it.
+    store.take(chore.id);
+  }
+
+  /** Open the edit sheet for a chore. */
+  function handleEdit(chore: ChoreDto) {
+    editChore = chore;
+    editOpen = true;
+  }
+
+  /**
+   * Snooze / un-snooze a chore (board quick-snooze). Thin pass-through to the
+   * store's optimistic snooze; the server resolves the floor date in the household
+   * timezone (MN4). `request.days` = N days from today; `request.until` = explicit
+   * "YYYY-MM-DD"; both omitted ⇒ un-snooze.
+   */
+  function handleSnooze(chore: ChoreDto, request: { days?: number; until?: string | null }) {
+    store.snooze(chore.id, request);
+  }
+
+  /** Seed the starter set (shown only when the board is empty). */
+  async function handleSeedStarter() {
+    await store.seedStarter();
+  }
+
+  // ── Quick-add (create → optional two-step photo upload, council C2) ───────
+  async function handleQuickAdd(value: QuickAddValue) {
+    quickAddSubmitting = true;
+    try {
+      // 1. POST the create JSON (no file in the body).
+      const created = await store.create(value.request);
+      // 2. Checklist items: a new chore has no id until now, so create each item
+      //    against the returned id (versionless). One bad item shouldn't block.
+      for (const title of value.subtasks) {
+        try {
+          await createSubtask(created.id, { title });
+        } catch {
+          // Skip a failed item; the chore + the rest still land.
+        }
+      }
+      // 3. If a photo was chosen, upload it to the dedicated /photo route.
+      if (value.photo) {
+        try {
+          await uploadChorePhoto(created.id, value.photo);
+        } catch {
+          // The chore exists; only the photo failed. Don't block the create.
+          showToast({ message: "Chore added, but the photo didn't upload.", kind: 'info' });
+        }
+      }
+      // Refetch once so the new checklist + photo render (store.create reconciled
+      // BEFORE these follow-on writes, so the board doesn't carry them yet).
+      if (value.subtasks.length > 0 || value.photo) {
+        await loadBoard();
+      }
+      quickAddOpen = false;
+      showToast({ message: `Added “${created.name}”.`, kind: 'success' });
+    } catch (e) {
+      // Create rejected — keep the sheet open so the user can fix + retry.
+      if (e instanceof ApiError && e.isClientRejection) {
+        showToast({ message: "That chore couldn't be added — check the details.", kind: 'error' });
+      } else {
+        showToast({ message: 'Something went wrong adding the chore.', kind: 'error' });
+      }
+    } finally {
+      quickAddSubmitting = false;
+    }
+  }
+
+  $effect(() => {
+    // One-time mount setup. MUST run exactly once — `loadBoard()` synchronously
+    // reads `store.board` (the spinner-on-first-load check) and its async
+    // `setBoard` REWRITES it, so WITHOUT untrack the effect would subscribe to the
+    // very state it updates → an infinite fetch→setBoard→re-run loop (~tens of
+    // req/s). `untrack` gives the body no reactive deps; liveness drives refreshes.
+    untrack(() => {
+      // Seed the viewing user's id once mounted (drives the Mine lens + "You").
+      store.currentUserId = ctx.userId;
+      // Wire the board refetch so the mutation layer can reconcile after a 409 /
+      // other 4xx (shares the SAME loader as liveness).
+      store.setRefresh(loadBoard);
+      loadBoard();
+      // Liveness: ~20s poll while visible + immediate refetch on refocus; pauses
+      // while hidden. NOT Blazor DataNotifier/PollingService (MN2).
+      liveness = startLiveness(loadBoard);
+    });
+    return () => {
+      liveness?.stop();
+      liveness = null;
+    };
+  });
+
+  // ── Equity fetch-on-open (the ONLY non-board fetcher — M11) ───────────────
+  // Load the equity payload when the Equity lens is open and the cache is stale
+  // (`!equityLoaded`). Reading `equityWindow` makes the effect re-run on a window
+  // switch (which the store also marks stale via setEquityWindow). The four v1.0
+  // lenses never trigger a fetch — they group the one board payload. A user who
+  // defaulted onto Equity lands here on mount (the store opens onto their default
+  // lens) and loads it the same way. The store guards re-entrancy + window races.
+  $effect(() => {
+    // Track the window so a switch re-runs this effect.
+    const _window = store.equityWindow;
+    void _window;
+    // Guard on `!equityError` so a FAILED load does not auto-retry forever: on error
+    // `equityLoaded` stays false, so without this the effect would re-fire the moment
+    // `equityLoading` clears. The explicit Retry (and a window switch) clears the error.
+    if (
+      store.lens === 'equity' &&
+      !store.equityLoaded &&
+      !store.equityLoading &&
+      !store.equityError
+    ) {
+      store.loadEquity();
+    }
+  });
+
+  // ── Recap fetch-on-open (a second cached fetcher, like equity — M11) ──────
+  // Load the recap payload when the Recap lens is open and the cache is stale.
+  // A user who defaulted onto Recap lands here on mount and loads it the same way.
+  // The store guards re-entrancy; invalidation (completions/snooze/edit) reloads it.
+  // `!recapError` guard: don't auto-retry a failed load in a loop — the Retry button
+  // (which clears the error) is the re-attempt path.
+  $effect(() => {
+    if (
+      store.lens === 'recap' &&
+      !store.recapLoaded &&
+      !store.recapLoading &&
+      !store.recapError
+    ) {
+      store.loadRecap();
+    }
+  });
+</script>
+
+<div class="ch-container">
+  <header class="ch-header">
+    <h1 class="ch-title">Chores</h1>
+    <div class="ch-header-end">
+      <span class="ch-user">{ctx.userName}</span>
+      <button
+        type="button"
+        class="ch-settings-btn"
+        aria-label="Digest settings"
+        onclick={() => (digestSettingsOpen = true)}
+      >
+        <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true">
+          <path
+            d="M19.14 12.94c.04-.3.06-.61.06-.94s-.02-.64-.07-.94l2.03-1.58a.49.49 0 0 0 .12-.61l-1.92-3.32a.49.49 0 0 0-.59-.22l-2.39.96a7.02 7.02 0 0 0-1.62-.94l-.36-2.54a.484.484 0 0 0-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54a7.02 7.02 0 0 0-1.62.94l-2.39-.96a.48.48 0 0 0-.59.22L2.74 8.87a.47.47 0 0 0 .12.61l2.03 1.58c-.05.3-.08.62-.08.94s.03.64.07.94L2.75 14.52a.49.49 0 0 0-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.36 1.04.67 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54a7.02 7.02 0 0 0 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32a.47.47 0 0 0-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z"
+            fill="currentColor"
+          />
+        </svg>
+      </button>
+    </div>
+  </header>
+
+  <div class="ch-toolbar">
+    <ViewSwitcher
+      active={store.lens}
+      defaultLens={store.defaultView ?? 'up-for-grabs'}
+      saving={store.savingDefaultView}
+      onSelect={(l) => store.setLens(l)}
+      onSetDefault={(l) => store.saveDefaultView(l)}
+    />
+  </div>
+
+  {#if store.error}
+    <div class="ch-inline-error" role="alert">
+      <span>{store.error}</span>
+      <button type="button" class="ch-retry" onclick={loadBoard}>Retry</button>
+    </div>
+  {/if}
+
+  {#if store.loading && !store.board}
+    <div class="ch-loading">Loading the board…</div>
+  {:else if store.board}
+    <!--
+      View routing (Model A board IA). The PRIMARY filters (Up for grabs / Mine /
+      All) all render the SAME unified attention-sectioned board — only the
+      filtered chore set differs (store.boardSections, driven by store.lens). The
+      two ORGANIZERS (Rooms / Equity) render their own surfaces. Every view is a
+      CLIENT-SIDE grouping of the ONE board payload — switching `store.lens` NEVER
+      refetches (M11). All share the same optimistic card handlers.
+    -->
+    {#if store.lens === 'up-for-grabs' || store.lens === 'mine' || store.lens === 'needs-attention'}
+      <NeedsAttentionBoard
+        sections={store.boardSections}
+        filterLens={store.lens}
+        currentUserId={store.currentUserId}
+        totalChores={store.boardTotalCount}
+        isPending={(id) => store.isPending(id)}
+        onClaim={handleClaim}
+        onDrop={handleDrop}
+        onComplete={handleComplete}
+        onHandOff={handleHandOff}
+        onTake={handleTake}
+        onAssign={handleAssign}
+        onCommit={handleCommit}
+        onLeave={handleLeave}
+        onEdit={handleEdit}
+        onSnooze={handleSnooze}
+      />
+    {:else if store.lens === 'rooms'}
+      <RoomsDashboard
+        groups={store.roomGroups}
+        currentUserId={store.currentUserId}
+        isPending={(id) => store.isPending(id)}
+        onClaim={handleClaim}
+        onDrop={handleDrop}
+        onComplete={handleComplete}
+        onHandOff={handleHandOff}
+        onTake={handleTake}
+        onAssign={handleAssign}
+        onCommit={handleCommit}
+        onLeave={handleLeave}
+        onEdit={handleEdit}
+        onSnooze={handleSnooze}
+      />
+    {:else if store.lens === 'equity'}
+      <!--
+        Equity lens — the one lens with its own (separately cached) payload
+        (store.equity via GET /api/chores/equity). The $effect above fetches it
+        on open + on window change; completions/refetches invalidate it. NEUTRAL
+        distribution, server values only (M12/MN9).
+      -->
+      <EquityBoard
+        equity={store.equity}
+        window={store.equityWindow}
+        loading={store.equityLoading}
+        error={store.equityError}
+        onWindow={(w) => store.setEquityWindow(w)}
+        onRetry={() => store.loadEquity()}
+        onCapacity={(t) => store.saveCapacity(t)}
+        savingCapacity={store.savingCapacity}
+      />
+    {:else if store.lens === 'recap'}
+      <!--
+        Recap lens — the in-app weekly recap (GET /api/chores/recap). The $effect
+        above fetches it on open; completions/snooze/edit invalidate it (folded into
+        invalidateEquity). Shows the SAME content the Discord digest posts plus the
+        week-over-week trend. Server values only; NO client date math (MN9).
+      -->
+      <RecapBoard
+        recap={store.recap}
+        loading={store.recapLoading}
+        error={store.recapError}
+        onRetry={() => store.loadRecap()}
+      />
+    {/if}
+  {:else if !store.loading}
+    <div class="ch-empty">No chore board data.</div>
+  {/if}
+
+  <!--
+    Empty-board prompt: shown only when the board has loaded but has zero chores.
+    Idempotent server-side — a second tap is a safe no-op.
+  -->
+  {#if store.board && store.board.chores.length === 0}
+    <div class="ch-seed-prompt">
+      <p class="ch-seed-text">No chores yet. Want to start with a suggested set?</p>
+      <button type="button" class="ch-seed-btn" onclick={handleSeedStarter}>
+        Load starter chores
+      </button>
+    </div>
+  {/if}
+</div>
+
+<button
+  type="button"
+  class="ch-fab"
+  aria-label="Add a chore"
+  onclick={() => (quickAddOpen = true)}
+  disabled={!store.board}
+>
+  <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+    <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" fill="currentColor" />
+  </svg>
+</button>
+
+<QuickAddSheet
+  open={quickAddOpen}
+  submitting={quickAddSubmitting}
+  members={store.board?.members ?? []}
+  rooms={store.board?.rooms ?? []}
+  onClose={() => (quickAddOpen = false)}
+  onSubmit={handleQuickAdd}
+/>
+
+<HandOffPicker
+  open={handOffOpen}
+  choreName={handOffChore?.name ?? ''}
+  members={store.board?.members ?? []}
+  mode={pickerMode}
+  excludeUserId={pickerMode === 'assign' ? null : (handOffChore?.assigneeUserId ?? null)}
+  onClose={() => {
+    handOffOpen = false;
+    handOffChore = null;
+  }}
+  onSelect={handleHandOffSelect}
+/>
+
+<CompleteDialog
+  open={completeOpen}
+  chore={completeChore}
+  members={store.board?.members ?? []}
+  currentUserId={store.currentUserId}
+  onClose={() => {
+    completeOpen = false;
+    completeChore = null;
+  }}
+  onSubmit={handleCompleteSubmit}
+/>
+
+<EditChoreSheet
+  open={editOpen}
+  chore={editChore}
+  members={store.board?.members ?? []}
+  rooms={store.board?.rooms ?? []}
+  onClose={() => {
+    editOpen = false;
+    editChore = null;
+  }}
+/>
+
+<DigestSettings
+  open={digestSettingsOpen}
+  onClose={() => (digestSettingsOpen = false)}
+/>
+
+<!-- Single shared tap-to-enlarge overlay; opened via showPhoto() from any surface. -->
+<PhotoLightbox />
+
+<style>
+  .ch-container {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 24px 16px 96px;
+  }
+  .ch-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 16px;
+  }
+  .ch-title {
+    margin: 0;
+    font-size: 2.125rem;
+    font-weight: 400;
+    color: var(--color-text);
+  }
+  .ch-header-end {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .ch-user {
+    color: var(--color-text-muted);
+    font-size: 0.875rem;
+  }
+  .ch-settings-btn {
+    display: grid;
+    place-items: center;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    color: var(--color-text-muted);
+    width: 36px;
+    height: 36px;
+    border-radius: var(--radius-sm);
+    padding: 0;
+    transition: color 0.15s, background-color 0.15s;
+  }
+  .ch-settings-btn:hover {
+    color: var(--color-text);
+    background: var(--color-action-hover);
+  }
+  .ch-toolbar {
+    margin-bottom: 24px;
+  }
+  .ch-loading,
+  .ch-empty {
+    padding: 48px 16px;
+    text-align: center;
+    color: var(--color-text-muted);
+  }
+  .ch-seed-prompt {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    padding: 32px 16px;
+    text-align: center;
+  }
+  .ch-seed-text {
+    margin: 0;
+    color: var(--color-text-muted);
+    font-size: 0.9375rem;
+  }
+  .ch-seed-btn {
+    font: inherit;
+    font-size: 0.9375rem;
+    font-weight: 500;
+    padding: 10px 24px;
+    border: 1px solid var(--color-primary);
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--color-primary);
+    cursor: pointer;
+    min-height: 44px;
+    transition: background-color 0.15s;
+  }
+  .ch-seed-btn:hover {
+    background: var(--color-action-hover);
+  }
+  .ch-inline-error {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 16px;
+    margin-bottom: 16px;
+    background: rgba(229, 57, 53, 0.08);
+    border-left: 4px solid var(--color-error);
+    border-radius: var(--radius-sm);
+    color: var(--color-error);
+    font-size: 0.875rem;
+  }
+  .ch-retry {
+    font: inherit;
+    border: none;
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+    padding: 4px 12px;
+    background: transparent;
+    color: var(--color-error);
+    font-weight: 500;
+  }
+  .ch-retry:hover {
+    background: rgba(229, 57, 53, 0.12);
+  }
+
+  .ch-fab {
+    position: fixed;
+    bottom: calc(24px + env(safe-area-inset-bottom, 0px));
+    right: 24px;
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    border: none;
+    background: var(--color-primary);
+    color: #fff;
+    display: grid;
+    place-items: center;
+    cursor: pointer;
+    box-shadow: var(--shadow-4);
+    transition:
+      background-color 0.15s,
+      transform 0.1s;
+    z-index: 1050;
+  }
+  /* Mobile: clear the MainLayout bottom nav + safe-area inset. */
+  @media (max-width: 960px) {
+    .ch-fab {
+      bottom: calc(80px + env(safe-area-inset-bottom, 0px));
+    }
+  }
+  .ch-fab:hover:not(:disabled) {
+    background: var(--color-primary-hover);
+  }
+  .ch-fab:active:not(:disabled) {
+    transform: scale(0.95);
+  }
+  .ch-fab:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+</style>

--- a/frontend/app/src/lib/chores/lib/api.ts
+++ b/frontend/app/src/lib/chores/lib/api.ts
@@ -1,0 +1,491 @@
+import type {
+  ChoreBoardDto,
+  ChoreDto,
+  ChoreSubtaskDto,
+  ChoreEquityDto,
+  ChoreRecapDto,
+  EquityWindow,
+  CapacityTier,
+  RoomDto,
+  EffortTier,
+  RecurrenceMode,
+  DigestSettingsView,
+  DigestSettingsUpdate,
+} from './types';
+
+const CHORES_BASE = '/api/chores';
+const ROOMS_BASE = '/api/rooms';
+
+/**
+ * Thrown on any non-2xx response. `status` lets callers distinguish the
+ * retryable concurrency conflict (409) from every other rejection.
+ *
+ * ⚠ WP-08 finding: the app re-executes empty-body API 404s through a Blazor
+ * `/not-found` page, so a server-side "not found" can arrive on the wire as an
+ * empty **400**, not 404. Therefore treat ANY 4xx as a non-retryable rejection
+ * EXCEPT 409, which is the genuine xmin concurrency conflict (WP-11 refetches
+ * the board and retries the mutation on 409 only).
+ */
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+
+  /** The retryable optimistic-concurrency conflict (refetch board + retry). */
+  get isConflict(): boolean {
+    return this.status === 409;
+  }
+
+  /**
+   * A non-retryable client rejection: validation / illegal transition / not
+   * found (which may surface as an empty 400 per the WP-08 re-execution
+   * behavior). Everything 4xx that is NOT 409.
+   */
+  get isClientRejection(): boolean {
+    return this.status >= 400 && this.status < 500 && this.status !== 409;
+  }
+}
+
+async function request<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    // Same-origin cookie auth — the host page is already authenticated.
+    credentials: 'include',
+    headers: { Accept: 'application/json', ...(init?.headers ?? {}) },
+    ...init,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new ApiError(res.status, text || res.statusText);
+  }
+  if (res.status === 204) return undefined as T;
+  return (await res.json()) as T;
+}
+
+function jsonBody(body: unknown): RequestInit {
+  return {
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  };
+}
+
+// ─── Mutation request/response shapes (typed now for WP-11) ─────────────────
+
+/** Concurrency token echoed on every chore mutation (xmin from ChoreDto.version). */
+export interface VersionRequest {
+  version: number;
+}
+
+export interface CreateChoreRequest {
+  name: string;
+  description?: string | null;
+  roomId?: number | null;
+  recurrenceMode: RecurrenceMode;
+  intervalDays?: number | null;
+  /** ISO date "YYYY-MM-DD" (DateOnly server-side). */
+  anchorDate?: string | null;
+  /** camelCase [Flags] enum string, e.g. "monday, thursday"; null when not Fixed-weekly. */
+  daysOfWeek?: string | null;
+  dayOfMonth?: number | null;
+  effortTier: EffortTier;
+  ownerUserId?: number | null;
+  assigneeUserId?: number | null;
+  photoPath?: string | null;
+  /** Optional emoji/short-code icon; "" or omitted = none. */
+  icon?: string;
+  /** Number of people required to satisfy the chore. Omit or 1 = normal single-person chore. */
+  requiredCount?: number;
+  /** Initial named roster for a multi-person chore (X>1) — each seeded as Assigned. Ignored for X=1. */
+  assignedUserIds?: number[];
+  /** ISO date "YYYY-MM-DD" — first-due floor at creation (null/omitted = due now). No client date math (MN4). */
+  snoozedUntil?: string | null;
+}
+
+/** No assignee — assignment never moves via edit. Carries the version. */
+export interface UpdateChoreRequest {
+  name: string;
+  description?: string | null;
+  roomId?: number | null;
+  recurrenceMode: RecurrenceMode;
+  intervalDays?: number | null;
+  anchorDate?: string | null;
+  daysOfWeek?: string | null;
+  dayOfMonth?: number | null;
+  effortTier: EffortTier;
+  ownerUserId?: number | null;
+  version: number;
+  /** council C4 — must round-trip so edit-photo works end-to-end. */
+  photoPath?: string | null;
+  /** Optional emoji/short-code icon; "" or omitted = none. */
+  icon?: string;
+  /** Number of distinct contributors required to satisfy the chore (WP-05). Omit or 1 = normal. */
+  requiredCount?: number;
+  /** ISO date "YYYY-MM-DD" — the next-due floor (snooze); null = no floor. Carried on the edit PUT (MN4). */
+  snoozedUntil?: string | null;
+}
+
+/**
+ * Body for PATCH /{id}/snooze — supply EXACTLY one of {days} / {until} (or {until:null} to un-snooze), plus
+ * the xmin `version`. `version` MUST be in the body (the server binds it from JSON; omitting it binds 0 → a
+ * spurious 409). The server resolves the floor date in the household timezone (MN4 — never client date math).
+ */
+export type SnoozeRequestBody =
+  | { days: number; version: number }
+  | { until: string | null; version: number };
+
+export interface SeedStarterResponse {
+  seeded: boolean;
+}
+
+/** targetUserId null ⇒ return-to-pile. */
+export interface HandOffRequest {
+  targetUserId?: number | null;
+  version: number;
+}
+
+export interface CompleteRequest {
+  note?: string | null;
+  photoPath?: string | null;
+  version: number;
+  /** Co-signers for multi-person chores (WP-05); omit for single-person completions. */
+  participantUserIds?: number[];
+}
+
+/** Add a named member to a multi-person chore's roster (Assigned). */
+export interface AssignRosterRequest {
+  subjectUserId: number;
+  version: number;
+}
+
+/** Leave/remove from a roster. subjectUserId omitted/null ⇒ the caller leaves. */
+export interface LeaveRosterRequest {
+  subjectUserId?: number | null;
+  version: number;
+}
+
+export interface PhotoUploadResponse {
+  photoPath: string;
+}
+
+export interface DefaultViewResponse {
+  view: string | null;
+}
+
+export interface ReorderRoomsRequest {
+  orderedRoomIds: number[];
+}
+
+export interface RoomUpsertRequest {
+  name: string;
+  icon?: string | null;
+  photoPath?: string | null;
+}
+
+// ─── Board read (the ONE payload all lenses group client-side, M11) ─────────
+
+export async function getBoard(): Promise<ChoreBoardDto> {
+  return request<ChoreBoardDto>(`${CHORES_BASE}/board`);
+}
+
+// ─── Equity read (separate cached payload — the ONLY non-board fetcher, M11) ──
+// The four v1.0 lenses group the one board payload client-side; the Equity lens
+// is the sole lens with its own endpoint. credentials:include like getBoard.
+
+export async function getEquity(
+  window: EquityWindow = 'week',
+): Promise<ChoreEquityDto> {
+  return request<ChoreEquityDto>(`${CHORES_BASE}/equity?window=${window}`);
+}
+
+// ─── Recap read (separate cached payload — like equity, its own endpoint) ─────
+// The in-app weekly recap (current-week digest content + week-over-week trend).
+// Read-only; `weeks` is the trend length (server clamps 1..26).
+
+export async function getRecap(weeks = 8): Promise<ChoreRecapDto> {
+  return request<ChoreRecapDto>(`${CHORES_BASE}/recap?weeks=${weeks}`);
+}
+
+// ─── Chore mutations (WP-11 wires these to optimistic UI + 409 retry) ───────
+
+export async function createChore(body: CreateChoreRequest): Promise<ChoreDto> {
+  return request<ChoreDto>(`${CHORES_BASE}/`, { method: 'POST', ...jsonBody(body) });
+}
+
+export async function updateChore(
+  choreId: number,
+  body: UpdateChoreRequest,
+): Promise<ChoreDto> {
+  return request<ChoreDto>(`${CHORES_BASE}/${choreId}`, { method: 'PUT', ...jsonBody(body) });
+}
+
+export async function deleteChore(choreId: number, version: number): Promise<void> {
+  await request<void>(`${CHORES_BASE}/${choreId}`, {
+    method: 'DELETE',
+    ...jsonBody({ version } satisfies VersionRequest),
+  });
+}
+
+export async function claimChore(choreId: number, version: number): Promise<ChoreDto> {
+  return request<ChoreDto>(`${CHORES_BASE}/${choreId}/claim`, {
+    method: 'POST',
+    ...jsonBody({ version } satisfies VersionRequest),
+  });
+}
+
+/** Take a chore held by someone else — assign it to the caller as a self-claim (displaces the holder). */
+export async function takeChore(choreId: number, version: number): Promise<ChoreDto> {
+  return request<ChoreDto>(`${CHORES_BASE}/${choreId}/take`, {
+    method: 'POST',
+    ...jsonBody({ version } satisfies VersionRequest),
+  });
+}
+
+export async function dropChore(choreId: number, version: number): Promise<ChoreDto> {
+  return request<ChoreDto>(`${CHORES_BASE}/${choreId}/drop`, {
+    method: 'POST',
+    ...jsonBody({ version } satisfies VersionRequest),
+  });
+}
+
+export async function handOffChore(
+  choreId: number,
+  body: HandOffRequest,
+): Promise<ChoreDto> {
+  return request<ChoreDto>(`${CHORES_BASE}/${choreId}/handoff`, {
+    method: 'POST',
+    ...jsonBody(body),
+  });
+}
+
+export async function completeChore(
+  choreId: number,
+  body: CompleteRequest,
+): Promise<ChoreDto> {
+  return request<ChoreDto>(`${CHORES_BASE}/${choreId}/complete`, {
+    method: 'POST',
+    ...jsonBody(body),
+  });
+}
+
+/**
+ * Set or clear a chore's next-due floor (snooze). `{days}` snoozes N days from today; `{until}` is an explicit
+ * "YYYY-MM-DD" (server validates it is > today); `{until:null}` un-snoozes. Returns the projected ChoreDto
+ * (carrying the fresh `snoozedUntil` + `isSnoozed` + recomputed `dueState`/`nextDueAt`). Same ApiError/409
+ * handling as the sibling mutations.
+ */
+export async function snoozeChore(choreId: number, body: SnoozeRequestBody): Promise<ChoreDto> {
+  return request<ChoreDto>(`${CHORES_BASE}/${choreId}/snooze`, {
+    method: 'PATCH',
+    ...jsonBody(body),
+  });
+}
+
+// ─── Roster mutations (multi-person named soft roster, rework) ──────────────
+// Each returns the projected ChoreDto; the store reconciles via the board GET
+// for the authoritative roster (the single-chore response carries an empty one).
+
+/** Assign a named member to a multi-person chore's roster (Assigned — a declinable pre-opt-in). */
+export async function assignRoster(
+  choreId: number,
+  subjectUserId: number,
+  version: number,
+): Promise<ChoreDto> {
+  return request<ChoreDto>(`${CHORES_BASE}/${choreId}/roster/assign`, {
+    method: 'POST',
+    ...jsonBody({ subjectUserId, version } satisfies AssignRosterRequest),
+  });
+}
+
+/** Commit the caller to a multi-person chore's roster ("I'm in" — self-opt-in or confirm). */
+export async function commitRoster(choreId: number, version: number): Promise<ChoreDto> {
+  return request<ChoreDto>(`${CHORES_BASE}/${choreId}/roster/commit`, {
+    method: 'POST',
+    ...jsonBody({ version } satisfies VersionRequest),
+  });
+}
+
+/** Leave/remove from a roster. `subjectUserId` null ⇒ the caller leaves. */
+export async function leaveRoster(
+  choreId: number,
+  subjectUserId: number | null,
+  version: number,
+): Promise<ChoreDto> {
+  return request<ChoreDto>(`${CHORES_BASE}/${choreId}/roster/leave`, {
+    method: 'POST',
+    ...jsonBody({ subjectUserId, version } satisfies LeaveRosterRequest),
+  });
+}
+
+// ─── Checklist / subtasks (Phase 14 — versionless / last-write-wins) ────────
+// NO version field anywhere: these touch only the subtask row, never the chore's
+// xmin. Create/Update return the affected ChoreSubtaskDto; Delete is 204 (no body).
+
+export interface CreateSubtaskRequest {
+  title: string;
+}
+
+export interface UpdateSubtaskRequest {
+  title?: string;
+  isDone?: boolean;
+  sortOrder?: number;
+}
+
+/** Add a checklist item to a chore. POST .../{choreId}/subtasks → the new ChoreSubtaskDto. */
+export async function createSubtask(
+  choreId: number,
+  body: CreateSubtaskRequest,
+): Promise<ChoreSubtaskDto> {
+  return request<ChoreSubtaskDto>(`${CHORES_BASE}/${choreId}/subtasks`, {
+    method: 'POST',
+    ...jsonBody(body),
+  });
+}
+
+/** Patch a checklist item (any subset of title/isDone/sortOrder). PUT → the updated ChoreSubtaskDto. */
+export async function updateSubtask(
+  choreId: number,
+  subtaskId: number,
+  body: UpdateSubtaskRequest,
+): Promise<ChoreSubtaskDto> {
+  return request<ChoreSubtaskDto>(`${CHORES_BASE}/${choreId}/subtasks/${subtaskId}`, {
+    method: 'PUT',
+    ...jsonBody(body),
+  });
+}
+
+/** Remove a checklist item. DELETE → 204 (no body). */
+export async function deleteSubtask(choreId: number, subtaskId: number): Promise<void> {
+  await request<void>(`${CHORES_BASE}/${choreId}/subtasks/${subtaskId}`, { method: 'DELETE' });
+}
+
+/**
+ * Re-order a chore's checklist — the full new order as a list of subtask ids. PUT → 204.
+ * Versionless / atomic on the server (mirrors reorderRooms); SortOrder is set by list position.
+ */
+export async function reorderSubtasks(choreId: number, orderedSubtaskIds: number[]): Promise<void> {
+  await request<void>(`${CHORES_BASE}/${choreId}/subtasks/reorder`, {
+    method: 'PUT',
+    ...jsonBody({ orderedSubtaskIds }),
+  });
+}
+
+/** Upload a chore photo (multipart field name `file`) → { photoPath } to pass in create/complete. */
+export async function uploadChorePhoto(
+  choreId: number,
+  file: File,
+): Promise<PhotoUploadResponse> {
+  const form = new FormData();
+  form.append('file', file);
+  // No Content-Type header — the browser sets the multipart boundary.
+  return request<PhotoUploadResponse>(`${CHORES_BASE}/${choreId}/photo`, {
+    method: 'POST',
+    body: form,
+  });
+}
+
+/**
+ * Seed the household with starter chores (WP-06 backfill endpoint).
+ * Idempotent — a second call returns `{ seeded: false }` (no-op).
+ */
+export async function seedStarter(): Promise<SeedStarterResponse> {
+  return request<SeedStarterResponse>(`${CHORES_BASE}/seed-starter`, { method: 'POST' });
+}
+
+/** Persist the caller's roaming default lens (WP-12). null/blank clears to default. */
+export async function setDefaultView(view: string | null): Promise<DefaultViewResponse> {
+  return request<DefaultViewResponse>(`${CHORES_BASE}/me/default-view`, {
+    method: 'PATCH',
+    ...jsonBody({ view }),
+  });
+}
+
+/**
+ * Persist the caller's OWN physical-capacity tier (Phase 15 WP-05/WP-06; self-set only — MN5). Mirrors
+ * `setDefaultView`. The input is NON-nullable (the UI always sends one of {Full, Reduced, Minimal} — there
+ * is no clear-to-null path); the endpoint echoes the persisted `{ tier }` on 200. The fresh tier also rides
+ * the next equity payload as `callerCapacityTier`, so the store invalidates equity after a successful PATCH.
+ */
+export async function setCapacity(tier: CapacityTier): Promise<{ tier: CapacityTier | null }> {
+  return request<{ tier: CapacityTier | null }>(`${CHORES_BASE}/me/capacity`, {
+    method: 'PATCH',
+    ...jsonBody({ tier }),
+  });
+}
+
+// ─── Digest settings (WP-11) ─────────────────────────────────────────────────
+//
+// ⚠ MN7 (write-only webhook): GET never returns the webhook URL — only
+// hasWebhook + a masked hint. The PUT body carries the URL only when
+// webhookAction is 'set'. Never log or render the URL client-side.
+
+/**
+ * Fetch the household's digest settings (safe view — no webhook URL).
+ * Returns enabled state, cadence, day, hour, hasWebhook + hint, lastSentAt.
+ */
+export async function getDigestSettings(): Promise<DigestSettingsView> {
+  return request<DigestSettingsView>(`${CHORES_BASE}/digest-settings`);
+}
+
+/**
+ * Persist digest settings. The tri-state `webhookAction` controls the secret:
+ *   'keep'  → leave the stored URL unchanged (omit webhookUrl)
+ *   'set'   → encrypt + store webhookUrl (include webhookUrl in body)
+ *   'clear' → remove the stored URL (omit webhookUrl)
+ * Returns the refreshed DigestSettingsView (no URL in response).
+ * ⚠ Do NOT log `body.webhookUrl`; do NOT put it in a query string.
+ */
+export async function updateDigestSettings(
+  body: DigestSettingsUpdate,
+): Promise<DigestSettingsView> {
+  return request<DigestSettingsView>(`${CHORES_BASE}/digest-settings`, {
+    method: 'PUT',
+    ...jsonBody(body),
+  });
+}
+
+// ─── Room admin (/api/rooms) ────────────────────────────────────────────────
+
+export async function listRooms(): Promise<RoomDto[]> {
+  return request<RoomDto[]>(`${ROOMS_BASE}/`);
+}
+
+export async function getRoom(roomId: number): Promise<RoomDto> {
+  return request<RoomDto>(`${ROOMS_BASE}/${roomId}`);
+}
+
+export async function createRoom(body: RoomUpsertRequest): Promise<RoomDto> {
+  return request<RoomDto>(`${ROOMS_BASE}/`, { method: 'POST', ...jsonBody(body) });
+}
+
+export async function updateRoom(
+  roomId: number,
+  body: RoomUpsertRequest,
+): Promise<RoomDto> {
+  return request<RoomDto>(`${ROOMS_BASE}/${roomId}`, { method: 'PUT', ...jsonBody(body) });
+}
+
+export async function deleteRoom(roomId: number): Promise<void> {
+  await request<void>(`${ROOMS_BASE}/${roomId}`, { method: 'DELETE' });
+}
+
+export async function reorderRooms(orderedRoomIds: number[]): Promise<void> {
+  await request<void>(`${ROOMS_BASE}/reorder`, {
+    method: 'POST',
+    ...jsonBody({ orderedRoomIds } satisfies ReorderRoomsRequest),
+  });
+}
+
+export async function uploadRoomPhoto(
+  roomId: number,
+  file: File,
+): Promise<PhotoUploadResponse> {
+  const form = new FormData();
+  form.append('file', file);
+  return request<PhotoUploadResponse>(`${ROOMS_BASE}/${roomId}/photo`, {
+    method: 'POST',
+    body: form,
+  });
+}

--- a/frontend/app/src/lib/chores/lib/components/ChoreCard.svelte
+++ b/frontend/app/src/lib/chores/lib/components/ChoreCard.svelte
@@ -1,0 +1,1358 @@
+<script lang="ts">
+  import type { ChoreDto, ChoreSubtaskDto, ColorTier, DueState, EffortTier, RecurrenceMode, RosterState } from '../types';
+  import { boardStore, memberFor, roomFor } from '../state.svelte';
+  import { showPhoto } from '../lightbox.svelte';
+  import MemberAvatar from '$lib/shared/MemberAvatar.svelte';
+  import { dndzone, type DndEvent } from 'svelte-dnd-action';
+
+  // ───────────────────────────────────────────────────────────────────────
+  // The shared chore card — used across every lens.
+  //
+  // ⚠ M5/M6: this card renders SERVER-computed state. `colorTier`/`dueState`
+  // come straight off the DTO and drive the visual; we NEVER recompute dueness
+  // or decay client-side and NEVER construct a Date from a bare 'YYYY-MM-DD'.
+  // The only Date use is locale formatting of a full ISO-8601 UTC timestamp for
+  // DISPLAY (nextDueAt / lastCompletedAt), which is safe.
+  //
+  // The claim / drop / hand-off / Done affordances are wired here (WP-11). Each
+  // calls a handler prop; the parent runs the optimistic store mutation + 409
+  // reconciliation. The card disables its controls while a mutation is in flight
+  // (`pending`) to prevent double-submit. The action elements keep their
+  // data-action tags for a clear seam.
+  // ───────────────────────────────────────────────────────────────────────
+
+  interface Props {
+    chore: ChoreDto;
+    /** The viewing user's id, to label "you" on owner/assignee. */
+    currentUserId: number;
+    /** True while a mutation for this chore is in flight (disables controls). */
+    pending?: boolean;
+    /**
+     * Show the room locator chip (which room this chore lives in). True for the
+     * cross-room lenses (Needs-attention / Up-for-grabs / Mine); the Rooms lens
+     * passes false since its cards are already grouped under a room header.
+     */
+    showRoom?: boolean;
+    onClaim?: (chore: ChoreDto) => void;
+    onDrop?: (chore: ChoreDto) => void;
+    onComplete?: (chore: ChoreDto) => void;
+    onHandOff?: (chore: ChoreDto) => void;
+    /** Take a chore held by someone else — assign it to the current user (one tap). */
+    onTake?: (chore: ChoreDto) => void;
+    /** Assign an up-for-grabs chore to a chosen member (opens the member picker). */
+    onAssign?: (chore: ChoreDto) => void;
+    /** Commit ("I'm in") on a multi-person chore's roster. */
+    onCommit?: (chore: ChoreDto) => void;
+    /** Leave ("Not me") a multi-person chore's roster. */
+    onLeave?: (chore: ChoreDto) => void;
+    /** Open the edit sheet for this chore. */
+    onEdit?: (chore: ChoreDto) => void;
+    /** Snooze / un-snooze this chore. `request.days` = N days from today; `request.until` = explicit
+     *  "YYYY-MM-DD"; both omitted ⇒ un-snooze. The server resolves the floor (MN4 — no client date math). */
+    onSnooze?: (chore: ChoreDto, request: { days?: number; until?: string | null }) => void;
+  }
+
+  let {
+    chore,
+    currentUserId,
+    pending = false,
+    showRoom = true,
+    onClaim,
+    onDrop,
+    onComplete,
+    onHandOff,
+    onTake,
+    onAssign,
+    onCommit,
+    onLeave,
+    onEdit,
+    onSnooze,
+  }: Props = $props();
+
+  // ── Named effort tiers (P3 — never the raw points number as primary) ─────
+  const EFFORT_LABEL: Record<EffortTier, string> = {
+    Quick: 'Quick',
+    Standard: 'Standard',
+    BigJob: 'Big job',
+  };
+
+  // ── Dueness pill copy (server `dueState`) ────────────────────────────────
+  const DUE_LABEL: Record<DueState, string> = {
+    overdue: 'Overdue',
+    dueToday: 'Due today',
+    scheduled: 'Scheduled',
+    notDue: 'On track',
+  };
+
+  let effortLabel = $derived(EFFORT_LABEL[chore.effortTier]);
+  let dueLabel = $derived(DUE_LABEL[chore.dueState]);
+
+  // colorTier (fresh|mid|due|overdue) is the decay accent — server-computed.
+  let tier = $derived<ColorTier>(chore.colorTier);
+
+  let owner = $derived(memberFor(chore.ownerUserId));
+  let assignee = $derived(memberFor(chore.assigneeUserId));
+
+  // ── Room locator (which room this chore lives in) ────────────────────────
+  // Resolved off the board's room rollups. null for roomless chores (General)
+  // or when `showRoom` is off (the Rooms lens, where cards are already grouped).
+  let room = $derived(showRoom ? roomFor(chore.roomId) : null);
+
+  let isUnclaimed = $derived(chore.assignmentKind === 'none' || chore.isClaimStale);
+  let isClaimed = $derived(chore.assignmentKind === 'claimed' && !chore.isClaimStale);
+  let isAssigned = $derived(chore.assignmentKind === 'assigned');
+
+  // ── Multi-person named roster (rework) ───────────────────────────────────
+  // SERVER fields only (MN3 — no client count/membership math). `roster` carries
+  // each member's derived state (assigned/in/done); `completedCount`/`requiredCount`
+  // are the authoritative "k of X" gate (fresh — the store reconciles via the board
+  // GET after each mutation). The viewer's OWN roster state drives which actions show.
+  let isMultiPerson = $derived(chore.requiredCount > 1);
+  let myRosterState = $derived<RosterState | null>(
+    chore.roster.find((m) => m.userId === currentUserId)?.state ?? null,
+  );
+  let iAmDone = $derived(myRosterState === 'done');
+  let onRoster = $derived(myRosterState !== null);
+  let rosterMembers = $derived(
+    chore.roster.map((m) => ({ userId: m.userId, state: m.state, member: memberFor(m.userId) })),
+  );
+
+  const ROSTER_LABEL: Record<RosterState, string> = {
+    assigned: 'Assigned',
+    in: "I'm in",
+    done: 'Done',
+  };
+  const ROSTER_GLYPH: Record<RosterState, string> = {
+    assigned: '○',
+    in: '●',
+    done: '✓',
+  };
+
+  // ── Who can do what (drives the action buttons) ──────────────────────────
+  // The viewing user "holds" the chore when they're the active (non-stale)
+  // assignee. Drop is Claimed-only (a deliberate Assigned chore can't be
+  // dropped — WP-04). The holder can hand off; ANYONE can take a chore held by
+  // someone else or reassign it — the service has no holder guard on hand-off
+  // ("anyone can reassign, no roles", ChoreService.HandOffAsync). Done is
+  // available on any non-pile chore (any member may complete — WP-04 M8).
+  let heldByMe = $derived(
+    chore.assigneeUserId === currentUserId &&
+      (isClaimed || isAssigned),
+  );
+  // Held (fresh, non-stale) by another member — surfaces Take it / Reassign so
+  // you can grab or pass a chore without coordinating with the current holder.
+  let heldByOther = $derived(!isUnclaimed && !heldByMe);
+  let canDrop = $derived(heldByMe && isClaimed);
+
+  // ── Recurrence hint (human, derived from the plain-string union) ─────────
+  const RECURRENCE_HINT: Record<RecurrenceMode, string> = {
+    OneOff: 'One-off',
+    Fixed: 'Scheduled',
+    Flexible: 'Recurring',
+  };
+  let recurrenceHint = $derived(RECURRENCE_HINT[chore.recurrenceMode]);
+
+  // ── Display-only date formatting (safe: full ISO-8601 UTC strings) ───────
+  // NEVER `new Date('YYYY-MM-DD')`. nextDueAt / lastCompletedAt are full
+  // ISO-8601 timestamps with a Z suffix, so `new Date(iso)` is locale-safe.
+  function formatDay(iso: string | null): string | null {
+    if (!iso) return null;
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return null;
+    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  }
+
+  let nextDueLabel = $derived(formatDay(chore.nextDueAt));
+  let lastDoneLabel = $derived(formatDay(chore.lastCompletedAt));
+
+  function nameOf(userId: number | null, displayName: string | null): string {
+    if (userId != null && userId === currentUserId) return 'You';
+    return displayName ?? 'Someone';
+  }
+
+  // ── Checklist / subtasks (Phase 14 — momentum aid, NEVER gates completion) ─
+  // Rendered only when the chore already has at least one item; the FIRST item
+  // is added from the edit sheet. All ops go straight to the versionless store
+  // path (boardStore.{toggle,remove,add}Subtask) — last-write-wins, no version,
+  // and they never disable the chore's own controls. No dueness/Date here.
+  let subtasks = $derived(chore.subtasks);
+  let hasChecklist = $derived(subtasks.length > 0);
+  let doneCount = $derived(subtasks.filter((s) => s.isDone).length);
+  let totalCount = $derived(subtasks.length);
+
+  /** Local collapse state — the checklist starts collapsed; the chip toggles it. */
+  let expanded = $state(false);
+  /** Inline "add item" draft for the expanded checklist. */
+  let newItemTitle = $state('');
+
+  function submitNewItem() {
+    const title = newItemTitle.trim();
+    if (!title) return;
+    boardStore.addSubtask(chore.id, title);
+    newItemTitle = '';
+  }
+
+  // ── Drag-reorder (svelte-dnd-action — the room-manager house pattern) ──────
+  // A local working list re-synced from the chore's subtasks except while a drag
+  // is in flight (a guard so a mid-drag board reload can't clobber the order). On
+  // drop we persist the new order via the versionless bulk reorder store path.
+  let checkRows = $state<ChoreSubtaskDto[]>([]);
+  let draggingChecklist = $state(false);
+  $effect(() => {
+    if (!draggingChecklist) checkRows = [...subtasks];
+  });
+
+  function handleChecklistConsider(e: CustomEvent<DndEvent<ChoreSubtaskDto>>) {
+    draggingChecklist = true;
+    checkRows = e.detail.items;
+  }
+  async function handleChecklistFinalize(e: CustomEvent<DndEvent<ChoreSubtaskDto>>) {
+    checkRows = e.detail.items;
+    const ordered = checkRows.map((s) => s.id);
+    try {
+      await boardStore.reorderSubtasks(chore.id, ordered);
+    } finally {
+      // Release the guard last so the resync lands on the persisted order.
+      draggingChecklist = false;
+    }
+  }
+
+  /** "Who ticked it" label for a done item — the member's initials (tooltip = name + when). */
+  function actorLabel(s: ChoreSubtaskDto): { initials: string; tooltip: string } | null {
+    if (!s.isDone || s.completedByUserId == null) return null;
+    const member = memberFor(s.completedByUserId);
+    if (!member) return null;
+    const when = formatDay(s.completedAt);
+    const you = s.completedByUserId === currentUserId;
+    const name = you ? 'you' : member.displayName;
+    return { initials: member.initials, tooltip: when ? `Done by ${name} · ${when}` : `Done by ${name}` };
+  }
+
+  // ── Snooze / set-next-due (board quick-snooze) ───────────────────────────
+  // The "Snooze" button reveals a small preset row; a preset or a picked date
+  // calls onSnooze with the RAW request — the server resolves the floor date in
+  // the household timezone (MN4 — NO client date math, no min/default computed
+  // here). The chip (when isSnoozed) binds the server `nextDueAt` (the
+  // schedule-aware RESUME date), never snoozedUntil.
+  let snoozeOpen = $state(false);
+
+  function doSnooze(request: { days?: number; until?: string | null }) {
+    onSnooze?.(chore, request);
+    snoozeOpen = false;
+  }
+
+  function onPickDate(e: Event) {
+    const input = e.currentTarget as HTMLInputElement;
+    const value = input.value; // raw "YYYY-MM-DD" — sent unchanged; server validates > today
+    if (value) doSnooze({ until: value });
+  }
+</script>
+
+<article
+  class="ch-card ch-tier-{tier}"
+  class:ch-card-stale={chore.isClaimStale}
+  class:ch-card-pending={pending}
+  aria-label={chore.name}
+  aria-busy={pending}
+>
+  <div class="ch-card-accent" aria-hidden="true"></div>
+
+  {#if chore.photoPath}
+    <!--
+      Leading photo thumbnail (v1.2). Same-origin served URL (/uploads/…), so
+      `src` works directly. Tap → shared lightbox. Fixed 56px square keeps row
+      height steady regardless of photo orientation; the icon emoji still leads
+      the name. No-photo chores render no thumbnail (unchanged from before).
+    -->
+    <button
+      type="button"
+      class="ch-card-thumb-btn"
+      data-action="photo"
+      onclick={() => showPhoto(chore.photoPath, chore.name)}
+      aria-label="View photo for {chore.name}"
+      title="View photo"
+    >
+      <img
+        class="ch-card-thumb"
+        src={chore.photoPath}
+        alt=""
+        width="56"
+        height="56"
+        loading="lazy"
+      />
+    </button>
+  {/if}
+
+  <div class="ch-card-main">
+    <div class="ch-card-top">
+      <h3 class="ch-card-name">
+        {#if chore.icon}<span class="ch-card-icon" aria-hidden="true">{chore.icon}</span>{/if}{chore.name}
+      </h3>
+      <span class="ch-pill ch-pill-{tier}" title="Due state: {dueLabel}">{dueLabel}</span>
+    </div>
+
+    {#if chore.description}
+      <p class="ch-card-desc">{chore.description}</p>
+    {/if}
+
+    <div class="ch-card-meta">
+      {#if hasChecklist}
+        <!--
+          Checklist progress chip — a tappable button that expands/collapses the
+          per-chore checklist below. Momentum surface only; never gates the
+          Complete button. ✓ done/total.
+        -->
+        <button
+          type="button"
+          class="ch-tag ch-tag-checklist"
+          class:ch-tag-checklist-done={doneCount === totalCount}
+          data-action="toggle-checklist"
+          aria-expanded={expanded}
+          onclick={() => (expanded = !expanded)}
+          title="Checklist: {doneCount} of {totalCount} done — tap to {expanded ? 'hide' : 'show'}"
+        >
+          <span aria-hidden="true">✓</span>
+          {doneCount}/{totalCount}
+        </button>
+      {/if}
+      {#if isMultiPerson}
+        <span
+          class="ch-tag ch-tag-cosign"
+          title="{chore.completedCount} of {chore.requiredCount} people have marked this done"
+        >
+          <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true">
+            <path
+              d="M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5s-3 1.34-3 3 1.34 3 3 3zm-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z"
+              fill="currentColor"
+            />
+          </svg>
+          {chore.completedCount} of {chore.requiredCount} done
+        </span>
+      {/if}
+      {#if room}
+        <span class="ch-tag ch-tag-room" title="Room: {room.name}">
+          {#if room.icon}
+            <span class="ch-tag-room-icon" aria-hidden="true">{room.icon}</span>
+          {:else}
+            <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true">
+              <path
+                d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5A2.5 2.5 0 1 1 12 6.5a2.5 2.5 0 0 1 0 5z"
+                fill="currentColor"
+              />
+            </svg>
+          {/if}
+          {room.name}
+        </span>
+      {/if}
+
+      <span class="ch-tag ch-tag-effort" title="Effort: {effortLabel}">
+        <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true">
+          <path d="M13 2 3 14h7l-1 8 10-12h-7l1-8z" fill="currentColor" />
+        </svg>
+        {effortLabel}
+      </span>
+
+      <span class="ch-tag ch-tag-recurrence" title="{recurrenceHint}">
+        <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true">
+          <path d="M12 6V3L8 7l4 4V8a4 4 0 1 1-4 4H6a6 6 0 1 0 6-6z" fill="currentColor" />
+        </svg>
+        {recurrenceHint}
+      </span>
+
+      {#if chore.isSnoozed}
+        <!--
+          Snoozed chip — the date binds to the server `nextDueAt` (the schedule-aware
+          RESUME date), NOT snoozedUntil: for a Fixed chore the two differ (the floor
+          skips a slot; the resume lands on the next cadence day). Server value only (MN4).
+        -->
+        <span class="ch-tag ch-tag-snoozed" title="Snoozed — resumes {nextDueLabel ?? 'on its next day'}">
+          💤 Snoozed{#if nextDueLabel} · due {nextDueLabel}{/if}
+        </span>
+      {:else if nextDueLabel}
+        <span class="ch-tag ch-tag-due" title="Next due {nextDueLabel}">
+          Next: {nextDueLabel}
+        </span>
+      {:else if lastDoneLabel}
+        <span class="ch-tag ch-tag-done" title="Last done {lastDoneLabel}">
+          Done {lastDoneLabel}
+        </span>
+      {/if}
+
+      <!--
+        Minder chip (the chore's ultimate owner — "makes sure it gets done").
+        Deliberately lives UP HERE among the chore's attribute chips, NOT down in
+        the footer next to the doer — the minder is a property of the chore, the
+        doer is the live work state. Rendering it as an eye-icon chip (no avatar)
+        keeps it visually distinct from the footer's avatar-led doer, so the two
+        roles never read as the same thing.
+      -->
+      {#if owner}
+        <span
+          class="ch-tag ch-tag-minder"
+          title="Minder — makes sure this gets done: {nameOf(chore.ownerUserId, owner.displayName)}"
+        >
+          <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true">
+            <path
+              d="M12 5c-5 0-9.27 3.11-11 7 1.73 3.89 6 7 11 7s9.27-3.11 11-7c-1.73-3.89-6-7-11-7zm0 12a5 5 0 1 1 0-10 5 5 0 0 1 0 10zm0-8a3 3 0 1 0 0 6 3 3 0 0 0 0-6z"
+              fill="currentColor"
+            />
+          </svg>
+          <span class="ch-tag-minder-role">Minder</span>
+          {nameOf(chore.ownerUserId, owner.displayName)}
+        </span>
+      {/if}
+    </div>
+
+    {#if hasChecklist && expanded}
+      <!--
+        Per-chore checklist (Phase 14). Each row is a tappable checkbox + title;
+        tapping toggles via the versionless store path. A subtle "×" removes the
+        item, and a done item shows "who ticked it". Rows drag to reorder
+        (svelte-dnd-action; persisted via the bulk reorder path). The add row sits
+        OUTSIDE the drag zone (every dndzone child is a draggable item). Subtasks
+        are a momentum aid only — they never gate the Done/Complete button.
+      -->
+      <ul
+        class="ch-checklist"
+        aria-label="Checklist for {chore.name}"
+        use:dndzone={{
+          items: checkRows,
+          type: `subtasks-${chore.id}`,
+          flipDurationMs: 150,
+          dropTargetStyle: {},
+          delayTouchStart: 250,
+        }}
+        onconsider={handleChecklistConsider}
+        onfinalize={handleChecklistFinalize}
+      >
+        {#each checkRows as s (s.id)}
+          {@const actor = actorLabel(s)}
+          <li class="ch-checkitem" class:ch-checkitem-done={s.isDone}>
+            <button
+              type="button"
+              class="ch-check-toggle"
+              data-action="subtask-toggle"
+              aria-pressed={s.isDone}
+              onclick={() => boardStore.toggleSubtask(chore.id, s.id, !s.isDone)}
+              title={s.isDone ? 'Mark not done' : 'Mark done'}
+            >
+              <span class="ch-check-box" aria-hidden="true">{s.isDone ? '✓' : ''}</span>
+              <span class="ch-check-title">{s.title}</span>
+            </button>
+            {#if actor}
+              <span class="ch-check-actor" title={actor.tooltip}>{actor.initials}</span>
+            {/if}
+            <button
+              type="button"
+              class="ch-check-del"
+              data-action="subtask-remove"
+              onclick={() => boardStore.removeSubtask(chore.id, s.id)}
+              title="Remove this item"
+              aria-label="Remove {s.title}"
+            >
+              ×
+            </button>
+          </li>
+        {/each}
+      </ul>
+      <div class="ch-checkadd">
+        <input
+          type="text"
+          class="ch-checkadd-input"
+          bind:value={newItemTitle}
+          autocomplete="off"
+          placeholder="Add an item…"
+          aria-label="Add a checklist item"
+          onkeydown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              submitNewItem();
+            }
+          }}
+        />
+        <button
+          type="button"
+          class="ch-checkadd-btn"
+          data-action="subtask-add"
+          onclick={submitNewItem}
+          disabled={!newItemTitle.trim()}
+          title="Add item"
+          aria-label="Add checklist item"
+        >
+          ＋
+        </button>
+      </div>
+    {/if}
+
+    <div class="ch-card-foot">
+      <!--
+        The footer people row is the DOER only — who's actively on it (roster /
+        claimed / assigned) or "Up for grabs". The minder moved up to the chip row
+        above so the two roles are visually separated (operator feedback).
+      -->
+      <div class="ch-people">
+        {#if isMultiPerson}
+          <div class="ch-roster" aria-label="Roster: {chore.completedCount} of {chore.requiredCount} done">
+            {#each rosterMembers as r (r.userId)}
+              {#if r.member}
+                <span
+                  class="ch-roster-member ch-roster-{r.state}"
+                  title="{nameOf(r.userId, r.member.displayName)} — {ROSTER_LABEL[r.state]}"
+                >
+                  <MemberAvatar
+                    name={r.member.displayName}
+                    initials={r.member.initials}
+                    pictureUrl={r.member.pictureUrl}
+                    size={26}
+                    relation={ROSTER_LABEL[r.state]}
+                  />
+                  <span class="ch-roster-badge" aria-hidden="true">{ROSTER_GLYPH[r.state]}</span>
+                </span>
+              {/if}
+            {/each}
+            {#if rosterMembers.length === 0}
+              <span class="ch-claim ch-claim-open">Needs {chore.requiredCount} — no one yet</span>
+            {/if}
+          </div>
+        {:else if isClaimed && assignee}
+          <span class="ch-claim ch-claim-claimed">
+            <MemberAvatar
+              name={assignee.displayName}
+              initials={assignee.initials}
+              pictureUrl={assignee.pictureUrl}
+              size={28}
+              relation="Claimed by"
+            />
+            <span class="ch-claim-label">{nameOf(chore.assigneeUserId, assignee.displayName)}</span>
+          </span>
+        {:else if isAssigned && assignee}
+          <span class="ch-claim ch-claim-assigned">
+            <MemberAvatar
+              name={assignee.displayName}
+              initials={assignee.initials}
+              pictureUrl={assignee.pictureUrl}
+              size={28}
+              relation="Assigned to"
+            />
+            <span class="ch-claim-label">{nameOf(chore.assigneeUserId, assignee.displayName)}</span>
+          </span>
+        {:else}
+          <span class="ch-claim ch-claim-open">Up for grabs</span>
+        {/if}
+      </div>
+
+      <!--
+        Action affordances (WP-11). Optimistic — the parent runs the store
+        mutation + 409 reconcile. Controls disable while a mutation is in flight
+        (`pending`) to prevent double-submit.
+      -->
+      <div class="ch-actions">
+        {#if isMultiPerson}
+          <!--
+            Multi-person chores are NOT claimable. Actions depend on the viewer's
+            roster state: done → waiting; on-roster → mark-done / not-me; assigned
+            or not-on-roster → I'm-in/I'll-help to join, plus mark-done (anyone may
+            complete toward the count). The store routes the chore to Mine (on
+            roster) or Up-for-grabs (not) — see state.svelte.ts.
+          -->
+          {#if iAmDone}
+            <button
+              type="button"
+              class="ch-btn ch-btn-ghost"
+              data-action="complete"
+              disabled
+              title="You've done your part — waiting on the others"
+            >
+              You're done ✓
+            </button>
+          {:else}
+            {#if !onRoster || myRosterState === 'assigned'}
+              <button
+                type="button"
+                class="ch-btn ch-btn-ghost"
+                data-action="commit"
+                onclick={() => onCommit?.(chore)}
+                disabled={pending}
+                title={onRoster ? "Confirm you're in" : "Join in — I'll help"}
+              >
+                {onRoster ? "I'm in" : "I'll help"}
+              </button>
+            {/if}
+            <button
+              type="button"
+              class="ch-btn ch-btn-primary"
+              data-action="complete"
+              onclick={() => onComplete?.(chore)}
+              disabled={pending}
+              title="Mark your part done"
+            >
+              Mark my part done
+            </button>
+            {#if onRoster}
+              <button
+                type="button"
+                class="ch-btn ch-btn-ghost"
+                data-action="leave"
+                onclick={() => onLeave?.(chore)}
+                disabled={pending}
+                title="I can't do this one — take me off"
+              >
+                Not me
+              </button>
+            {/if}
+          {/if}
+        {:else if isUnclaimed}
+          <button
+            type="button"
+            class="ch-btn ch-btn-primary"
+            data-action="claim"
+            onclick={() => onClaim?.(chore)}
+            disabled={pending}
+            title="Claim this chore"
+          >
+            Claim
+          </button>
+          {#if onAssign}
+            <!--
+              Assign an up-for-grabs chore to a specific person (opens the member
+              picker). Lands a deliberate Assigned via the hand-off endpoint — the
+              same mechanism "Reassign" uses on held chores, just surfaced from the
+              pile. Distinct from Claim (self) and Take (grab someone else's).
+            -->
+            <button
+              type="button"
+              class="ch-btn ch-btn-ghost"
+              data-action="assign"
+              onclick={() => onAssign?.(chore)}
+              disabled={pending}
+              title="Assign this chore to someone"
+            >
+              Assign
+            </button>
+          {/if}
+        {:else}
+          {#if heldByMe}
+            <button
+              type="button"
+              class="ch-btn ch-btn-ghost"
+              data-action="handoff"
+              onclick={() => onHandOff?.(chore)}
+              disabled={pending}
+              title="Hand off or release this chore"
+            >
+              Hand off
+            </button>
+            {#if canDrop}
+              <button
+                type="button"
+                class="ch-btn ch-btn-ghost"
+                data-action="drop"
+                onclick={() => onDrop?.(chore)}
+                disabled={pending}
+                title="Put this chore back in the pile"
+              >
+                Drop
+              </button>
+            {/if}
+          {:else if heldByOther}
+            <!--
+              Held by someone else. Take it (claim it for yourself in one tap —
+              covering for someone who's out/sick, no need to coordinate) or
+              Reassign it to another member / release it via the shared hand-off
+              picker. Take lands a self-CLAIM (not a sticky assignment), so a
+              recurring chore returns to the pile after you finish it; completion
+              already credits the completer, so Take-then-Done attributes the
+              work to you.
+            -->
+            <button
+              type="button"
+              class="ch-btn ch-btn-ghost"
+              data-action="take"
+              onclick={() => onTake?.(chore)}
+              disabled={pending}
+              title="Take this chore — claim it for yourself"
+            >
+              Take it
+            </button>
+            <button
+              type="button"
+              class="ch-btn ch-btn-ghost"
+              data-action="handoff"
+              onclick={() => onHandOff?.(chore)}
+              disabled={pending}
+              title="Reassign this chore to someone else or release it"
+            >
+              Reassign
+            </button>
+          {/if}
+          <!-- Single-person chore — today's exact one-tap Done (unchanged, P2). -->
+          <button
+            type="button"
+            class="ch-btn ch-btn-primary"
+            data-action="complete"
+            onclick={() => onComplete?.(chore)}
+            disabled={pending}
+            title="Mark this chore done"
+          >
+            Done
+          </button>
+        {/if}
+        {#if onSnooze}
+          <!--
+            Snooze / un-snooze — available on any chore regardless of claim state (a
+            chore-level "not today" lever). Snooze opens an inline preset row below;
+            Un-snooze clears the floor in one tap. Server resolves the date (MN4).
+          -->
+          {#if chore.isSnoozed}
+            <button
+              type="button"
+              class="ch-btn ch-btn-ghost"
+              data-action="unsnooze"
+              onclick={() => doSnooze({ until: null })}
+              disabled={pending}
+              title="Un-snooze — make this active again now"
+            >
+              Un-snooze
+            </button>
+          {:else}
+            <button
+              type="button"
+              class="ch-btn ch-btn-ghost"
+              data-action="snooze"
+              onclick={() => (snoozeOpen = !snoozeOpen)}
+              disabled={pending}
+              aria-expanded={snoozeOpen}
+              title="Snooze — not today"
+            >
+              Snooze
+            </button>
+          {/if}
+        {/if}
+        {#if onEdit}
+          <button
+            type="button"
+            class="ch-btn ch-btn-icon"
+            data-action="edit"
+            onclick={() => onEdit?.(chore)}
+            disabled={pending}
+            title="Edit this chore"
+            aria-label="Edit {chore.name}"
+          >
+            <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
+              <path
+                d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04a1 1 0 0 0 0-1.41l-2.34-2.34a1 1 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+        {/if}
+      </div>
+    </div>
+
+    {#if onSnooze && snoozeOpen && !chore.isSnoozed}
+      <!--
+        Snooze preset row. Presets send {days} (server adds them to today in the
+        household tz); "Pick a date" sends the RAW <input type="date"> value as
+        {until} unchanged and relies on server validation for > today — no client
+        min/default (MN4). The chip/date everywhere come from the server, never math.
+      -->
+      <div class="ch-snooze-menu" role="group" aria-label="Snooze until">
+        <button type="button" class="ch-snooze-preset" onclick={() => doSnooze({ days: 1 })} disabled={pending}>
+          Tomorrow
+        </button>
+        <button type="button" class="ch-snooze-preset" onclick={() => doSnooze({ days: 3 })} disabled={pending}>
+          3 days
+        </button>
+        <button type="button" class="ch-snooze-preset" onclick={() => doSnooze({ days: 7 })} disabled={pending}>
+          1 week
+        </button>
+        <label class="ch-snooze-pick">
+          <span>Pick a date</span>
+          <input type="date" onchange={onPickDate} disabled={pending} aria-label="Snooze until a date" />
+        </label>
+      </div>
+    {/if}
+  </div>
+</article>
+
+<style>
+  /*
+   * Decay accent is driven entirely by the server `colorTier`
+   * (fresh|mid|due|overdue). We map each tier to a token-based accent color
+   * via a per-tier `--accent` custom property; the card never derives the tier.
+   */
+  .ch-card {
+    --accent: var(--color-line-strong);
+    position: relative;
+    display: flex;
+    background: var(--color-surface);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-1);
+    overflow: hidden;
+    transition: box-shadow 0.15s;
+  }
+  .ch-card:hover {
+    box-shadow: var(--shadow-2);
+  }
+  .ch-card-stale {
+    /* A stale claim reads as effectively up-for-grabs (WP-04/05 UX). */
+    opacity: 0.92;
+  }
+  .ch-card-pending {
+    /* A mutation is in flight — dim the card while we await the server. */
+    opacity: 0.6;
+  }
+
+  /* ── colorTier → accent (the ONLY place the tier maps to a color) ──────── */
+  .ch-tier-fresh {
+    --accent: var(--color-success);
+  }
+  .ch-tier-mid {
+    --accent: var(--color-info);
+  }
+  .ch-tier-due {
+    --accent: var(--color-warning);
+  }
+  .ch-tier-overdue {
+    --accent: var(--color-error);
+  }
+
+  .ch-card-accent {
+    flex-shrink: 0;
+    width: 6px;
+    background: var(--accent);
+  }
+
+  /* ── Leading photo thumbnail (v1.2) — tap to enlarge ───────────────────── */
+  .ch-card-thumb-btn {
+    flex-shrink: 0;
+    align-self: flex-start;
+    margin: 12px 0 12px 12px;
+    padding: 0;
+    border: none;
+    background: transparent;
+    border-radius: 8px;
+    cursor: zoom-in;
+    line-height: 0;
+    -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation;
+  }
+  .ch-card-thumb {
+    display: block;
+    width: 56px;
+    height: 56px;
+    border-radius: 8px;
+    object-fit: cover;
+    background: var(--color-action-hover);
+  }
+  .ch-card-thumb-btn:hover .ch-card-thumb {
+    filter: brightness(1.04);
+  }
+  .ch-card-thumb-btn:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+
+  .ch-card-main {
+    flex: 1;
+    min-width: 0;
+    padding: 12px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    /* Query container so the footer can lay itself out against the CARD's own
+       width (not the viewport) — a card is narrow on mobile and wide on desktop
+       regardless of screen size. Drives the @container rule on .ch-card-foot. */
+    container-type: inline-size;
+  }
+
+  .ch-card-top {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+  }
+  .ch-card-name {
+    margin: 0;
+    font-size: 1.0625rem;
+    font-weight: 500;
+    line-height: 1.3;
+    color: var(--color-text);
+    overflow-wrap: anywhere;
+  }
+  /* Optional chore icon leads the name (parity with room cards). */
+  .ch-card-icon {
+    margin-right: 6px;
+  }
+
+  /* ── Dueness pill — tinted by the same colorTier accent ────────────────── */
+  .ch-pill {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    height: 22px;
+    padding: 0 10px;
+    border-radius: 11px;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+    white-space: nowrap;
+    color: #fff;
+    background: var(--accent);
+  }
+  /* Fresh/mid pills sit quieter — outline rather than solid. */
+  .ch-pill-fresh,
+  .ch-pill-mid {
+    color: var(--accent);
+    background: transparent;
+    border: 1px solid var(--accent);
+  }
+
+  .ch-card-desc {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+    line-height: 1.4;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+  }
+
+  .ch-card-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .ch-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    height: 22px;
+    padding: 0 8px;
+    border-radius: var(--radius-sm);
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--color-text-muted);
+    background: var(--color-action-hover);
+    white-space: nowrap;
+  }
+  .ch-tag svg {
+    flex-shrink: 0;
+  }
+  /* Room locator chip — tinted distinct from the muted effort/recurrence tags
+     so "which room" reads as the card's primary orientation cue. */
+  .ch-tag-room {
+    color: #fff;
+    background: var(--color-primary-soft);
+  }
+  .ch-tag-room-icon {
+    font-size: 0.875rem;
+    line-height: 1;
+  }
+  /* Co-sign progress chip ("X of N done") — solid tint with white text so it
+     reads as a status cue distinct from the muted effort/recurrence tags. The
+     accent color carries the meaning; the same fill the room locator uses. */
+  .ch-tag-cosign {
+    color: #fff;
+    background: var(--color-info);
+    font-weight: 600;
+  }
+  /* Minder chip — the chore's ultimate owner. A quiet, bordered "accountability"
+     cue (eye icon + uppercase role + name) that reads distinctly from both the
+     muted attribute chips and the footer's avatar-led doer. */
+  .ch-tag-minder {
+    color: var(--color-text);
+    background: transparent;
+    border: 1px solid var(--color-line-strong);
+    font-weight: 500;
+  }
+  .ch-tag-minder svg {
+    color: var(--color-primary);
+  }
+  .ch-tag-minder-role {
+    text-transform: uppercase;
+    font-size: 0.625rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    color: var(--color-text-muted);
+  }
+  /* Checklist progress chip — a tappable button styled like the other meta tags.
+     A subtle bordered pill so it reads as interactive without shouting; goes
+     green-tinted once every item is checked. Never gates completion. */
+  .ch-tag-checklist {
+    font: inherit;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--color-text-muted);
+    border: 1px solid var(--color-line-strong);
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation;
+  }
+  .ch-tag-checklist:hover {
+    background: var(--color-action-hover);
+    color: var(--color-text);
+  }
+  .ch-tag-checklist-done {
+    color: var(--color-success);
+    border-color: var(--color-success);
+  }
+
+  /*
+   * Footer layout — STACKED by default (mobile-first). The doer strip drops to
+   * its own row at the BOTTOM via column-reverse (DOM order stays people→actions,
+   * which keeps a sane tab order — the doer strip has no focusable elements). This
+   * fixes the mobile overlap where a long assignee name ran under the "Take it"
+   * button (the actions were flex-shrink:0 and the name had no room). The wide-card
+   * @container rule below puts them back side-by-side when there's space.
+   */
+  .ch-card-foot {
+    display: flex;
+    flex-direction: column-reverse;
+    align-items: stretch;
+    gap: 10px;
+    margin-top: 2px;
+  }
+  .ch-people {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    /* The doer's own bespoke space — a divider sets it apart from the actions. */
+    padding-top: 8px;
+    border-top: 1px solid var(--color-line);
+  }
+  .ch-claim {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+  }
+  .ch-claim-label {
+    font-weight: 500;
+    color: var(--color-text);
+  }
+  .ch-claim-open {
+    font-style: italic;
+  }
+
+  /* ── Multi-person roster strip (avatars badged assigned ○ / in ● / done ✓) ── */
+  .ch-roster {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .ch-roster-member {
+    position: relative;
+    display: inline-flex;
+  }
+  /* An assigned (not-yet-confirmed) member reads quieter than a committed one. */
+  .ch-roster-assigned {
+    opacity: 0.65;
+  }
+  .ch-roster-badge {
+    position: absolute;
+    right: -3px;
+    bottom: -3px;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    font-size: 9px;
+    line-height: 1;
+    color: #fff;
+    background: var(--color-text-muted);
+    box-shadow: 0 0 0 2px var(--color-surface);
+  }
+  .ch-roster-in .ch-roster-badge {
+    background: var(--color-info);
+  }
+  .ch-roster-done .ch-roster-badge {
+    background: var(--color-success);
+  }
+
+  /* ── Per-chore checklist (Phase 14) ─────────────────────────────────────── */
+  .ch-checklist {
+    list-style: none;
+    margin: 0;
+    padding: 8px 0 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    border-top: 1px solid var(--color-line);
+  }
+  .ch-checkitem {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+  /* The tappable label region (checkbox + title) is the whole left side — a
+     comfortable mobile target. */
+  .ch-check-toggle {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    /* A flex <button> centers its content under the UA stylesheet — text-align is
+       ignored for flex children — so pin the checkbox + title hard-left. */
+    justify-content: flex-start;
+    gap: 10px;
+    font: inherit;
+    font-size: 0.875rem;
+    text-align: left;
+    color: var(--color-text);
+    background: transparent;
+    border: none;
+    border-radius: var(--radius-sm);
+    padding: 8px 6px;
+    min-height: 40px;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation;
+  }
+  .ch-check-toggle:hover {
+    background: var(--color-action-hover);
+  }
+  .ch-check-box {
+    flex-shrink: 0;
+    width: 20px;
+    height: 20px;
+    display: grid;
+    place-items: center;
+    border: 1.5px solid var(--color-line-strong);
+    border-radius: 5px;
+    font-size: 13px;
+    line-height: 1;
+    color: #fff;
+  }
+  .ch-checkitem-done .ch-check-box {
+    background: var(--color-success);
+    border-color: var(--color-success);
+  }
+  .ch-check-title {
+    overflow-wrap: anywhere;
+  }
+  .ch-checkitem-done .ch-check-title {
+    text-decoration: line-through;
+    color: var(--color-text-muted);
+  }
+  .ch-check-del {
+    flex-shrink: 0;
+    width: 32px;
+    height: 32px;
+    display: grid;
+    place-items: center;
+    font-size: 1.125rem;
+    line-height: 1;
+    color: var(--color-text-muted);
+    background: transparent;
+    border: none;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation;
+  }
+  .ch-check-del:hover {
+    background: var(--color-action-hover);
+    color: var(--color-error);
+  }
+  /* "Who ticked it" tag — the actor's initials beside a done item. */
+  .ch-check-actor {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 22px;
+    height: 22px;
+    padding: 0 6px;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    line-height: 1;
+    color: var(--color-text-muted);
+    background: var(--color-action-hover);
+    border-radius: 999px;
+    cursor: default;
+  }
+  .ch-checkadd {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding-top: 4px;
+  }
+  .ch-checkadd-input {
+    flex: 1;
+    min-width: 0;
+    font: inherit;
+    font-size: 0.875rem;
+    color: inherit;
+    padding: 8px 10px;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    min-height: 40px;
+  }
+  .ch-checkadd-input:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -1px;
+    border-color: var(--color-primary);
+  }
+  .ch-checkadd-btn {
+    flex-shrink: 0;
+    width: 40px;
+    height: 40px;
+    display: grid;
+    place-items: center;
+    font-size: 1.125rem;
+    color: var(--color-primary);
+    background: transparent;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation;
+  }
+  .ch-checkadd-btn:hover:not(:disabled) {
+    background: var(--color-action-hover);
+  }
+  .ch-checkadd-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .ch-actions {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+
+  /*
+   * Wide card (desktop / tablet — the card itself is ≥460px): restore the
+   * original single-row footer with the doer on the left and actions on the
+   * right. Below this, the stacked layout above keeps the assignee name and the
+   * action buttons from ever colliding regardless of how many buttons show.
+   */
+  @container (min-width: 460px) {
+    .ch-card-foot {
+      flex-direction: row;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+    }
+    .ch-people {
+      min-width: 0;
+      padding-top: 0;
+      border-top: none;
+    }
+    .ch-actions {
+      flex-wrap: nowrap;
+      flex-shrink: 0;
+    }
+  }
+  .ch-btn {
+    font: inherit;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    border: 1px solid transparent;
+    border-radius: var(--radius-sm);
+    padding: 6px 14px;
+    min-height: 34px;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation;
+  }
+  .ch-btn-primary {
+    background: var(--color-primary);
+    color: #fff;
+  }
+  .ch-btn-primary:hover:not(:disabled) {
+    background: var(--color-primary-hover);
+  }
+  .ch-btn-ghost {
+    background: transparent;
+    color: var(--color-primary);
+    border-color: var(--color-line-strong);
+  }
+  .ch-btn-ghost:hover:not(:disabled) {
+    background: var(--color-action-hover);
+  }
+  .ch-btn:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+  .ch-btn-icon {
+    background: transparent;
+    color: var(--color-text-muted);
+    border-color: var(--color-line-strong);
+    padding: 6px 8px;
+    display: grid;
+    place-items: center;
+  }
+  .ch-btn-icon:hover:not(:disabled) {
+    background: var(--color-action-hover);
+    color: var(--color-text);
+  }
+
+  /* ── Snoozed chip — a quiet "resting" cue, distinct from the dueness tags. ── */
+  .ch-tag-snoozed {
+    color: var(--color-text);
+    background: transparent;
+    border: 1px solid var(--color-line-strong);
+    font-weight: 500;
+  }
+
+  /* ── Snooze preset row (revealed under the actions when "Snooze" is tapped) ── */
+  .ch-snooze-menu {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+    margin-top: 10px;
+    padding-top: 10px;
+    border-top: 1px dashed var(--color-line);
+  }
+  .ch-snooze-preset {
+    font: inherit;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: var(--color-primary);
+    background: transparent;
+    border: 1px solid var(--color-line-strong);
+    border-radius: 18px;
+    padding: 6px 14px;
+    min-height: 34px;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation;
+  }
+  .ch-snooze-preset:hover:not(:disabled) {
+    background: var(--color-action-hover);
+  }
+  .ch-snooze-preset:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+  .ch-snooze-pick {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+  }
+  .ch-snooze-pick input[type='date'] {
+    font: inherit;
+    font-size: 0.8125rem;
+    color: inherit;
+    padding: 6px 8px;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    min-height: 34px;
+  }
+</style>

--- a/frontend/app/src/lib/chores/lib/components/CompleteDialog.svelte
+++ b/frontend/app/src/lib/chores/lib/components/CompleteDialog.svelte
@@ -1,0 +1,310 @@
+<script lang="ts">
+  // ───────────────────────────────────────────────────────────────────────
+  // Complete dialog (WP-07, D7). Shown ONLY for multi-person (co-sign) chores
+  // — `requiredCount > 1`. Mirrors the HandOffPicker modal pattern: a styled
+  // <dialog> hosted in App.svelte, opened via the card's `onComplete` callback.
+  //
+  // It lets the present member record who marked the chore done — themselves
+  // (prefilled) plus, optionally, another household member who's also present
+  // (the escape hatch that satisfies the count in one action). Members already
+  // in `contributorUserIds` have signed THIS occurrence already; they're shown
+  // checked + disabled (D6 distinctness — the server dedupes regardless).
+  //
+  // v1 is participant selection ONLY — there is no completion note/photo UI in
+  // the app today, so adding one is out of scope (WP-07 boundary).
+  //
+  // SERVER fields only (MN3): `completedCount`/`requiredCount`/`contributorUserIds`
+  // come straight off the chore DTO; no client count/membership math.
+  // ───────────────────────────────────────────────────────────────────────
+  import type { ChoreDto, MemberDto } from '../types';
+  import { memberFor } from '../state.svelte';
+  import MemberAvatar from '$lib/shared/MemberAvatar.svelte';
+
+  interface Props {
+    open: boolean;
+    /** The target co-sign chore (null while closed). Drives the heading + progress. */
+    chore: ChoreDto | null;
+    members: MemberDto[];
+    /** The viewing user's id — prefilled as a participant. */
+    currentUserId: number;
+    onClose: () => void;
+    /** The chosen NEW participant ids (current user + any newly selected; never the already-in). */
+    onSubmit: (participantUserIds: number[]) => void;
+  }
+
+  let { open, chore, members, currentUserId, onClose, onSubmit }: Props = $props();
+
+  let dialogEl: HTMLDialogElement | null = $state(null);
+
+  // The members who have already completed THIS occurrence — the roster's done members (server field).
+  let alreadyIn = $derived<number[]>(
+    (chore?.roster ?? []).filter((m) => m.state === 'done').map((m) => m.userId),
+  );
+
+  // The members the user can newly select (everyone NOT already in). The
+  // current user, if not already in, is prefilled (see `selected` seeding).
+  let selectable = $derived(members.filter((m) => !alreadyIn.includes(m.userId)));
+
+  // Newly-selected participant ids (excludes the already-in contributors). A
+  // Set swapped by reference so the `$state` reactivity fires.
+  let selected = $state(new Set<number>());
+
+  // (Re)seed the selection whenever the dialog opens for a chore: prefill the
+  // current user if they haven't already signed. Tracking `open`/`chore` makes
+  // this re-run on each open (and on a target change).
+  $effect(() => {
+    if (!dialogEl) return;
+    if (open && !dialogEl.open) {
+      const next = new Set<number>();
+      const doneIds = (chore?.roster ?? []).filter((m) => m.state === 'done').map((m) => m.userId);
+      if (chore && !doneIds.includes(currentUserId)) {
+        next.add(currentUserId);
+      }
+      selected = next;
+      dialogEl.showModal();
+    } else if (!open && dialogEl.open) {
+      dialogEl.close();
+    }
+  });
+
+  function toggle(userId: number): void {
+    const next = new Set(selected);
+    if (next.has(userId)) next.delete(userId);
+    else next.add(userId);
+    selected = next;
+  }
+
+  function nameOf(userId: number): string {
+    if (userId === currentUserId) return 'You';
+    return memberFor(userId)?.displayName ?? 'Someone';
+  }
+
+  // At least the current user (or one newly-selected member) is required to
+  // submit. If the user is already in, they must pick someone new.
+  let canSubmit = $derived(selected.size > 0);
+
+  function submit(): void {
+    if (!canSubmit) return;
+    // The server dedupes against existing contributors, but we send only the
+    // NEW ids ("who's signing now") — never re-send the already-in.
+    onSubmit([...selected]);
+  }
+</script>
+
+<dialog bind:this={dialogEl} onclose={onClose} class="ch-dialog">
+  {#if open && chore}
+    <div class="ch-dialog-body">
+      <h2>Mark done</h2>
+      <p class="ch-dialog-sub">
+        “{chore.name}” needs {chore.requiredCount} people — {chore.completedCount} of {chore.requiredCount}
+        done. Who's marking it done?
+      </p>
+
+      {#if alreadyIn.length > 0}
+        <div class="ch-cd-already">
+          <span class="ch-cd-already-label">Already in</span>
+          <div class="ch-cd-already-list">
+            {#each alreadyIn as uid (uid)}
+              {@const m = memberFor(uid)}
+              <span class="ch-cd-already-chip" title="{nameOf(uid)} has marked this done">
+                <MemberAvatar
+                  name={m?.displayName ?? null}
+                  initials={m?.initials ?? null}
+                  pictureUrl={m?.pictureUrl ?? null}
+                  size={22}
+                  relation="Marked done by"
+                />
+                {nameOf(uid)}
+              </span>
+            {/each}
+          </div>
+        </div>
+      {/if}
+
+      <div class="ch-cd-list" role="group" aria-label="Who's marking this done">
+        {#if selectable.length === 0}
+          <p class="ch-cd-empty">Everyone has already marked this done.</p>
+        {:else}
+          {#each selectable as member (member.userId)}
+            <label class="ch-cd-row" class:checked={selected.has(member.userId)}>
+              <input
+                type="checkbox"
+                checked={selected.has(member.userId)}
+                onchange={() => toggle(member.userId)}
+              />
+              <MemberAvatar
+                name={member.displayName}
+                initials={member.initials}
+                pictureUrl={member.pictureUrl}
+                size={28}
+                relation="Mark done for"
+              />
+              <span class="ch-cd-name">{nameOf(member.userId)}</span>
+            </label>
+          {/each}
+        {/if}
+      </div>
+
+      <div class="ch-dialog-actions">
+        <button type="button" class="ch-btn-ghost" onclick={onClose}>Cancel</button>
+        <button type="button" class="ch-btn-solid" onclick={submit} disabled={!canSubmit}>
+          Mark done
+        </button>
+      </div>
+    </div>
+  {/if}
+</dialog>
+
+<style>
+  /* Gate the layout to [open] so the CLOSED dialog never paints a full-viewport
+     overlay that eats clicks (project memory: dialog-display-css-click-trap). */
+  .ch-dialog[open] {
+    position: fixed;
+    inset: 0;
+    margin: auto;
+    border: none;
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text);
+    padding: 0;
+    width: min(420px, calc(100vw - 32px));
+    max-height: calc(100vh - 32px);
+    box-shadow: var(--shadow-4);
+  }
+  .ch-dialog::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+  }
+  .ch-dialog-body {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 24px;
+  }
+  .ch-dialog h2 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 500;
+  }
+  .ch-dialog-sub {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+
+  /* ── Already-signed contributors ──────────────────────────────────────── */
+  .ch-cd-already {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .ch-cd-already-label {
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-text-muted);
+  }
+  .ch-cd-already-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .ch-cd-already-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.8125rem;
+    color: var(--color-text);
+    background: var(--color-action-hover);
+    border-radius: var(--radius-sm);
+    padding: 4px 10px 4px 4px;
+  }
+
+  /* ── Selectable participants ──────────────────────────────────────────── */
+  .ch-cd-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: 4px;
+  }
+  .ch-cd-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    text-align: left;
+    font: inherit;
+    color: inherit;
+    background: transparent;
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-sm);
+    padding: 10px 12px;
+    min-height: 48px;
+    cursor: pointer;
+    transition:
+      background-color 0.15s,
+      border-color 0.15s;
+  }
+  .ch-cd-row:hover {
+    background: var(--color-action-hover);
+    border-color: var(--color-line-strong);
+  }
+  .ch-cd-row.checked {
+    border-color: var(--color-primary);
+    background: var(--color-action-hover);
+  }
+  .ch-cd-row input[type='checkbox'] {
+    width: 18px;
+    height: 18px;
+    accent-color: var(--color-primary);
+    cursor: pointer;
+  }
+  .ch-cd-name {
+    font-weight: 500;
+    flex: 1;
+    min-width: 0;
+  }
+  .ch-cd-empty {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+
+  .ch-dialog-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 8px;
+  }
+  .ch-btn-ghost {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    border: none;
+    cursor: pointer;
+    min-height: 40px;
+    font-weight: 500;
+    background: transparent;
+    color: var(--color-primary);
+  }
+  .ch-btn-ghost:hover {
+    background: var(--color-action-hover);
+  }
+  .ch-btn-solid {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    border: none;
+    cursor: pointer;
+    min-height: 40px;
+    font-weight: 500;
+    background: var(--color-primary);
+    color: #fff;
+  }
+  .ch-btn-solid:hover:not(:disabled) {
+    background: var(--color-primary-hover);
+  }
+  .ch-btn-solid:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+</style>

--- a/frontend/app/src/lib/chores/lib/components/DigestSettings.svelte
+++ b/frontend/app/src/lib/chores/lib/components/DigestSettings.svelte
@@ -1,0 +1,553 @@
+<script lang="ts">
+  // ─────────────────────────────────────────────────────────────────────────
+  // Digest-settings sheet (WP-11). A bottom sheet to configure the household's
+  // weekly Discord digest: enabled toggle, send day + hour, and a WRITE-ONLY
+  // webhook field.
+  //
+  // ⚠ MN7 (write-only webhook): the stored webhook URL is NEVER fetched,
+  //   rendered, or logged here. GET returns only `hasWebhook` + `webhookHint`.
+  //   The input is type="url" + autocomplete="off"; the value is sent to the
+  //   server only when the user has typed something (webhookAction:'set').
+  //   "Remove" sends webhookAction:'clear'; an untouched input sends 'keep'.
+  //
+  // ⚠ MN9 (no client date math): lastSentAt is an ISO-8601 UTC string.
+  //   We render it with `new Date(isoString).toLocaleString()` — constructing a
+  //   Date from a full ISO timestamp (NOT from 'YYYY-MM-DD') is safe in all
+  //   timezones. We never use `new Date('YYYY-MM-DD')`.
+  // ─────────────────────────────────────────────────────────────────────────
+  import type { DigestDay, DigestSettingsView, DigestSettingsUpdate, WebhookAction } from '../types';
+  import { getDigestSettings, updateDigestSettings, ApiError } from '../api';
+  import { showToast } from '$lib/shared/toast-store.svelte';
+
+  interface Props {
+    open: boolean;
+    onClose: () => void;
+  }
+
+  let { open, onClose }: Props = $props();
+
+  // ── Form state ────────────────────────────────────────────────────────────
+  let enabled = $state(false);
+  let sendDayOfWeek = $state<DigestDay>('sunday');
+  let sendHourLocal = $state(9);
+
+  /**
+   * Tri-state webhook control:
+   *  - 'keep'  — input untouched; send webhookAction:'keep'
+   *  - 'set'   — user has typed a new URL; send webhookAction:'set' + webhookUrl
+   *  - 'clear' — user clicked Remove; send webhookAction:'clear'
+   * We track the intent here so 'keep' is the default when the user opens the
+   * sheet and does not touch the webhook field.
+   */
+  let webhookAction = $state<WebhookAction>('keep');
+  /**
+   * The new URL the user typed. ONLY sent to the server when webhookAction='set'.
+   * Never logged, never rendered back, never placed in a query string (MN7).
+   */
+  let pendingWebhookUrl = $state('');
+
+  /** The last-loaded view (for the status display + reset). */
+  let view = $state<DigestSettingsView | null>(null);
+  let loadError = $state<string | null>(null);
+  let fetchInFlight = $state(false);
+  let submitting = $state(false);
+  let localError = $state<string | null>(null);
+
+  let dialogEl: HTMLDialogElement | null = $state(null);
+
+  const DAYS: { id: DigestDay; label: string }[] = [
+    { id: 'sunday', label: 'Sun' },
+    { id: 'monday', label: 'Mon' },
+    { id: 'tuesday', label: 'Tue' },
+    { id: 'wednesday', label: 'Wed' },
+    { id: 'thursday', label: 'Thu' },
+    { id: 'friday', label: 'Fri' },
+    { id: 'saturday', label: 'Sat' },
+  ];
+
+  /** Format hour 0–23 as a friendly AM/PM label. */
+  function formatHour(h: number): string {
+    if (h === 0) return '12 AM (midnight)';
+    if (h === 12) return '12 PM (noon)';
+    return h < 12 ? `${h} AM` : `${h - 12} PM`;
+  }
+
+  function resetForm(v: DigestSettingsView): void {
+    enabled = v.enabled;
+    sendDayOfWeek = v.sendDayOfWeek;
+    sendHourLocal = v.sendHourLocal;
+    webhookAction = 'keep';
+    pendingWebhookUrl = '';
+    localError = null;
+  }
+
+  async function load(): Promise<void> {
+    fetchInFlight = true;
+    loadError = null;
+    try {
+      const v = await getDigestSettings();
+      view = v;
+      resetForm(v);
+    } catch (e) {
+      loadError =
+        e instanceof ApiError
+          ? `Couldn't load digest settings (HTTP ${e.status}).`
+          : "Couldn't load digest settings right now.";
+    } finally {
+      fetchInFlight = false;
+    }
+  }
+
+  $effect(() => {
+    if (!dialogEl) return;
+    if (open && !dialogEl.open) {
+      dialogEl.showModal();
+      // Load fresh settings each time the sheet opens.
+      void load();
+    } else if (!open && dialogEl.open) {
+      dialogEl.close();
+    }
+  });
+
+  /** Called when the user types in the "Replace webhook" input. */
+  function onWebhookInput(e: Event): void {
+    const val = (e.currentTarget as HTMLInputElement).value;
+    // Updating pendingWebhookUrl; do NOT log val (MN7).
+    pendingWebhookUrl = val;
+    webhookAction = val.length > 0 ? 'set' : 'keep';
+  }
+
+  /** "Remove" clears the stored URL (sends webhookAction:'clear'). */
+  function handleRemoveWebhook(): void {
+    pendingWebhookUrl = '';
+    webhookAction = 'clear';
+  }
+
+  /** Undo a pending Remove or Replace (revert to 'keep'). */
+  function handleKeepWebhook(): void {
+    pendingWebhookUrl = '';
+    webhookAction = 'keep';
+  }
+
+  async function handleSubmit(e: SubmitEvent): Promise<void> {
+    e.preventDefault();
+    if (submitting) return;
+
+    // Validate: if the user is setting a new URL it must be non-empty.
+    if (webhookAction === 'set' && !pendingWebhookUrl.trim()) {
+      localError = 'Paste a Discord webhook URL to save it, or leave the field empty to keep the current one.';
+      return;
+    }
+
+    localError = null;
+    submitting = true;
+
+    const body: DigestSettingsUpdate = {
+      enabled,
+      cadence: 'weekly',
+      sendDayOfWeek,
+      sendHourLocal,
+      webhookAction,
+      // Include webhookUrl ONLY when setting — never send it on keep/clear (MN7).
+      ...(webhookAction === 'set' ? { webhookUrl: pendingWebhookUrl } : {}),
+    };
+
+    try {
+      const updated = await updateDigestSettings(body);
+      view = updated;
+      // Reset the webhook input to 'keep' after a successful save so re-opening
+      // the sheet doesn't re-show the typed URL.
+      resetForm(updated);
+      showToast({ message: 'Digest settings saved.', kind: 'success' });
+      onClose();
+    } catch (e) {
+      if (e instanceof ApiError && e.isClientRejection) {
+        localError = "The settings couldn't be saved — check the webhook URL.";
+        showToast({ message: "Digest settings couldn't be saved.", kind: 'error' });
+      } else {
+        showToast({ message: 'Something went wrong saving digest settings.', kind: 'error' });
+      }
+    } finally {
+      submitting = false;
+    }
+  }
+
+  /**
+   * Render a lastSentAt ISO-8601 UTC string as a human-friendly local time.
+   * We construct Date from the full ISO timestamp (includes time + 'Z') —
+   * this is MN9-safe. NEVER use `new Date('YYYY-MM-DD')`.
+   */
+  function formatLastSent(iso: string): string {
+    // Full ISO-8601 UTC string (e.g. "2026-05-30T09:00:00Z") is safe to parse
+    // because it includes the time component and the 'Z' offset — no ambiguous
+    // date-only string involved (MN9 safe).
+    return new Date(iso).toLocaleString();
+  }
+</script>
+
+<dialog bind:this={dialogEl} onclose={onClose} class="ch-sheet">
+  <form method="dialog" onsubmit={handleSubmit}>
+    <header class="ch-sheet-head">
+      <h2>Weekly Digest</h2>
+    </header>
+
+    <div class="ch-sheet-body">
+      {#if fetchInFlight}
+        <p class="ch-hint">Loading settings…</p>
+      {:else if loadError}
+        <p class="ch-sheet-error" role="alert">{loadError}</p>
+        <button type="button" class="ch-btn-ghost" onclick={load}>Retry</button>
+      {:else if view}
+        <!-- Enabled toggle -->
+        <label class="ch-field ch-toggle-field">
+          <span class="ch-field-label">Send weekly digest</span>
+          <input
+            type="checkbox"
+            role="switch"
+            bind:checked={enabled}
+            aria-label="Enable weekly digest"
+          />
+        </label>
+
+        <!-- Send day -->
+        <fieldset class="ch-field" disabled={!enabled}>
+          <legend class="ch-field-label">Send day</legend>
+          <div class="ch-chip-row" role="group" aria-label="Send day of week">
+            {#each DAYS as day (day.id)}
+              <button
+                type="button"
+                class="ch-chip"
+                class:active={sendDayOfWeek === day.id}
+                aria-pressed={sendDayOfWeek === day.id}
+                onclick={() => (sendDayOfWeek = day.id)}
+              >
+                {day.label}
+              </button>
+            {/each}
+          </div>
+        </fieldset>
+
+        <!-- Send hour -->
+        <fieldset class="ch-field" disabled={!enabled}>
+          <legend class="ch-field-label">Send time (local)</legend>
+          <div class="ch-hour-row">
+            <input
+              type="range"
+              min="0"
+              max="23"
+              step="1"
+              bind:value={sendHourLocal}
+              aria-label="Send hour"
+              class="ch-hour-slider"
+            />
+            <span class="ch-hour-label">{formatHour(sendHourLocal)}</span>
+          </div>
+        </fieldset>
+
+        <!-- Webhook (WRITE-ONLY — MN7) -->
+        <fieldset class="ch-field">
+          <legend class="ch-field-label">Discord webhook</legend>
+
+          <!-- Status display: show hasWebhook + hint. NEVER show the actual URL. -->
+          <p class="ch-hint ch-webhook-status">
+            {#if webhookAction === 'clear'}
+              <span class="ch-webhook-pending-clear">Will be removed on save.</span>
+            {:else if view.hasWebhook && webhookAction === 'keep'}
+              Webhook set ••••{view.webhookHint ?? ''}
+            {:else if !view.hasWebhook && webhookAction === 'keep'}
+              Not configured
+            {:else if webhookAction === 'set'}
+              New webhook will be saved.
+            {/if}
+          </p>
+
+          {#if webhookAction === 'clear'}
+            <!-- Pending removal — offer an undo -->
+            <button type="button" class="ch-btn-ghost ch-webhook-undo" onclick={handleKeepWebhook}>
+              Undo remove
+            </button>
+          {:else if webhookAction === 'set'}
+            <!-- URL typed — show the input + offer to cancel the replacement -->
+            <input
+              type="url"
+              autocomplete="off"
+              placeholder="https://discord.com/api/webhooks/…"
+              class="ch-webhook-input"
+              aria-label="New Discord webhook URL"
+              value={pendingWebhookUrl}
+              oninput={onWebhookInput}
+            />
+            <button type="button" class="ch-btn-ghost ch-webhook-undo" onclick={handleKeepWebhook}>
+              Cancel replacement
+            </button>
+          {:else}
+            <!-- 'keep' state — show the replace input + optional Remove -->
+            <input
+              type="url"
+              autocomplete="off"
+              placeholder={view.hasWebhook ? 'Paste a new URL to replace it' : 'Paste Discord webhook URL'}
+              class="ch-webhook-input"
+              aria-label="Replace Discord webhook URL"
+              value={pendingWebhookUrl}
+              oninput={onWebhookInput}
+            />
+            {#if view.hasWebhook}
+              <button
+                type="button"
+                class="ch-btn-ghost ch-webhook-remove"
+                onclick={handleRemoveWebhook}
+              >
+                Remove webhook
+              </button>
+            {/if}
+          {/if}
+        </fieldset>
+
+        <!-- Last sent -->
+        {#if view.lastSentAt}
+          <p class="ch-hint ch-last-sent">
+            Last sent: {formatLastSent(view.lastSentAt)}
+          </p>
+        {/if}
+
+        {#if localError}
+          <p class="ch-sheet-error" role="alert">{localError}</p>
+        {/if}
+      {/if}
+    </div>
+
+    <footer class="ch-sheet-actions">
+      <button type="button" class="ch-btn-ghost" onclick={onClose} disabled={submitting}>
+        Cancel
+      </button>
+      <button
+        type="submit"
+        class="ch-btn-primary"
+        disabled={submitting || fetchInFlight || !!loadError}
+      >
+        {submitting ? 'Saving…' : 'Save settings'}
+      </button>
+    </footer>
+  </form>
+</dialog>
+
+<style>
+  .ch-sheet {
+    border: none;
+    padding: 0;
+    background: var(--color-surface);
+    color: var(--color-text);
+    box-shadow: var(--shadow-4);
+    width: min(520px, 100vw);
+    max-height: 90vh;
+    margin: auto auto 0;
+    border-radius: var(--radius-md) var(--radius-md) 0 0;
+  }
+  @media (min-width: 600px) {
+    .ch-sheet {
+      margin: auto;
+      border-radius: var(--radius-md);
+    }
+  }
+  .ch-sheet::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+  }
+  .ch-sheet form {
+    display: flex;
+    flex-direction: column;
+    max-height: 90vh;
+  }
+  .ch-sheet-head {
+    padding: 20px 24px 8px;
+  }
+  .ch-sheet-head h2 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 500;
+  }
+  .ch-sheet-body {
+    overflow-y: auto;
+    padding: 8px 24px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+  }
+
+  .ch-field {
+    border: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .ch-field[disabled] {
+    opacity: 0.45;
+    pointer-events: none;
+  }
+  .ch-field-label {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--color-text-muted);
+    padding: 0;
+  }
+
+  /* Toggle row */
+  .ch-toggle-field {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .ch-toggle-field input[type='checkbox'] {
+    width: 44px;
+    height: 24px;
+    cursor: pointer;
+    accent-color: var(--color-primary);
+  }
+
+  /* Day chips */
+  .ch-chip-row {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+  }
+  .ch-chip {
+    font: inherit;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    border: 1px solid var(--color-line-strong);
+    background: transparent;
+    color: var(--color-text-muted);
+    padding: 6px 10px;
+    min-height: 36px;
+    border-radius: 18px;
+    cursor: pointer;
+    transition:
+      background-color 0.15s,
+      color 0.15s,
+      border-color 0.15s;
+  }
+  .ch-chip.active {
+    background: var(--color-primary);
+    border-color: var(--color-primary);
+    color: #fff;
+  }
+  .ch-chip:hover:not(.active) {
+    background: var(--color-action-hover);
+    color: var(--color-text);
+  }
+
+  /* Hour slider */
+  .ch-hour-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+  .ch-hour-slider {
+    flex: 1;
+    accent-color: var(--color-primary);
+    cursor: pointer;
+  }
+  .ch-hour-label {
+    font-size: 0.875rem;
+    color: var(--color-text);
+    min-width: 108px;
+    white-space: nowrap;
+  }
+
+  /* Webhook */
+  .ch-webhook-status {
+    margin-bottom: 4px;
+  }
+  .ch-webhook-pending-clear {
+    color: var(--color-error);
+    font-style: italic;
+  }
+  .ch-webhook-input {
+    font: inherit;
+    color: inherit;
+    padding: 10px 12px;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    min-height: 44px;
+    width: 100%;
+    box-sizing: border-box;
+  }
+  .ch-webhook-input:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -1px;
+    border-color: var(--color-primary);
+  }
+  .ch-webhook-remove {
+    align-self: flex-start;
+    color: var(--color-error);
+    font-size: 0.875rem;
+    padding: 4px 0;
+  }
+  .ch-webhook-remove:hover {
+    background: transparent;
+    text-decoration: underline;
+  }
+  .ch-webhook-undo {
+    align-self: flex-start;
+    font-size: 0.875rem;
+    padding: 4px 0;
+  }
+
+  .ch-last-sent {
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+    margin: 0;
+  }
+
+  .ch-hint {
+    margin: 0;
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+  }
+  .ch-sheet-error {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--color-error);
+  }
+
+  .ch-sheet-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 16px 24px calc(20px + env(safe-area-inset-bottom, 0px));
+    border-top: 1px solid var(--color-line);
+  }
+  .ch-btn-ghost,
+  .ch-btn-primary {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    border: none;
+    cursor: pointer;
+    min-height: 44px;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+  }
+  .ch-btn-ghost {
+    background: transparent;
+    color: var(--color-primary);
+  }
+  .ch-btn-ghost:hover:not(:disabled) {
+    background: var(--color-action-hover);
+  }
+  .ch-btn-primary {
+    background: var(--color-primary);
+    color: #fff;
+    box-shadow: var(--shadow-1);
+  }
+  .ch-btn-primary:hover:not(:disabled) {
+    background: var(--color-primary-hover);
+  }
+  .ch-btn-primary:disabled,
+  .ch-btn-ghost:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+</style>

--- a/frontend/app/src/lib/chores/lib/components/EditChoreSheet.svelte
+++ b/frontend/app/src/lib/chores/lib/components/EditChoreSheet.svelte
@@ -1,0 +1,1296 @@
+<script lang="ts">
+  // ───────────────────────────────────────────────────────────────────────
+  // Edit-chore sheet (WP-10). A bottom sheet pre-filled from an existing
+  // ChoreDto that drives PUT /api/chores/{id} via the store.
+  //
+  //  • Same 3-segment cadence as QuickAddSheet (D4-B; NO monthly-on-day):
+  //      Just once       → OneOff
+  //      Every N days    → Flexible (+ positive intervalDays)
+  //      Specific day(s) → Fixed   (+ a DaysOfWeek selection)
+  //  • Assignment is NOT editable (v1.0 D6 — moves via claim/handoff).
+  //  • Edit-photo (council C4): if the user picks a new file, we upload it
+  //    first (POST /photo → { photoPath }) then include the returned path in
+  //    the PUT body. To keep the existing photo, send the current photoPath
+  //    unchanged. No file in the JSON body (same two-step as QuickAdd C2).
+  //
+  // ⚠ MN9: no `new Date('YYYY-MM-DD')` anywhere. intervalDays is a plain
+  //   positive integer; daysOfWeek is a weekday CSV; anchorDate (one-off due
+  //   date) is the date input's "YYYY-MM-DD" string passed straight through.
+  // ───────────────────────────────────────────────────────────────────────
+  import type { EffortTier, RecurrenceMode, MemberDto, RoomRollupDto, ChoreDto } from '../types';
+  import type { UpdateChoreRequest } from '../api';
+  import { boardStore } from '../state.svelte';
+  import { uploadChorePhoto, createRoom, uploadRoomPhoto } from '../api';
+  import { showToast } from '$lib/shared/toast-store.svelte';
+  import { minFloorDate } from '../dates';
+  import IconPicker from './IconPicker.svelte';
+
+  interface Props {
+    open: boolean;
+    /** The chore being edited — used to pre-fill the form. */
+    chore: ChoreDto | null;
+    /** Household members for the optional owner picker. */
+    members: MemberDto[];
+    /** Room rollups from the board. */
+    rooms: RoomRollupDto[];
+    onClose: () => void;
+  }
+
+  let { open, chore, members, rooms, onClose }: Props = $props();
+
+  type Cadence = 'once' | 'everyN' | 'days';
+
+  // ── Form state ────────────────────────────────────────────────────────────
+  let name = $state('');
+  let description = $state('');
+  /** Optional emoji icon; '' = none. Reuses the shared <IconPicker>. */
+  let choreIcon = $state<string>('');
+  let cadence = $state<Cadence>('once');
+  let intervalDays = $state('3');
+  let selectedDays = $state(new Set<string>());
+  /** "YYYY-MM-DD" for the "Just once" due date; '' = none. Passed straight as anchorDate. */
+  let dueDate = $state('');
+  /**
+   * "YYYY-MM-DD" next-due floor (snooze) for a RECURRING chore; '' = no floor. Pre-filled from the chore's
+   * snoozedUntil; sent as `snoozedUntil` in the PUT (MN4 — passed straight through, no Date construction). Only
+   * surfaced for recurring cadences; for a OneOff the due-date field is the reschedule lever instead.
+   */
+  let nextDueDate = $state('');
+  let effort = $state<EffortTier>('Standard');
+  let roomId = $state<number | null>(null);
+  let ownerUserId = $state<number | null>(null);
+  /**
+   * Single-person assignee (null = up for grabs). Assignment is NOT part of the
+   * PUT contract — it's applied via the dedicated hand-off endpoint after the
+   * metadata save (see handleSubmit). Only meaningful when requiredCount === 1.
+   */
+  let assignTo = $state<number | null>(null);
+  /**
+   * Multi-person roster selection (when requiredCount > 1). Pre-filled from the
+   * chore's current roster; reconciled via the roster assign/leave endpoints on
+   * save. Ignored when requiredCount === 1 (that path uses `assignTo`).
+   */
+  let assignedUserIds = $state<number[]>([]);
+  /** 1 = single person (default); ≥2 = multi-person requirement. */
+  let requiredCount = $state(1);
+  let existingPhotoPath = $state<string | null>(null);
+  let newPhotoFile = $state<File | null>(null);
+  let localError = $state<string | null>(null);
+  let submitting = $state(false);
+  // Delete is a two-tap confirm (irreversible). The store's optimistic remove() handles
+  // rollback + reconcile + error toast; we just close the sheet after firing it.
+  let confirmingDelete = $state(false);
+  let deleting = $state(false);
+
+  // ── Inline "new room" (v1.2 quick win) ─────────────────────────────────────
+  // Create a room without leaving the sheet (the full room manager is deferred —
+  // see ROADMAP Phase 12). Created rooms are merged into the picker chips below
+  // and selected immediately; a later board reload carries them in `rooms`.
+  let createdRooms = $state<RoomRollupDto[]>([]);
+  let showNewRoom = $state(false);
+  let newRoomName = $state('');
+  let newRoomIcon = $state<string>('🧹');
+  let newRoomPhotoFile = $state<File | null>(null);
+  let newRoomError = $state<string | null>(null);
+  let creatingRoom = $state(false);
+
+  let dialogEl: HTMLDialogElement | null = $state(null);
+  let nameInput: HTMLInputElement | null = $state(null);
+
+  const CADENCES: { id: Cadence; label: string }[] = [
+    { id: 'once', label: 'Just once' },
+    { id: 'everyN', label: 'Every N days' },
+    { id: 'days', label: 'Specific day(s)' },
+  ];
+
+  const EFFORTS: { id: EffortTier; label: string }[] = [
+    { id: 'Quick', label: 'Quick' },
+    { id: 'Standard', label: 'Standard' },
+    { id: 'BigJob', label: 'Big job' },
+  ];
+
+  // camelCase flag names — must match the C# [Flags] ChoreDaysOfWeek enum
+  // serialized via JsonStringEnumConverter(CamelCase). Sunday-first.
+  const WEEKDAYS: { flag: string; short: string }[] = [
+    { flag: 'sunday', short: 'Sun' },
+    { flag: 'monday', short: 'Mon' },
+    { flag: 'tuesday', short: 'Tue' },
+    { flag: 'wednesday', short: 'Wed' },
+    { flag: 'thursday', short: 'Thu' },
+    { flag: 'friday', short: 'Fri' },
+    { flag: 'saturday', short: 'Sat' },
+  ];
+
+  // Picker chips = board rooms + any just-created rooms, deduped by id (the board
+  // copy wins once a reload carries real counts). General (roomId null) renders
+  // separately, so it's excluded here.
+  let roomChips = $derived.by(() => {
+    const byId = new Map<number, RoomRollupDto>();
+    for (const r of createdRooms) if (r.roomId !== null) byId.set(r.roomId, r);
+    for (const r of rooms) if (r.roomId !== null) byId.set(r.roomId, r);
+    return [...byId.values()].sort((a, b) => a.sortOrder - b.sortOrder);
+  });
+
+  async function addNewRoom(): Promise<void> {
+    const trimmed = newRoomName.trim();
+    if (!trimmed) {
+      newRoomError = 'Give the room a name.';
+      return;
+    }
+    if (creatingRoom) return;
+    newRoomError = null;
+    creatingRoom = true;
+    try {
+      const created = await createRoom({ name: trimmed, icon: newRoomIcon });
+      // Optional cover photo: upload after create (we now have the room id), then
+      // carry the returned path on the local rollup. A failed upload still keeps
+      // the room — only the photo is skipped (a later board reload reconciles).
+      let createdPhotoPath = created.photoPath;
+      if (newRoomPhotoFile) {
+        try {
+          const up = await uploadRoomPhoto(created.id, newRoomPhotoFile);
+          createdPhotoPath = up.photoPath;
+        } catch {
+          showToast({ message: "Room added, but the photo didn't upload.", kind: 'info' });
+        }
+      }
+      createdRooms = [
+        ...createdRooms,
+        {
+          roomId: created.id,
+          name: created.name,
+          icon: created.icon,
+          photoPath: createdPhotoPath,
+          sortOrder: created.sortOrder,
+          choreCount: 0,
+          dueCount: 0,
+          status: 'clean',
+        },
+      ];
+      roomId = created.id;
+      newRoomName = '';
+      newRoomPhotoFile = null;
+      showNewRoom = false;
+    } catch {
+      newRoomError = "Couldn't create the room — try again.";
+    } finally {
+      creatingRoom = false;
+    }
+  }
+
+  /**
+   * Parse the DTO's camelCase weekday CSV (e.g. "monday, thursday") back into the
+   * weekday flag Set the buttons bind to. Tolerant of spacing/casing so it matches
+   * the WEEKDAYS flags regardless of how the server enum serializes.
+   */
+  function parseDaysOfWeek(csv: string | null): Set<string> {
+    if (!csv) return new Set<string>();
+    return new Set(
+      csv
+        .split(',')
+        .map((s) => s.trim().toLowerCase())
+        .filter(Boolean),
+    );
+  }
+
+  /** Derive the cadence + sub-values from the ChoreDto when pre-filling. */
+  function choreToFormState(c: ChoreDto): void {
+    name = c.name;
+    description = c.description ?? '';
+    choreIcon = c.icon ?? '';
+    roomId = c.roomId ?? null;
+    effort = c.effortTier;
+    ownerUserId = c.ownerUserId ?? null;
+    // Single-person assignment, pre-filled from the chore's CURRENT holder
+    // (assigned or claimed); a None/pile chore reads as "Up for grabs" (null).
+    assignTo = c.assignmentKind !== 'none' ? (c.assigneeUserId ?? null) : null;
+    // Multi-person roster pre-fill — everyone currently on the roster (the board
+    // payload carries the authoritative roster for X>1 chores).
+    assignedUserIds = c.roster.map((m) => m.userId);
+    requiredCount = c.requiredCount ?? 1;
+    existingPhotoPath = c.photoPath;
+    newPhotoFile = null;
+    localError = null;
+    confirmingDelete = false;
+    deleting = false;
+    // One-off due date (anchorDate "YYYY-MM-DD"). Pre-filled unconditionally so it
+    // survives toggling cadence away from and back to "Just once" within an edit.
+    dueDate = c.anchorDate ?? '';
+    // Next-due floor (snooze) for a recurring chore — pre-filled ONLY when the floor is ACTIVE
+    // (server-computed `isSnoozed` = today < snoozedUntil; NO client date math). An expired floor reads
+    // blank so an unrelated edit never re-sends a past date — which the server now rejects (ValidateFloor).
+    nextDueDate = c.isSnoozed ? (c.snoozedUntil ?? '') : '';
+
+    // Map recurrenceMode → cadence (D4-B; no monthly-on-day). The DTO now echoes
+    // intervalDays + daysOfWeek (camelCase CSV) + anchorDate so we pre-fill the
+    // sub-values too — fixes editing a fixed-weekly / every-N / dated one-off chore
+    // losing the existing selection.
+    switch (c.recurrenceMode) {
+      case 'OneOff':
+        cadence = 'once';
+        intervalDays = '3';
+        selectedDays = new Set<string>();
+        break;
+      case 'Flexible':
+        cadence = 'everyN';
+        intervalDays = c.intervalDays != null ? String(c.intervalDays) : '3';
+        selectedDays = new Set<string>();
+        break;
+      case 'Fixed':
+        cadence = 'days';
+        intervalDays = '3';
+        selectedDays = parseDaysOfWeek(c.daysOfWeek);
+        break;
+    }
+  }
+
+  $effect(() => {
+    if (!dialogEl) return;
+    if (open && chore && !dialogEl.open) {
+      choreToFormState(chore);
+      dialogEl.showModal();
+      queueMicrotask(() => nameInput?.focus());
+    } else if (!open && dialogEl.open) {
+      dialogEl.close();
+    }
+  });
+
+  function toggleDay(flag: string) {
+    const next = new Set(selectedDays);
+    if (next.has(flag)) next.delete(flag);
+    else next.add(flag);
+    selectedDays = next;
+  }
+
+  /** Toggle a member in the multi-person roster selection (requiredCount > 1). */
+  function toggleAssignee(userId: number) {
+    assignedUserIds = assignedUserIds.includes(userId)
+      ? assignedUserIds.filter((id) => id !== userId)
+      : [...assignedUserIds, userId];
+  }
+
+  function onPhotoChange(e: Event) {
+    const input = e.currentTarget as HTMLInputElement;
+    newPhotoFile = input.files && input.files.length > 0 ? input.files[0] : null;
+  }
+
+  // ── Checklist (optional) — immediate / versionless store ops (Phase 14) ────
+  // These run independently of the sheet's PUT-on-Save flow: each calls the
+  // versionless store path (boardStore.{add,rename,remove}Subtask) at once. The
+  // sheet renders the chore's LIVE subtasks straight off the (deep-reactive)
+  // board chore, so an add/remove reflects without a local mirror. Checking
+  // items is from the card; the sheet manages the list. Never gates completion.
+  let newSubtaskTitle = $state('');
+
+  // Render the checklist from the LIVE board chore (looked up by id), NOT the
+  // `chore` prop. App captures that prop reference when the sheet opens, so a
+  // liveness refetch (~20s) swaps the board proxy underneath and the prop goes
+  // stale — an added item lands on the live proxy but the sheet kept rendering
+  // the old one (it only showed after save/close/reopen). The id-based lookup
+  // always tracks the current proxy, so add/remove/rename reflect immediately.
+  let liveSubtasks = $derived(
+    (chore ? boardStore.choresById.get(chore.id)?.subtasks : null) ?? chore?.subtasks ?? [],
+  );
+
+  function addSubtaskItem(): void {
+    if (!chore) return;
+    const title = newSubtaskTitle.trim();
+    if (!title) return;
+    boardStore.addSubtask(chore.id, title);
+    newSubtaskTitle = '';
+  }
+
+  /** Rename on blur/Enter only when the value actually changed (store ignores blanks/no-ops). */
+  function renameSubtaskItem(subtaskId: number, value: string): void {
+    if (!chore) return;
+    boardStore.renameSubtask(chore.id, subtaskId, value);
+  }
+
+  /** Map the 3-button cadence into the API recurrence fields (D4-B). */
+  function buildRecurrence():
+    | { ok: true; mode: RecurrenceMode; intervalDays: number | null; daysOfWeek: string | null }
+    | { ok: false; message: string } {
+    switch (cadence) {
+      case 'once':
+        return { ok: true, mode: 'OneOff', intervalDays: null, daysOfWeek: null };
+      case 'everyN': {
+        const n = Number(intervalDays);
+        if (!Number.isInteger(n) || n < 1) {
+          return { ok: false, message: 'Enter how many days between this chore (1 or more).' };
+        }
+        return { ok: true, mode: 'Flexible', intervalDays: n, daysOfWeek: null };
+      }
+      case 'days': {
+        if (selectedDays.size === 0) {
+          return { ok: false, message: 'Pick at least one day of the week.' };
+        }
+        const csv = WEEKDAYS.filter((d) => selectedDays.has(d.flag))
+          .map((d) => d.flag)
+          .join(', ');
+        return { ok: true, mode: 'Fixed', intervalDays: null, daysOfWeek: csv };
+      }
+    }
+  }
+
+  async function handleSubmit(e: SubmitEvent) {
+    e.preventDefault();
+    if (submitting || !chore) return;
+    const trimmed = name.trim();
+    if (!trimmed) {
+      localError = 'Give the chore a name.';
+      return;
+    }
+    const recurrence = buildRecurrence();
+    if (!recurrence.ok) {
+      localError = recurrence.message;
+      return;
+    }
+    localError = null;
+    submitting = true;
+
+    try {
+      // Edit-photo flow (council C4): if the user picked a new file, upload it
+      // first to get a photoPath, then include it in the PUT body.
+      // To keep the existing photo, send the current photoPath unchanged.
+      let resolvedPhotoPath: string | null = existingPhotoPath;
+      if (newPhotoFile) {
+        try {
+          const uploadResult = await uploadChorePhoto(chore.id, newPhotoFile);
+          resolvedPhotoPath = uploadResult.photoPath;
+        } catch {
+          // The edit can still proceed without a photo.
+          showToast({ message: "Photo upload failed — saving other changes.", kind: 'info' });
+          resolvedPhotoPath = existingPhotoPath;
+        }
+      }
+
+      const body: UpdateChoreRequest = {
+        name: trimmed,
+        description: description.trim() || null,
+        roomId,
+        recurrenceMode: recurrence.mode,
+        intervalDays: recurrence.intervalDays,
+        // One-off due date: pass the date input's "YYYY-MM-DD" straight through as
+        // anchorDate (no Date construction — MN9). Recurring cadences send null; the
+        // server manages their anchor dates.
+        anchorDate: cadence === 'once' ? dueDate || null : null,
+        daysOfWeek: recurrence.daysOfWeek,
+        dayOfMonth: null,
+        effortTier: effort,
+        icon: choreIcon,
+        ownerUserId,
+        requiredCount,
+        version: chore.version,
+        photoPath: resolvedPhotoPath,
+        // Next-due floor (snooze). For a recurring chore it's the "Next due date" field above (blank ⇒ clear).
+        // For a OneOff there is no floor field — the "Due date" (anchorDate) IS the reschedule lever (sheet
+        // header note): so when the user CHANGES the due date, clear any existing floor so the new date is
+        // authoritative (the calculator uses SnoozedUntil ?? AnchorDate — a stale floor would otherwise silently
+        // override the edit). When the due date is untouched, preserve the floor so an unrelated edit (e.g. a
+        // rename) never drops a card-set snooze. Plain string compare of the date inputs — no Date math (MN4).
+        snoozedUntil:
+          recurrence.mode === 'OneOff'
+            ? (dueDate !== (chore.anchorDate ?? '') ? null : (chore.snoozedUntil ?? null))
+            : nextDueDate || null,
+      };
+
+      // Snapshot the roster BEFORE the save so the multi-person reconcile diffs
+      // against the chore's pre-edit roster (the PUT response carries an empty one).
+      const originalRoster = chore.roster.map((m) => ({ userId: m.userId, state: m.state }));
+
+      await boardStore.edit(chore.id, body);
+
+      // Assignment isn't part of the PUT contract — it moves via the dedicated
+      // claim/hand-off + roster endpoints. Apply it AFTER the metadata save:
+      // boardStore.edit just refreshed this chore's version in the board, so the
+      // follow-on read carries a fresh xmin (no self-409).
+      if (requiredCount === 1) {
+        // Single-person: a member target lands a deliberate Assigned via hand-off;
+        // clearing back to "Up for grabs" returns a held chore to the pile.
+        const currentAssignee =
+          chore.assignmentKind !== 'none' ? (chore.assigneeUserId ?? null) : null;
+        if (assignTo !== currentAssignee) {
+          if (assignTo === null) {
+            if (currentAssignee !== null) await boardStore.handOff(chore.id, null);
+          } else {
+            await boardStore.handOff(chore.id, assignTo);
+          }
+        }
+      } else {
+        // Multi-person: reconcile the named roster to the chosen set (adds/removes
+        // via the roster endpoints, diffed against the pre-edit roster).
+        await boardStore.applyRosterSelection(chore.id, originalRoster, assignedUserIds);
+      }
+
+      onClose();
+    } finally {
+      submitting = false;
+    }
+  }
+
+  async function handleDelete() {
+    if (!chore || deleting) return;
+    deleting = true;
+    try {
+      // Optimistic removal + rollback/reconcile + error toast all live in the store.
+      await boardStore.remove(chore.id);
+      onClose();
+    } finally {
+      deleting = false;
+    }
+  }
+</script>
+
+<dialog bind:this={dialogEl} onclose={onClose} class="ch-sheet">
+  <form method="dialog" onsubmit={handleSubmit}>
+    <header class="ch-sheet-head">
+      <h2>Edit chore</h2>
+    </header>
+
+    <div class="ch-sheet-body">
+      <label class="ch-field">
+        <span class="ch-field-label">What needs doing?</span>
+        <input
+          bind:this={nameInput}
+          type="text"
+          bind:value={name}
+          required
+          autocomplete="off"
+          placeholder="e.g. Wipe down the counters"
+        />
+      </label>
+
+      <label class="ch-field">
+        <span class="ch-field-label">Description (optional)</span>
+        <input
+          type="text"
+          bind:value={description}
+          autocomplete="off"
+          placeholder="Any extra detail…"
+        />
+      </label>
+
+      <fieldset class="ch-field">
+        <legend class="ch-field-label">Icon (optional)</legend>
+        <div class="ch-icon-row">
+          <button
+            type="button"
+            class="ch-chip"
+            class:active={choreIcon === ''}
+            aria-pressed={choreIcon === ''}
+            onclick={() => (choreIcon = '')}
+          >
+            No icon
+          </button>
+          <IconPicker value={choreIcon || null} onSelect={(i) => (choreIcon = i)} label="Chore icon" />
+        </div>
+      </fieldset>
+
+      <fieldset class="ch-field">
+        <legend class="ch-field-label">How often?</legend>
+        <div class="ch-segmented" role="group" aria-label="How often">
+          {#each CADENCES as c (c.id)}
+            <button
+              type="button"
+              class="ch-seg"
+              class:active={cadence === c.id}
+              aria-pressed={cadence === c.id}
+              onclick={() => (cadence = c.id)}
+            >
+              {c.label}
+            </button>
+          {/each}
+        </div>
+
+        {#if cadence === 'once'}
+          <label class="ch-subfield">
+            <span class="ch-subfield-label">Due date (optional)</span>
+            <input type="date" bind:value={dueDate} aria-label="Due date" />
+          </label>
+        {:else if cadence === 'everyN'}
+          <label class="ch-subfield">
+            <span class="ch-subfield-label">Every</span>
+            <input
+              type="text"
+              inputmode="numeric"
+              pattern="[0-9]*"
+              bind:value={intervalDays}
+              class="ch-interval-input"
+              aria-label="Number of days"
+            />
+            <span class="ch-subfield-label">days</span>
+          </label>
+        {:else if cadence === 'days'}
+          <div class="ch-weekdays" role="group" aria-label="Days of the week">
+            {#each WEEKDAYS as day (day.flag)}
+              <button
+                type="button"
+                class="ch-day"
+                class:active={selectedDays.has(day.flag)}
+                aria-pressed={selectedDays.has(day.flag)}
+                onclick={() => toggleDay(day.flag)}
+              >
+                {day.short}
+              </button>
+            {/each}
+          </div>
+        {/if}
+
+        {#if cadence === 'everyN' || cadence === 'days'}
+          <!--
+            Next due date (snooze floor). Recurring-only: a OneOff uses its Due date
+            above. Sent as snoozedUntil in the PUT; the date input's "YYYY-MM-DD" is
+            passed straight through (MN4 — no Date construction). Clearing it un-snoozes.
+          -->
+          <label class="ch-subfield">
+            <span class="ch-subfield-label">Next due date (optional)</span>
+            <input type="date" bind:value={nextDueDate} aria-label="Next due date" min={minFloorDate()} />
+          </label>
+          <p class="ch-hint">
+            Setting a next-due date doesn't change the schedule — this chore will still come due on its normal
+            recurring day(s) from then on.
+          </p>
+        {/if}
+      </fieldset>
+
+      <fieldset class="ch-field">
+        <legend class="ch-field-label">Effort</legend>
+        <div class="ch-chip-row" role="group" aria-label="Effort">
+          {#each EFFORTS as e (e.id)}
+            <button
+              type="button"
+              class="ch-chip"
+              class:active={effort === e.id}
+              aria-pressed={effort === e.id}
+              onclick={() => (effort = e.id)}
+            >
+              {e.label}
+            </button>
+          {/each}
+        </div>
+      </fieldset>
+
+      {#if members.length >= 2}
+        <fieldset class="ch-field">
+          <legend class="ch-field-label">How many people?</legend>
+          <div class="ch-chip-row" role="group" aria-label="How many people">
+            <button
+              type="button"
+              class="ch-chip"
+              class:active={requiredCount === 1}
+              aria-pressed={requiredCount === 1}
+              onclick={() => (requiredCount = 1)}
+            >
+              One person
+            </button>
+            <button
+              type="button"
+              class="ch-chip"
+              class:active={requiredCount > 1}
+              aria-pressed={requiredCount > 1}
+              onclick={() => { if (requiredCount < 2) requiredCount = 2; }}
+            >
+              Needs more than one
+            </button>
+          </div>
+          {#if requiredCount > 1}
+            <div class="ch-chip-row" role="group" aria-label="Number of people needed">
+              {#each { length: members.length - 1 } as _, i (i)}
+                {@const n = i + 2}
+                <button
+                  type="button"
+                  class="ch-chip"
+                  class:active={requiredCount === n}
+                  aria-pressed={requiredCount === n}
+                  onclick={() => (requiredCount = n)}
+                >
+                  Needs {n} people
+                </button>
+              {/each}
+            </div>
+          {/if}
+        </fieldset>
+      {/if}
+
+      <fieldset class="ch-field">
+        <legend class="ch-field-label">Room</legend>
+        <div class="ch-chip-row" role="group" aria-label="Room">
+          <button
+            type="button"
+            class="ch-chip"
+            class:active={roomId === null}
+            aria-pressed={roomId === null}
+            onclick={() => (roomId = null)}
+          >
+            🏠 General
+          </button>
+          {#each roomChips as room (room.roomId ?? 'general')}
+            {#if room.roomId !== null}
+              <button
+                type="button"
+                class="ch-chip"
+                class:active={roomId === room.roomId}
+                aria-pressed={roomId === room.roomId}
+                onclick={() => (roomId = room.roomId)}
+              >
+                {room.icon} {room.name}
+              </button>
+            {/if}
+          {/each}
+          {#if !showNewRoom}
+            <button
+              type="button"
+              class="ch-chip ch-chip-add"
+              onclick={() => {
+                showNewRoom = true;
+                newRoomError = null;
+              }}
+            >
+              ＋ New room
+            </button>
+          {/if}
+        </div>
+
+        {#if showNewRoom}
+          <div class="ch-newroom">
+            <IconPicker value={newRoomIcon} onSelect={(i) => (newRoomIcon = i)} label="New room icon" />
+            <div class="ch-newroom-row">
+              <input
+                type="text"
+                bind:value={newRoomName}
+                autocomplete="off"
+                placeholder="Room name (e.g. Garage)"
+                aria-label="New room name"
+                onkeydown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    addNewRoom();
+                  }
+                }}
+              />
+              <button
+                type="button"
+                class="ch-btn-primary ch-newroom-add"
+                onclick={addNewRoom}
+                disabled={creatingRoom || !newRoomName.trim()}
+              >
+                {creatingRoom ? 'Adding…' : 'Add'}
+              </button>
+              <button
+                type="button"
+                class="ch-btn-ghost"
+                onclick={() => {
+                  showNewRoom = false;
+                  newRoomName = '';
+                  newRoomPhotoFile = null;
+                  newRoomError = null;
+                }}
+                disabled={creatingRoom}
+              >
+                Cancel
+              </button>
+            </div>
+            <label class="ch-newroom-photo">
+              <span class="ch-hint">Cover photo (optional)</span>
+              <input
+                type="file"
+                accept="image/*"
+                onchange={(e) => {
+                  const input = e.currentTarget as HTMLInputElement;
+                  newRoomPhotoFile = input.files && input.files.length > 0 ? input.files[0] : null;
+                }}
+              />
+              {#if newRoomPhotoFile}
+                <span class="ch-hint">{newRoomPhotoFile.name}</span>
+              {/if}
+            </label>
+            {#if newRoomError}
+              <p class="ch-sheet-error" role="alert">{newRoomError}</p>
+            {/if}
+          </div>
+        {/if}
+      </fieldset>
+
+      <fieldset class="ch-field">
+        <legend class="ch-field-label">Minder (optional)</legend>
+        <div class="ch-chip-row" role="group" aria-label="Minder">
+          <button
+            type="button"
+            class="ch-chip"
+            class:active={ownerUserId === null}
+            aria-pressed={ownerUserId === null}
+            onclick={() => (ownerUserId = null)}
+          >
+            No minder
+          </button>
+          {#each members as member (member.userId)}
+            <button
+              type="button"
+              class="ch-chip"
+              class:active={ownerUserId === member.userId}
+              aria-pressed={ownerUserId === member.userId}
+              onclick={() => (ownerUserId = member.userId)}
+            >
+              {member.displayName}
+            </button>
+          {/each}
+        </div>
+      </fieldset>
+
+      <!--
+        Assignment is applied through the dedicated assignment endpoints on save
+        (handleSubmit), NOT the PUT body — so the assignment trio / roster events
+        stay the single source of truth.
+          • single-person (requiredCount === 1): "Assign to" one member, via hand-off.
+          • multi-person (requiredCount > 1): "Assign people", reconciled against the
+            chore's named roster via roster assign/leave.
+        The field tracks the LIVE requiredCount, so flipping "How many people?"
+        above swaps which picker shows.
+      -->
+      {#if requiredCount === 1}
+        <fieldset class="ch-field">
+          <legend class="ch-field-label">Assign to (optional)</legend>
+          <div class="ch-chip-row" role="group" aria-label="Assign to">
+            <button
+              type="button"
+              class="ch-chip"
+              class:active={assignTo === null}
+              aria-pressed={assignTo === null}
+              onclick={() => (assignTo = null)}
+            >
+              Up for grabs
+            </button>
+            {#each members as member (member.userId)}
+              <button
+                type="button"
+                class="ch-chip"
+                class:active={assignTo === member.userId}
+                aria-pressed={assignTo === member.userId}
+                onclick={() => (assignTo = member.userId)}
+              >
+                {member.displayName}
+              </button>
+            {/each}
+          </div>
+          <p class="ch-hint">Pin this on one person, or leave it up for grabs for anyone to claim.</p>
+        </fieldset>
+      {:else}
+        <fieldset class="ch-field">
+          <legend class="ch-field-label">Assign people (optional)</legend>
+          <div class="ch-chip-row" role="group" aria-label="Assign people">
+            {#each members as member (member.userId)}
+              <button
+                type="button"
+                class="ch-chip"
+                class:active={assignedUserIds.includes(member.userId)}
+                aria-pressed={assignedUserIds.includes(member.userId)}
+                onclick={() => toggleAssignee(member.userId)}
+              >
+                {member.displayName}
+              </button>
+            {/each}
+          </div>
+          <p class="ch-hint">
+            Name who's on this one — assigning is a suggestion: anyone can still join (“I'm in”) or
+            step off. Removing someone else needs you to be the chore's minder or creator.
+          </p>
+        </fieldset>
+      {/if}
+
+      {#if chore}
+        <fieldset class="ch-field">
+          <legend class="ch-field-label">Checklist (optional)</legend>
+          {#if liveSubtasks.length > 0}
+            <ul class="ch-subtasks">
+              {#each liveSubtasks as s (s.id)}
+                <li class="ch-subtask-row">
+                  <input
+                    type="text"
+                    class="ch-subtask-input"
+                    value={s.title}
+                    autocomplete="off"
+                    aria-label="Checklist item"
+                    onblur={(e) => renameSubtaskItem(s.id, (e.currentTarget as HTMLInputElement).value)}
+                    onkeydown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault();
+                        (e.currentTarget as HTMLInputElement).blur();
+                      }
+                    }}
+                  />
+                  <button
+                    type="button"
+                    class="ch-subtask-del"
+                    onclick={() => boardStore.removeSubtask(chore.id, s.id)}
+                    title="Remove this item"
+                    aria-label="Remove {s.title}"
+                  >
+                    ×
+                  </button>
+                </li>
+              {/each}
+            </ul>
+          {/if}
+          <div class="ch-subtask-add">
+            <input
+              type="text"
+              class="ch-subtask-input"
+              bind:value={newSubtaskTitle}
+              autocomplete="off"
+              placeholder="Add an item…"
+              aria-label="Add a checklist item"
+              onkeydown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  addSubtaskItem();
+                }
+              }}
+            />
+            <button
+              type="button"
+              class="ch-btn-primary ch-subtask-add-btn"
+              onclick={addSubtaskItem}
+              disabled={!newSubtaskTitle.trim()}
+            >
+              Add
+            </button>
+          </div>
+          <p class="ch-hint">
+            A quick checklist for this chore — anyone can tick items off from the card. It's optional and
+            never needed to finish the chore.
+          </p>
+        </fieldset>
+      {/if}
+
+      <label class="ch-field">
+        <span class="ch-field-label">Photo (optional)</span>
+        {#if existingPhotoPath && !newPhotoFile}
+          <p class="ch-hint">Photo attached — pick a new file to replace it.</p>
+        {/if}
+        <input type="file" accept="image/*" onchange={onPhotoChange} />
+        {#if newPhotoFile}
+          <span class="ch-hint">{newPhotoFile.name} (will replace existing)</span>
+        {/if}
+      </label>
+
+      {#if localError}
+        <p class="ch-sheet-error" role="alert">{localError}</p>
+      {/if}
+    </div>
+
+    <footer class="ch-sheet-actions">
+      {#if confirmingDelete}
+        <span class="ch-delete-confirm-text" role="alert">Delete this chore? This can't be undone.</span>
+        <button
+          type="button"
+          class="ch-btn-ghost"
+          onclick={() => (confirmingDelete = false)}
+          disabled={deleting}
+        >
+          Keep it
+        </button>
+        <button type="button" class="ch-btn-danger" onclick={handleDelete} disabled={deleting}>
+          {deleting ? 'Deleting…' : 'Delete'}
+        </button>
+      {:else}
+        <button
+          type="button"
+          class="ch-btn-danger-ghost ch-delete-trigger"
+          onclick={() => (confirmingDelete = true)}
+          disabled={submitting}
+        >
+          Delete
+        </button>
+        <button type="button" class="ch-btn-ghost" onclick={onClose} disabled={submitting}>
+          Cancel
+        </button>
+        <button type="submit" class="ch-btn-primary" disabled={submitting || !name.trim()}>
+          {submitting ? 'Saving…' : 'Save changes'}
+        </button>
+      {/if}
+    </footer>
+  </form>
+</dialog>
+
+<style>
+  .ch-sheet {
+    border: none;
+    padding: 0;
+    background: var(--color-surface);
+    color: var(--color-text);
+    box-shadow: var(--shadow-4);
+    width: min(520px, 100vw);
+    max-height: 90vh;
+    margin: auto auto 0;
+    border-radius: var(--radius-md) var(--radius-md) 0 0;
+  }
+  @media (min-width: 600px) {
+    .ch-sheet {
+      margin: auto;
+      border-radius: var(--radius-md);
+    }
+  }
+  .ch-sheet::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+  }
+  .ch-sheet form {
+    display: flex;
+    flex-direction: column;
+    max-height: 90vh;
+  }
+  .ch-sheet-head {
+    padding: 20px 24px 8px;
+  }
+  .ch-sheet-head h2 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 500;
+  }
+  .ch-sheet-body {
+    overflow-y: auto;
+    padding: 8px 24px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+  }
+
+  .ch-field {
+    border: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .ch-field-label {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--color-text-muted);
+    padding: 0;
+  }
+  input[type='text'] {
+    font: inherit;
+    color: inherit;
+    padding: 10px 12px;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    min-height: 44px;
+  }
+  input[type='text']:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -1px;
+    border-color: var(--color-primary);
+  }
+  input[type='file'] {
+    font: inherit;
+    color: var(--color-text-muted);
+    font-size: 0.875rem;
+  }
+  input[type='date'] {
+    font: inherit;
+    color: inherit;
+    padding: 10px 12px;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    min-height: 44px;
+  }
+
+  .ch-segmented {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+  }
+  .ch-seg {
+    flex: 1;
+    min-width: 96px;
+    font: inherit;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    border: 1px solid var(--color-line-strong);
+    background: transparent;
+    color: var(--color-text-muted);
+    padding: 8px 10px;
+    min-height: 40px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition:
+      background-color 0.15s,
+      color 0.15s,
+      border-color 0.15s;
+  }
+  .ch-seg.active {
+    background: var(--color-primary);
+    border-color: var(--color-primary);
+    color: #fff;
+  }
+  .ch-seg:hover:not(.active) {
+    background: var(--color-action-hover);
+    color: var(--color-text);
+  }
+
+  .ch-subfield {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+  .ch-subfield-label {
+    color: var(--color-text-muted);
+  }
+  .ch-interval-input {
+    width: 72px;
+    text-align: center;
+  }
+
+  .ch-weekdays {
+    display: flex;
+    gap: 4px;
+    flex-wrap: wrap;
+  }
+  .ch-day {
+    font: inherit;
+    font-size: 0.75rem;
+    font-weight: 500;
+    width: 44px;
+    min-height: 40px;
+    border: 1px solid var(--color-line-strong);
+    background: transparent;
+    color: var(--color-text-muted);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition:
+      background-color 0.15s,
+      color 0.15s,
+      border-color 0.15s;
+  }
+  .ch-day.active {
+    background: var(--color-primary);
+    border-color: var(--color-primary);
+    color: #fff;
+  }
+  .ch-day:hover:not(.active) {
+    background: var(--color-action-hover);
+    color: var(--color-text);
+  }
+
+  .ch-chip-row {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  /* Icon field: the "No icon" chip sits inline with the emoji palette. */
+  .ch-icon-row {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+  .ch-chip {
+    font: inherit;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    border: 1px solid var(--color-line-strong);
+    background: transparent;
+    color: var(--color-text-muted);
+    padding: 6px 14px;
+    min-height: 36px;
+    border-radius: 18px;
+    cursor: pointer;
+    transition:
+      background-color 0.15s,
+      color 0.15s,
+      border-color 0.15s;
+  }
+  .ch-chip.active {
+    background: var(--color-primary);
+    border-color: var(--color-primary);
+    color: #fff;
+  }
+  .ch-chip:hover:not(.active) {
+    background: var(--color-action-hover);
+    color: var(--color-text);
+  }
+
+  /* Inline "new room" (v1.2) */
+  .ch-chip-add {
+    border-style: dashed;
+  }
+  .ch-newroom {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-top: 10px;
+    padding: 12px;
+    border: 1px dashed var(--color-line-strong);
+    border-radius: var(--radius-sm);
+  }
+  .ch-newroom-row {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+  .ch-newroom-row input[type='text'] {
+    flex: 1;
+    min-width: 140px;
+  }
+  .ch-newroom-add {
+    min-height: 44px;
+  }
+  .ch-newroom-photo {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .ch-hint {
+    margin: 0;
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+  }
+  .ch-sheet-error {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--color-error);
+  }
+
+  /* ── Checklist (optional) — manage list within the edit sheet (Phase 14) ── */
+  .ch-subtasks {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .ch-subtask-row,
+  .ch-subtask-add {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .ch-subtask-input {
+    flex: 1;
+    min-width: 0;
+    font: inherit;
+    color: inherit;
+    padding: 10px 12px;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    min-height: 44px;
+  }
+  .ch-subtask-input:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -1px;
+    border-color: var(--color-primary);
+  }
+  .ch-subtask-del {
+    flex-shrink: 0;
+    width: 44px;
+    height: 44px;
+    display: grid;
+    place-items: center;
+    font-size: 1.25rem;
+    line-height: 1;
+    color: var(--color-text-muted);
+    background: transparent;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+  }
+  .ch-subtask-del:hover {
+    background: var(--color-action-hover);
+    color: var(--color-error);
+  }
+  .ch-subtask-add-btn {
+    flex-shrink: 0;
+    min-height: 44px;
+  }
+
+  .ch-sheet-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 16px 24px calc(20px + env(safe-area-inset-bottom, 0px));
+    border-top: 1px solid var(--color-line);
+  }
+  .ch-btn-ghost,
+  .ch-btn-primary {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    border: none;
+    cursor: pointer;
+    min-height: 44px;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+  }
+  .ch-btn-ghost {
+    background: transparent;
+    color: var(--color-primary);
+  }
+  .ch-btn-ghost:hover:not(:disabled) {
+    background: var(--color-action-hover);
+  }
+  .ch-btn-primary {
+    background: var(--color-primary);
+    color: #fff;
+    box-shadow: var(--shadow-1);
+  }
+  .ch-btn-primary:hover:not(:disabled) {
+    background: var(--color-primary-hover);
+  }
+  .ch-btn-primary:disabled,
+  .ch-btn-ghost:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  /* Destructive delete (irreversible — two-tap confirm). */
+  .ch-btn-danger,
+  .ch-btn-danger-ghost {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    min-height: 44px;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+  }
+  .ch-btn-danger {
+    background: var(--color-error);
+    color: #fff;
+    border: none;
+    box-shadow: var(--shadow-1);
+  }
+  .ch-btn-danger:hover:not(:disabled) {
+    filter: brightness(0.92);
+  }
+  .ch-btn-danger-ghost {
+    background: transparent;
+    color: var(--color-error);
+    border: 1px solid var(--color-error);
+  }
+  .ch-btn-danger-ghost:hover:not(:disabled) {
+    background: var(--color-action-hover);
+  }
+  .ch-btn-danger:disabled,
+  .ch-btn-danger-ghost:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  /* Delete sits left; Cancel/Save stay right. */
+  .ch-delete-trigger {
+    margin-right: auto;
+  }
+  .ch-delete-confirm-text {
+    margin-right: auto;
+    align-self: center;
+    font-size: 0.875rem;
+    color: var(--color-text);
+  }
+</style>

--- a/frontend/app/src/lib/chores/lib/components/EquityBoard.svelte
+++ b/frontend/app/src/lib/chores/lib/components/EquityBoard.svelte
@@ -1,0 +1,642 @@
+<script lang="ts">
+  import type { ChoreEquityDto, EquityWindow, CapacityTier } from '../types';
+  import MemberAvatar from '$lib/shared/MemberAvatar.svelte';
+
+  // ───────────────────────────────────────────────────────────────────────
+  // Equity lens (the headline v1.1 view) — a NEUTRAL distribution of who has
+  // carried the household's completion load over a window. NOT a leaderboard:
+  // no ranking, no medals, no "winner/loser", no "behind" labels (M12/MN8).
+  // It's a glanceable "how is the load spread", with a neutral equal-share
+  // reference line so over/under the even split reads as information, not blame.
+  //
+  // ⚠ Contract: `sharePct` / `equalSharePct` are PERCENT 0..100 (WP-02). The bar
+  //   width and the printed value use them DIRECTLY — NO client `* 100`.
+  // ⚠ The falling-behind / up-for-grabs counts come STRAIGHT off the equity
+  //   payload (WP-02 added them) — we never cross-reference the board DTO.
+  // ⚠ All values are server-computed; this component does NO date math (MN9),
+  //   no `new Date('YYYY-MM-DD')`, no dueness/decay recompute.
+  //
+  // The store owns the fetch + window switch + cache invalidation; this is a
+  // pure render of `equity` plus loading/empty/error states. The week/all toggle
+  // calls `onWindow`, which updates the store's `equityWindow` and triggers a
+  // reload via App.svelte's $effect.
+  // ───────────────────────────────────────────────────────────────────────
+
+  interface Props {
+    equity: ChoreEquityDto | null;
+    window: EquityWindow;
+    loading: boolean;
+    error: string | null;
+    /** Switch the reporting window (week/all). Reload happens via the App effect. */
+    onWindow: (window: EquityWindow) => void;
+    /** Retry after an error (re-runs loadEquity for the current window). */
+    onRetry: () => void;
+    /** Set the CURRENT user's own physical-capacity tier (self-only — MN5). */
+    onCapacity: (tier: CapacityTier) => void;
+    /** True while a capacity PATCH is in flight (disables the selector). */
+    savingCapacity: boolean;
+  }
+
+  let { equity, window, loading, error, onWindow, onRetry, onCapacity, savingCapacity }: Props =
+    $props();
+
+  const WINDOWS: { id: EquityWindow; label: string }[] = [
+    { id: 'week', label: 'This week' },
+    { id: 'all', label: 'All time' },
+  ];
+
+  // ── Self-only capacity selector (Phase 15 WP-06, MN5/M6) ──────────────────
+  // The current user sets ONLY their own physical-capacity tier. Descriptive,
+  // never evaluative (M6): "Full" / "Reduced" / "Minimal" describe how much
+  // physical work a member can take on right now — NOT a performance rating.
+  // The selected tier reshapes each member's EXPECTED reference line (below);
+  // it is NOT a target/quota or a blame label.
+  const CAPACITY_TIERS: { id: CapacityTier; label: string }[] = [
+    { id: 'Full', label: 'Full' },
+    { id: 'Reduced', label: 'Reduced' },
+    { id: 'Minimal', label: 'Minimal' },
+  ];
+
+  // The caller's current tier rides the equity payload (null ⇒ Full). No separate fetch (M7/P4).
+  let callerTier = $derived<CapacityTier>(equity?.callerCapacityTier ?? 'Full');
+
+  // Render a percent without trailing-zero noise (e.g. 25 → "25", 41.7 → "41.7").
+  // Pure number formatting — NOT date math. Values already arrive as 0..100.
+  function pct(value: number): string {
+    return Number.isInteger(value) ? String(value) : value.toFixed(1);
+  }
+
+  // Show the strip only when there is a real multi-member distribution; a solo
+  // household (or empty window) is noise as a distribution.
+  let hasDistribution = $derived(
+    equity != null && equity.members.length > 0 && equity.totalCompletions > 0,
+  );
+
+  // ── Planning footprint (Phase 15) ────────────────────────────────────────
+  // The four planning lanes (chores set up / recipes / list items / hand-offs)
+  // are ALL-TIME, un-blended labeled tallies riding `equity.planning` (no new
+  // fetch — M7). They show INDEPENDENTLY of the physical distribution gate above:
+  // a low-physical, high-planning member (the founding case) must still surface,
+  // so this section renders whenever there is ANY planning signal even if
+  // `totalCompletions` is 0. NEVER sum the lanes, NEVER blend with points (MN4);
+  // neutral framing only — no winner/loser, no ranking (M6). Order by display
+  // name (stable, neutral — mirrors the physical rows).
+  let planning = $derived(equity?.planning ?? []);
+
+  let hasPlanningSignal = $derived(
+    planning.some(
+      (m) =>
+        m.choresSetUp + m.recipesAdded + m.listItemsCurated + m.handOffs > 0,
+    ),
+  );
+
+  let planningRows = $derived(
+    [...planning].sort((a, b) => a.displayName.localeCompare(b.displayName)),
+  );
+</script>
+
+<div class="ch-equity">
+  <header class="ch-equity-head">
+    <div class="ch-equity-titles">
+      <h2 class="ch-equity-title">Physical board-load — this week</h2>
+      <p class="ch-equity-sub">How the chore load has been shared — not a scoreboard.</p>
+    </div>
+    <div class="ch-equity-windows" role="group" aria-label="Equity window">
+      {#each WINDOWS as w (w.id)}
+        <button
+          type="button"
+          class="ch-equity-window"
+          class:active={window === w.id}
+          aria-pressed={window === w.id}
+          onclick={() => onWindow(w.id)}
+        >
+          {w.label}
+        </button>
+      {/each}
+    </div>
+  </header>
+
+  <!-- Self-only physical-capacity selector (Phase 15 WP-06). The current user sets ONLY their own tier
+       (MN5). Descriptive, not evaluative (M6): it reshapes that member's EXPECTED reference line below —
+       it is never a score, target, or blame label. -->
+  <div class="ch-cap">
+    <span class="ch-cap-label" id="ch-cap-label">My physical capacity</span>
+    <div class="ch-cap-options" role="group" aria-labelledby="ch-cap-label">
+      {#each CAPACITY_TIERS as tier (tier.id)}
+        <button
+          type="button"
+          class="ch-cap-option"
+          class:active={callerTier === tier.id}
+          aria-pressed={callerTier === tier.id}
+          disabled={savingCapacity}
+          onclick={() => onCapacity(tier.id)}
+        >
+          {tier.label}
+        </button>
+      {/each}
+    </div>
+    <p class="ch-cap-hint">
+      Sets your own expected share of physical chores — descriptive, not a target.
+    </p>
+  </div>
+
+  {#if error}
+    <div class="ch-equity-error" role="alert">
+      <span>{error}</span>
+      <button type="button" class="ch-equity-retry" onclick={onRetry}>Retry</button>
+    </div>
+  {:else if loading && equity == null}
+    <div class="ch-equity-state">Loading the household load…</div>
+  {:else if equity != null && hasDistribution}
+    <section class="ch-equity-dist" aria-label="Per-member share of the load">
+      <!-- Each row is a proportional bar at the member's actual share (`sharePct`).
+           A neutral reference marker sits at THAT member's capacity-weighted EXPECTED
+           share (`expectedSharePct`, Phase 15 WP-06) — so a Reduced/Minimal member's
+           reference shifts to reflect their stated capacity, not a single flat line.
+           Descriptive only — no ranking, no highlight of high/low (M6). Server values
+           verbatim — NO client math (M7/MN9). -->
+      <ul class="ch-equity-rows">
+        {#each equity.members as member (member.userId)}
+          <li class="ch-equity-row">
+            <span class="ch-equity-who">
+              <MemberAvatar
+                name={member.displayName}
+                initials={member.initials}
+                pictureUrl={member.pictureUrl}
+                size={28}
+              />
+              <span class="ch-equity-name">{member.displayName}</span>
+            </span>
+            <span class="ch-equity-track">
+              <span
+                class="ch-equity-bar"
+                style="width: {member.sharePct}%;"
+                aria-hidden="true"
+              ></span>
+              <span
+                class="ch-equity-ref"
+                style="left: {member.expectedSharePct}%;"
+                aria-hidden="true"
+              ></span>
+            </span>
+            <span class="ch-equity-figures">
+              <span class="ch-equity-share">{pct(member.sharePct)}%</span>
+              <span class="ch-equity-points">
+                {member.points}
+                {member.points === 1 ? 'pt' : 'pts'} · {member.completions} done
+              </span>
+            </span>
+          </li>
+        {/each}
+      </ul>
+
+      <p class="ch-equity-legend">
+        <span class="ch-equity-legend-ref" aria-hidden="true"></span>
+        The marker shows each person's expected share, adjusted for their stated capacity.
+      </p>
+
+      <!-- Outstanding work — discrete entries, distinct from the completed-effort
+           bars above. "Up for grabs" = active chores nobody owns (AssignmentKind.None
+           or a stale claim); "Falling behind" = active chores past due. These are
+           household-level CHORE counts (never a per-person blame label, M12/MN8), and
+           come straight off the equity payload (no board cross-reference). -->
+      <div class="ch-equity-outstanding" aria-label="Outstanding work">
+        <div class="ch-equity-stat" aria-label="{equity.upForGrabsCount} up for grabs">
+          <span class="ch-equity-stat-icon" aria-hidden="true">🙋</span>
+          <span class="ch-equity-stat-count">{equity.upForGrabsCount}</span>
+          <span class="ch-equity-stat-label">up for grabs</span>
+        </div>
+        <div class="ch-equity-stat" aria-label="{equity.fallingBehindCount} falling behind">
+          <span class="ch-equity-stat-icon" aria-hidden="true">⏳</span>
+          <span class="ch-equity-stat-count">{equity.fallingBehindCount}</span>
+          <span class="ch-equity-stat-label">falling behind</span>
+        </div>
+      </div>
+    </section>
+  {:else}
+    <div class="ch-equity-state">
+      <p class="ch-equity-empty-head">Nothing logged yet.</p>
+      <p>No completions in this window — the load picture fills in as chores get done.</p>
+    </div>
+  {/if}
+
+  <!-- ── Planning footprint (Phase 15) ─────────────────────────────────────
+       All-time system-building & coordination labor, as neutral labeled
+       tallies per member. Gated on its OWN `hasPlanningSignal` — independent of
+       the physical distribution above — so a low-physical, high-planning member
+       still shows even when this window has zero completions. NO summed total,
+       NO blended score (MN4); descriptive only, ordered by name (M6). Rides
+       `equity.planning` — no new fetch (M7). -->
+  {#if equity != null && hasPlanningSignal}
+    <section class="ch-plan" aria-label="System-building and coordination, all time">
+      <header class="ch-plan-head">
+        <h3 class="ch-plan-title">System-building &amp; coordination — all time</h3>
+        <p class="ch-plan-sub">
+          Setup and coordination work, counted across all time — separate from the
+          physical load above, never blended into a single score.
+        </p>
+      </header>
+      <ul class="ch-plan-rows">
+        {#each planningRows as member (member.userId)}
+          <li class="ch-plan-row">
+            <span class="ch-plan-name">{member.displayName}</span>
+            <span class="ch-plan-tallies">
+              <span class="ch-plan-tally">
+                {member.choresSetUp}
+                {member.choresSetUp === 1 ? 'chore set up' : 'chores set up'}
+              </span>
+              <span class="ch-plan-dot" aria-hidden="true">·</span>
+              <span class="ch-plan-tally">
+                {member.recipesAdded}
+                {member.recipesAdded === 1 ? 'recipe' : 'recipes'}
+              </span>
+              <span class="ch-plan-dot" aria-hidden="true">·</span>
+              <span class="ch-plan-tally">
+                {member.listItemsCurated}
+                {member.listItemsCurated === 1 ? 'list item' : 'list items'}
+              </span>
+              <span class="ch-plan-dot" aria-hidden="true">·</span>
+              <span class="ch-plan-tally">
+                {member.handOffs}
+                {member.handOffs === 1 ? 'hand-off' : 'hand-offs'}
+              </span>
+            </span>
+          </li>
+        {/each}
+      </ul>
+    </section>
+  {/if}
+</div>
+
+<style>
+  .ch-equity {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .ch-equity-head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+  .ch-equity-titles {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .ch-equity-title {
+    margin: 0;
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: var(--color-text);
+  }
+  .ch-equity-sub {
+    margin: 0;
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+  }
+
+  /* ── Window toggle ────────────────────────────────────────────────────── */
+  .ch-equity-windows {
+    display: inline-flex;
+    gap: 2px;
+    padding: 3px;
+    background: var(--color-action-hover);
+    border-radius: var(--radius-md);
+  }
+  .ch-equity-window {
+    font: inherit;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
+    padding: 6px 14px;
+    min-height: 34px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    white-space: nowrap;
+    transition:
+      background-color 0.15s,
+      color 0.15s;
+    -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation;
+  }
+  .ch-equity-window:hover:not(.active) {
+    color: var(--color-text);
+  }
+  .ch-equity-window.active {
+    background: var(--color-surface);
+    color: var(--color-text);
+    box-shadow: var(--shadow-1);
+  }
+  .ch-equity-window:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -2px;
+  }
+
+  /* ── Self-only capacity selector ──────────────────────────────────────── */
+  .ch-cap {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .ch-cap-label {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: var(--color-text);
+  }
+  .ch-cap-options {
+    display: inline-flex;
+    gap: 2px;
+    padding: 3px;
+    background: var(--color-action-hover);
+    border-radius: var(--radius-md);
+    align-self: flex-start;
+  }
+  .ch-cap-option {
+    font: inherit;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
+    padding: 6px 14px;
+    min-height: 34px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    white-space: nowrap;
+    transition:
+      background-color 0.15s,
+      color 0.15s;
+    -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation;
+  }
+  .ch-cap-option:hover:not(.active):not(:disabled) {
+    color: var(--color-text);
+  }
+  .ch-cap-option.active {
+    background: var(--color-surface);
+    color: var(--color-text);
+    box-shadow: var(--shadow-1);
+  }
+  .ch-cap-option:disabled {
+    cursor: default;
+    opacity: 0.7;
+  }
+  .ch-cap-option:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -2px;
+  }
+  .ch-cap-hint {
+    margin: 0;
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+
+  /* ── Distribution rows ────────────────────────────────────────────────── */
+  .ch-equity-dist {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 16px;
+    background: var(--color-action-hover);
+    border-radius: var(--radius-md);
+  }
+  .ch-equity-rows {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+  .ch-equity-row {
+    display: grid;
+    grid-template-columns: minmax(120px, 1fr) minmax(0, 2.4fr) minmax(96px, auto);
+    align-items: center;
+    gap: 12px;
+  }
+  .ch-equity-who {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+  }
+  .ch-equity-name {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--color-text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  /* The bar track + neutral equal-share reference line. */
+  .ch-equity-track {
+    position: relative;
+    height: 16px;
+    background: var(--color-surface);
+    border-radius: 8px;
+    overflow: hidden;
+  }
+  .ch-equity-bar {
+    position: absolute;
+    inset: 0 auto 0 0;
+    height: 100%;
+    /* Neutral single fill — no per-member ranking color, no good/bad scale. */
+    background: var(--color-primary);
+    border-radius: 8px;
+    transition: width 0.2s ease;
+  }
+  .ch-equity-ref {
+    position: absolute;
+    top: -3px;
+    bottom: -3px;
+    width: 0;
+    border-left: 2px dashed var(--color-text-muted);
+    transform: translateX(-1px);
+  }
+
+  .ch-equity-figures {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    line-height: 1.2;
+    text-align: right;
+  }
+  .ch-equity-share {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--color-text);
+    font-variant-numeric: tabular-nums;
+  }
+  .ch-equity-points {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+
+  .ch-equity-legend {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 0;
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .ch-equity-legend-ref {
+    display: inline-block;
+    width: 0;
+    height: 12px;
+    border-left: 2px dashed var(--color-text-muted);
+  }
+
+  /* ── Outstanding work: up-for-grabs / falling-behind ───────────────────── */
+  /* Discrete entries with a dashed edge (= unclaimed / outstanding) so they read
+     distinctly from the solid completed-effort member bars above. */
+  .ch-equity-outstanding {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .ch-equity-stat {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    padding: 7px 12px;
+    background: var(--color-surface);
+    border: 1px dashed var(--color-line-strong);
+    border-radius: var(--radius-sm);
+  }
+  .ch-equity-stat-icon {
+    font-size: 0.9375rem;
+    line-height: 1;
+  }
+  .ch-equity-stat-count {
+    font-size: 0.9375rem;
+    font-weight: 600;
+    color: var(--color-text);
+    font-variant-numeric: tabular-nums;
+  }
+  .ch-equity-stat-label {
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+  }
+
+  /* ── Planning footprint (Phase 15) ────────────────────────────────────── */
+  /* Neutral labeled tallies — plain source nouns, no bars, no ranking, no
+     summed total. Visually a quiet block beneath the physical distribution. */
+  .ch-plan {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 16px;
+    background: var(--color-action-hover);
+    border-radius: var(--radius-md);
+  }
+  .ch-plan-head {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .ch-plan-title {
+    margin: 0;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    color: var(--color-text);
+  }
+  .ch-plan-sub {
+    margin: 0;
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .ch-plan-rows {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .ch-plan-row {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .ch-plan-name {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--color-text);
+  }
+  .ch-plan-tallies {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 6px;
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+  }
+  .ch-plan-tally {
+    font-variant-numeric: tabular-nums;
+  }
+  .ch-plan-dot {
+    color: var(--color-text-muted);
+    opacity: 0.6;
+  }
+
+  /* ── Loading / empty / error states ───────────────────────────────────── */
+  .ch-equity-state {
+    padding: 40px 16px;
+    text-align: center;
+    color: var(--color-text-muted);
+  }
+  .ch-equity-empty-head {
+    font-size: 1.125rem;
+    font-weight: 500;
+    color: var(--color-text);
+    margin: 0 0 4px;
+  }
+  .ch-equity-error {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 16px;
+    background: rgba(229, 57, 53, 0.08);
+    border-left: 4px solid var(--color-error);
+    border-radius: var(--radius-sm);
+    color: var(--color-error);
+    font-size: 0.875rem;
+  }
+  .ch-equity-retry {
+    font: inherit;
+    border: none;
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+    padding: 4px 12px;
+    background: transparent;
+    color: var(--color-error);
+    font-weight: 500;
+  }
+  .ch-equity-retry:hover {
+    background: rgba(229, 57, 53, 0.12);
+  }
+
+  /* Stack the row on narrow viewports so the bar keeps usable width. */
+  @media (max-width: 560px) {
+    .ch-equity-row {
+      grid-template-columns: 1fr;
+      gap: 6px;
+    }
+    .ch-equity-figures {
+      flex-direction: row;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 8px;
+      text-align: left;
+    }
+  }
+</style>

--- a/frontend/app/src/lib/chores/lib/components/HandOffPicker.svelte
+++ b/frontend/app/src/lib/chores/lib/components/HandOffPicker.svelte
@@ -1,0 +1,196 @@
+<script lang="ts">
+  // ───────────────────────────────────────────────────────────────────────
+  // Hand-off picker (WP-11). A small modal listing household members so the
+  // current holder can pass a chore to someone else — or release it back to the
+  // pile ("Leave for anyone"). The parent runs the store `handOff` mutation
+  // (optimistic + 409 reconcile) with the chosen target (null ⇒ pile).
+  // ───────────────────────────────────────────────────────────────────────
+  import type { MemberDto } from '../types';
+  import MemberAvatar from '$lib/shared/MemberAvatar.svelte';
+
+  interface Props {
+    open: boolean;
+    /** Chore name, for the dialog heading. */
+    choreName: string;
+    members: MemberDto[];
+    /** Hide the current holder from the list (no point handing to yourself). */
+    excludeUserId?: number | null;
+    /**
+     * 'handoff' (default) — passing a HELD chore on, with a "Leave for anyone"
+     * pile option. 'assign' — pushing an UP-FOR-GRABS chore onto someone; the
+     * pile option is hidden (it's already in the pile) and the copy says "Assign".
+     * Both call the SAME hand-off mechanism server-side (a member target ⇒ Assigned).
+     */
+    mode?: 'handoff' | 'assign';
+    onClose: () => void;
+    /** targetUserId null ⇒ return to the pile ("Leave for anyone"). */
+    onSelect: (targetUserId: number | null) => void;
+  }
+
+  let { open, choreName, members, excludeUserId = null, mode = 'handoff', onClose, onSelect }: Props =
+    $props();
+
+  let dialogEl: HTMLDialogElement | null = $state(null);
+
+  let isAssign = $derived(mode === 'assign');
+  let heading = $derived(isAssign ? 'Assign chore' : 'Hand off');
+  let subtitle = $derived(
+    isAssign
+      ? `Pick who should take “${choreName}”.`
+      : `Pass “${choreName}” to someone — or leave it for anyone.`,
+  );
+
+  let pickable = $derived(members.filter((m) => m.userId !== excludeUserId));
+
+  $effect(() => {
+    if (!dialogEl) return;
+    if (open && !dialogEl.open) {
+      dialogEl.showModal();
+    } else if (!open && dialogEl.open) {
+      dialogEl.close();
+    }
+  });
+
+  function choose(targetUserId: number | null) {
+    onSelect(targetUserId);
+  }
+</script>
+
+<dialog bind:this={dialogEl} onclose={onClose} class="ch-dialog">
+  <div class="ch-dialog-body">
+    <h2>{heading}</h2>
+    <p class="ch-dialog-sub">{subtitle}</p>
+
+    <div class="ch-handoff-list">
+      {#if !isAssign}
+        <button type="button" class="ch-handoff-row ch-handoff-pile" onclick={() => choose(null)}>
+          <span class="ch-handoff-pile-icon" aria-hidden="true">↩</span>
+          <span class="ch-handoff-name">Leave for anyone</span>
+          <span class="ch-handoff-hint">No one gets nagged</span>
+        </button>
+      {/if}
+
+      {#each pickable as member (member.userId)}
+        <button type="button" class="ch-handoff-row" onclick={() => choose(member.userId)}>
+          <MemberAvatar
+            name={member.displayName}
+            initials={member.initials}
+            pictureUrl={member.pictureUrl}
+            size={28}
+            relation={isAssign ? 'Assign to' : 'Hand off to'}
+          />
+          <span class="ch-handoff-name">{member.displayName}</span>
+        </button>
+      {/each}
+    </div>
+
+    <div class="ch-dialog-actions">
+      <button type="button" class="ch-btn-ghost" onclick={onClose}>Cancel</button>
+    </div>
+  </div>
+</dialog>
+
+<style>
+  .ch-dialog {
+    position: fixed;
+    inset: 0;
+    margin: auto;
+    border: none;
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text);
+    padding: 0;
+    width: min(420px, calc(100vw - 32px));
+    max-height: calc(100vh - 32px);
+    box-shadow: var(--shadow-4);
+  }
+  .ch-dialog::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+  }
+  .ch-dialog-body {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 24px;
+  }
+  .ch-dialog h2 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 500;
+  }
+  .ch-dialog-sub {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+
+  .ch-handoff-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: 4px;
+  }
+  .ch-handoff-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    text-align: left;
+    font: inherit;
+    color: inherit;
+    background: transparent;
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-sm);
+    padding: 10px 12px;
+    min-height: 48px;
+    cursor: pointer;
+    transition:
+      background-color 0.15s,
+      border-color 0.15s;
+  }
+  .ch-handoff-row:hover {
+    background: var(--color-action-hover);
+    border-color: var(--color-line-strong);
+  }
+  .ch-handoff-name {
+    font-weight: 500;
+    flex: 1;
+    min-width: 0;
+  }
+  .ch-handoff-hint {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .ch-handoff-pile-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    background: var(--color-action-hover);
+    color: var(--color-text-muted);
+    font-size: 1rem;
+  }
+
+  .ch-dialog-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 8px;
+  }
+  .ch-btn-ghost {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    border: none;
+    cursor: pointer;
+    min-height: 40px;
+    font-weight: 500;
+    background: transparent;
+    color: var(--color-primary);
+  }
+  .ch-btn-ghost:hover {
+    background: var(--color-action-hover);
+  }
+</style>

--- a/frontend/app/src/lib/chores/lib/components/IconPicker.svelte
+++ b/frontend/app/src/lib/chores/lib/components/IconPicker.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+  // ───────────────────────────────────────────────────────────────────────
+  // IconPicker (v1.2) — a tiny curated emoji palette, reused by the inline
+  // "new room" form (room icon) and the chore add/edit sheets (chore icon).
+  // Emoji match the island's existing visual language (room rollups already
+  // render emoji icons). Pure presentational: the parent owns `value` and is
+  // notified via `onSelect` — no internal state, no date math.
+  // ───────────────────────────────────────────────────────────────────────
+  interface Props {
+    /** Currently-selected icon (emoji), or null for none. */
+    value: string | null;
+    /** Notified with the picked emoji. */
+    onSelect: (icon: string) => void;
+    /** Optional preset palette override. */
+    icons?: string[];
+    /** Accessible group label. */
+    label?: string;
+  }
+
+  // Curated palette covering the standard household rooms people set up, plus
+  // common chore icons. Grouped by area so a room icon is easy to find.
+  const DEFAULT_ICONS = [
+    // Kitchen & dining
+    '🍳', '🍽️', '🥫', '☕',
+    // Living, media & den
+    '🛋️', '📺', '🔥',
+    // Bedrooms & bath
+    '🛏️', '🚿', '🛁', '🚽',
+    // Kids
+    '🧸', '🍼',
+    // Work & study
+    '💻', '📚',
+    // Entry, closet, storage, stairs & utility
+    '🚪', '🧥', '📦', '🪜', '🔧',
+    // Garage, home & outdoors
+    '🚗', '🏡', '🌳', '🪴', '🌿',
+    // Pets
+    '🐾', '🐶', '🐱',
+    // Cleaning & chores
+    '🧹', '🧺', '🧽', '🗑️', '🪟',
+    // Other spaces
+    '🪑', '🏋️',
+  ];
+
+  let { value, onSelect, icons = DEFAULT_ICONS, label = 'Icon' }: Props = $props();
+</script>
+
+<div class="ch-iconpick" role="group" aria-label={label}>
+  {#each icons as icon (icon)}
+    <button
+      type="button"
+      class="ch-iconpick-opt"
+      class:active={value === icon}
+      aria-pressed={value === icon}
+      aria-label={icon}
+      onclick={() => onSelect(icon)}
+    >
+      {icon}
+    </button>
+  {/each}
+</div>
+
+<style>
+  .ch-iconpick {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .ch-iconpick-opt {
+    font: inherit;
+    font-size: 1.125rem;
+    line-height: 1;
+    width: 40px;
+    height: 40px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--color-line-strong);
+    background: transparent;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition:
+      border-color 0.15s,
+      background-color 0.15s,
+      transform 0.1s;
+    -webkit-tap-highlight-color: transparent;
+  }
+  .ch-iconpick-opt:hover:not(.active) {
+    background: var(--color-action-hover);
+  }
+  .ch-iconpick-opt.active {
+    border-color: var(--color-primary);
+    background: var(--color-action-hover);
+    box-shadow: inset 0 0 0 1px var(--color-primary);
+  }
+  .ch-iconpick-opt:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 1px;
+  }
+</style>

--- a/frontend/app/src/lib/chores/lib/components/NeedsAttentionBoard.svelte
+++ b/frontend/app/src/lib/chores/lib/components/NeedsAttentionBoard.svelte
@@ -1,0 +1,169 @@
+<script lang="ts">
+  import type { NeedsAttentionSection } from '../state.svelte';
+  import type { ChoreDto, ChoreLensId } from '../types';
+  import ChoreCard from './ChoreCard.svelte';
+
+  // ───────────────────────────────────────────────────────────────────────
+  // The unified board (Phase 14 — Model A board IA). It ALWAYS sections by
+  // attention (Falling behind → Due now → Coming up, dirtiest-first). The active
+  // PRIMARY FILTER (Up for grabs / Mine / All) decides WHICH chore set is
+  // sectioned — that selection happens upstream in the store (`boardSections`),
+  // so this component just renders whatever sections it's handed.
+  //
+  // ⚠ M11: the sections are a CLIENT-SIDE grouping of the ONE board payload — no
+  // fetch on filter switch. ⚠ M5/M6: ordering + bucketing read the SERVER
+  // `dueState`; no client dueness recompute.
+  //
+  // `filterLens` is used ONLY to pick the empty-state copy for the active filter.
+  // ───────────────────────────────────────────────────────────────────────
+
+  interface Props {
+    sections: NeedsAttentionSection[];
+    /** The active primary filter — drives the empty-state copy only. */
+    filterLens: ChoreLensId;
+    currentUserId: number;
+    /** Total chores in the active filter's set BEFORE the section split (empty state). */
+    totalChores: number;
+    /** True while a mutation for the given chore id is in flight. */
+    isPending: (choreId: number) => boolean;
+    onClaim: (chore: ChoreDto) => void;
+    onDrop: (chore: ChoreDto) => void;
+    onComplete: (chore: ChoreDto) => void;
+    onHandOff: (chore: ChoreDto) => void;
+    onTake: (chore: ChoreDto) => void;
+    onAssign: (chore: ChoreDto) => void;
+    onCommit: (chore: ChoreDto) => void;
+    onLeave: (chore: ChoreDto) => void;
+    onEdit: (chore: ChoreDto) => void;
+    onSnooze: (chore: ChoreDto, request: { days?: number; until?: string | null }) => void;
+  }
+
+  let {
+    sections,
+    filterLens,
+    currentUserId,
+    totalChores,
+    isPending,
+    onClaim,
+    onDrop,
+    onComplete,
+    onHandOff,
+    onTake,
+    onAssign,
+    onCommit,
+    onLeave,
+    onEdit,
+    onSnooze,
+  }: Props = $props();
+
+  // The active filter's set is empty when its pre-section count is 0 (equivalent
+  // to every section being empty). Drive the empty state off `totalChores` so the
+  // count the store computed is the single source for "is the board empty".
+  let hasVisible = $derived(totalChores > 0);
+
+  // Empty-state copy per active primary filter.
+  const EMPTY_COPY: Record<ChoreLensId, { head: string; body: string }> = {
+    'up-for-grabs': { head: 'Nothing up for grabs.', body: 'Every chore has someone on it. Nice.' },
+    mine: { head: 'Nothing on your plate.', body: "You're not holding any chores right now." },
+    'needs-attention': { head: 'All clear.', body: 'No active chores right now.' },
+    // The organizers (rooms/equity/recap) never render this board, but the map must be total.
+    rooms: { head: 'All clear.', body: 'No active chores right now.' },
+    equity: { head: 'All clear.', body: 'No active chores right now.' },
+    recap: { head: 'All clear.', body: 'No active chores right now.' },
+  };
+  let emptyCopy = $derived(EMPTY_COPY[filterLens] ?? EMPTY_COPY['needs-attention']);
+</script>
+
+<div class="ch-board">
+  {#if hasVisible}
+    {#each sections as section (section.id)}
+      <section class="ch-section">
+        <header class="ch-section-head">
+          <h2 class="ch-section-title">{section.title}</h2>
+          <span class="ch-section-count">{section.chores.length}</span>
+        </header>
+        <div class="ch-section-cards">
+          {#each section.chores as chore (chore.id)}
+            <ChoreCard
+              {chore}
+              {currentUserId}
+              pending={isPending(chore.id)}
+              {onClaim}
+              {onDrop}
+              {onComplete}
+              {onHandOff}
+              {onTake}
+              {onAssign}
+              {onCommit}
+              {onLeave}
+              {onEdit}
+              {onSnooze}
+            />
+          {/each}
+        </div>
+      </section>
+    {/each}
+  {:else}
+    <div class="ch-board-empty">
+      <p class="ch-board-empty-head">{emptyCopy.head}</p>
+      <p>{emptyCopy.body}</p>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .ch-board {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+  }
+
+  .ch-section {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .ch-section-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .ch-section-title {
+    margin: 0;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-text-muted);
+  }
+  .ch-section-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 22px;
+    height: 22px;
+    padding: 0 7px;
+    border-radius: 11px;
+    background: var(--color-action-hover);
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--color-text-muted);
+  }
+  .ch-section-cards {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .ch-board-empty {
+    padding: 48px 16px;
+    text-align: center;
+    color: var(--color-text-muted);
+  }
+  .ch-board-empty-head {
+    font-size: 1.125rem;
+    font-weight: 500;
+    color: var(--color-text);
+    margin: 0 0 4px;
+  }
+</style>

--- a/frontend/app/src/lib/chores/lib/components/PhotoLightbox.svelte
+++ b/frontend/app/src/lib/chores/lib/components/PhotoLightbox.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+  // ───────────────────────────────────────────────────────────────────────
+  // PhotoLightbox (v1.2) — the single shared tap-to-enlarge overlay. Reads the
+  // module lightbox store and renders the active photo in a native <dialog>,
+  // the same pattern the sheets use (showModal() + ::backdrop). Tap anywhere
+  // dismisses; Esc closes natively. Mounted ONCE in App.svelte.
+  //
+  // The <dialog> fills the viewport and centers the image so the whole surface
+  // is a dismiss target (matching the zoom-out cursor on the photo).
+  //
+  // ⚠ Never trigger window.alert/confirm here — this is the <dialog> overlay.
+  // ───────────────────────────────────────────────────────────────────────
+  import { lightbox, closePhoto } from '../lightbox.svelte';
+
+  let dialogEl: HTMLDialogElement | null = $state(null);
+  let lb = $derived(lightbox());
+
+  $effect(() => {
+    if (!dialogEl) return;
+    if (lb.src && !dialogEl.open) dialogEl.showModal();
+    else if (!lb.src && dialogEl.open) dialogEl.close();
+  });
+
+  // A photo viewer dismisses on tap anywhere (image or backdrop) — the natural
+  // mobile gesture; Esc also closes via the dialog's native `onclose`.
+  function onClick() {
+    closePhoto();
+  }
+</script>
+
+<dialog
+  bind:this={dialogEl}
+  class="ch-lightbox"
+  onclose={closePhoto}
+  onclick={onClick}
+  aria-label="Enlarged photo"
+>
+  {#if lb.src}
+    <img class="ch-lightbox-img" src={lb.src} alt={lb.alt} />
+  {/if}
+</dialog>
+
+<style>
+  /*
+   * ⚠ Only style `display` on the OPEN dialog. Setting `display` on the bare
+   * `.ch-lightbox` would override the UA `dialog:not([open]) { display: none }`
+   * rule (author > UA), leaving a transparent full-viewport layer on top that
+   * swallows every click when the lightbox is closed. Gate it to [open].
+   */
+  .ch-lightbox[open] {
+    display: grid;
+    place-items: center;
+  }
+  .ch-lightbox {
+    border: none;
+    margin: 0;
+    padding: 0;
+    inset: 0;
+    width: 100vw;
+    max-width: 100vw;
+    height: 100dvh;
+    max-height: 100dvh;
+    background: transparent;
+    overflow: hidden;
+  }
+  .ch-lightbox::backdrop {
+    background: rgba(0, 0, 0, 0.82);
+  }
+  .ch-lightbox-img {
+    display: block;
+    max-width: 92vw;
+    max-height: 88dvh;
+    width: auto;
+    height: auto;
+    border-radius: 8px;
+    box-shadow: var(--shadow-4);
+    cursor: zoom-out;
+  }
+</style>

--- a/frontend/app/src/lib/chores/lib/components/QuickAddSheet.svelte
+++ b/frontend/app/src/lib/chores/lib/components/QuickAddSheet.svelte
@@ -1,0 +1,1043 @@
+<script lang="ts">
+  // ───────────────────────────────────────────────────────────────────────
+  // Quick-add sheet (WP-11). A bottom sheet from the FAB to create a chore.
+  //
+  //  • What needs doing  — free text (required)
+  //  • How often         — 3 segmented buttons (D4-B; NO monthly-on-day):
+  //                          Just once       → OneOff
+  //                          Every N days     → Flexible (+ positive intervalDays)
+  //                          Specific day(s)  → Fixed   (+ a DaysOfWeek selection)
+  //  • Effort            — Quick / Standard / Big job chips (NAMED tiers, P3 —
+  //                        never a raw number field)
+  //  • Room              — optional chip row defaulting to General
+  //  • Who's on it       — optional; default "Leave for anyone" (pile), with copy
+  //                        that no one gets nagged
+  //  • Photo             — optional; TWO-STEP (council C2): the parent POSTs the
+  //                        create JSON first (no file), then uploads the photo to
+  //                        the dedicated /photo route. This sheet just hands the
+  //                        chosen File up; it NEVER puts a file in the JSON body.
+  //
+  // ⚠ M5/M6: no `new Date('YYYY-MM-DD')` anywhere. The "Every N days" cadence is
+  // a plain positive integer; "Specific day(s)" is a weekday flag set. "Just once"
+  // takes an optional due date — the native date input yields a "YYYY-MM-DD" string
+  // we pass straight through as anchorDate (no Date construction). Recurring cadences
+  // send no anchorDate (the server derives their dueness from cadence + completion).
+  // ───────────────────────────────────────────────────────────────────────
+  import type { EffortTier, RecurrenceMode, MemberDto, RoomRollupDto } from '../types';
+  import type { CreateChoreRequest } from '../api';
+  import { createRoom, uploadRoomPhoto } from '../api';
+  import { showToast } from '$lib/shared/toast-store.svelte';
+  import { minFloorDate } from '../dates';
+  import IconPicker from './IconPicker.svelte';
+
+  /** What the parent needs to create the chore + (optionally) attach a photo. */
+  export interface QuickAddValue {
+    request: CreateChoreRequest;
+    photo: File | null;
+    /** Checklist item titles — created by the parent AFTER the chore POST returns an id. */
+    subtasks: string[];
+  }
+
+  interface Props {
+    open: boolean;
+    submitting: boolean;
+    /** Household members for the optional assignee picker. */
+    members: MemberDto[];
+    /** Room rollups from the board (incl. the virtual General group, roomId null). */
+    rooms: RoomRollupDto[];
+    onClose: () => void;
+    onSubmit: (value: QuickAddValue) => Promise<void> | void;
+  }
+
+  let { open, submitting, members, rooms, onClose, onSubmit }: Props = $props();
+
+  // ── Form state ───────────────────────────────────────────────────────────
+  type Cadence = 'once' | 'everyN' | 'days';
+
+  let name = $state('');
+  /** Optional emoji icon; '' = none. Reuses the shared <IconPicker>. */
+  let choreIcon = $state<string>('');
+  let cadence = $state<Cadence>('once');
+  let intervalDays = $state('3'); // string for input coercion; parsed at submit
+  let selectedDays = $state(new Set<string>());
+  /** "YYYY-MM-DD" for the "Just once" due date; '' = none. Passed straight as anchorDate. */
+  let dueDate = $state('');
+  /**
+   * "YYYY-MM-DD" first-due floor for a RECURRING chore; '' = due now (the burst fix — a new recurring chore
+   * otherwise reads due immediately). Sent as `snoozedUntil` on create (MN4 — passed straight through).
+   */
+  let firstDueDate = $state('');
+  let effort = $state<EffortTier>('Standard');
+  /** null ⇒ General (roomless). */
+  let roomId = $state<number | null>(null);
+  /** null ⇒ "Leave for anyone" (pile). */
+  let assigneeUserId = $state<number | null>(null);
+  /** 1 = single person (default); ≥2 = multi-person requirement. */
+  let requiredCount = $state(1);
+  /** Named roster for a multi-person chore (assigned at create as a soft pre-opt-in). Ignored when 1. */
+  let assignedUserIds = $state<number[]>([]);
+  let photo = $state<File | null>(null);
+  let localError = $state<string | null>(null);
+
+  // ── Checklist (optional) — collected locally; a new chore has no id yet, so
+  //    subtasks can't attach until it exists. The parent (App.handleQuickAdd)
+  //    creates each item after the chore POST returns an id.
+  let subtaskTitles = $state<string[]>([]);
+  let newSubtaskTitle = $state('');
+
+  function addSubtaskDraft(): void {
+    const t = newSubtaskTitle.trim();
+    if (!t) return;
+    subtaskTitles = [...subtaskTitles, t];
+    newSubtaskTitle = '';
+  }
+  function removeSubtaskDraft(index: number): void {
+    subtaskTitles = subtaskTitles.filter((_, i) => i !== index);
+  }
+
+  // ── Inline "new room" (v1.2 quick win) ─────────────────────────────────────
+  // Create a room without leaving the sheet (the full room manager is deferred —
+  // see ROADMAP Phase 12). Created rooms merge into the picker chips and are
+  // selected immediately; a later board reload carries them in `rooms`.
+  let createdRooms = $state<RoomRollupDto[]>([]);
+  let showNewRoom = $state(false);
+  let newRoomName = $state('');
+  let newRoomIcon = $state<string>('🧹');
+  let newRoomPhotoFile = $state<File | null>(null);
+  let newRoomError = $state<string | null>(null);
+  let creatingRoom = $state(false);
+
+  let dialogEl: HTMLDialogElement | null = $state(null);
+  let nameInput: HTMLInputElement | null = $state(null);
+
+  const CADENCES: { id: Cadence; label: string }[] = [
+    { id: 'once', label: 'Just once' },
+    { id: 'everyN', label: 'Every N days' },
+    { id: 'days', label: 'Specific day(s)' },
+  ];
+
+  const EFFORTS: { id: EffortTier; label: string }[] = [
+    { id: 'Quick', label: 'Quick' },
+    { id: 'Standard', label: 'Standard' },
+    { id: 'BigJob', label: 'Big job' },
+  ];
+
+  // camelCase flag names — must match the C# [Flags] ChoreDaysOfWeek enum
+  // serialized via JsonStringEnumConverter(CamelCase). Sunday-first.
+  const WEEKDAYS: { flag: string; short: string }[] = [
+    { flag: 'sunday', short: 'Sun' },
+    { flag: 'monday', short: 'Mon' },
+    { flag: 'tuesday', short: 'Tue' },
+    { flag: 'wednesday', short: 'Wed' },
+    { flag: 'thursday', short: 'Thu' },
+    { flag: 'friday', short: 'Fri' },
+    { flag: 'saturday', short: 'Sat' },
+  ];
+
+  // Picker chips = board rooms + any just-created rooms, deduped by id (the board
+  // copy wins once a reload carries real counts). General (roomId null) renders
+  // separately, so it's excluded here.
+  let roomChips = $derived.by(() => {
+    const byId = new Map<number, RoomRollupDto>();
+    for (const r of createdRooms) if (r.roomId !== null) byId.set(r.roomId, r);
+    for (const r of rooms) if (r.roomId !== null) byId.set(r.roomId, r);
+    return [...byId.values()].sort((a, b) => a.sortOrder - b.sortOrder);
+  });
+
+  async function addNewRoom(): Promise<void> {
+    const trimmed = newRoomName.trim();
+    if (!trimmed) {
+      newRoomError = 'Give the room a name.';
+      return;
+    }
+    if (creatingRoom) return;
+    newRoomError = null;
+    creatingRoom = true;
+    try {
+      const created = await createRoom({ name: trimmed, icon: newRoomIcon });
+      // Optional cover photo: upload after create (we now have the room id), then
+      // carry the returned path on the local rollup. A failed upload still keeps
+      // the room — only the photo is skipped (a later board reload reconciles).
+      let createdPhotoPath = created.photoPath;
+      if (newRoomPhotoFile) {
+        try {
+          const up = await uploadRoomPhoto(created.id, newRoomPhotoFile);
+          createdPhotoPath = up.photoPath;
+        } catch {
+          showToast({ message: "Room added, but the photo didn't upload.", kind: 'info' });
+        }
+      }
+      createdRooms = [
+        ...createdRooms,
+        {
+          roomId: created.id,
+          name: created.name,
+          icon: created.icon,
+          photoPath: createdPhotoPath,
+          sortOrder: created.sortOrder,
+          choreCount: 0,
+          dueCount: 0,
+          status: 'clean',
+        },
+      ];
+      roomId = created.id;
+      newRoomName = '';
+      newRoomPhotoFile = null;
+      showNewRoom = false;
+    } catch {
+      newRoomError = "Couldn't create the room — try again.";
+    } finally {
+      creatingRoom = false;
+    }
+  }
+
+  function reset() {
+    name = '';
+    choreIcon = '';
+    cadence = 'once';
+    intervalDays = '3';
+    selectedDays = new Set<string>();
+    dueDate = '';
+    firstDueDate = '';
+    effort = 'Standard';
+    roomId = null;
+    assigneeUserId = null;
+    requiredCount = 1;
+    assignedUserIds = [];
+    photo = null;
+    subtaskTitles = [];
+    newSubtaskTitle = '';
+    localError = null;
+    // Reset the inline new-room form UI (keep createdRooms — a later board reload dedups them).
+    showNewRoom = false;
+    newRoomName = '';
+    newRoomPhotoFile = null;
+    newRoomError = null;
+    creatingRoom = false;
+  }
+
+  $effect(() => {
+    if (!dialogEl) return;
+    if (open && !dialogEl.open) {
+      reset();
+      dialogEl.showModal();
+      queueMicrotask(() => nameInput?.focus());
+    } else if (!open && dialogEl.open) {
+      dialogEl.close();
+    }
+  });
+
+  function toggleDay(flag: string) {
+    const next = new Set(selectedDays);
+    if (next.has(flag)) next.delete(flag);
+    else next.add(flag);
+    selectedDays = next;
+  }
+
+  /** Toggle a member in the multi-person create-time roster (assigned). */
+  function toggleAssignee(userId: number) {
+    assignedUserIds = assignedUserIds.includes(userId)
+      ? assignedUserIds.filter((id) => id !== userId)
+      : [...assignedUserIds, userId];
+  }
+
+  function onPhotoChange(e: Event) {
+    const input = e.currentTarget as HTMLInputElement;
+    photo = input.files && input.files.length > 0 ? input.files[0] : null;
+  }
+
+  /** Map the 3-button cadence into the API recurrence fields (D4-B). */
+  function buildRecurrence():
+    | { ok: true; mode: RecurrenceMode; intervalDays: number | null; daysOfWeek: string | null }
+    | { ok: false; message: string } {
+    switch (cadence) {
+      case 'once':
+        return { ok: true, mode: 'OneOff', intervalDays: null, daysOfWeek: null };
+      case 'everyN': {
+        const n = Number(intervalDays);
+        if (!Number.isInteger(n) || n < 1) {
+          return { ok: false, message: 'Enter how many days between this chore (1 or more).' };
+        }
+        // Flexible: recurring, decays from the last completion over N days.
+        return { ok: true, mode: 'Flexible', intervalDays: n, daysOfWeek: null };
+      }
+      case 'days': {
+        if (selectedDays.size === 0) {
+          return { ok: false, message: 'Pick at least one day of the week.' };
+        }
+        // Fixed weekly-on-weekday. CSV of camelCase flag names.
+        const csv = WEEKDAYS.filter((d) => selectedDays.has(d.flag))
+          .map((d) => d.flag)
+          .join(', ');
+        return { ok: true, mode: 'Fixed', intervalDays: null, daysOfWeek: csv };
+      }
+    }
+  }
+
+  async function handleSubmit(e: SubmitEvent) {
+    e.preventDefault();
+    if (submitting) return;
+    const trimmed = name.trim();
+    if (!trimmed) {
+      localError = 'Give the chore a name.';
+      return;
+    }
+    const recurrence = buildRecurrence();
+    if (!recurrence.ok) {
+      localError = recurrence.message;
+      return;
+    }
+    localError = null;
+
+    const request: CreateChoreRequest = {
+      name: trimmed,
+      description: null,
+      roomId,
+      recurrenceMode: recurrence.mode,
+      intervalDays: recurrence.intervalDays,
+      anchorDate: cadence === 'once' ? dueDate || null : null,
+      daysOfWeek: recurrence.daysOfWeek,
+      dayOfMonth: null,
+      effortTier: effort,
+      icon: choreIcon,
+      ownerUserId: null,
+      // X=1 uses the single-holder trio; X>1 ignores it and seeds the named roster instead.
+      assigneeUserId: requiredCount > 1 ? null : assigneeUserId,
+      requiredCount,
+      assignedUserIds: requiredCount > 1 ? assignedUserIds : undefined,
+      // First-due floor (recurring only; OneOff uses anchorDate). Blank ⇒ due now.
+      snoozedUntil: cadence === 'once' ? null : firstDueDate || null,
+      // Photo is NEVER in the create JSON (council C2) — the parent uploads it
+      // separately to /api/chores/{id}/photo after the create returns an id.
+      photoPath: null,
+    };
+
+    await onSubmit({ request, photo, subtasks: subtaskTitles });
+  }
+</script>
+
+<dialog bind:this={dialogEl} onclose={onClose} class="ch-sheet">
+  <form method="dialog" onsubmit={handleSubmit}>
+    <header class="ch-sheet-head">
+      <h2>Add a chore</h2>
+    </header>
+
+    <div class="ch-sheet-body">
+      <label class="ch-field">
+        <span class="ch-field-label">What needs doing?</span>
+        <input
+          bind:this={nameInput}
+          type="text"
+          bind:value={name}
+          required
+          autocomplete="off"
+          placeholder="e.g. Wipe down the counters"
+        />
+      </label>
+
+      <fieldset class="ch-field">
+        <legend class="ch-field-label">Icon (optional)</legend>
+        <div class="ch-icon-row">
+          <button
+            type="button"
+            class="ch-chip"
+            class:active={choreIcon === ''}
+            aria-pressed={choreIcon === ''}
+            onclick={() => (choreIcon = '')}
+          >
+            No icon
+          </button>
+          <IconPicker value={choreIcon || null} onSelect={(i) => (choreIcon = i)} label="Chore icon" />
+        </div>
+      </fieldset>
+
+      <fieldset class="ch-field">
+        <legend class="ch-field-label">How often?</legend>
+        <div class="ch-segmented" role="group" aria-label="How often">
+          {#each CADENCES as c (c.id)}
+            <button
+              type="button"
+              class="ch-seg"
+              class:active={cadence === c.id}
+              aria-pressed={cadence === c.id}
+              onclick={() => (cadence = c.id)}
+            >
+              {c.label}
+            </button>
+          {/each}
+        </div>
+
+        {#if cadence === 'once'}
+          <label class="ch-subfield">
+            <span class="ch-subfield-label">Due date (optional)</span>
+            <input type="date" bind:value={dueDate} aria-label="Due date" />
+          </label>
+        {:else if cadence === 'everyN'}
+          <label class="ch-subfield">
+            <span class="ch-subfield-label">Every</span>
+            <input
+              type="text"
+              inputmode="numeric"
+              pattern="[0-9]*"
+              bind:value={intervalDays}
+              class="ch-interval-input"
+              aria-label="Number of days"
+            />
+            <span class="ch-subfield-label">days</span>
+          </label>
+        {:else if cadence === 'days'}
+          <div class="ch-weekdays" role="group" aria-label="Days of the week">
+            {#each WEEKDAYS as day (day.flag)}
+              <button
+                type="button"
+                class="ch-day"
+                class:active={selectedDays.has(day.flag)}
+                aria-pressed={selectedDays.has(day.flag)}
+                onclick={() => toggleDay(day.flag)}
+              >
+                {day.short}
+              </button>
+            {/each}
+          </div>
+        {/if}
+
+        {#if cadence === 'everyN' || cadence === 'days'}
+          <!--
+            First-due date (recurring only). Blank = due now; a future date holds the
+            new chore as Scheduled until then (the burst fix). Sent as snoozedUntil on
+            create; the date input's "YYYY-MM-DD" is passed straight through (MN4).
+          -->
+          <label class="ch-subfield">
+            <span class="ch-subfield-label">First due (optional)</span>
+            <input type="date" bind:value={firstDueDate} aria-label="First due date" min={minFloorDate()} />
+          </label>
+        {/if}
+      </fieldset>
+
+      <fieldset class="ch-field">
+        <legend class="ch-field-label">Effort</legend>
+        <div class="ch-chip-row" role="group" aria-label="Effort">
+          {#each EFFORTS as e (e.id)}
+            <button
+              type="button"
+              class="ch-chip"
+              class:active={effort === e.id}
+              aria-pressed={effort === e.id}
+              onclick={() => (effort = e.id)}
+            >
+              {e.label}
+            </button>
+          {/each}
+        </div>
+      </fieldset>
+
+      {#if members.length >= 2}
+        <fieldset class="ch-field">
+          <legend class="ch-field-label">How many people?</legend>
+          <div class="ch-chip-row" role="group" aria-label="How many people">
+            <button
+              type="button"
+              class="ch-chip"
+              class:active={requiredCount === 1}
+              aria-pressed={requiredCount === 1}
+              onclick={() => (requiredCount = 1)}
+            >
+              One person
+            </button>
+            <button
+              type="button"
+              class="ch-chip"
+              class:active={requiredCount > 1}
+              aria-pressed={requiredCount > 1}
+              onclick={() => { if (requiredCount < 2) requiredCount = 2; }}
+            >
+              Needs more than one
+            </button>
+          </div>
+          {#if requiredCount > 1}
+            <div class="ch-chip-row" role="group" aria-label="Number of people needed">
+              {#each { length: members.length - 1 } as _, i (i)}
+                {@const n = i + 2}
+                <button
+                  type="button"
+                  class="ch-chip"
+                  class:active={requiredCount === n}
+                  aria-pressed={requiredCount === n}
+                  onclick={() => (requiredCount = n)}
+                >
+                  Needs {n} people
+                </button>
+              {/each}
+            </div>
+          {/if}
+        </fieldset>
+      {/if}
+
+      <fieldset class="ch-field">
+        <legend class="ch-field-label">Room</legend>
+        <div class="ch-chip-row" role="group" aria-label="Room">
+          <button
+            type="button"
+            class="ch-chip"
+            class:active={roomId === null}
+            aria-pressed={roomId === null}
+            onclick={() => (roomId = null)}
+          >
+            🏠 General
+          </button>
+          {#each roomChips as room (room.roomId ?? 'general')}
+            {#if room.roomId !== null}
+              <button
+                type="button"
+                class="ch-chip"
+                class:active={roomId === room.roomId}
+                aria-pressed={roomId === room.roomId}
+                onclick={() => (roomId = room.roomId)}
+              >
+                {room.icon} {room.name}
+              </button>
+            {/if}
+          {/each}
+          {#if !showNewRoom}
+            <button
+              type="button"
+              class="ch-chip ch-chip-add"
+              onclick={() => {
+                showNewRoom = true;
+                newRoomError = null;
+              }}
+            >
+              ＋ New room
+            </button>
+          {/if}
+        </div>
+
+        {#if showNewRoom}
+          <div class="ch-newroom">
+            <IconPicker value={newRoomIcon} onSelect={(i) => (newRoomIcon = i)} label="New room icon" />
+            <div class="ch-newroom-row">
+              <input
+                type="text"
+                bind:value={newRoomName}
+                autocomplete="off"
+                placeholder="Room name (e.g. Garage)"
+                aria-label="New room name"
+                onkeydown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    addNewRoom();
+                  }
+                }}
+              />
+              <button
+                type="button"
+                class="ch-btn-primary ch-newroom-add"
+                onclick={addNewRoom}
+                disabled={creatingRoom || !newRoomName.trim()}
+              >
+                {creatingRoom ? 'Adding…' : 'Add'}
+              </button>
+              <button
+                type="button"
+                class="ch-btn-ghost"
+                onclick={() => {
+                  showNewRoom = false;
+                  newRoomName = '';
+                  newRoomPhotoFile = null;
+                  newRoomError = null;
+                }}
+                disabled={creatingRoom}
+              >
+                Cancel
+              </button>
+            </div>
+            <label class="ch-newroom-photo">
+              <span class="ch-hint">Cover photo (optional)</span>
+              <input
+                type="file"
+                accept="image/*"
+                onchange={(e) => {
+                  const input = e.currentTarget as HTMLInputElement;
+                  newRoomPhotoFile = input.files && input.files.length > 0 ? input.files[0] : null;
+                }}
+              />
+              {#if newRoomPhotoFile}
+                <span class="ch-hint">{newRoomPhotoFile.name}</span>
+              {/if}
+            </label>
+            {#if newRoomError}
+              <p class="ch-sheet-error" role="alert">{newRoomError}</p>
+            {/if}
+          </div>
+        {/if}
+      </fieldset>
+
+      <fieldset class="ch-field">
+        <legend class="ch-field-label">
+          {requiredCount > 1 ? 'Assign people (optional)' : "Who's on it?"}
+        </legend>
+        {#if requiredCount > 1}
+          <div class="ch-chip-row" role="group" aria-label="Assign people">
+            {#each members as member (member.userId)}
+              <button
+                type="button"
+                class="ch-chip"
+                class:active={assignedUserIds.includes(member.userId)}
+                aria-pressed={assignedUserIds.includes(member.userId)}
+                onclick={() => toggleAssignee(member.userId)}
+              >
+                {member.displayName}
+              </button>
+            {/each}
+          </div>
+          <p class="ch-hint">
+            Name up to {requiredCount} — or leave it open and let people pitch in. Assigning is just a
+            suggestion: anyone can join (“I'm in”) or step off.
+          </p>
+        {:else}
+          <div class="ch-chip-row" role="group" aria-label="Assignee">
+            <button
+              type="button"
+              class="ch-chip"
+              class:active={assigneeUserId === null}
+              aria-pressed={assigneeUserId === null}
+              onclick={() => (assigneeUserId = null)}
+            >
+              Leave for anyone
+            </button>
+            {#each members as member (member.userId)}
+              <button
+                type="button"
+                class="ch-chip"
+                class:active={assigneeUserId === member.userId}
+                aria-pressed={assigneeUserId === member.userId}
+                onclick={() => (assigneeUserId = member.userId)}
+              >
+                {member.displayName}
+              </button>
+            {/each}
+          </div>
+          {#if assigneeUserId === null}
+            <p class="ch-hint">Anyone can pick it up — no one gets nagged.</p>
+          {/if}
+        {/if}
+      </fieldset>
+
+      <fieldset class="ch-field">
+        <legend class="ch-field-label">Checklist (optional)</legend>
+        {#if subtaskTitles.length > 0}
+          <ul class="ch-subtasks">
+            {#each subtaskTitles as t, i (i)}
+              <li class="ch-subtask-row">
+                <span class="ch-subtask-text">{t}</span>
+                <button
+                  type="button"
+                  class="ch-subtask-del"
+                  onclick={() => removeSubtaskDraft(i)}
+                  title="Remove this item"
+                  aria-label="Remove {t}"
+                >
+                  ×
+                </button>
+              </li>
+            {/each}
+          </ul>
+        {/if}
+        <div class="ch-subtask-add">
+          <input
+            type="text"
+            class="ch-subtask-input"
+            bind:value={newSubtaskTitle}
+            autocomplete="off"
+            placeholder="Add an item…"
+            aria-label="Add a checklist item"
+            onkeydown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                addSubtaskDraft();
+              }
+            }}
+          />
+          <button
+            type="button"
+            class="ch-btn-primary ch-subtask-add-btn"
+            onclick={addSubtaskDraft}
+            disabled={!newSubtaskTitle.trim()}
+          >
+            Add
+          </button>
+        </div>
+        <p class="ch-hint">
+          A quick checklist anyone can tick off from the card — optional, and never needed to finish the chore.
+        </p>
+      </fieldset>
+
+      <label class="ch-field">
+        <span class="ch-field-label">Photo (optional)</span>
+        <input type="file" accept="image/*" onchange={onPhotoChange} />
+        {#if photo}
+          <span class="ch-hint">{photo.name}</span>
+        {/if}
+      </label>
+
+      {#if localError}
+        <p class="ch-sheet-error" role="alert">{localError}</p>
+      {/if}
+    </div>
+
+    <footer class="ch-sheet-actions">
+      <button type="button" class="ch-btn-ghost" onclick={onClose} disabled={submitting}>
+        Cancel
+      </button>
+      <button type="submit" class="ch-btn-primary" disabled={submitting || !name.trim()}>
+        {submitting ? 'Adding…' : 'Add chore'}
+      </button>
+    </footer>
+  </form>
+</dialog>
+
+<style>
+  .ch-sheet {
+    border: none;
+    padding: 0;
+    background: var(--color-surface);
+    color: var(--color-text);
+    box-shadow: var(--shadow-4);
+    width: min(520px, 100vw);
+    max-height: 90vh;
+    /* Bottom sheet on mobile; centered card on wide screens. */
+    margin: auto auto 0;
+    border-radius: var(--radius-md) var(--radius-md) 0 0;
+  }
+  @media (min-width: 600px) {
+    .ch-sheet {
+      margin: auto;
+      border-radius: var(--radius-md);
+    }
+  }
+  .ch-sheet::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+  }
+  .ch-sheet form {
+    display: flex;
+    flex-direction: column;
+    max-height: 90vh;
+  }
+  .ch-sheet-head {
+    padding: 20px 24px 8px;
+  }
+  .ch-sheet-head h2 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 500;
+  }
+  .ch-sheet-body {
+    overflow-y: auto;
+    padding: 8px 24px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+  }
+
+  .ch-field {
+    border: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .ch-field-label {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--color-text-muted);
+    padding: 0;
+  }
+  input[type='text'] {
+    font: inherit;
+    color: inherit;
+    padding: 10px 12px;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    min-height: 44px;
+  }
+  input[type='text']:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -1px;
+    border-color: var(--color-primary);
+  }
+  input[type='file'] {
+    font: inherit;
+    color: var(--color-text-muted);
+    font-size: 0.875rem;
+  }
+  input[type='date'] {
+    font: inherit;
+    color: inherit;
+    padding: 10px 12px;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    min-height: 44px;
+  }
+
+  .ch-segmented {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+  }
+  .ch-seg {
+    flex: 1;
+    min-width: 96px;
+    font: inherit;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    border: 1px solid var(--color-line-strong);
+    background: transparent;
+    color: var(--color-text-muted);
+    padding: 8px 10px;
+    min-height: 40px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition:
+      background-color 0.15s,
+      color 0.15s,
+      border-color 0.15s;
+  }
+  .ch-seg.active {
+    background: var(--color-primary);
+    border-color: var(--color-primary);
+    color: #fff;
+  }
+  .ch-seg:hover:not(.active) {
+    background: var(--color-action-hover);
+    color: var(--color-text);
+  }
+
+  .ch-subfield {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+  .ch-subfield-label {
+    color: var(--color-text-muted);
+  }
+  .ch-interval-input {
+    width: 72px;
+    text-align: center;
+  }
+
+  .ch-weekdays {
+    display: flex;
+    gap: 4px;
+    flex-wrap: wrap;
+  }
+  .ch-day {
+    font: inherit;
+    font-size: 0.75rem;
+    font-weight: 500;
+    width: 44px;
+    min-height: 40px;
+    border: 1px solid var(--color-line-strong);
+    background: transparent;
+    color: var(--color-text-muted);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition:
+      background-color 0.15s,
+      color 0.15s,
+      border-color 0.15s;
+  }
+  .ch-day.active {
+    background: var(--color-primary);
+    border-color: var(--color-primary);
+    color: #fff;
+  }
+  .ch-day:hover:not(.active) {
+    background: var(--color-action-hover);
+    color: var(--color-text);
+  }
+
+  .ch-chip-row {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  /* Icon field: the "No icon" chip sits inline with the emoji palette. */
+  .ch-icon-row {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+  .ch-chip {
+    font: inherit;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    border: 1px solid var(--color-line-strong);
+    background: transparent;
+    color: var(--color-text-muted);
+    padding: 6px 14px;
+    min-height: 36px;
+    border-radius: 18px;
+    cursor: pointer;
+    transition:
+      background-color 0.15s,
+      color 0.15s,
+      border-color 0.15s;
+  }
+  .ch-chip.active {
+    background: var(--color-primary);
+    border-color: var(--color-primary);
+    color: #fff;
+  }
+  .ch-chip:hover:not(.active) {
+    background: var(--color-action-hover);
+    color: var(--color-text);
+  }
+
+  /* Inline "new room" (v1.2) */
+  .ch-chip-add {
+    border-style: dashed;
+  }
+  .ch-newroom {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-top: 10px;
+    padding: 12px;
+    border: 1px dashed var(--color-line-strong);
+    border-radius: var(--radius-sm);
+  }
+  .ch-newroom-row {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+  .ch-newroom-row input[type='text'] {
+    flex: 1;
+    min-width: 140px;
+  }
+  .ch-newroom-add {
+    min-height: 44px;
+  }
+  .ch-newroom-photo {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .ch-hint {
+    margin: 0;
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+  }
+  .ch-sheet-error {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--color-error);
+  }
+
+  /* ── Checklist (optional) — draft items collected before the chore exists ── */
+  .ch-subtasks {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .ch-subtask-row,
+  .ch-subtask-add {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .ch-subtask-text {
+    flex: 1;
+    min-width: 0;
+    overflow-wrap: anywhere;
+    font-size: 0.875rem;
+  }
+  .ch-subtask-input {
+    flex: 1;
+    min-width: 0;
+    font: inherit;
+    color: inherit;
+    padding: 10px 12px;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    min-height: 44px;
+  }
+  .ch-subtask-input:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -1px;
+    border-color: var(--color-primary);
+  }
+  .ch-subtask-del {
+    flex-shrink: 0;
+    width: 44px;
+    height: 44px;
+    display: grid;
+    place-items: center;
+    font-size: 1.25rem;
+    line-height: 1;
+    color: var(--color-text-muted);
+    background: transparent;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+  }
+  .ch-subtask-del:hover {
+    background: var(--color-action-hover);
+    color: var(--color-error);
+  }
+  .ch-subtask-add-btn {
+    flex-shrink: 0;
+    min-height: 44px;
+  }
+
+  .ch-sheet-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 16px 24px calc(20px + env(safe-area-inset-bottom, 0px));
+    border-top: 1px solid var(--color-line);
+  }
+  .ch-btn-ghost,
+  .ch-btn-primary {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    border: none;
+    cursor: pointer;
+    min-height: 44px;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+  }
+  .ch-btn-ghost {
+    background: transparent;
+    color: var(--color-primary);
+  }
+  .ch-btn-ghost:hover:not(:disabled) {
+    background: var(--color-action-hover);
+  }
+  .ch-btn-primary {
+    background: var(--color-primary);
+    color: #fff;
+    box-shadow: var(--shadow-1);
+  }
+  .ch-btn-primary:hover:not(:disabled) {
+    background: var(--color-primary-hover);
+  }
+  .ch-btn-primary:disabled,
+  .ch-btn-ghost:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+</style>

--- a/frontend/app/src/lib/chores/lib/components/RecapBoard.svelte
+++ b/frontend/app/src/lib/chores/lib/components/RecapBoard.svelte
@@ -1,0 +1,467 @@
+<script lang="ts">
+  import type { ChoreRecapDto } from '../types';
+
+  // ───────────────────────────────────────────────────────────────────────
+  // Recap lens — the in-app view of the weekly recap. Two parts:
+  //   1. THIS WEEK — the SAME content the Discord digest posts (collective
+  //      headline, per-member effort split, "needs attention" chores, "up for
+  //      grabs" count). So the app and the channel never tell a different story.
+  //   2. WEEK OVER WEEK — a column chart of completions per week (the trend the
+  //      digest can't show), current week highlighted as the partial last bar.
+  //
+  // ⚠ Framing (mirrors the digest, M12/MN8): collective + non-punitive. The
+  //   distribution is neutral (alphabetical, no ranking); "needs attention" names
+  //   CHORES, not people. No leaderboard.
+  // ⚠ MN9 — NO client date math. `weekStartLocal` is a "YYYY-MM-DD" string already
+  //   resolved in the household timezone server-side; we format it by SPLITTING the
+  //   parts (never `new Date('YYYY-MM-DD')`, which would shift the day in US zones).
+  // ⚠ All values are server-computed; this is a pure render plus loading/empty/error.
+  //   The store owns the fetch + cache invalidation.
+  // ───────────────────────────────────────────────────────────────────────
+
+  interface Props {
+    recap: ChoreRecapDto | null;
+    loading: boolean;
+    error: string | null;
+    /** Retry after an error (re-runs loadRecap). */
+    onRetry: () => void;
+  }
+
+  let { recap, loading, error, onRetry }: Props = $props();
+
+  const MONTHS = [
+    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+  ];
+
+  /**
+   * Format a "YYYY-MM-DD" week-start as a short "Mon D" label. MN9-safe: we parse
+   * the parts ourselves and NEVER construct a Date from a date-only string.
+   */
+  function weekLabel(iso: string): string {
+    const parts = iso.split('-');
+    const m = Number.parseInt(parts[1] ?? '', 10);
+    const d = Number.parseInt(parts[2] ?? '', 10);
+    if (!m || !d || m < 1 || m > 12) return iso;
+    return `${MONTHS[m - 1]} ${d}`;
+  }
+
+  /** Percent without trailing-zero noise (25 → "25", 41.7 → "41.7"). Values arrive 0..100. */
+  function pct(value: number): string {
+    return Number.isInteger(value) ? String(value) : value.toFixed(1);
+  }
+
+  let current = $derived(recap?.current ?? null);
+  let trend = $derived(recap?.trend ?? []);
+
+  // Show the per-member split only when there's a real multi-member week.
+  let hasDistribution = $derived(
+    current != null && current.distribution.length > 0 && current.totalCompletions > 0,
+  );
+
+  // Column-chart scaling: tallest bar = the busiest week (min 1 to avoid /0).
+  let maxCompletions = $derived(
+    Math.max(1, ...trend.map((t) => t.totalCompletions)),
+  );
+
+  // Only worth drawing the trend if there's more than the current (partial) week,
+  // or any past activity to compare against.
+  let hasTrend = $derived(trend.length > 1);
+</script>
+
+<div class="ch-recap">
+  {#if error}
+    <div class="ch-recap-error" role="alert">
+      <span>{error}</span>
+      <button type="button" class="ch-recap-retry" onclick={onRetry}>Retry</button>
+    </div>
+  {:else if loading && recap == null}
+    <div class="ch-recap-state">Loading the recap…</div>
+  {:else if current != null}
+    <!-- ── This week ─────────────────────────────────────────────────────── -->
+    <section class="ch-recap-current" aria-label="This week's recap">
+      <header class="ch-recap-head">
+        <p class="ch-recap-eyebrow">Week of {weekLabel(current.weekStartLocal)}</p>
+        <h2 class="ch-recap-headline">{current.headline}</h2>
+      </header>
+
+      <div class="ch-recap-totals">
+        <div class="ch-recap-total">
+          <span class="ch-recap-total-num">{current.totalCompletions}</span>
+          <span class="ch-recap-total-label">
+            {current.totalCompletions === 1 ? 'chore done' : 'chores done'}
+          </span>
+        </div>
+        <div class="ch-recap-total">
+          <span class="ch-recap-total-num">{current.totalPoints}</span>
+          <span class="ch-recap-total-label">
+            {current.totalPoints === 1 ? 'point' : 'points'}
+          </span>
+        </div>
+        <div class="ch-recap-total">
+          <span class="ch-recap-total-num">{current.upForGrabsCount}</span>
+          <span class="ch-recap-total-label">up for grabs</span>
+        </div>
+      </div>
+
+      {#if hasDistribution}
+        <!-- Per-member effort split — neutral (alphabetical, no ranking). Bar width
+             is the member's actual share (`sharePct`, percent 0..100 — used directly). -->
+        <ul class="ch-recap-rows" aria-label="This week's effort by person">
+          {#each current.distribution as member (member.displayName)}
+            <li class="ch-recap-row">
+              <span class="ch-recap-name">{member.displayName}</span>
+              <span class="ch-recap-track">
+                <span
+                  class="ch-recap-bar"
+                  style="width: {member.sharePct}%;"
+                  aria-hidden="true"
+                ></span>
+              </span>
+              <span class="ch-recap-figures">
+                <span class="ch-recap-share">{pct(member.sharePct)}%</span>
+                <span class="ch-recap-points">
+                  {member.points}
+                  {member.points === 1 ? 'pt' : 'pts'}
+                </span>
+              </span>
+            </li>
+          {/each}
+        </ul>
+      {:else}
+        <p class="ch-recap-empty-week">Nothing logged this week yet — it fills in as chores get done.</p>
+      {/if}
+
+      {#if current.fallingBehind.length > 0}
+        <!-- Needs attention — names CHORES, not people (M12/MN8). Same list the digest sends. -->
+        <div class="ch-recap-attention">
+          <span class="ch-recap-attention-label">⏰ Needs attention</span>
+          <ul class="ch-recap-chips">
+            {#each current.fallingBehind as name (name)}
+              <li class="ch-recap-chip">{name}</li>
+            {/each}
+          </ul>
+        </div>
+      {/if}
+    </section>
+
+    <!-- ── Week over week ────────────────────────────────────────────────── -->
+    {#if hasTrend}
+      <section class="ch-recap-trend" aria-label="Chores completed each week">
+        <header class="ch-recap-trend-head">
+          <h3 class="ch-recap-trend-title">Week over week</h3>
+          <p class="ch-recap-trend-sub">Chores completed each week — this week is the last bar.</p>
+        </header>
+        <ol class="ch-recap-chart">
+          {#each trend as week (week.weekStartLocal)}
+            <li class="ch-recap-col" class:is-current={week.isCurrent}>
+              <span class="ch-recap-col-num">{week.totalCompletions}</span>
+              <span class="ch-recap-col-track" aria-hidden="true">
+                <span
+                  class="ch-recap-col-bar"
+                  style="height: {(week.totalCompletions / maxCompletions) * 100}%;"
+                ></span>
+              </span>
+              <span class="ch-recap-col-label">
+                {week.isCurrent ? 'This week' : weekLabel(week.weekStartLocal)}
+              </span>
+            </li>
+          {/each}
+        </ol>
+      </section>
+    {/if}
+  {:else}
+    <div class="ch-recap-state">
+      <p class="ch-recap-empty-head">No recap yet.</p>
+      <p>The weekly recap fills in as chores get completed.</p>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .ch-recap {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  /* ── This week ──────────────────────────────────────────────────────────── */
+  .ch-recap-current {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding: 16px;
+    background: var(--color-action-hover);
+    border-radius: var(--radius-md);
+  }
+  .ch-recap-head {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .ch-recap-eyebrow {
+    margin: 0;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-text-muted);
+  }
+  .ch-recap-headline {
+    margin: 0;
+    font-size: 1.125rem;
+    font-weight: 600;
+    line-height: 1.3;
+    color: var(--color-text);
+  }
+
+  .ch-recap-totals {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+  .ch-recap-total {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    padding: 10px 18px;
+    background: var(--color-surface);
+    border-radius: var(--radius-sm);
+    min-width: 84px;
+  }
+  .ch-recap-total-num {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--color-text);
+    font-variant-numeric: tabular-nums;
+    line-height: 1;
+  }
+  .ch-recap-total-label {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+
+  /* Per-member effort rows (neutral single fill — no ranking color). */
+  .ch-recap-rows {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .ch-recap-row {
+    display: grid;
+    grid-template-columns: minmax(96px, 1fr) minmax(0, 2.4fr) minmax(72px, auto);
+    align-items: center;
+    gap: 12px;
+  }
+  .ch-recap-name {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--color-text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .ch-recap-track {
+    position: relative;
+    height: 16px;
+    background: var(--color-surface);
+    border-radius: 8px;
+    overflow: hidden;
+  }
+  .ch-recap-bar {
+    position: absolute;
+    inset: 0 auto 0 0;
+    height: 100%;
+    background: var(--color-primary);
+    border-radius: 8px;
+    transition: width 0.2s ease;
+  }
+  .ch-recap-figures {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    line-height: 1.2;
+    text-align: right;
+  }
+  .ch-recap-share {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--color-text);
+    font-variant-numeric: tabular-nums;
+  }
+  .ch-recap-points {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .ch-recap-empty-week {
+    margin: 0;
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+  }
+
+  /* Needs attention — chore-name chips. */
+  .ch-recap-attention {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .ch-recap-attention-label {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: var(--color-text);
+  }
+  .ch-recap-chips {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .ch-recap-chip {
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+    background: var(--color-surface);
+    border: 1px dashed var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    padding: 5px 10px;
+  }
+
+  /* ── Week over week (column chart) ──────────────────────────────────────── */
+  .ch-recap-trend {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 16px;
+    background: var(--color-action-hover);
+    border-radius: var(--radius-md);
+  }
+  .ch-recap-trend-head {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .ch-recap-trend-title {
+    margin: 0;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    color: var(--color-text);
+  }
+  .ch-recap-trend-sub {
+    margin: 0;
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .ch-recap-chart {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    align-items: flex-end;
+    gap: 6px;
+    min-height: 140px;
+  }
+  .ch-recap-col {
+    flex: 1 1 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+  }
+  .ch-recap-col-num {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: var(--color-text-muted);
+    font-variant-numeric: tabular-nums;
+  }
+  .ch-recap-col-track {
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    width: 100%;
+    height: 96px;
+  }
+  .ch-recap-col-bar {
+    width: 70%;
+    max-width: 36px;
+    min-height: 3px;
+    background: var(--color-line-strong);
+    border-radius: 4px 4px 0 0;
+    transition: height 0.2s ease;
+  }
+  /* The current (in-progress) week reads as the live bar. */
+  .ch-recap-col.is-current .ch-recap-col-bar {
+    background: var(--color-primary);
+  }
+  .ch-recap-col.is-current .ch-recap-col-num,
+  .ch-recap-col.is-current .ch-recap-col-label {
+    color: var(--color-text);
+    font-weight: 600;
+  }
+  .ch-recap-col-label {
+    font-size: 0.6875rem;
+    color: var(--color-text-muted);
+    text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 100%;
+  }
+
+  /* ── Loading / empty / error ────────────────────────────────────────────── */
+  .ch-recap-state {
+    padding: 40px 16px;
+    text-align: center;
+    color: var(--color-text-muted);
+  }
+  .ch-recap-empty-head {
+    font-size: 1.125rem;
+    font-weight: 500;
+    color: var(--color-text);
+    margin: 0 0 4px;
+  }
+  .ch-recap-error {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 16px;
+    background: rgba(229, 57, 53, 0.08);
+    border-left: 4px solid var(--color-error);
+    border-radius: var(--radius-sm);
+    color: var(--color-error);
+    font-size: 0.875rem;
+  }
+  .ch-recap-retry {
+    font: inherit;
+    border: none;
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+    padding: 4px 12px;
+    background: transparent;
+    color: var(--color-error);
+    font-weight: 500;
+  }
+  .ch-recap-retry:hover {
+    background: rgba(229, 57, 53, 0.12);
+  }
+
+  @media (max-width: 560px) {
+    .ch-recap-row {
+      grid-template-columns: 1fr;
+      gap: 6px;
+    }
+    .ch-recap-figures {
+      flex-direction: row;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 8px;
+      text-align: left;
+    }
+  }
+</style>

--- a/frontend/app/src/lib/chores/lib/components/RoomEditSheet.svelte
+++ b/frontend/app/src/lib/chores/lib/components/RoomEditSheet.svelte
@@ -1,0 +1,345 @@
+<script lang="ts">
+  // ───────────────────────────────────────────────────────────────────────
+  // Edit-room sheet (v1.2 — minimal room manager). A bottom sheet to rename a
+  // room, change its icon, and set/replace/remove its cover photo. Opened from
+  // the Rooms lens drill-in header (real rooms only — never the virtual
+  // General group). The full room manager (reorder / delete) is still deferred.
+  //
+  //  • Photo (council C4 parity with the chore edit-photo flow): if the user
+  //    picks a new file we upload it first (POST /api/rooms/{id}/photo →
+  //    { photoPath }) then send the returned path in the PUT body. To keep the
+  //    existing photo, send the current photoPath unchanged; to remove it, send
+  //    null. No file ever goes in the JSON body.
+  //
+  // A room change is not a chore mutation (no optimistic path), so on success we
+  // refetch the ONE board payload via boardStore.reloadBoard() — the dashboard
+  // cover / drill hero then render the new photo authoritatively.
+  // ───────────────────────────────────────────────────────────────────────
+  import type { RoomRollupDto } from '../types';
+  import type { RoomUpsertRequest } from '../api';
+  import { updateRoom, uploadRoomPhoto } from '../api';
+  import { boardStore } from '../state.svelte';
+  import { showToast } from '$lib/shared/toast-store.svelte';
+  import IconPicker from './IconPicker.svelte';
+
+  interface Props {
+    open: boolean;
+    /** The room being edited (a real room — roomId never null). */
+    room: RoomRollupDto | null;
+    onClose: () => void;
+  }
+
+  let { open, room, onClose }: Props = $props();
+
+  // ── Form state ────────────────────────────────────────────────────────────
+  let name = $state('');
+  let roomIcon = $state<string>('🧹');
+  let existingPhotoPath = $state<string | null>(null);
+  let newPhotoFile = $state<File | null>(null);
+  /** Set true to drop the existing photo (sends photoPath null). */
+  let removePhoto = $state(false);
+  let localError = $state<string | null>(null);
+  let submitting = $state(false);
+
+  let dialogEl: HTMLDialogElement | null = $state(null);
+  let nameInput: HTMLInputElement | null = $state(null);
+
+  // Local object-URL preview of a freshly-picked file (revoked on change/close).
+  let previewUrl = $derived(newPhotoFile ? URL.createObjectURL(newPhotoFile) : null);
+
+  function roomToForm(r: RoomRollupDto): void {
+    name = r.name;
+    roomIcon = r.icon || '🧹';
+    existingPhotoPath = r.photoPath;
+    newPhotoFile = null;
+    removePhoto = false;
+    localError = null;
+  }
+
+  $effect(() => {
+    if (!dialogEl) return;
+    if (open && room && !dialogEl.open) {
+      roomToForm(room);
+      dialogEl.showModal();
+      queueMicrotask(() => nameInput?.focus());
+    } else if (!open && dialogEl.open) {
+      dialogEl.close();
+    }
+  });
+
+  // Revoke the object URL when the picked file changes or the sheet unmounts.
+  $effect(() => {
+    const url = previewUrl;
+    return () => {
+      if (url) URL.revokeObjectURL(url);
+    };
+  });
+
+  function onPhotoChange(e: Event) {
+    const input = e.currentTarget as HTMLInputElement;
+    newPhotoFile = input.files && input.files.length > 0 ? input.files[0] : null;
+    if (newPhotoFile) removePhoto = false;
+  }
+
+  async function handleSubmit(e: SubmitEvent) {
+    e.preventDefault();
+    if (submitting || !room || room.roomId === null) return;
+    const trimmed = name.trim();
+    if (!trimmed) {
+      localError = 'Give the room a name.';
+      return;
+    }
+    localError = null;
+    submitting = true;
+    const roomId = room.roomId;
+
+    try {
+      // Resolve the photo: remove → null; new file → upload then use the path;
+      // otherwise keep what's there. A failed upload keeps the existing photo.
+      let resolvedPhotoPath: string | null = existingPhotoPath;
+      if (removePhoto) {
+        resolvedPhotoPath = null;
+      } else if (newPhotoFile) {
+        try {
+          const uploadResult = await uploadRoomPhoto(roomId, newPhotoFile);
+          resolvedPhotoPath = uploadResult.photoPath;
+        } catch {
+          showToast({ message: 'Photo upload failed — saving other changes.', kind: 'info' });
+          resolvedPhotoPath = existingPhotoPath;
+        }
+      }
+
+      const body: RoomUpsertRequest = {
+        name: trimmed,
+        icon: roomIcon,
+        photoPath: resolvedPhotoPath,
+      };
+      await updateRoom(roomId, body);
+      // Refetch so the dashboard cover / drill hero reflect the change.
+      await boardStore.reloadBoard();
+      showToast({ message: 'Room updated.', kind: 'success' });
+      onClose();
+    } catch {
+      localError = "Couldn't save the room — try again.";
+    } finally {
+      submitting = false;
+    }
+  }
+</script>
+
+<dialog bind:this={dialogEl} onclose={onClose} class="ch-sheet">
+  <form method="dialog" onsubmit={handleSubmit}>
+    <header class="ch-sheet-head">
+      <h2>Edit room</h2>
+    </header>
+
+    <div class="ch-sheet-body">
+      <label class="ch-field">
+        <span class="ch-field-label">Room name</span>
+        <input
+          bind:this={nameInput}
+          type="text"
+          bind:value={name}
+          required
+          autocomplete="off"
+          placeholder="e.g. Kitchen"
+        />
+      </label>
+
+      <fieldset class="ch-field">
+        <legend class="ch-field-label">Icon</legend>
+        <IconPicker value={roomIcon} onSelect={(i) => (roomIcon = i)} label="Room icon" />
+      </fieldset>
+
+      <fieldset class="ch-field">
+        <legend class="ch-field-label">Cover photo (optional)</legend>
+        {#if previewUrl}
+          <img class="ch-room-photo-preview" src={previewUrl} alt="New cover preview" />
+          <span class="ch-hint">{newPhotoFile?.name} (will replace the current photo)</span>
+        {:else if existingPhotoPath && !removePhoto}
+          <img class="ch-room-photo-preview" src={existingPhotoPath} alt="Current cover" />
+          <span class="ch-hint">Pick a new file to replace it.</span>
+        {:else if removePhoto}
+          <span class="ch-hint">The cover photo will be removed.</span>
+        {/if}
+        <input type="file" accept="image/*" onchange={onPhotoChange} />
+        {#if existingPhotoPath && !newPhotoFile}
+          <button
+            type="button"
+            class="ch-btn-danger-ghost ch-room-photo-remove"
+            onclick={() => (removePhoto = !removePhoto)}
+          >
+            {removePhoto ? 'Keep current photo' : 'Remove photo'}
+          </button>
+        {/if}
+      </fieldset>
+
+      {#if localError}
+        <p class="ch-sheet-error" role="alert">{localError}</p>
+      {/if}
+    </div>
+
+    <footer class="ch-sheet-actions">
+      <button type="button" class="ch-btn-ghost" onclick={onClose} disabled={submitting}>
+        Cancel
+      </button>
+      <button type="submit" class="ch-btn-primary" disabled={submitting || !name.trim()}>
+        {submitting ? 'Saving…' : 'Save changes'}
+      </button>
+    </footer>
+  </form>
+</dialog>
+
+<style>
+  .ch-sheet {
+    border: none;
+    padding: 0;
+    background: var(--color-surface);
+    color: var(--color-text);
+    box-shadow: var(--shadow-4);
+    width: min(520px, 100vw);
+    max-height: 90vh;
+    margin: auto auto 0;
+    border-radius: var(--radius-md) var(--radius-md) 0 0;
+  }
+  @media (min-width: 600px) {
+    .ch-sheet {
+      margin: auto;
+      border-radius: var(--radius-md);
+    }
+  }
+  .ch-sheet::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+  }
+  .ch-sheet form {
+    display: flex;
+    flex-direction: column;
+    max-height: 90vh;
+  }
+  .ch-sheet-head {
+    padding: 20px 24px 8px;
+  }
+  .ch-sheet-head h2 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 500;
+  }
+  .ch-sheet-body {
+    overflow-y: auto;
+    padding: 8px 24px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+  }
+
+  .ch-field {
+    border: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .ch-field-label {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--color-text-muted);
+    padding: 0;
+  }
+  input[type='text'] {
+    font: inherit;
+    color: inherit;
+    padding: 10px 12px;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    min-height: 44px;
+  }
+  input[type='text']:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -1px;
+    border-color: var(--color-primary);
+  }
+  input[type='file'] {
+    font: inherit;
+    color: var(--color-text-muted);
+    font-size: 0.875rem;
+  }
+
+  .ch-room-photo-preview {
+    width: 100%;
+    max-height: 160px;
+    object-fit: cover;
+    border-radius: var(--radius-sm);
+    background: var(--color-action-hover);
+    display: block;
+  }
+  .ch-room-photo-remove {
+    align-self: flex-start;
+  }
+
+  .ch-hint {
+    margin: 0;
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+  }
+  .ch-sheet-error {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--color-error);
+  }
+
+  .ch-sheet-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 16px 24px calc(20px + env(safe-area-inset-bottom, 0px));
+    border-top: 1px solid var(--color-line);
+  }
+  .ch-btn-ghost,
+  .ch-btn-primary {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    border: none;
+    cursor: pointer;
+    min-height: 44px;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+  }
+  .ch-btn-ghost {
+    background: transparent;
+    color: var(--color-primary);
+  }
+  .ch-btn-ghost:hover:not(:disabled) {
+    background: var(--color-action-hover);
+  }
+  .ch-btn-primary {
+    background: var(--color-primary);
+    color: #fff;
+    box-shadow: var(--shadow-1);
+  }
+  .ch-btn-primary:hover:not(:disabled) {
+    background: var(--color-primary-hover);
+  }
+  .ch-btn-primary:disabled,
+  .ch-btn-ghost:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  .ch-btn-danger-ghost {
+    font: inherit;
+    padding: 8px 16px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    min-height: 40px;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+    background: transparent;
+    color: var(--color-error);
+    border: 1px solid var(--color-error);
+  }
+  .ch-btn-danger-ghost:hover {
+    background: var(--color-action-hover);
+  }
+</style>

--- a/frontend/app/src/lib/chores/lib/components/RoomManagerSheet.svelte
+++ b/frontend/app/src/lib/chores/lib/components/RoomManagerSheet.svelte
@@ -1,0 +1,565 @@
+<script lang="ts">
+  // ───────────────────────────────────────────────────────────────────────
+  // Manage-rooms sheet (v1.2 room manager) — the reorder / delete / add surface
+  // that builds directly on the shipped RoomEditSheet (rename / icon / photo).
+  // Opened from the Rooms-lens dashboard header. Real rooms only; the virtual
+  // General group (roomId === null) is shown as a non-editable reference.
+  //
+  //  • Reorder: drag rows (svelte-dnd-action — the shopping-list island's house
+  //    pattern). On drop we POST the new order (reorderRooms) then reloadBoard()
+  //    so the dashboard re-sorts authoritatively.
+  //  • Delete: two-tap confirm. The server (RoomService.DeleteRoomAsync) moves
+  //    the room's chores to General and deletes its photo in one write — the
+  //    confirm copy says so, using the room's server-computed choreCount.
+  //  • Add: a thin inline create (reuses createRoom + the shared IconPicker), so
+  //    room management is consolidated here as well as in the chore sheets.
+  //  • Edit (rename / icon / photo): delegated to the existing RoomEditSheet via
+  //    onEditRoom — we do NOT duplicate that surface.
+  //
+  // A room change is not a chore mutation (no xmin / optimistic path); every
+  // mutation is call-the-API then boardStore.reloadBoard(), matching RoomEditSheet.
+  // ───────────────────────────────────────────────────────────────────────
+  import type { RoomGroup } from '../state.svelte';
+  import type { RoomRollupDto } from '../types';
+  import { createRoom, deleteRoom, reorderRooms } from '../api';
+  import { boardStore } from '../state.svelte';
+  import { showToast } from '$lib/shared/toast-store.svelte';
+  import IconPicker from './IconPicker.svelte';
+  import { dndzone, type DndEvent } from 'svelte-dnd-action';
+
+  interface Props {
+    open: boolean;
+    /** All room groups from the board (incl. the virtual General group). */
+    groups: RoomGroup[];
+    /** Open the shipped per-room edit sheet (rename / icon / photo). */
+    onEditRoom: (room: RoomRollupDto) => void;
+    onClose: () => void;
+  }
+
+  let { open, groups, onEditRoom, onClose }: Props = $props();
+
+  /** A draggable row — svelte-dnd-action needs a stable `id` per item. */
+  interface RoomRow {
+    id: number;
+    rollup: RoomRollupDto;
+  }
+
+  let dialogEl: HTMLDialogElement | null = $state(null);
+
+  // Local working list for the drag zone. Re-synced from `groups` except while a
+  // drag is in flight, so a mid-flight board reload can't clobber the ordering.
+  let rows = $state<RoomRow[]>([]);
+  let dragging = $state(false);
+
+  // The virtual General group (roomless chores) — shown as a non-editable note.
+  let general = $derived<RoomRollupDto | null>(
+    groups.find((g) => g.rollup.roomId === null)?.rollup ?? null,
+  );
+
+  function syncRows(): void {
+    rows = groups
+      .filter((g) => g.rollup.roomId !== null)
+      .map((g) => g.rollup)
+      .sort((a, b) => a.sortOrder - b.sortOrder)
+      .map((rollup) => ({ id: rollup.roomId as number, rollup }));
+  }
+
+  // Re-derive the working list whenever the board changes and we're not dragging
+  // (covers reloadBoard() after add / delete / reorder / a delegated edit).
+  $effect(() => {
+    if (!dragging) syncRows();
+  });
+
+  $effect(() => {
+    if (!dialogEl) return;
+    if (open && !dialogEl.open) {
+      resetAdd();
+      cancelDelete();
+      dialogEl.showModal();
+    } else if (!open && dialogEl.open) {
+      dialogEl.close();
+    }
+  });
+
+  // ── Reorder ────────────────────────────────────────────────────────────────
+  function handleConsider(e: CustomEvent<DndEvent<RoomRow>>): void {
+    dragging = true;
+    rows = e.detail.items;
+  }
+  async function handleFinalize(e: CustomEvent<DndEvent<RoomRow>>): Promise<void> {
+    rows = e.detail.items;
+    const ordered = rows.map((r) => r.id);
+    try {
+      await reorderRooms(ordered);
+      await boardStore.reloadBoard();
+    } catch {
+      showToast({ message: "Couldn't save the new order — refreshed.", kind: 'info' });
+      await boardStore.reloadBoard();
+    } finally {
+      // Release the drag guard last so the resync lands on the server order.
+      dragging = false;
+    }
+  }
+
+  // ── Delete (two-tap confirm — irreversible at the room level) ────────────────
+  let confirmDeleteId = $state<number | null>(null);
+  let deletingId = $state<number | null>(null);
+
+  function askDelete(id: number): void {
+    confirmDeleteId = id;
+  }
+  function cancelDelete(): void {
+    confirmDeleteId = null;
+  }
+  async function doDelete(row: RoomRow): Promise<void> {
+    if (deletingId !== null) return;
+    deletingId = row.id;
+    try {
+      await deleteRoom(row.id);
+      await boardStore.reloadBoard();
+      showToast({ message: `“${row.rollup.name}” deleted.`, kind: 'success' });
+    } catch {
+      showToast({ message: "Couldn't delete the room. Please try again.", kind: 'error' });
+    } finally {
+      deletingId = null;
+      confirmDeleteId = null;
+    }
+  }
+
+  /** Confirm copy spells out the M3 server behavior: chores fall back to General. */
+  function deleteConfirmText(rollup: RoomRollupDto): string {
+    const n = rollup.choreCount;
+    if (n === 0) return `Delete “${rollup.name}”? It has no chores.`;
+    return `Delete “${rollup.name}”? Its ${n} ${n === 1 ? 'chore' : 'chores'} will move to General.`;
+  }
+
+  // ── Add (thin inline create — reuses the createRoom path) ────────────────────
+  let showAdd = $state(false);
+  let newName = $state('');
+  let newIcon = $state<string>('🧹');
+  let addError = $state<string | null>(null);
+  let adding = $state(false);
+
+  function resetAdd(): void {
+    showAdd = false;
+    newName = '';
+    newIcon = '🧹';
+    addError = null;
+  }
+  async function addRoom(): Promise<void> {
+    const trimmed = newName.trim();
+    if (!trimmed) {
+      addError = 'Give the room a name.';
+      return;
+    }
+    if (adding) return;
+    addError = null;
+    adding = true;
+    try {
+      await createRoom({ name: trimmed, icon: newIcon });
+      await boardStore.reloadBoard();
+      resetAdd();
+    } catch {
+      addError = "Couldn't create the room — try again.";
+    } finally {
+      adding = false;
+    }
+  }
+</script>
+
+<dialog bind:this={dialogEl} onclose={onClose} class="ch-sheet">
+  <div class="ch-sheet-inner">
+    <header class="ch-sheet-head">
+      <h2>Manage rooms</h2>
+      <p class="ch-sheet-subhead">Reorder, rename, set a photo, or remove a room.</p>
+    </header>
+
+    <div class="ch-sheet-body">
+      {#if rows.length > 0}
+        <ul
+          class="ch-rm-list"
+          use:dndzone={{
+            items: rows,
+            type: 'rooms',
+            flipDurationMs: 150,
+            dropTargetStyle: {},
+            delayTouchStart: 250,
+          }}
+          onconsider={handleConsider}
+          onfinalize={handleFinalize}
+        >
+          {#each rows as row (row.id)}
+            <li class="ch-rm-row">
+              {#if confirmDeleteId === row.id}
+                <span class="ch-rm-confirm" role="alert">{deleteConfirmText(row.rollup)}</span>
+                <span class="ch-rm-confirm-actions">
+                  <button
+                    type="button"
+                    class="ch-btn-ghost"
+                    onclick={cancelDelete}
+                    disabled={deletingId === row.id}
+                  >
+                    Keep
+                  </button>
+                  <button
+                    type="button"
+                    class="ch-btn-danger"
+                    onclick={() => doDelete(row)}
+                    disabled={deletingId === row.id}
+                  >
+                    {deletingId === row.id ? 'Deleting…' : 'Delete'}
+                  </button>
+                </span>
+              {:else}
+                <span class="ch-rm-handle" aria-hidden="true">⠿</span>
+                <span class="ch-rm-icon" aria-hidden="true">{row.rollup.icon}</span>
+                <span class="ch-rm-name">{row.rollup.name}</span>
+                <span class="ch-rm-count">
+                  {row.rollup.choreCount}
+                  {row.rollup.choreCount === 1 ? 'chore' : 'chores'}
+                </span>
+                <span class="ch-rm-actions">
+                  <button
+                    type="button"
+                    class="ch-rm-iconbtn"
+                    aria-label="Edit {row.rollup.name}"
+                    onclick={() => onEditRoom(row.rollup)}
+                  >
+                    ✏️
+                  </button>
+                  <button
+                    type="button"
+                    class="ch-rm-iconbtn ch-rm-iconbtn-danger"
+                    aria-label="Delete {row.rollup.name}"
+                    onclick={() => askDelete(row.id)}
+                  >
+                    🗑️
+                  </button>
+                </span>
+              {/if}
+            </li>
+          {/each}
+        </ul>
+      {:else}
+        <p class="ch-hint">No rooms yet. Add one below, or create a room while adding a chore.</p>
+      {/if}
+
+      {#if general}
+        <p class="ch-rm-general">
+          <span aria-hidden="true">{general.icon}</span>
+          General — where roomless chores (and a deleted room's chores) live. Not editable.
+        </p>
+      {/if}
+
+      {#if showAdd}
+        <div class="ch-newroom">
+          <IconPicker value={newIcon} onSelect={(i) => (newIcon = i)} label="New room icon" />
+          <div class="ch-newroom-row">
+            <input
+              type="text"
+              bind:value={newName}
+              autocomplete="off"
+              placeholder="Room name (e.g. Garage)"
+              aria-label="New room name"
+              onkeydown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  addRoom();
+                }
+              }}
+            />
+            <button
+              type="button"
+              class="ch-btn-primary ch-newroom-add"
+              onclick={addRoom}
+              disabled={adding || !newName.trim()}
+            >
+              {adding ? 'Adding…' : 'Add'}
+            </button>
+            <button type="button" class="ch-btn-ghost" onclick={resetAdd} disabled={adding}>
+              Cancel
+            </button>
+          </div>
+          {#if addError}
+            <p class="ch-sheet-error" role="alert">{addError}</p>
+          {/if}
+        </div>
+      {:else}
+        <button
+          type="button"
+          class="ch-chip ch-chip-add ch-rm-add"
+          onclick={() => {
+            showAdd = true;
+            addError = null;
+          }}
+        >
+          ＋ Add room
+        </button>
+      {/if}
+    </div>
+
+    <footer class="ch-sheet-actions">
+      <button type="button" class="ch-btn-primary" onclick={onClose}>Done</button>
+    </footer>
+  </div>
+</dialog>
+
+<style>
+  /* ── Sheet shell (parity with EditChoreSheet / RoomEditSheet) ─────────────── */
+  .ch-sheet {
+    border: none;
+    padding: 0;
+    background: var(--color-surface);
+    color: var(--color-text);
+    box-shadow: var(--shadow-4);
+    width: min(520px, 100vw);
+    max-height: 90vh;
+    margin: auto auto 0;
+    border-radius: var(--radius-md) var(--radius-md) 0 0;
+  }
+  @media (min-width: 600px) {
+    .ch-sheet {
+      margin: auto;
+      border-radius: var(--radius-md);
+    }
+  }
+  .ch-sheet::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+  }
+  .ch-sheet-inner {
+    display: flex;
+    flex-direction: column;
+    max-height: 90vh;
+  }
+  .ch-sheet-head {
+    padding: 20px 24px 8px;
+  }
+  .ch-sheet-head h2 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 500;
+  }
+  .ch-sheet-subhead {
+    margin: 4px 0 0;
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+  }
+  .ch-sheet-body {
+    overflow-y: auto;
+    padding: 12px 24px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  /* ── Room list ────────────────────────────────────────────────────────────── */
+  .ch-rm-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .ch-rm-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-height: 52px;
+    padding: 8px 10px;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+  }
+  .ch-rm-handle {
+    flex-shrink: 0;
+    color: var(--color-text-muted);
+    font-size: 1.125rem;
+    line-height: 1;
+    cursor: grab;
+    padding: 4px;
+    -webkit-tap-highlight-color: transparent;
+  }
+  .ch-rm-icon {
+    flex-shrink: 0;
+    font-size: 1.25rem;
+    line-height: 1;
+  }
+  .ch-rm-name {
+    flex: 1;
+    min-width: 0;
+    font-weight: 500;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .ch-rm-count {
+    flex-shrink: 0;
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .ch-rm-actions {
+    flex-shrink: 0;
+    display: inline-flex;
+    gap: 4px;
+  }
+  .ch-rm-iconbtn {
+    font: inherit;
+    font-size: 1rem;
+    line-height: 1;
+    border: 1px solid var(--color-line-strong);
+    background: transparent;
+    border-radius: var(--radius-sm);
+    min-width: 40px;
+    min-height: 40px;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+  }
+  .ch-rm-iconbtn:hover {
+    background: var(--color-action-hover);
+  }
+  .ch-rm-iconbtn-danger:hover {
+    border-color: var(--color-error);
+  }
+
+  /* ── Inline delete confirm (two-tap) ──────────────────────────────────────── */
+  .ch-rm-confirm {
+    flex: 1;
+    min-width: 0;
+    font-size: 0.8125rem;
+    color: var(--color-text);
+  }
+  .ch-rm-confirm-actions {
+    flex-shrink: 0;
+    display: inline-flex;
+    gap: 6px;
+  }
+
+  /* ── General reference + add ──────────────────────────────────────────────── */
+  .ch-rm-general {
+    margin: 0;
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+    padding: 8px 10px;
+    border: 1px dashed var(--color-line);
+    border-radius: var(--radius-sm);
+  }
+  .ch-rm-add {
+    align-self: flex-start;
+  }
+
+  .ch-hint {
+    margin: 0;
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+  }
+  .ch-sheet-error {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--color-error);
+  }
+
+  /* ── Inline "new room" (parity with the chore sheets' create form) ────────── */
+  .ch-newroom {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 12px;
+    border: 1px dashed var(--color-line-strong);
+    border-radius: var(--radius-sm);
+  }
+  .ch-newroom-row {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+  .ch-newroom-row input[type='text'] {
+    flex: 1;
+    min-width: 140px;
+    font: inherit;
+    color: inherit;
+    padding: 10px 12px;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    min-height: 44px;
+  }
+  .ch-newroom-row input[type='text']:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -1px;
+    border-color: var(--color-primary);
+  }
+  .ch-newroom-add {
+    min-height: 44px;
+  }
+  .ch-chip {
+    font: inherit;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    border: 1px solid var(--color-line-strong);
+    background: transparent;
+    color: var(--color-text-muted);
+    padding: 6px 14px;
+    min-height: 40px;
+    border-radius: 18px;
+    cursor: pointer;
+  }
+  .ch-chip:hover {
+    background: var(--color-action-hover);
+    color: var(--color-text);
+  }
+  .ch-chip-add {
+    border-style: dashed;
+  }
+
+  /* ── Footer actions (parity with the other sheets) ────────────────────────── */
+  .ch-sheet-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 16px 24px calc(20px + env(safe-area-inset-bottom, 0px));
+    border-top: 1px solid var(--color-line);
+  }
+  .ch-btn-ghost,
+  .ch-btn-primary,
+  .ch-btn-danger {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    border: none;
+    cursor: pointer;
+    min-height: 44px;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+  }
+  .ch-btn-ghost {
+    background: transparent;
+    color: var(--color-primary);
+  }
+  .ch-btn-ghost:hover:not(:disabled) {
+    background: var(--color-action-hover);
+  }
+  .ch-btn-primary {
+    background: var(--color-primary);
+    color: #fff;
+    box-shadow: var(--shadow-1);
+  }
+  .ch-btn-primary:hover:not(:disabled) {
+    background: var(--color-primary-hover);
+  }
+  .ch-btn-danger {
+    background: var(--color-error);
+    color: #fff;
+    box-shadow: var(--shadow-1);
+  }
+  .ch-btn-danger:hover:not(:disabled) {
+    filter: brightness(0.92);
+  }
+  .ch-btn-ghost:disabled,
+  .ch-btn-primary:disabled,
+  .ch-btn-danger:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+</style>

--- a/frontend/app/src/lib/chores/lib/components/RoomsDashboard.svelte
+++ b/frontend/app/src/lib/chores/lib/components/RoomsDashboard.svelte
@@ -1,0 +1,636 @@
+<script lang="ts">
+  import type { RoomGroup } from '../state.svelte';
+  import type { ChoreDto, RoomRollupDto, RoomRollupStatus } from '../types';
+  import { showPhoto } from '../lightbox.svelte';
+  import ChoreCard from './ChoreCard.svelte';
+  import RoomEditSheet from './RoomEditSheet.svelte';
+  import RoomManagerSheet from './RoomManagerSheet.svelte';
+
+  // ───────────────────────────────────────────────────────────────────────
+  // Rooms lens (S7) — a rollup dashboard (D9): one card per room (incl. the
+  // virtual "General" group, roomId === null) showing the room's dirtiness
+  // status (clean / attention / needs-work) computed SERVER-SIDE. Tapping a
+  // room drills into its chore list, rendered with the shared `ChoreCard`.
+  //
+  // ⚠ M5/M6/M11: the rollup `status` + `dueCount` are SERVER-computed and
+  // arrive on the board payload; we never recompute dirtiness here. This is a
+  // CLIENT-SIDE grouping of the ONE board payload — no fetch on drill-in.
+  // ───────────────────────────────────────────────────────────────────────
+
+  interface Props {
+    groups: RoomGroup[];
+    currentUserId: number;
+    isPending: (choreId: number) => boolean;
+    onClaim: (chore: ChoreDto) => void;
+    onDrop: (chore: ChoreDto) => void;
+    onComplete: (chore: ChoreDto) => void;
+    onHandOff: (chore: ChoreDto) => void;
+    onTake: (chore: ChoreDto) => void;
+    onAssign: (chore: ChoreDto) => void;
+    onCommit: (chore: ChoreDto) => void;
+    onLeave: (chore: ChoreDto) => void;
+    onEdit: (chore: ChoreDto) => void;
+    onSnooze: (chore: ChoreDto, request: { days?: number; until?: string | null }) => void;
+  }
+
+  let {
+    groups,
+    currentUserId,
+    isPending,
+    onClaim,
+    onDrop,
+    onComplete,
+    onHandOff,
+    onTake,
+    onAssign,
+    onCommit,
+    onLeave,
+    onEdit,
+    onSnooze,
+  }: Props = $props();
+
+  // The drilled-into room (by roomId; null = the General group; undefined = the
+  // dashboard grid). Number-or-null can't disambiguate "General" from "grid", so
+  // we track a separate boolean.
+  let openRoomId = $state<number | null>(null);
+  let drilledIn = $state(false);
+
+  let openGroup = $derived.by<RoomGroup | null>(() => {
+    if (!drilledIn) return null;
+    return groups.find((g) => (g.rollup.roomId ?? null) === openRoomId) ?? null;
+  });
+
+  function openRoom(group: RoomGroup): void {
+    openRoomId = group.rollup.roomId ?? null;
+    drilledIn = true;
+  }
+  function backToGrid(): void {
+    drilledIn = false;
+    openRoomId = null;
+  }
+
+  // ── Server rollup status → label / accent (no client dirtiness recompute) ──
+  const STATUS_LABEL: Record<RoomRollupStatus, string> = {
+    clean: 'All clean',
+    attention: 'Needs a look',
+    needsWork: 'Needs work',
+  };
+
+  // ── Room edit (v1.2 minimal room manager) ─────────────────────────────────
+  // Editing is only offered for real rooms (roomId !== null) — never the virtual
+  // General group. RoomEditSheet handles updateRoom + photo upload + board reload.
+  let editOpen = $state(false);
+  let editRoom = $state<RoomRollupDto | null>(null);
+
+  function openEditRoom(rollup: RoomRollupDto): void {
+    editRoom = rollup;
+    editOpen = true;
+  }
+
+  let canEditOpenRoom = $derived((openGroup?.rollup.roomId ?? null) !== null);
+
+  // ── Manage rooms (v1.2 room manager: reorder / delete / add) ───────────────
+  // A list surface over the real rooms; per-room rename / icon / photo is
+  // delegated to the existing RoomEditSheet (no duplication). Shown only when
+  // there's at least one real room to manage (General is virtual).
+  let manageOpen = $state(false);
+  let hasRealRooms = $derived(groups.some((g) => g.rollup.roomId !== null));
+</script>
+
+{#if openGroup}
+  <!-- Drill-in: a single room's chore list. -->
+  <div class="ch-rooms-drill">
+    <div class="ch-rooms-drill-bar">
+      <button type="button" class="ch-rooms-back" onclick={backToGrid}>
+        <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+          <path d="M15 18l-6-6 6-6" fill="none" stroke="currentColor" stroke-width="2" />
+        </svg>
+        All rooms
+      </button>
+      {#if canEditOpenRoom}
+        <button type="button" class="ch-rooms-edit" onclick={() => openEditRoom(openGroup.rollup)}>
+          <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
+            <path
+              d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04a1 1 0 0 0 0-1.41l-2.34-2.34a1 1 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+              fill="currentColor"
+            />
+          </svg>
+          Edit room
+        </button>
+      {/if}
+    </div>
+
+    {#if openGroup.rollup.photoPath}
+      <!--
+        Photo'd room → hero band. The emoji still leads the name (operator's
+        hybrid) so identity is anchored even with a cover. Tap the photo to
+        enlarge (shared lightbox); the overlay text is non-interactive.
+      -->
+      <header class="ch-room-hero">
+        <button
+          type="button"
+          class="ch-room-hero-zoom"
+          onclick={() => showPhoto(openGroup.rollup.photoPath, openGroup.rollup.name)}
+          aria-label="View photo for {openGroup.rollup.name}"
+        >
+          <img
+            class="ch-room-hero-img"
+            src={openGroup.rollup.photoPath}
+            alt=""
+            loading="lazy"
+          />
+        </button>
+        <div class="ch-room-hero-overlay" aria-hidden="true">
+          <div class="ch-room-hero-text">
+            <h2 class="ch-room-hero-name">
+              <span class="ch-room-hero-emoji">{openGroup.rollup.icon}</span>
+              {openGroup.rollup.name}
+            </h2>
+            <span class="ch-room-hero-sub">
+              {openGroup.rollup.choreCount}
+              {openGroup.rollup.choreCount === 1 ? 'chore' : 'chores'}
+              {#if openGroup.rollup.dueCount > 0}
+                · {openGroup.rollup.dueCount} need attention
+              {/if}
+            </span>
+          </div>
+          <span class="ch-room-status ch-status-{openGroup.rollup.status}">
+            {STATUS_LABEL[openGroup.rollup.status]}
+          </span>
+        </div>
+      </header>
+    {:else}
+      <header class="ch-room-head">
+        <span class="ch-room-icon" aria-hidden="true">{openGroup.rollup.icon}</span>
+        <div class="ch-room-head-text">
+          <h2 class="ch-room-name">{openGroup.rollup.name}</h2>
+          <span class="ch-room-sub">
+            {openGroup.rollup.choreCount}
+            {openGroup.rollup.choreCount === 1 ? 'chore' : 'chores'}
+            {#if openGroup.rollup.dueCount > 0}
+              · {openGroup.rollup.dueCount} need attention
+            {/if}
+          </span>
+        </div>
+        <span class="ch-room-status ch-status-{openGroup.rollup.status}">
+          {STATUS_LABEL[openGroup.rollup.status]}
+        </span>
+      </header>
+    {/if}
+
+    {#if openGroup.chores.length > 0}
+      <div class="ch-room-cards">
+        {#each openGroup.chores as chore (chore.id)}
+          <ChoreCard
+            {chore}
+            {currentUserId}
+            showRoom={false}
+            pending={isPending(chore.id)}
+            {onClaim}
+            {onDrop}
+            {onComplete}
+            {onHandOff}
+            {onTake}
+            {onAssign}
+            {onCommit}
+            {onLeave}
+            {onEdit}
+            {onSnooze}
+          />
+        {/each}
+      </div>
+    {:else}
+      <div class="ch-rooms-empty">
+        <p class="ch-rooms-empty-head">Nothing here.</p>
+        <p>This room has no active chores.</p>
+      </div>
+    {/if}
+  </div>
+{:else}
+  <!-- Dashboard: one rollup card per room. -->
+  {#if hasRealRooms}
+    <div class="ch-rooms-managebar">
+      <button type="button" class="ch-rooms-manage" onclick={() => (manageOpen = true)}>
+        <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
+          <path
+            d="M3 6h18M3 12h18M3 18h18"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+          />
+        </svg>
+        Manage rooms
+      </button>
+    </div>
+  {/if}
+  {#if groups.length > 0}
+    <div class="ch-rooms-grid">
+      {#each groups as group (group.rollup.roomId ?? 'general')}
+        <button
+          type="button"
+          class="ch-room-card ch-status-{group.rollup.status}"
+          onclick={() => openRoom(group)}
+          aria-label="{group.rollup.name}: {STATUS_LABEL[group.rollup.status]}, {group.rollup
+            .choreCount} chores"
+        >
+          {#if group.rollup.photoPath}
+            <!-- Cover image (v1.2). Part of the drill-in button — tapping it opens
+                 the room. The emoji still leads the name below. -->
+            <img class="ch-room-cover" src={group.rollup.photoPath} alt="" loading="lazy" />
+          {/if}
+          <span class="ch-room-card-row">
+            <span class="ch-room-card-accent" aria-hidden="true"></span>
+            <span class="ch-room-card-body">
+              <span class="ch-room-card-top">
+                <span class="ch-room-card-icon" aria-hidden="true">{group.rollup.icon}</span>
+                <span class="ch-room-card-name">{group.rollup.name}</span>
+              </span>
+              <span class="ch-room-card-meta">
+                <span class="ch-room-status-pill ch-status-{group.rollup.status}">
+                  {STATUS_LABEL[group.rollup.status]}
+                </span>
+                <span class="ch-room-card-counts">
+                  {#if group.rollup.dueCount > 0}
+                    {group.rollup.dueCount} due · {group.rollup.choreCount} total
+                  {:else}
+                    {group.rollup.choreCount}
+                    {group.rollup.choreCount === 1 ? 'chore' : 'chores'}
+                  {/if}
+                </span>
+              </span>
+            </span>
+            <svg
+              class="ch-room-card-chevron"
+              viewBox="0 0 24 24"
+              width="20"
+              height="20"
+              aria-hidden="true"
+            >
+              <path d="M9 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="2" />
+            </svg>
+          </span>
+        </button>
+      {/each}
+    </div>
+  {:else}
+    <div class="ch-rooms-empty">
+      <p class="ch-rooms-empty-head">No rooms yet.</p>
+      <p>Chores will show up here once there are rooms.</p>
+    </div>
+  {/if}
+{/if}
+
+<RoomEditSheet
+  open={editOpen}
+  room={editRoom}
+  onClose={() => {
+    editOpen = false;
+    editRoom = null;
+  }}
+/>
+
+<!--
+  Manage-rooms list (reorder / delete / add). Per-room rename / icon / photo is
+  delegated to the RoomEditSheet above — opening it stacks on top of the manager,
+  which stays open so several rooms can be managed in one pass.
+-->
+<RoomManagerSheet
+  open={manageOpen}
+  {groups}
+  onEditRoom={(room) => openEditRoom(room)}
+  onClose={() => (manageOpen = false)}
+/>
+
+<style>
+  /* ── Status accent (server-computed rollup status; never derived here) ──── */
+  .ch-status-clean {
+    --status-accent: var(--color-success);
+  }
+  .ch-status-attention {
+    --status-accent: var(--color-warning);
+  }
+  .ch-status-needsWork {
+    --status-accent: var(--color-error);
+  }
+
+  /* ── Dashboard grid ─────────────────────────────────────────────────────── */
+  /* Manage-rooms entry — sits above the grid, mirrors the drill-in Edit button. */
+  .ch-rooms-managebar {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 12px;
+  }
+  .ch-rooms-manage {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font: inherit;
+    font-size: 0.875rem;
+    font-weight: 500;
+    border: 1px solid var(--color-line-strong);
+    background: transparent;
+    color: var(--color-text-muted);
+    padding: 6px 12px;
+    min-height: 36px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+    transition:
+      background-color 0.15s,
+      color 0.15s;
+  }
+  .ch-rooms-manage:hover {
+    background: var(--color-action-hover);
+    color: var(--color-text);
+  }
+  .ch-rooms-manage:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+  .ch-rooms-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 12px;
+  }
+  .ch-room-card {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    text-align: left;
+    font: inherit;
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    box-shadow: var(--shadow-1);
+    cursor: pointer;
+    overflow: hidden;
+    padding: 0;
+    transition:
+      box-shadow 0.15s,
+      transform 0.1s;
+    -webkit-tap-highlight-color: transparent;
+  }
+  /* The accent | body | chevron row; sits below the optional cover image. */
+  .ch-room-card-row {
+    display: flex;
+    align-items: stretch;
+    flex: 1;
+    min-width: 0;
+  }
+  /* Cover image (v1.2) — full-width strip across the top of a photo'd room. */
+  .ch-room-cover {
+    width: 100%;
+    height: 84px;
+    object-fit: cover;
+    display: block;
+    background: var(--color-action-hover);
+  }
+  .ch-room-card:hover {
+    box-shadow: var(--shadow-2);
+  }
+  .ch-room-card:active {
+    transform: scale(0.99);
+  }
+  .ch-room-card:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+  .ch-room-card-accent {
+    flex-shrink: 0;
+    width: 6px;
+    background: var(--status-accent);
+  }
+  .ch-room-card-body {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 14px 14px 14px 12px;
+  }
+  .ch-room-card-top {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+  }
+  .ch-room-card-icon {
+    font-size: 1.5rem;
+    line-height: 1;
+    flex-shrink: 0;
+  }
+  .ch-room-card-name {
+    font-size: 1.0625rem;
+    font-weight: 500;
+    color: var(--color-text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .ch-room-card-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .ch-room-card-counts {
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+  }
+  .ch-room-card-chevron {
+    align-self: center;
+    margin-right: 10px;
+    color: var(--color-text-muted);
+    flex-shrink: 0;
+  }
+
+  /* ── Status pill (dashboard + drill header) ─────────────────────────────── */
+  .ch-room-status-pill,
+  .ch-room-status {
+    display: inline-flex;
+    align-items: center;
+    align-self: flex-start;
+    height: 22px;
+    padding: 0 10px;
+    border-radius: 11px;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+    white-space: nowrap;
+    color: var(--status-accent);
+    background: transparent;
+    border: 1px solid var(--status-accent);
+  }
+  /* Needs-work reads loudest — solid fill. */
+  .ch-status-needsWork.ch-room-status-pill,
+  .ch-room-status.ch-status-needsWork {
+    color: #fff;
+    background: var(--status-accent);
+    border-color: var(--status-accent);
+  }
+
+  /* ── Drill-in ───────────────────────────────────────────────────────────── */
+  .ch-rooms-drill {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+  .ch-rooms-back {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    align-self: flex-start;
+    font: inherit;
+    font-size: 0.875rem;
+    font-weight: 500;
+    border: none;
+    background: transparent;
+    color: var(--color-primary);
+    padding: 4px 8px 4px 0;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+  }
+  .ch-rooms-back:hover {
+    text-decoration: underline;
+  }
+  .ch-rooms-back:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+    border-radius: var(--radius-sm);
+  }
+  /* Drill-in bar: back (left) + Edit room (right, real rooms only). */
+  .ch-rooms-drill-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+  }
+  .ch-rooms-edit {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font: inherit;
+    font-size: 0.875rem;
+    font-weight: 500;
+    border: 1px solid var(--color-line-strong);
+    background: transparent;
+    color: var(--color-text-muted);
+    padding: 6px 12px;
+    min-height: 36px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+    transition:
+      background-color 0.15s,
+      color 0.15s;
+  }
+  .ch-rooms-edit:hover {
+    background: var(--color-action-hover);
+    color: var(--color-text);
+  }
+  .ch-rooms-edit:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+
+  /* ── Drill-in hero (photo'd room) — emoji-led title overlaid, tap to zoom ── */
+  .ch-room-hero {
+    position: relative;
+    border-radius: var(--radius-md);
+    overflow: hidden;
+  }
+  .ch-room-hero-zoom {
+    display: block;
+    width: 100%;
+    padding: 0;
+    border: none;
+    background: transparent;
+    cursor: zoom-in;
+    line-height: 0;
+    -webkit-tap-highlight-color: transparent;
+  }
+  .ch-room-hero-img {
+    display: block;
+    width: 100%;
+    height: 140px;
+    object-fit: cover;
+    background: var(--color-action-hover);
+  }
+  .ch-room-hero-overlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 12px 14px;
+    background: linear-gradient(to top, rgba(0, 0, 0, 0.62), rgba(0, 0, 0, 0) 70%);
+    pointer-events: none; /* clicks fall through to the zoom button */
+  }
+  .ch-room-hero-text {
+    min-width: 0;
+  }
+  .ch-room-hero-name {
+    margin: 0;
+    font-size: 1.375rem;
+    font-weight: 600;
+    color: #fff;
+    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
+  }
+  .ch-room-hero-emoji {
+    margin-right: 4px;
+  }
+  .ch-room-hero-sub {
+    font-size: 0.8125rem;
+    color: rgba(255, 255, 255, 0.92);
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+  }
+  /* Clean/attention pills need a backing to read on a photo; needsWork stays solid. */
+  .ch-room-hero-overlay .ch-room-status:not(.ch-status-needsWork) {
+    background: rgba(0, 0, 0, 0.4);
+    border-color: rgba(255, 255, 255, 0.5);
+    color: #fff;
+  }
+  .ch-room-head {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+  .ch-room-icon {
+    font-size: 2rem;
+    line-height: 1;
+    flex-shrink: 0;
+  }
+  .ch-room-head-text {
+    flex: 1;
+    min-width: 0;
+  }
+  .ch-room-name {
+    margin: 0;
+    font-size: 1.375rem;
+    font-weight: 500;
+    color: var(--color-text);
+  }
+  .ch-room-sub {
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+  }
+  .ch-room-cards {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .ch-rooms-empty {
+    padding: 48px 16px;
+    text-align: center;
+    color: var(--color-text-muted);
+  }
+  .ch-rooms-empty-head {
+    font-size: 1.125rem;
+    font-weight: 500;
+    color: var(--color-text);
+    margin: 0 0 4px;
+  }
+</style>

--- a/frontend/app/src/lib/chores/lib/components/ViewSwitcher.svelte
+++ b/frontend/app/src/lib/chores/lib/components/ViewSwitcher.svelte
@@ -1,0 +1,287 @@
+<script lang="ts">
+  import type { ChoreLensId } from '../types';
+
+  // ───────────────────────────────────────────────────────────────────────
+  // View control (Phase 14 — Model A board IA). Two grouped controls + the
+  // roaming 📌 "set as default":
+  //
+  //   PRIMARY (prominent segmented control) — the board's main affordance. It
+  //   picks WHICH chore set the always-attention-sectioned board shows:
+  //     Up for grabs · Mine · All   (lens ids up-for-grabs / mine / needs-attention)
+  //
+  //   SECONDARY (visually lighter, off to the side) — on-demand ORGANIZERS that
+  //   reorganize the board differently, NOT co-equal filters:
+  //     Rooms · Equity   (Equity reads as the most tucked-away — back seat)
+  //
+  // Switching is CLIENT-SIDE only (sets the store `lens`); it NEVER refetches
+  // (M11). Every view groups the ONE already-loaded payload (Equity keeps its
+  // own separate cached fetch).
+  //
+  // The 📌 control pins the ACTIVE view (any of the 5 ids) as the user's per-user
+  // default. The default is SERVER-PERSISTED (User.ChoresDefaultView) so it roams
+  // across devices — NOT localStorage (D18). The island reads the current default
+  // from the board payload's `userDefaultView` (in the store); this control only
+  // writes it via `onSetDefault`, and shows the 📌 dot on whichever view is the
+  // current default (across BOTH groups).
+  // ───────────────────────────────────────────────────────────────────────
+
+  interface Props {
+    /** The active lens id (read from the store). */
+    active: ChoreLensId;
+    /** The user's persisted default lens (null ⇒ Up-for-grabs, resolved upstream). */
+    defaultLens: ChoreLensId;
+    /** True while a default-view PATCH is in flight (disables the control). */
+    saving: boolean;
+    /** Set the active lens (writes the store). Switching never refetches (M11). */
+    onSelect: (lens: ChoreLensId) => void;
+    /** Pin the active lens as the roaming default (PATCH /me/default-view). */
+    onSetDefault: (lens: ChoreLensId) => void;
+  }
+
+  let { active, defaultLens, saving, onSelect, onSetDefault }: Props = $props();
+
+  const LENS_LABEL: Record<ChoreLensId, string> = {
+    'up-for-grabs': 'Up for grabs',
+    mine: 'Mine',
+    'needs-attention': 'All',
+    rooms: 'Rooms',
+    recap: 'Recap',
+    equity: 'Board load',
+  };
+
+  // The primary segmented filters (board filters) vs the secondary organizers.
+  const PRIMARY: ChoreLensId[] = ['up-for-grabs', 'mine', 'needs-attention'];
+  const SECONDARY: ChoreLensId[] = ['rooms', 'recap', 'equity'];
+
+  let isActiveDefault = $derived(active === defaultLens);
+</script>
+
+<div class="ch-switcher-bar">
+  <div class="ch-switcher-views">
+    <!-- PRIMARY: the prominent segmented filter — the main affordance. -->
+    <div class="ch-segment" role="tablist" aria-label="Board filter">
+      {#each PRIMARY as lens (lens)}
+        <button
+          type="button"
+          role="tab"
+          class="ch-segment-tab"
+          class:active={lens === active}
+          aria-selected={lens === active}
+          onclick={() => onSelect(lens)}
+        >
+          {LENS_LABEL[lens]}
+          {#if lens === defaultLens}
+            <span class="ch-default-dot" title="Your default view" aria-label="Your default view">📌</span>
+          {/if}
+        </button>
+      {/each}
+    </div>
+
+    <!-- SECONDARY: lighter, de-emphasized organizers (Equity tucked furthest). -->
+    <div class="ch-organizers" role="group" aria-label="Other views">
+      {#each SECONDARY as lens (lens)}
+        <button
+          type="button"
+          class="ch-organizer"
+          class:active={lens === active}
+          class:is-equity={lens === 'equity'}
+          aria-pressed={lens === active}
+          onclick={() => onSelect(lens)}
+        >
+          {LENS_LABEL[lens]}
+          {#if lens === defaultLens}
+            <span class="ch-default-dot" title="Your default view" aria-label="Your default view">📌</span>
+          {/if}
+        </button>
+      {/each}
+    </div>
+  </div>
+
+  <button
+    type="button"
+    class="ch-set-default"
+    class:is-default={isActiveDefault}
+    onclick={() => onSetDefault(active)}
+    disabled={saving || isActiveDefault}
+    aria-pressed={isActiveDefault}
+    title={isActiveDefault
+      ? `“${LENS_LABEL[active]}” is your default view`
+      : `Open onto “${LENS_LABEL[active]}” by default`}
+  >
+    <span class="ch-set-default-icon" aria-hidden="true">📌</span>
+    {#if isActiveDefault}
+      Default view
+    {:else if saving}
+      Saving…
+    {:else}
+      Set as default
+    {/if}
+  </button>
+</div>
+
+<style>
+  .ch-switcher-bar {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    flex-wrap: wrap;
+    justify-content: space-between;
+  }
+  .ch-switcher-views {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    flex-wrap: wrap;
+    min-width: 0;
+  }
+
+  /* ── PRIMARY segmented control (prominent) ──────────────────────────────── */
+  .ch-segment {
+    display: inline-flex;
+    gap: 2px;
+    padding: 3px;
+    background: var(--color-action-hover);
+    border-radius: var(--radius-md);
+    max-width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+  }
+  .ch-segment::-webkit-scrollbar {
+    display: none;
+  }
+  .ch-segment-tab {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    font: inherit;
+    font-size: 0.875rem;
+    font-weight: 500;
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
+    padding: 8px 16px;
+    min-height: 38px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    white-space: nowrap;
+    transition:
+      background-color 0.15s,
+      color 0.15s;
+    -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation;
+  }
+  .ch-segment-tab:hover:not(.active) {
+    color: var(--color-text);
+  }
+  .ch-segment-tab.active {
+    background: var(--color-surface);
+    color: var(--color-text);
+    box-shadow: var(--shadow-1);
+  }
+  .ch-segment-tab:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -2px;
+  }
+
+  /* ── SECONDARY organizers (de-emphasized) ───────────────────────────────── */
+  .ch-organizers {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+  }
+  .ch-organizer {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font: inherit;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
+    padding: 6px 10px;
+    min-height: 34px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    white-space: nowrap;
+    opacity: 0.8;
+    transition:
+      background-color 0.15s,
+      color 0.15s,
+      opacity 0.15s;
+    -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation;
+  }
+  .ch-organizer:hover:not(.active) {
+    color: var(--color-text);
+    background: var(--color-action-hover);
+    opacity: 1;
+  }
+  .ch-organizer.active {
+    color: var(--color-text);
+    background: var(--color-action-hover);
+    opacity: 1;
+    box-shadow: inset 0 -2px 0 var(--color-primary);
+  }
+  .ch-organizer:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -2px;
+  }
+  /* Equity reads as the most tucked-away (back seat) — lighter still. */
+  .ch-organizer.is-equity:not(.active) {
+    font-size: 0.75rem;
+    opacity: 0.65;
+  }
+
+  .ch-default-dot {
+    font-size: 0.6875rem;
+    line-height: 1;
+  }
+
+  /* ── 📌 roaming set-as-default ───────────────────────────────────────────── */
+  .ch-set-default {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font: inherit;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    border: 1px solid var(--color-line-strong);
+    background: transparent;
+    color: var(--color-text-muted);
+    padding: 7px 14px;
+    min-height: 38px;
+    border-radius: 19px;
+    cursor: pointer;
+    white-space: nowrap;
+    transition:
+      background-color 0.15s,
+      color 0.15s,
+      border-color 0.15s;
+    -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation;
+  }
+  .ch-set-default:hover:not(:disabled) {
+    color: var(--color-text);
+    background: var(--color-action-hover);
+  }
+  .ch-set-default:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+  .ch-set-default.is-default {
+    color: var(--color-primary);
+    border-color: var(--color-primary);
+    cursor: default;
+  }
+  .ch-set-default:disabled:not(.is-default) {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+  .ch-set-default-icon {
+    font-size: 0.875rem;
+    line-height: 1;
+  }
+</style>

--- a/frontend/app/src/lib/chores/lib/dates.ts
+++ b/frontend/app/src/lib/chores/lib/dates.ts
@@ -1,0 +1,24 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Tiny date helpers for the island. The board NEVER does dueness/decay date
+// math client-side (MN4) — `dueState`/`colorTier`/`isSnoozed` are all server-
+// computed. The one thing the client legitimately needs is a LOWER BOUND for
+// the snooze/first-due date pickers, so a user can't pick today/past in a field
+// that means "defer to the future". The server is the authority (it rejects a
+// non-future floor — ChoresEndpoints.ValidateFloor); this only bounds the picker.
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Local today + 1, formatted "YYYY-MM-DD", for a date input's `min`. Built from
+ * LOCAL date PARTS — never `new Date('YYYY-MM-DD')` and never a UTC ISO slice
+ * (`toISOString().slice(0,10)`), either of which shifts the day backward in a
+ * US timezone. A cross-tz member could still see the household's day boundary
+ * differ by one, but the picker bound is advisory only — the server validates.
+ */
+export function minFloorDate(): string {
+  const d = new Date();
+  d.setDate(d.getDate() + 1);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}

--- a/frontend/app/src/lib/chores/lib/lightbox.svelte.ts
+++ b/frontend/app/src/lib/chores/lib/lightbox.svelte.ts
@@ -1,0 +1,37 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Photo lightbox (v1.2) — a single shared tap-to-enlarge overlay for the
+// chores island. Any surface (the ChoreCard leading thumbnail, the room
+// drill-in hero) calls showPhoto(src, alt) to enlarge a photo; one
+// <PhotoLightbox> mounted in App.svelte renders it as a native <dialog>
+// (showModal() + ::backdrop — Esc closes natively, backdrop click dismisses).
+//
+// Mirrors the toasts store: a module-private `$state` object read via the
+// `lightbox()` accessor and mutated only through the exported helpers. We never
+// export a reassigned `$state` rune directly (Svelte 5 rune rule / CORRECTION).
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface LightboxState {
+  /** The photo URL shown full-size, or null when the lightbox is closed. */
+  src: string | null;
+  /** Alt text for the enlarged image. */
+  alt: string;
+}
+
+const store = $state<LightboxState>({ src: null, alt: '' });
+
+/** The live lightbox state (reactive — read inside markup / effects). */
+export function lightbox(): Readonly<LightboxState> {
+  return store;
+}
+
+/** Open the lightbox on a photo. No-op for a blank/missing src. */
+export function showPhoto(src: string | null | undefined, alt = ''): void {
+  if (!src) return;
+  store.src = src;
+  store.alt = alt;
+}
+
+/** Close the lightbox. */
+export function closePhoto(): void {
+  store.src = null;
+}

--- a/frontend/app/src/lib/chores/lib/liveness.ts
+++ b/frontend/app/src/lib/chores/lib/liveness.ts
@@ -1,0 +1,73 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Liveness — lightweight collaboration refresh for the chores island.
+//
+// A change made by another household member should appear within ~20s while
+// the tab is VISIBLE, and immediately when the tab regains focus. We do this
+// with a plain interval + `visibilitychange`, NOT Blazor's DataNotifier /
+// PresenceService / PollingService (those are SignalR-circuit-bound — MN2).
+//
+// The poll PAUSES while the tab is hidden (D11): no interval ticks fire when
+// `document.hidden` is true, and on re-show we refetch once immediately, then
+// resume the interval. This keeps background tabs quiet.
+// ─────────────────────────────────────────────────────────────────────────
+
+const POLL_INTERVAL_MS = 20_000;
+
+export interface LivenessHandle {
+  /** Tear down the interval + visibility listener. Call on unmount. */
+  stop(): void;
+}
+
+/**
+ * Start polling. `refresh` is the board reload (App.svelte's loader). It is
+ * only invoked while the document is visible. Returns a handle whose `stop()`
+ * removes the interval + listener.
+ */
+export function startLiveness(refresh: () => void): LivenessHandle {
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  function tick() {
+    // Guard: never poll while hidden (the interval is cleared on hide, but this
+    // is belt-and-suspenders in case a tick is queued at the moment of hiding).
+    if (document.visibilityState === 'visible') {
+      refresh();
+    }
+  }
+
+  function startInterval() {
+    if (timer != null) return;
+    timer = setInterval(tick, POLL_INTERVAL_MS);
+  }
+
+  function stopInterval() {
+    if (timer != null) {
+      clearInterval(timer);
+      timer = null;
+    }
+  }
+
+  function handleVisibility() {
+    if (document.visibilityState === 'visible') {
+      // Re-show: refetch immediately, then resume the interval.
+      refresh();
+      startInterval();
+    } else {
+      // Hidden: pause polling entirely.
+      stopInterval();
+    }
+  }
+
+  document.addEventListener('visibilitychange', handleVisibility);
+
+  // Begin polling only if we start visible.
+  if (document.visibilityState === 'visible') {
+    startInterval();
+  }
+
+  return {
+    stop() {
+      stopInterval();
+      document.removeEventListener('visibilitychange', handleVisibility);
+    },
+  };
+}

--- a/frontend/app/src/lib/chores/lib/state.svelte.ts
+++ b/frontend/app/src/lib/chores/lib/state.svelte.ts
@@ -1,0 +1,1283 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Board store — the SINGLE source of truth for the chores island.
+//
+// One `ChoreBoardDto` is fetched (App.svelte) and held here. Every view is a
+// CLIENT-SIDE grouping of that one payload (M11) — switching never refetches.
+// The derived groupings below (the attention-sectioned board — filtered to
+// Up-for-grabs / Mine / All — plus the Rooms organizer) all read the same
+// `board` and recompute reactively.
+//
+// ⚠ Svelte 5 rune rule (global CORRECTION): never `export` a reassigned
+// `$state`/`$derived` from a module. We wrap the mutable state in a class
+// instance and export the instance — the runes live as `$state`/`$derived`
+// fields on the object, which is the supported pattern.
+//
+// ⚠ M5/M6: this store NEVER recomputes dueness/decay. `colorTier`/`dueState`
+// are taken straight from the server DTO. No `new Date('YYYY-MM-DD')` anywhere.
+// ─────────────────────────────────────────────────────────────────────────
+
+import type {
+  ChoreBoardDto,
+  ChoreDto,
+  ChoreSubtaskDto,
+  ChoreEquityDto,
+  ChoreRecapDto,
+  EquityWindow,
+  CapacityTier,
+  RoomRollupDto,
+  MemberDto,
+  ChoreLensId,
+  DueState,
+  RosterState,
+} from './types';
+import { CHORE_LENSES } from './types';
+import {
+  ApiError,
+  claimChore,
+  takeChore,
+  dropChore,
+  completeChore,
+  snoozeChore,
+  handOffChore,
+  assignRoster,
+  commitRoster,
+  leaveRoster,
+  createChore,
+  deleteChore,
+  updateChore,
+  createSubtask,
+  updateSubtask,
+  deleteSubtask,
+  reorderSubtasks,
+  seedStarter as apiSeedStarter,
+  setDefaultView,
+  setCapacity,
+  getEquity,
+  getRecap,
+  type CreateChoreRequest,
+  type UpdateChoreRequest,
+  type CompleteRequest,
+} from './api';
+import { showToast } from '$lib/shared/toast-store.svelte';
+
+/** One attention bucket of the unified board (Falling behind / Due now / Coming up). */
+export interface NeedsAttentionSection {
+  id: 'falling-behind' | 'due-now' | 'coming-up';
+  title: string;
+  chores: ChoreDto[];
+}
+
+/** A room with its rollup metadata + the chores that belong to it. */
+export interface RoomGroup {
+  rollup: RoomRollupDto;
+  chores: ChoreDto[];
+}
+
+/**
+ * Rank a chore for "dirtiest-first" ordering WITHIN a section. We order by the
+ * server-computed `dueState` (overdue first), then by `nextDueAt` soonest, then
+ * by id for stability. We do NOT recompute dueness — we only sort on the
+ * server's verdict (M5).
+ */
+const DUE_STATE_RANK: Record<DueState, number> = {
+  overdue: 0,
+  dueToday: 1,
+  scheduled: 2,
+  notDue: 3,
+};
+
+function sortDirtiestFirst(a: ChoreDto, b: ChoreDto): number {
+  const r = DUE_STATE_RANK[a.dueState] - DUE_STATE_RANK[b.dueState];
+  if (r !== 0) return r;
+  // Soonest next-due first; nulls sort last. Compare ISO strings lexically —
+  // ISO-8601 UTC strings are lexically ordered, so this is safe WITHOUT parsing
+  // them into Date objects (M5 — never construct dates for logic).
+  const an = a.nextDueAt;
+  const bn = b.nextDueAt;
+  if (an !== bn) {
+    if (an == null) return 1;
+    if (bn == null) return -1;
+    return an < bn ? -1 : 1;
+  }
+  return a.id - b.id;
+}
+
+class BoardStore {
+  /** The one fetched payload. null until the first load resolves. */
+  board = $state<ChoreBoardDto | null>(null);
+  loading = $state(true);
+  /** Human-readable error message; null when healthy. */
+  error = $state<string | null>(null);
+
+  /** The active lens (ViewSwitcher). Defaults to Up-for-grabs. */
+  lens = $state<ChoreLensId>('up-for-grabs');
+
+  /** This household member's userId — set once on init from the shell context. */
+  currentUserId = $state(0);
+
+  /**
+   * The persisted roaming default lens (per-user, server-stored on
+   * `User.ChoresDefaultView`). Mirrors `board.userDefaultView` (null ⇒
+   * Up-for-grabs). Kept as a local field so the "set as default" affordance
+   * reflects success immediately without a board refetch.
+   */
+  defaultView = $state<ChoreLensId | null>(null);
+  /** True while a `setDefaultView` PATCH is in flight (disables the control). */
+  savingDefaultView = $state(false);
+  /** Guards `initLensFromDefault` so the landing lens is set only on first load. */
+  private defaultViewInitialized = false;
+
+  /**
+   * True while a `setCapacity` PATCH is in flight (disables the self-only capacity selector). The caller's
+   * CURRENT tier is read off `equity?.callerCapacityTier` (no separate state) — Phase 15 WP-06, P4.
+   */
+  savingCapacity = $state(false);
+
+  /**
+   * Chore ids with an in-flight mutation. Drives per-card disabled state +
+   * double-submit prevention (M-in-flight). A `Set` swapped by reference so the
+   * `$state` reactivity fires.
+   */
+  pendingChoreIds = $state(new Set<number>());
+
+  // ── Equity lens (the one non-board fetcher — M11) ─────────────────────────
+  //
+  // The Equity lens reads a SEPARATE cached payload (GET /api/chores/equity),
+  // not the board. It is the only lens that fetches; the four v1.0 lenses group
+  // the one board payload. The cached payload goes STALE when completions/chores
+  // change, so any such action invalidates it (`equityLoaded = false`) and — if
+  // the equity lens is currently open — reloads it immediately. App.svelte's
+  // $effect performs the fetch-on-open (and on window change). All values are
+  // server-computed; NO client date math (MN9).
+
+  /** The cached equity payload. null until first loaded (or after invalidation+reload). */
+  equity = $state<ChoreEquityDto | null>(null);
+  /** The reporting window. Switching it triggers a reload via the App effect. */
+  equityWindow = $state<EquityWindow>('week');
+  /** True while a `loadEquity()` fetch is in flight. */
+  equityLoading = $state(false);
+  /** Human-readable equity error; null when healthy. */
+  equityError = $state<string | null>(null);
+  /** True once a fetch for the CURRENT window has resolved successfully. The
+   *  App effect loads when `lens === 'equity' && !equityLoaded`; invalidation
+   *  flips this back to false so the next view (or the active lens) reloads. */
+  equityLoaded = $state(false);
+
+  // ── Recap lens (the second non-board fetcher — like equity, its own endpoint) ─
+  //
+  // The Recap lens reads a SEPARATE cached payload (GET /api/chores/recap): the
+  // current week's digest content + the week-over-week trend. Same lifecycle as
+  // equity — fetch-on-open (App.svelte $effect), and invalidated whenever a
+  // completion/snooze/edit shifts the underlying data (folded into
+  // `invalidateEquity`, since both caches go stale on the same events). All values
+  // are server-computed; NO client date math (MN9).
+
+  /** The cached recap payload. null until first loaded (or after invalidation+reload). */
+  recap = $state<ChoreRecapDto | null>(null);
+  /** True while a `loadRecap()` fetch is in flight. */
+  recapLoading = $state(false);
+  /** Human-readable recap error; null when healthy. */
+  recapError = $state<string | null>(null);
+  /** True once a recap fetch has resolved; invalidation flips it back so the App effect reloads. */
+  recapLoaded = $state(false);
+
+  /**
+   * The board refetch hook, wired by App.svelte (`store.setRefresh(loadBoard)`).
+   * The mutation layer calls it to reconcile after a 409 (xmin conflict — M7/M12)
+   * or any other 4xx rejection, so the user sees the true server state. Liveness
+   * shares the SAME loader, so a post-mutation refetch reuses it.
+   */
+  private refresh: (() => Promise<void>) | null = null;
+
+  // ── Lookups off the single payload ─────────────────────────────────────
+
+  /** userId → member, for owner/assignee avatar rendering. */
+  membersById = $derived.by(() => {
+    const map = new Map<number, MemberDto>();
+    for (const m of this.board?.members ?? []) map.set(m.userId, m);
+    return map;
+  });
+
+  /**
+   * roomId → room rollup, for the per-card room locator chip. REAL rooms only —
+   * the virtual General group (roomId === null, roomless chores) is excluded so a
+   * roomless card shows no chip rather than a noisy "General" tag.
+   */
+  roomsById = $derived.by(() => {
+    const map = new Map<number, RoomRollupDto>();
+    for (const r of this.board?.rooms ?? []) {
+      if (r.roomId != null) map.set(r.roomId, r);
+    }
+    return map;
+  });
+
+  /** All board chores (empty when unloaded). */
+  chores = $derived<ChoreDto[]>(this.board?.chores ?? []);
+
+  /** id → chore, used to resolve `needsAttentionChoreIds` into chores. */
+  choresById = $derived.by(() => {
+    const map = new Map<number, ChoreDto>();
+    for (const c of this.chores) map.set(c.id, c);
+    return map;
+  });
+
+  // ── Rooms lens (grouping seam — full UI is WP-12) ────────────────────────
+  //
+  // Buckets the one payload by roomId against the server rollups, including the
+  // virtual General group (roomId === null). WP-12 builds the rooms-drill UI;
+  // this derived grouping is the seam it will consume.
+
+  roomGroups = $derived.by<RoomGroup[]>(() => {
+    const board = this.board;
+    if (!board) return [];
+    const byRoom = new Map<number | null, ChoreDto[]>();
+    for (const c of this.chores) {
+      const key = c.roomId ?? null;
+      if (!byRoom.has(key)) byRoom.set(key, []);
+      byRoom.get(key)!.push(c);
+    }
+    // Server provides the rollups (incl. General) pre-sorted by sortOrder.
+    return [...board.rooms]
+      .sort((a, b) => a.sortOrder - b.sortOrder)
+      .map((rollup) => ({
+        rollup,
+        chores: (byRoom.get(rollup.roomId ?? null) ?? []).slice().sort(sortDirtiestFirst),
+      }));
+  });
+
+  // ── Up-for-grabs lens (grouping seam — full UI is WP-12) ─────────────────
+  //
+  // Unclaimed pile chores PLUS stale claims (isClaimStale — pile-eligible per
+  // WP-04/05 stale-claim UX). Dirtiest-first. WP-12 builds the lane UI.
+
+  upForGrabsChores = $derived.by<ChoreDto[]>(() => {
+    const uid = this.currentUserId;
+    return this.chores
+      .filter((c) => {
+        // A snoozed chore is NOT up-for-grabs — it carries no pressure until it
+        // resumes (WP-04). Excluded from the pile regardless of assignment/roster.
+        if (c.isSnoozed) return false;
+        // Multi-person chores are up-for-grabs to anyone NOT yet on the roster —
+        // they can join ("I'm in") or just do their part. Members already on the
+        // roster (assigned / in / done) see it in Mine instead.
+        if (c.requiredCount > 1 && c.completedCount < c.requiredCount) {
+          return !c.roster.some((m) => m.userId === uid);
+        }
+        return c.assignmentKind === 'none' || c.isClaimStale;
+      })
+      .slice()
+      .sort(sortDirtiestFirst);
+  });
+
+  // ── Mine lens (grouping seam — full UI is WP-12) ─────────────────────────
+  //
+  // Chores owned by OR actively claimed/assigned to the current user (excluding
+  // stale claims, which are effectively back in the pile). Dirtiest-first.
+
+  mineChores = $derived.by<ChoreDto[]>(() => {
+    const uid = this.currentUserId;
+    return this.chores
+      .filter((c) => {
+        // A multi-person chore is "mine" if I'm on its roster in any state
+        // (assigned/in/done) — awaiting my confirm, my part, or done-and-waiting
+        // on the others. If I'm not on the roster it's an up-for-grabs chore, not
+        // mine. Multi-person chores aren't claimable, so the claim/owner rules
+        // below don't apply to them.
+        if (c.requiredCount > 1 && c.completedCount < c.requiredCount) {
+          return c.roster.some((m) => m.userId === uid);
+        }
+        const heldByMe =
+          c.assigneeUserId === uid && c.assignmentKind !== 'none' && !c.isClaimStale;
+        const ownedByMe = c.ownerUserId === uid;
+        return heldByMe || ownedByMe;
+      })
+      .slice()
+      .sort(sortDirtiestFirst);
+  });
+
+  // ── Unified attention-sectioned board (Phase 14 — Model A board IA) ──────
+  //
+  // The board ALWAYS sections by attention (Falling behind / Due now / Coming
+  // up). The active PRIMARY FILTER (lens) only picks WHICH chore set is sectioned:
+  //   'up-for-grabs' ⇒ the pile (upForGrabsChores)
+  //   'mine'         ⇒ what I hold (mineChores)
+  //   'needs-attention' (relabeled "All") ⇒ every active chore (chores)
+  // We order each set dirtiest-first (server `dueState`, then `nextDueAt`) and
+  // bucket by the server `dueState` — NO client dueness recompute (M5/M11). The
+  // Rooms / Equity organizers are reached via the secondary control, not here.
+  //
+  // Declared AFTER upForGrabsChores / mineChores: a class `$derived` field's
+  // initializer runs in declaration order at construction, so it must follow the
+  // fields it reads.
+
+  boardSections = $derived.by<NeedsAttentionSection[]>(() => {
+    const set =
+      this.lens === 'up-for-grabs'
+        ? this.upForGrabsChores
+        : this.lens === 'mine'
+          ? this.mineChores
+          : this.chores; // 'needs-attention' ⇒ All
+    const ordered = [...set].sort(sortDirtiestFirst);
+    const fallingBehind: ChoreDto[] = [];
+    const dueNow: ChoreDto[] = [];
+    const comingUp: ChoreDto[] = [];
+    for (const c of ordered) {
+      // Snoozed chores are pressure-free: always "Coming up" (with the chip), never
+      // Falling behind / Due now — even if a pre-snooze dueState briefly lingers in
+      // the optimistic window before the server reports Scheduled (WP-04, MN4).
+      if (c.isSnoozed) comingUp.push(c);
+      else if (c.dueState === 'overdue') fallingBehind.push(c);
+      else if (c.dueState === 'dueToday') dueNow.push(c);
+      else comingUp.push(c); // scheduled / notDue pile chores
+    }
+    const sections: NeedsAttentionSection[] = [
+      { id: 'falling-behind', title: 'Falling behind', chores: fallingBehind },
+      { id: 'due-now', title: 'Due now', chores: dueNow },
+      { id: 'coming-up', title: 'Coming up', chores: comingUp },
+    ];
+    return sections.filter((s) => s.chores.length > 0);
+  });
+
+  /** Count of the active filter's set BEFORE the section split (for the empty state). */
+  boardTotalCount = $derived(
+    this.lens === 'up-for-grabs'
+      ? this.upForGrabsChores.length
+      : this.lens === 'mine'
+        ? this.mineChores.length
+        : this.chores.length,
+  );
+
+  setBoard(next: ChoreBoardDto): void {
+    this.board = next;
+    this.error = null;
+    // Keep the local default mirror in sync with the authoritative payload, and
+    // (on the FIRST load only) land on the user's roaming default lens.
+    this.defaultView = coerceLens(next.userDefaultView);
+    this.initLensFromDefault();
+    // The board refetch path (loadBoard / setRefresh / liveness) may have
+    // included a completion from another user, so the cached equity payload is
+    // potentially stale. Invalidate (and reload if the equity lens is active).
+    this.invalidateEquity();
+  }
+
+  setLens(next: ChoreLensId): void {
+    this.lens = next;
+  }
+
+  // ── Equity lens fetch + invalidation ──────────────────────────────────────
+
+  /** Switch the reporting window. The window change drops the cache so the App
+   *  effect reloads for the new window (it watches `equityWindow`). */
+  setEquityWindow(next: EquityWindow): void {
+    if (this.equityWindow === next) return;
+    this.equityWindow = next;
+    this.equityLoaded = false;
+    // A window switch is a fresh attempt — clear any prior error so the App effect
+    // (now guarded on `!equityError`) loads the new window instead of staying stuck.
+    this.equityError = null;
+  }
+
+  /**
+   * Fetch the equity payload for the CURRENT window. Called by App.svelte's
+   * $effect when the equity lens is open and the cache is stale (fetch-once per
+   * window). Sets `equityLoaded` on success so the effect doesn't refetch on
+   * every reactive tick.
+   */
+  async loadEquity(): Promise<void> {
+    if (this.equityLoading) return;
+    this.equityLoading = true;
+    this.equityError = null;
+    const window = this.equityWindow;
+    try {
+      const result = await getEquity(window);
+      // Guard against a window switch landing mid-flight — only commit if the
+      // requested window is still the active one.
+      if (this.equityWindow === window) {
+        this.equity = result;
+        this.equityLoaded = true;
+      }
+    } catch (e) {
+      this.equityError =
+        e instanceof ApiError
+          ? `Couldn't load the equity view (HTTP ${e.status}).`
+          : "Couldn't load the equity view right now.";
+    } finally {
+      this.equityLoading = false;
+    }
+  }
+
+  /**
+   * Invalidate the cached equity payload — it's a separate cached read that goes
+   * stale whenever completions/chores change (council MAJOR). Drops the cache and,
+   * if the equity lens is currently open, reloads it immediately so the user
+   * never sees a stale distribution. Called after `complete(...)` succeeds and
+   * on every board refetch (`setBoard`). WP-10's `seedStarter()` calls this too.
+   */
+  invalidateEquity(): void {
+    this.equityLoaded = false;
+    if (this.lens === 'equity') {
+      void this.loadEquity();
+    }
+    // The recap reads the same completion-derived data, so it goes stale on the
+    // exact same events — cascade the invalidation (reloads now if recap is open).
+    this.invalidateRecap();
+  }
+
+  // ── Recap lens fetch + invalidation (mirrors equity) ──────────────────────
+
+  /**
+   * Fetch the recap payload (current week + week-over-week trend). Called by
+   * App.svelte's $effect when the recap lens is open and the cache is stale.
+   * Sets `recapLoaded` on success so the effect doesn't refetch every tick.
+   */
+  async loadRecap(): Promise<void> {
+    if (this.recapLoading) return;
+    this.recapLoading = true;
+    this.recapError = null;
+    try {
+      this.recap = await getRecap();
+      this.recapLoaded = true;
+    } catch (e) {
+      this.recapError =
+        e instanceof ApiError
+          ? `Couldn't load the recap (HTTP ${e.status}).`
+          : "Couldn't load the recap right now.";
+    } finally {
+      this.recapLoading = false;
+    }
+  }
+
+  /** Drop the cached recap; reload immediately if the recap lens is open. */
+  invalidateRecap(): void {
+    this.recapLoaded = false;
+    if (this.lens === 'recap') {
+      void this.loadRecap();
+    }
+  }
+
+  // ── Roaming per-user default view (S10/D18) ───────────────────────────────
+  //
+  // The default lens is PER-USER and SERVER-PERSISTED (User.ChoresDefaultView),
+  // so it roams across devices — NOT localStorage (D18). It arrives on the board
+  // payload as `userDefaultView` (null ⇒ Up-for-grabs); no separate GET. The
+  // PATCH allowlist validates against the SAME canonical lens ids (ChoreLens.All).
+
+  /**
+   * On the FIRST board load, open the lens the user pinned as their default
+   * (null ⇒ Up-for-grabs). Runs once — later refetches (liveness, post-
+   * mutation reconcile) must NOT yank the user off whatever lens they switched
+   * to in-session.
+   */
+  private initLensFromDefault(): void {
+    if (this.defaultViewInitialized) return;
+    this.defaultViewInitialized = true;
+    this.lens = this.defaultView ?? 'up-for-grabs';
+  }
+
+  /** Is the given lens the user's current persisted default? */
+  isDefaultView(lens: ChoreLensId): boolean {
+    return (this.defaultView ?? 'up-for-grabs') === lens;
+  }
+
+  /**
+   * Pin a lens as the user's roaming default (persists via PATCH
+   * /api/chores/me/default-view). The lens switch itself is local + instant
+   * (M11 — no refetch); this only writes the preference. On an ApiError we keep
+   * the local lens but surface a NON-BLOCKING toast — the switch still works,
+   * only the persistence failed.
+   */
+  async saveDefaultView(lens: ChoreLensId): Promise<void> {
+    if (this.savingDefaultView) return;
+    // Already the default — no-op (the control renders as "current default").
+    if (this.isDefaultView(lens)) return;
+    this.savingDefaultView = true;
+    const previous = this.defaultView;
+    // Optimistic: reflect the new default at once.
+    this.defaultView = lens;
+    if (this.board) this.board.userDefaultView = lens;
+    try {
+      const result = await setDefaultView(lens);
+      // Server echoes the persisted value; reconcile to it.
+      const confirmed = coerceLens(result.view);
+      this.defaultView = confirmed;
+      if (this.board) this.board.userDefaultView = result.view;
+      showToast({ message: 'This is now your default view.', kind: 'success' });
+    } catch (e) {
+      // Roll back the optimistic default; the lens stays switched (local only).
+      this.defaultView = previous;
+      if (this.board) this.board.userDefaultView = previous;
+      const msg =
+        e instanceof ApiError
+          ? "Couldn't save your default view — it'll stay this session only."
+          : "Couldn't save your default view right now.";
+      showToast({ message: msg, kind: 'info' });
+    } finally {
+      this.savingDefaultView = false;
+    }
+  }
+
+  // ── Self-only physical-capacity tier (Phase 15 WP-06, MN5/P4) ─────────────
+  //
+  // The capacity tier is PER-USER and SERVER-PERSISTED (User.PhysicalCapacityTier), so it roams across
+  // devices like the default view — NOT localStorage. It arrives on every equity payload as
+  // `callerCapacityTier` (null ⇒ Full); no separate GET (M7). The PATCH writes ONLY the caller's own row
+  // (MN5 — no way to set another member's tier). On success we invalidate the equity cache so the
+  // per-member EXPECTED references recompute with the new weighting (the fresh tier rides the reload).
+
+  /**
+   * Set the current user's OWN physical-capacity tier (PATCH /api/chores/me/capacity). Self-set only —
+   * never another member's (MN5). On success: invalidate the cached equity so the expected references
+   * recompute (and reload now if the equity lens is open). On an ApiError we surface a non-blocking toast;
+   * the previously rendered tier stays until the next equity reload reconciles.
+   */
+  async saveCapacity(tier: CapacityTier): Promise<void> {
+    if (this.savingCapacity) return;
+    // No-op if it's already the caller's current tier (null ⇒ Full).
+    if ((this.equity?.callerCapacityTier ?? 'Full') === tier) return;
+    this.savingCapacity = true;
+    try {
+      await setCapacity(tier);
+      // The new tier rides the next equity payload as `callerCapacityTier`; recompute expected refs.
+      this.invalidateEquity();
+    } catch (e) {
+      const msg =
+        e instanceof ApiError
+          ? "Couldn't update your capacity right now — please try again."
+          : "Couldn't update your capacity right now.";
+      showToast({ message: msg, kind: 'info' });
+    } finally {
+      this.savingCapacity = false;
+    }
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Mutation layer (WP-11) — optimistic updates + xmin-409 reconciliation.
+  //
+  // MODEL (every action follows this shape via `runOptimistic`):
+  //   1. OPTIMISTIC: immediately patch the matching chore in `board.chores` to
+  //      the expected post-action state (e.g. claim → assigneeUserId=me,
+  //      assignmentKind='claimed', claimedAt=now ISO). The card re-renders at
+  //      once. We do NOT recompute dueness/decay (M5/M6) — `colorTier`/`dueState`
+  //      stay as the server last reported until the authoritative response lands.
+  //   2. SUCCESS: the server returns the updated `ChoreDto` (with the NEW xmin
+  //      `version`). Replace the chore with it — the next mutation then carries a
+  //      fresh version (avoids a self-inflicted 409). The authoritative
+  //      tier/dueness come from THIS DTO, never a client recompute.
+  //   3. 409 (ApiError.isConflict — the retryable xmin conflict): someone else
+  //      changed the chore. Roll back the optimistic patch and REFETCH the board
+  //      so the user sees the true state (e.g. claimed by someone else). We do
+  //      NOT silently retry — that could clobber the other user's claim (MN8
+  //      spirit). A brief "someone got there first — refreshed" notice explains it.
+  //   4. OTHER 4xx (ApiError.isClientRejection — non-retryable: validation, an
+  //      illegal transition, or the WP-08 empty-400-that-is-really-404): roll
+  //      back, refetch to resync, surface a non-alarming toast. Not a crash.
+  //   5. NETWORK / 5xx: roll back + error toast; the action can be retried.
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /** Wire the board refetch (App.svelte's loader). Used for 409/4xx reconcile. */
+  setRefresh(refresh: () => Promise<void>): void {
+    this.refresh = refresh;
+  }
+
+  /**
+   * Public board refetch for the room-admin surface (RoomEditSheet + the inline
+   * new-room photo). A room create/edit/photo change is not a chore mutation, so
+   * it has no optimistic path — after it succeeds we refetch the ONE board
+   * payload so the updated rollup (name / icon / photoPath cover) renders
+   * authoritatively. Shares the same loader as liveness + 409 reconcile.
+   */
+  async reloadBoard(): Promise<void> {
+    await this.reconcile();
+  }
+
+  /** Is a mutation in flight for this chore? (disable its controls). */
+  isPending(choreId: number): boolean {
+    return this.pendingChoreIds.has(choreId);
+  }
+
+  private markPending(choreId: number, on: boolean): void {
+    const next = new Set(this.pendingChoreIds);
+    if (on) next.add(choreId);
+    else next.delete(choreId);
+    this.pendingChoreIds = next;
+  }
+
+  /** Find a chore by id in the current board (null if the board is unloaded). */
+  private choreById(choreId: number): ChoreDto | null {
+    return this.board?.chores.find((c) => c.id === choreId) ?? null;
+  }
+
+  /** Replace the chore in `board.chores` with the authoritative server DTO. */
+  private applyChore(updated: ChoreDto): void {
+    const board = this.board;
+    if (!board) return;
+    const idx = board.chores.findIndex((c) => c.id === updated.id);
+    if (idx >= 0) {
+      board.chores[idx] = updated;
+    }
+  }
+
+  private async reconcile(): Promise<void> {
+    if (this.refresh) await this.refresh();
+  }
+
+  /** Is this chore a multi-person (co-sign) chore per the CURRENT board? */
+  private isMultiPerson(choreId: number): boolean {
+    return (this.choreById(choreId)?.requiredCount ?? 1) > 1;
+  }
+
+  /**
+   * Mutation runner for MULTI-PERSON (`requiredCount > 1`) chores. Unlike
+   * `runOptimistic`, it applies NO optimistic patch: a single co-sign
+   * (claim / drop / hand-off / partial complete) does NOT change the card to a
+   * "done" state, and — critically — the single-chore mutation RESPONSE carries
+   * `completedCount = 0` for the co-sign progress (the board GET is the only
+   * authoritative source, see WP-07). So we fire the call, then `reconcile()`
+   * (full board refetch) so the card reflects the true current-occurrence
+   * progress (or drops off / resets if the count was just satisfied). The 409 /
+   * other-4xx / network branches mirror `runOptimistic` exactly — refetch +
+   * surface, never an auto-retry.
+   *
+   * The returned DTO is still applied first so the version stays fresh even in
+   * the (rare) window before the reconcile lands; the reconcile then overwrites
+   * the whole board with authoritative progress.
+   */
+  private async runMultiPersonMutation(
+    choreId: number,
+    call: (chore: ChoreDto) => Promise<ChoreDto>,
+    conflictMessage: string,
+  ): Promise<void> {
+    if (this.pendingChoreIds.has(choreId)) return;
+    const chore = this.choreById(choreId);
+    if (!chore) return;
+
+    const snapshot: ChoreDto = { ...chore };
+    this.markPending(choreId, true);
+    try {
+      const updated = await call(snapshot);
+      this.applyChore(updated);
+      // Authoritative co-sign progress comes only from the board GET (the
+      // mutation response can't signal "X of N" — it returns completedCount=0).
+      await this.reconcile();
+    } catch (e) {
+      if (e instanceof ApiError && e.isConflict) {
+        await this.reconcile();
+        showToast({ message: conflictMessage, kind: 'info' });
+      } else if (e instanceof ApiError && e.isClientRejection) {
+        // Incl. the D6 distinctness rejection (a non-409 4xx). Resync + notice.
+        await this.reconcile();
+        showToast({
+          message: "That didn't go through — the board has been refreshed.",
+          kind: 'info',
+        });
+      } else {
+        showToast({ message: 'Something went wrong. Please try again.', kind: 'error' });
+      }
+    } finally {
+      this.markPending(choreId, false);
+    }
+  }
+
+  /**
+   * Core optimistic runner. Snapshots the chore, applies an optimistic patch,
+   * fires the request, then commits the returned DTO or rolls back + reconciles
+   * per the 409 / 4xx / network model documented above.
+   *
+   * @param choreId   the target chore
+   * @param patch     fields to optimistically merge onto the chore
+   * @param call      the API call (returns the authoritative ChoreDto)
+   * @param conflictMessage  the "someone got there first" notice for a 409
+   */
+  private async runOptimistic(
+    choreId: number,
+    patch: Partial<ChoreDto>,
+    call: (chore: ChoreDto) => Promise<ChoreDto>,
+    conflictMessage: string,
+  ): Promise<void> {
+    // Double-submit guard: ignore if a mutation is already in flight.
+    if (this.pendingChoreIds.has(choreId)) return;
+    const chore = this.choreById(choreId);
+    if (!chore) return;
+
+    // Snapshot the fields we touch so we can roll back precisely.
+    const snapshot: ChoreDto = { ...chore };
+    Object.assign(chore, patch);
+    this.markPending(choreId, true);
+
+    try {
+      const updated = await call(snapshot);
+      this.applyChore(updated);
+    } catch (e) {
+      // Roll back the optimistic patch first, regardless of failure mode.
+      const current = this.choreById(choreId);
+      if (current) Object.assign(current, snapshot);
+
+      if (e instanceof ApiError && e.isConflict) {
+        // 409 — xmin concurrency conflict (M7/M12). Refetch + non-alarming notice.
+        await this.reconcile();
+        showToast({ message: conflictMessage, kind: 'info' });
+      } else if (e instanceof ApiError && e.isClientRejection) {
+        // Other 4xx (incl. the empty-400-from-404 WP-08 quirk). Resync + notice.
+        await this.reconcile();
+        showToast({
+          message: "That didn't go through — the board has been refreshed.",
+          kind: 'info',
+        });
+      } else {
+        // Network / 5xx — leave the board as-is (rolled back), allow retry.
+        showToast({
+          message: 'Something went wrong. Please try again.',
+          kind: 'error',
+        });
+      }
+    } finally {
+      this.markPending(choreId, false);
+    }
+  }
+
+  /** Claim an unclaimed (or stale-claimed) pile chore for the current user. */
+  async claim(choreId: number): Promise<void> {
+    const me = this.currentUserId;
+    const call = (c: ChoreDto) => claimChore(c.id, c.version);
+    // Multi-person: reconcile after so the card never shows a stale
+    // `completedCount=0` from the single-chore response (WP-07). Assignment
+    // isn't co-sign progress, but the response carries no live progress at all,
+    // so we re-read the board for truth. Single-person path untouched.
+    if (this.isMultiPerson(choreId)) {
+      await this.runMultiPersonMutation(choreId, call, 'Someone got there first — board refreshed.');
+      return;
+    }
+    await this.runOptimistic(
+      choreId,
+      {
+        assigneeUserId: me,
+        assignmentKind: 'claimed',
+        claimedAt: new Date().toISOString(),
+        isClaimStale: false,
+      },
+      call,
+      'Someone got there first — board refreshed.',
+    );
+  }
+
+  /**
+   * Take a chore currently held by another member — grab it as a self-claim
+   * ("covering" for someone out/sick). The server displaces the holder and
+   * lands a Claimed (NOT a sticky Assigned), so a recurring chore returns to the
+   * pile after the taker completes it. Optimistic end-state is the same as claim.
+   */
+  async take(choreId: number): Promise<void> {
+    const me = this.currentUserId;
+    const call = (c: ChoreDto) => takeChore(c.id, c.version);
+    if (this.isMultiPerson(choreId)) {
+      await this.runMultiPersonMutation(choreId, call, 'That chore changed — board refreshed.');
+      return;
+    }
+    await this.runOptimistic(
+      choreId,
+      {
+        assigneeUserId: me,
+        assignmentKind: 'claimed',
+        claimedAt: new Date().toISOString(),
+        isClaimStale: false,
+      },
+      call,
+      'That chore changed — board refreshed.',
+    );
+  }
+
+  /** Drop a chore the current user holds (returns it to the pile). */
+  async drop(choreId: number): Promise<void> {
+    const call = (c: ChoreDto) => dropChore(c.id, c.version);
+    if (this.isMultiPerson(choreId)) {
+      await this.runMultiPersonMutation(choreId, call, 'That chore changed — board refreshed.');
+      return;
+    }
+    await this.runOptimistic(
+      choreId,
+      { assigneeUserId: null, assignmentKind: 'none', claimedAt: null, isClaimStale: false },
+      call,
+      'That chore changed — board refreshed.',
+    );
+  }
+
+  /**
+   * Mark a chore done. `extra` may carry a note / already-uploaded photo path
+   * and — for multi-person (co-sign) chores — the `participantUserIds` recorded
+   * via the complete dialog (WP-07). The `api.ts` CompleteRequest already has
+   * the field; we pass it straight through.
+   *
+   * SINGLE-PERSON (`requiredCount == 1`): the EXISTING optimistic path —
+   * stamp `lastCompletedAt` then commit the returned DTO. Behaviorally identical
+   * to before this WP.
+   *
+   * MULTI-PERSON (`requiredCount > 1`): no optimistic `{ lastCompletedAt }`
+   * patch (a partial co-sign is NOT "done"); fire then reconcile so the card
+   * shows the authoritative "X of N" (or drops off when the count is satisfied).
+   * The mutation response can't signal progress (returns completedCount=0), so
+   * the board refetch is the only correct source — see WP-07.
+   */
+  async complete(
+    choreId: number,
+    extra?: { note?: string | null; photoPath?: string | null; participantUserIds?: number[] },
+  ): Promise<void> {
+    const call = (c: ChoreDto) =>
+      completeChore(c.id, {
+        note: extra?.note ?? null,
+        photoPath: extra?.photoPath ?? null,
+        participantUserIds: extra?.participantUserIds,
+        version: c.version,
+      } satisfies CompleteRequest);
+
+    if (this.isMultiPerson(choreId)) {
+      await this.runMultiPersonMutation(choreId, call, 'That chore changed — board refreshed.');
+    } else {
+      await this.runOptimistic(
+        choreId,
+        // Optimistically reflect "just completed" by stamping lastCompletedAt.
+        // We do NOT recompute dueness/colorTier — the authoritative post-completion
+        // tier (e.g. recurring chore's next dueness) comes from the returned DTO.
+        { lastCompletedAt: new Date().toISOString() },
+        call,
+        'That chore changed — board refreshed.',
+      );
+    }
+    // A completion shifts the distribution — invalidate the cached equity so it
+    // reloads when next viewed (or now, if the equity lens is active). The
+    // single-person happy path doesn't refetch the board, so this is its only
+    // equity hook; the multi-person path already reconciled via setBoard (which
+    // also invalidates), and a 409/4xx reconciled the same way.
+    this.invalidateEquity();
+  }
+
+  /**
+   * Snooze / set-next-due (the board quick-snooze). `request.days` snoozes N days from today; `request.until`
+   * is an explicit "YYYY-MM-DD"; both omitted/null ⇒ un-snooze. The server resolves the floor in the household
+   * timezone (MN4 — no client date math). Optimistic patch is just `{ isSnoozed }`: the section logic keys on
+   * `isSnoozed` so the card moves to "Coming up" / out of the pile at once; the authoritative
+   * `dueState`/`colorTier`/`nextDueAt`/`snoozedUntil` come from the returned DTO (the chip binds `nextDueAt`).
+   * Multi-person chores take the reconcile path (the single-chore response carries no live co-sign progress).
+   */
+  async snooze(choreId: number, request: { days?: number; until?: string | null }): Promise<void> {
+    const call = (c: ChoreDto) =>
+      snoozeChore(
+        c.id,
+        request.days != null
+          ? { days: request.days, version: c.version }
+          : { until: request.until ?? null, version: c.version },
+      );
+
+    if (this.isMultiPerson(choreId)) {
+      await this.runMultiPersonMutation(choreId, call, 'That chore changed — board refreshed.');
+    } else {
+      const isUnsnooze = request.days == null && (request.until ?? null) === null;
+      await this.runOptimistic(
+        choreId,
+        { isSnoozed: !isUnsnooze },
+        call,
+        'That chore changed — board refreshed.',
+      );
+    }
+    // Snooze shifts the up-for-grabs / falling-behind equity counts (WP-04) — invalidate the cached payload.
+    this.invalidateEquity();
+  }
+
+  // ── Roster (multi-person named soft roster, rework) ───────────────────────
+  // All three are multi-person-only and use the runMultiPersonMutation path
+  // (fire → reconcile via the board GET; never auto-retry on 409/4xx — MN4).
+
+  /**
+   * Commit the current user to a multi-person chore's roster ("I'm in" — self-opt-in or confirming an
+   * assignment). The single-chore response carries an empty roster, so we reconcile via the board GET.
+   */
+  async commit(choreId: number): Promise<void> {
+    await this.runMultiPersonMutation(
+      choreId,
+      (c) => commitRoster(c.id, c.version),
+      'That chore changed — board refreshed.',
+    );
+  }
+
+  /** Leave a multi-person chore's roster (decline / "not me"). */
+  async leave(choreId: number): Promise<void> {
+    await this.runMultiPersonMutation(
+      choreId,
+      (c) => leaveRoster(c.id, null, c.version),
+      'That chore changed — board refreshed.',
+    );
+  }
+
+  /** Assign a named member to a multi-person chore's roster (Assigned — from the edit sheet). */
+  async assign(choreId: number, subjectUserId: number): Promise<void> {
+    await this.runMultiPersonMutation(
+      choreId,
+      (c) => assignRoster(c.id, subjectUserId, c.version),
+      'That chore changed — board refreshed.',
+    );
+  }
+
+  /**
+   * Remove a NAMED member from a multi-person chore's roster. Server-guarded:
+   * only the chore's creator or owner may remove someone else (anyone may remove
+   * themselves via `leave`). A rejected remove reconciles + surfaces a notice.
+   */
+  async removeFromRoster(choreId: number, subjectUserId: number): Promise<void> {
+    await this.runMultiPersonMutation(
+      choreId,
+      (c) => leaveRoster(c.id, subjectUserId, c.version),
+      'That chore changed — board refreshed.',
+    );
+  }
+
+  /**
+   * Reconcile a multi-person chore's named roster to a chosen member set (the
+   * edit sheet's "Assign people"). Diffs `selectedUserIds` against
+   * `originalRoster` (the roster captured at edit time): assigns anyone newly
+   * selected, removes anyone deselected who is still assigned/in. DONE members
+   * are never removed — their contribution stands. Runs sequentially so each op
+   * carries a fresh version (every roster mutation reconciles the board). Adding
+   * is unguarded; removing OTHERS is creator/owner-only server-side, so a rejected
+   * remove just surfaces a gentle notice and the board reconciles to the truth.
+   */
+  async applyRosterSelection(
+    choreId: number,
+    originalRoster: { userId: number; state: RosterState }[],
+    selectedUserIds: number[],
+  ): Promise<void> {
+    const selected = new Set(selectedUserIds);
+    const currentIds = new Set(originalRoster.map((m) => m.userId));
+    const toAdd = selectedUserIds.filter((id) => !currentIds.has(id));
+    const toRemove = originalRoster
+      .filter((m) => m.state !== 'done' && !selected.has(m.userId))
+      .map((m) => m.userId);
+    for (const id of toAdd) {
+      await this.assign(choreId, id);
+    }
+    for (const id of toRemove) {
+      await this.removeFromRoster(choreId, id);
+    }
+  }
+
+  /**
+   * Hand a chore off to another member, or back to the pile (targetUserId null).
+   */
+  async handOff(choreId: number, targetUserId: number | null): Promise<void> {
+    const toPile = targetUserId == null;
+    const call = (c: ChoreDto) => handOffChore(c.id, { targetUserId, version: c.version });
+    if (this.isMultiPerson(choreId)) {
+      await this.runMultiPersonMutation(choreId, call, 'That chore changed — board refreshed.');
+      return;
+    }
+    await this.runOptimistic(
+      choreId,
+      toPile
+        ? { assigneeUserId: null, assignmentKind: 'none', claimedAt: null, isClaimStale: false }
+        : {
+            // Hand-off to a member is a deliberate Assigned server-side
+            // (SetAssigned) — reflect that optimistically so the taker doesn't
+            // see a "Drop" flash (Drop is Claimed-only) before the board GET.
+            assigneeUserId: targetUserId,
+            assignmentKind: 'assigned',
+            claimedAt: new Date().toISOString(),
+            isClaimStale: false,
+          },
+      call,
+      'That chore changed — board refreshed.',
+    );
+  }
+
+  /**
+   * Create a chore (quick-add). NOT optimistic — a new chore has no id/version
+   * to reconcile against and the server-computed dueness/rollups are needed, so
+   * we POST then refetch the whole board to render the new card authoritatively.
+   * Returns the created chore so the caller can chain a photo upload if needed.
+   * Throws on failure so the dialog can keep itself open + surface the error.
+   */
+  async create(body: CreateChoreRequest): Promise<ChoreDto> {
+    const created = await createChore(body);
+    await this.reconcile();
+    return created;
+  }
+
+  /**
+   * Edit a chore's metadata (name, description, room, recurrence, effort, owner,
+   * photoPath) via PUT /api/chores/{id}. Optimistic — applies the expected updates
+   * at once and reconciles on failure.
+   *
+   * Assignment is NOT editable here (v1.0 D6 — moves only via claim/handoff).
+   * No client date math (MN9) — anchorDate/daysOfWeek/intervalDays come straight
+   * from the caller (mapped in EditChoreSheet).
+   *
+   * On 409 (xmin conflict): roll back + reconcile + info toast.
+   * On other 4xx: roll back + reconcile + info toast.
+   * On network/5xx: roll back + error toast.
+   *
+   * The reconcile (loadBoard) path calls setBoard → invalidateEquity, so equity
+   * cache invalidation is handled automatically there. On the happy path the
+   * returned DTO replaces the chore in-place; equity is also invalidated (a name/
+   * room/recurrence change could affect the board the digest reads, even if the
+   * equity endpoint caches on completions).
+   */
+  async edit(choreId: number, body: UpdateChoreRequest): Promise<void> {
+    // Optimistic patch: apply the editable fields we can preview before the
+    // round-trip. We intentionally don't touch assignee/assignment fields (D6).
+    const patch: Partial<ChoreDto> = {
+      name: body.name,
+      description: body.description ?? null,
+      roomId: body.roomId ?? null,
+      recurrenceMode: body.recurrenceMode,
+      effortTier: body.effortTier,
+      ownerUserId: body.ownerUserId ?? null,
+    };
+    await this.runOptimistic(
+      choreId,
+      patch,
+      (_snapshot) => updateChore(choreId, body),
+      'Someone edited that chore at the same time — board refreshed.',
+    );
+    // On the happy path `runOptimistic` replaced the chore with the returned DTO
+    // but did NOT call setBoard, so invalidate equity manually here.
+    this.invalidateEquity();
+  }
+
+  /**
+   * Seed the household with the starter chore set (POST /api/chores/seed-starter).
+   * Idempotent server-side — safe to call repeatedly; `seeded: false` if already done.
+   * On success: refetch the board (which calls setBoard → invalidateEquity) + success toast.
+   * On failure: error toast (no board mutation to roll back).
+   */
+  async seedStarter(): Promise<void> {
+    try {
+      const result = await apiSeedStarter();
+      // Refetch the board so new chores appear. setBoard calls invalidateEquity.
+      await this.reconcile();
+      if (result.seeded) {
+        showToast({ message: 'Starter chores added.', kind: 'success' });
+      }
+      // seeded=false is idempotent (already had chores) — refetch is still useful
+      // to keep the board fresh; no toast so there's no noise.
+    } catch {
+      showToast({ message: "Couldn't load starter chores. Please try again.", kind: 'error' });
+    }
+  }
+
+  /** Delete a chore (optimistic removal + rollback/refetch on failure). */
+  async remove(choreId: number): Promise<void> {
+    if (this.pendingChoreIds.has(choreId)) return;
+    const board = this.board;
+    if (!board) return;
+    const idx = board.chores.findIndex((c) => c.id === choreId);
+    if (idx < 0) return;
+    const removed = board.chores[idx];
+
+    board.chores = board.chores.filter((c) => c.id !== choreId);
+    this.markPending(choreId, true);
+    try {
+      await deleteChore(choreId, removed.version);
+    } catch (e) {
+      // Restore the removed chore, then reconcile / surface.
+      await this.reconcile();
+      if (e instanceof ApiError && (e.isConflict || e.isClientRejection)) {
+        showToast({ message: 'That chore changed — board refreshed.', kind: 'info' });
+      } else {
+        // Network/5xx: the refetch may not have restored it; put it back.
+        if (this.board && !this.board.chores.some((c) => c.id === choreId)) {
+          this.board.chores = [...this.board.chores, removed];
+        }
+        showToast({ message: 'Something went wrong. Please try again.', kind: 'error' });
+      }
+    } finally {
+      this.markPending(choreId, false);
+    }
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Checklist / subtasks (Phase 14) — VERSIONLESS / last-write-wins.
+  //
+  // These are deliberately NOT on the optimistic `runOptimistic`/xmin path: a
+  // subtask carries no concurrency token, never gates completion, and a check
+  // mid-conflict is not worth a 409 dance. The model is simpler: mutate
+  // `board.chores[i].subtasks` IN PLACE (deep-reactive per M11), fire the
+  // versionless API call, and on ANY error `reconcile()` (board refetch) + a
+  // calm `info` toast. We do NOT touch `pendingChoreIds` — a subtask op must
+  // never disable the whole card's chore controls. NO Date is built here.
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Add a checklist item to a chore. Add is infrequent, so we await then push
+   * the server DTO (no temp id) — keeping the list sorted by sortOrder. A
+   * blank/whitespace title is ignored client-side (no call).
+   */
+  async addSubtask(choreId: number, title: string): Promise<void> {
+    if (!this.board) return;
+    const chore = this.choreById(choreId);
+    if (!chore) return;
+    const trimmed = title.trim();
+    if (!trimmed) return;
+    try {
+      const created = await createSubtask(choreId, { title: trimmed });
+      const current = this.choreById(choreId);
+      if (!current) return;
+      current.subtasks = sortSubtasks([...current.subtasks, created]);
+    } catch {
+      await this.reconcile();
+      showToast({ message: "Couldn't add that item — the list was refreshed.", kind: 'info' });
+    }
+  }
+
+  /**
+   * Toggle a checklist item's done state — the HOT path, so it's optimistic:
+   * flip `isDone` in place immediately, then PUT. Replace with the returned DTO
+   * on success; reconcile + calm toast on error.
+   */
+  async toggleSubtask(choreId: number, subtaskId: number, isDone: boolean): Promise<void> {
+    if (!this.board) return;
+    const chore = this.choreById(choreId);
+    if (!chore) return;
+    const item = chore.subtasks.find((s) => s.id === subtaskId);
+    if (!item) return;
+    const previous = item.isDone;
+    const previousActor = item.completedByUserId;
+    const previousAt = item.completedAt;
+    // Optimistic — must feel instant. Show ME as the actor immediately on a tick; clear on untick.
+    // completedAt stays null until the authoritative DTO swaps in (the store builds NO Date — MN).
+    item.isDone = isDone;
+    item.completedByUserId = isDone ? this.currentUserId : null;
+    item.completedAt = null;
+    try {
+      const updated = await updateSubtask(choreId, subtaskId, { isDone });
+      this.replaceSubtask(choreId, updated);
+    } catch {
+      // Roll back the optimistic flip + actor, then resync to be safe.
+      const cur = this.choreById(choreId)?.subtasks.find((s) => s.id === subtaskId);
+      if (cur) {
+        cur.isDone = previous;
+        cur.completedByUserId = previousActor;
+        cur.completedAt = previousAt;
+      }
+      await this.reconcile();
+      showToast({ message: "Couldn't update that item — the list was refreshed.", kind: 'info' });
+    }
+  }
+
+  /**
+   * Re-order a chore's checklist (versionless). Apply the new order in place (set each
+   * sortOrder to its index so the row order is stable), persist via the bulk reorder
+   * endpoint, and reconcile + calm toast on error. Does NOT touch pendingChoreIds.
+   */
+  async reorderSubtasks(choreId: number, orderedIds: number[]): Promise<void> {
+    if (!this.board) return;
+    const chore = this.choreById(choreId);
+    if (!chore) return;
+    const byId = new Map(chore.subtasks.map((s) => [s.id, s]));
+    const reordered = orderedIds
+      .map((id) => byId.get(id))
+      .filter((s): s is ChoreSubtaskDto => s !== undefined);
+    // Guard: if the id set doesn't line up (stale), just resync rather than risk dropping items.
+    if (reordered.length !== chore.subtasks.length) {
+      await this.reconcile();
+      return;
+    }
+    reordered.forEach((s, i) => (s.sortOrder = i)); // optimistic in-place
+    chore.subtasks = reordered;
+    try {
+      await reorderSubtasks(choreId, orderedIds);
+    } catch {
+      await this.reconcile();
+      showToast({ message: "Couldn't save the new order — the list was refreshed.", kind: 'info' });
+    }
+  }
+
+  /**
+   * Rename a checklist item (optimistic). A blank/whitespace title is ignored
+   * client-side (no call). Replace with the server DTO on success; reconcile +
+   * calm toast on error.
+   */
+  async renameSubtask(choreId: number, subtaskId: number, title: string): Promise<void> {
+    if (!this.board) return;
+    const chore = this.choreById(choreId);
+    if (!chore) return;
+    const item = chore.subtasks.find((s) => s.id === subtaskId);
+    if (!item) return;
+    const trimmed = title.trim();
+    if (!trimmed) return; // ignore blank rename
+    if (trimmed === item.title) return; // no-op
+    const previous = item.title;
+    item.title = trimmed; // optimistic
+    try {
+      const updated = await updateSubtask(choreId, subtaskId, { title: trimmed });
+      this.replaceSubtask(choreId, updated);
+    } catch {
+      const cur = this.choreById(choreId)?.subtasks.find((s) => s.id === subtaskId);
+      if (cur) cur.title = previous;
+      await this.reconcile();
+      showToast({ message: "Couldn't rename that item — the list was refreshed.", kind: 'info' });
+    }
+  }
+
+  /**
+   * Remove a checklist item (optimistic splice). Reconcile + calm toast on error.
+   */
+  async removeSubtask(choreId: number, subtaskId: number): Promise<void> {
+    if (!this.board) return;
+    const chore = this.choreById(choreId);
+    if (!chore) return;
+    const item = chore.subtasks.find((s) => s.id === subtaskId);
+    if (!item) return;
+    chore.subtasks = chore.subtasks.filter((s) => s.id !== subtaskId); // optimistic
+    try {
+      await deleteSubtask(choreId, subtaskId);
+    } catch {
+      await this.reconcile();
+      showToast({ message: "Couldn't remove that item — the list was refreshed.", kind: 'info' });
+    }
+  }
+
+  /** Replace one subtask in a chore's list with the authoritative server DTO (kept sorted). */
+  private replaceSubtask(choreId: number, updated: ChoreSubtaskDto): void {
+    const chore = this.choreById(choreId);
+    if (!chore) return;
+    chore.subtasks = sortSubtasks(
+      chore.subtasks.map((s) => (s.id === updated.id ? updated : s)),
+    );
+  }
+}
+
+/** Stable ordering for a chore's checklist — by sortOrder, then id for ties. */
+function sortSubtasks(items: ChoreSubtaskDto[]): ChoreSubtaskDto[] {
+  return [...items].sort((a, b) => a.sortOrder - b.sortOrder || a.id - b.id);
+}
+
+/**
+ * The single shared store instance. Components import this and read its
+ * `$state`/`$derived` fields reactively. We export the INSTANCE (not the runes
+ * themselves) so the CORRECTIONS rune-export rule is respected.
+ */
+export const boardStore = new BoardStore();
+
+/** Resolve a member for avatar display; null when unknown/unassigned. */
+export function memberFor(userId: number | null | undefined): MemberDto | null {
+  if (userId == null) return null;
+  return boardStore.membersById.get(userId) ?? null;
+}
+
+/**
+ * Resolve a room rollup (name + icon) for a chore's roomId, for the per-card
+ * room locator chip. null when the chore is roomless (the virtual General group)
+ * or the roomId is unknown — callers render no chip in that case.
+ */
+export function roomFor(roomId: number | null | undefined): RoomRollupDto | null {
+  if (roomId == null) return null;
+  return boardStore.roomsById.get(roomId) ?? null;
+}
+
+/**
+ * Coerce a persisted `userDefaultView` string to a canonical `ChoreLensId`.
+ * null/blank/unknown ⇒ null (⇒ Up-for-grabs default). The server allowlist
+ * is authoritative (ChoreLens.All), but we re-validate defensively so an
+ * unexpected value never selects a non-existent lens.
+ */
+function coerceLens(view: string | null): ChoreLensId | null {
+  if (!view) return null;
+  return (CHORE_LENSES as readonly string[]).includes(view) ? (view as ChoreLensId) : null;
+}

--- a/frontend/app/src/lib/chores/lib/types.ts
+++ b/frontend/app/src/lib/chores/lib/types.ts
@@ -1,0 +1,363 @@
+// ─────────────────────────────────────────────────────────────────────────
+// FROZEN board DTO contract — mirrors the WP-05 board read model EXACTLY.
+// Source of truth: tests/FamilyCoordinationApp.Tests/Fixtures/ChoreBoard/board.json
+// (M9 consumer-audit tripwire: a DTO shape change updates THIS interface AND
+//  that fixture in lockstep). JSON keys are camelCase.
+//
+// ⚠ CASING GOTCHA (load-bearing — secondary risk is island/DTO drift):
+//   - `dueState`, `colorTier`, `assignmentKind`, rollup `status` are real C#
+//     enums serialized via JsonStringEnumConverter(CamelCase) → camelCase
+//     string unions below.
+//   - `recurrenceMode` and `effortTier` are stored on the DTO as PLAIN strings
+//     (entity-enum `.ToString()`, NOT routed through the converter) → they
+//     serialize PascalCase. Their TS unions below MUST be PascalCase.
+// ─────────────────────────────────────────────────────────────────────────
+
+/** PascalCase — plain string on the DTO (NOT enum-converted). */
+export type RecurrenceMode = 'OneOff' | 'Fixed' | 'Flexible';
+
+/** PascalCase — plain string on the DTO (NOT enum-converted). */
+export type EffortTier = 'Quick' | 'Standard' | 'BigJob';
+
+/** camelCase — enum via JsonStringEnumConverter(CamelCase). Server-computed dueness. */
+export type DueState = 'notDue' | 'dueToday' | 'overdue' | 'scheduled';
+
+/** camelCase — enum via JsonStringEnumConverter(CamelCase). Server-computed decay tier. */
+export type ColorTier = 'fresh' | 'mid' | 'due' | 'overdue';
+
+/** camelCase — enum via JsonStringEnumConverter(CamelCase). */
+export type AssignmentKind = 'none' | 'assigned' | 'claimed';
+
+/**
+ * camelCase — enum via JsonStringEnumConverter(CamelCase). A member's DERIVED state on a multi-person
+ * chore's named roster (rework): `assigned` = suggested (a pre-opt-in, no reply); `in` = committed
+ * ("I'm in"); `done` = completed their part this occurrence.
+ */
+export type RosterState = 'assigned' | 'in' | 'done';
+
+/** One member of a multi-person chore's derived roster. */
+export interface RosterMemberDto {
+  userId: number;
+  state: RosterState;
+}
+
+/** camelCase — enum via JsonStringEnumConverter(CamelCase). Room rollup dirtiness. */
+export type RoomRollupStatus = 'clean' | 'attention' | 'needsWork';
+
+/**
+ * A lightweight per-chore checklist item (Phase 14). Versionless / last-write-wins (no concurrency token).
+ * A momentum aid only — never gates completion; resets on a recurring chore's satisfying completion.
+ */
+export interface ChoreSubtaskDto {
+  id: number;
+  title: string;
+  isDone: boolean;
+  sortOrder: number;
+  /** "Who ticked it" actor — non-null IFF isDone (per-occurrence). Resolve via membersById/memberFor. */
+  completedByUserId: number | null;
+  /** ISO-8601 UTC (Z) when it was ticked; null when not done. Server-stamped — build no Date client-side. */
+  completedAt: string | null;
+}
+
+export interface ChoreDto {
+  id: number;
+  name: string;
+  /** Optional emoji/short-code icon (parity with room icons); "" = none. */
+  icon: string;
+  description: string | null;
+  roomId: number | null;
+  recurrenceMode: RecurrenceMode;
+  /** Recurrence sub-value echoed for edit pre-fill (Flexible "every N days"); null otherwise. */
+  intervalDays: number | null;
+  /** camelCase CSV of weekday flags (e.g. "monday, thursday") for Fixed chores; null otherwise. */
+  daysOfWeek: string | null;
+  /** ISO date "YYYY-MM-DD" — a one-off chore's due date (maps to anchorDate); null otherwise. */
+  anchorDate: string | null;
+  /** Server-computed — NEVER recompute dueness client-side (M5/M6). */
+  dueState: DueState;
+  /** Server-computed — NEVER recompute the decay tier client-side (M5/M6). */
+  colorTier: ColorTier;
+  /** ISO-8601 UTC (Z). Server-computed; render only — do not derive dueness from it. */
+  nextDueAt: string | null;
+  /** ISO date "YYYY-MM-DD" — the snooze / set-next-due floor; null = no floor. For the edit-sheet pre-fill. */
+  snoozedUntil: string | null;
+  /** Server-computed gate (today < snoozedUntil). The filter + Home read THIS — never date-math snoozedUntil. */
+  isSnoozed: boolean;
+  isClaimStale: boolean;
+  effortTier: EffortTier;
+  effortPoints: number;
+  ownerUserId: number | null;
+  assigneeUserId: number | null;
+  assignmentKind: AssignmentKind;
+  claimedAt: string | null;
+  lastCompletedAt: string | null;
+  photoPath: string | null;
+  /** xmin optimistic-concurrency token. Echo back on mutations (WP-11). */
+  version: number;
+  /** 1 = normal chore; >1 = multi-person (named roster). Always ≥ 1. */
+  requiredCount: number;
+  /** Distinct members DONE toward the CURRENT open occurrence (0..requiredCount) — the gate. Board GET only. */
+  completedCount: number;
+  /** Named roster + per-member state (assigned/in/done), ascending by userId. [] = open / single-person. */
+  roster: RosterMemberDto[];
+  /** Per-chore checklist (Phase 14); momentum aid, never gates completion. Ordered by sortOrder; [] = none. */
+  subtasks: ChoreSubtaskDto[];
+}
+
+export interface RoomRollupDto {
+  /** null = the virtual "General" group (roomless chores). */
+  roomId: number | null;
+  name: string;
+  icon: string;
+  photoPath: string | null;
+  /** General sorts last (int.MaxValue = 2147483647). */
+  sortOrder: number;
+  choreCount: number;
+  dueCount: number;
+  status: RoomRollupStatus;
+}
+
+export interface MemberDto {
+  userId: number;
+  displayName: string;
+  initials: string;
+  pictureUrl: string | null;
+}
+
+export interface ChoreBoardDto {
+  chores: ChoreDto[];
+  rooms: RoomRollupDto[];
+  members: MemberDto[];
+  /** Overdue/dueToday OR unclaimed pile, server-ordered. */
+  needsAttentionChoreIds: number[];
+  /** Persisted lens id; null ⇒ Up-for-grabs. One of ChoreLens (see below). */
+  userDefaultView: string | null;
+}
+
+// ─── Rooms (admin surface, /api/rooms) ──────────────────────────────────────
+
+export interface RoomDto {
+  id: number;
+  name: string;
+  icon: string;
+  photoPath: string | null;
+  sortOrder: number;
+}
+
+// ─── Canonical lens ids (M-canonical-lens / council M6) ─────────────────────
+// Must match the C# ChoreLens.All allowlist used by PATCH /me/default-view —
+// the server validates the persisted default against these EXACT ids, so none
+// may be removed. No ad-hoc casings. Switching groups the ONE board payload
+// client-side (no per-lens endpoint — M11).
+//
+// Model A board IA (Phase 14) reinterprets them in the island: the first three
+// are PRIMARY board filters (up-for-grabs / mine / needs-attention="All") over a
+// single attention-sectioned board; rooms / equity are on-demand ORGANIZERS. The
+// ViewSwitcher defines the grouping/labels explicitly, so this order is just for
+// tidiness — it is NOT load-bearing.
+
+export type ChoreLensId =
+  | 'up-for-grabs'
+  | 'mine'
+  | 'needs-attention'
+  | 'rooms'
+  | 'equity'
+  | 'recap';
+
+export const CHORE_LENSES: readonly ChoreLensId[] = [
+  'up-for-grabs',
+  'mine',
+  'needs-attention',
+  'rooms',
+  'equity',
+  'recap',
+] as const;
+
+// ─── Equity lens DTO (FROZEN — mirrors WP-02 ChoreEquityDto EXACTLY) ─────────
+// Source of truth: tests/FamilyCoordinationApp.Tests/Fixtures/ChoreEquity/equity.json
+// (M7 lockstep tripwire: a shape change updates THIS interface AND that fixture).
+// Served at GET /api/chores/equity?window=week|all. JSON keys are camelCase.
+//
+// ⚠ `window` is a PLAIN string on the DTO ('week'|'all'). `sharePct` /
+//   `equalSharePct` are PERCENT values in 0..100 (e.g. 41.7) — render them
+//   DIRECTLY as a percent (no client `* 100`). All values are server-computed;
+//   render only — NO client date math (MN9), no leaderboard/ranking framing (M12).
+
+/** The equity reporting window. Plain string on the DTO. */
+export type EquityWindow = 'week' | 'all';
+
+/**
+ * A member's physical-capacity tier (Phase 15). Mirrors the C# `CapacityTier.All` casing EXACTLY
+ * (PascalCase strings — NOT enum-converted). `null` on the DTO ⇒ Full (the pre-migration default).
+ */
+export type CapacityTier = 'Full' | 'Reduced' | 'Minimal';
+
+/** Per-member share of the household's completion load over the window. */
+export interface MemberShareDto {
+  userId: number;
+  displayName: string;
+  initials: string;
+  pictureUrl: string | null;
+  points: number;
+  completions: number;
+  /** PERCENT 0..100 (e.g. 41.7). Render directly — no client `* 100`. */
+  sharePct: number;
+  /**
+   * The member's capacity-WEIGHTED expected share (PERCENT 0..100, UNROUNDED — format for display; Phase 15
+   * WP-05). The island draws THIS as each member's per-member reference line instead of the single flat
+   * equal-share marker. `sharePct` stays the RAW actual bar. Render directly — no client `* 100`.
+   */
+  expectedSharePct: number;
+}
+
+/**
+ * Per-member planning/coordination footprint (Phase 15). ALL-TIME, un-blended labeled tallies — the
+ * server computes them all-time regardless of `window` (D5). Plain integer COUNTS (no percent, no weight);
+ * NEVER summed into a blended score (MN4). Mirrors the C# `MemberPlanningDto` and the `planning` array in
+ * equity.json EXACTLY (M5 lockstep).
+ */
+export interface MemberPlanningDto {
+  userId: number;
+  displayName: string;
+  choresSetUp: number;
+  recipesAdded: number;
+  listItemsCurated: number;
+  handOffs: number;
+}
+
+export interface ChoreEquityDto {
+  window: EquityWindow;
+  totalPoints: number;
+  totalCompletions: number;
+  /** PERCENT 0..100 — the neutral equal-share reference line. */
+  equalSharePct: number;
+  fallingBehindCount: number;
+  upForGrabsCount: number;
+  members: MemberShareDto[];
+  /**
+   * All-time planning footprint per member (Phase 15). Always present (defaults to [] server-side) —
+   * INDEPENDENT of `window`. Render as neutral labeled tallies; never sum/blend with physical points (MN4).
+   */
+  planning: MemberPlanningDto[];
+  /**
+   * The REQUESTING user's own physical-capacity tier (Phase 15 WP-05, P4); `null` ⇒ Full (the pre-migration
+   * default). Rides the equity payload so the self-only capacity selector reflects state without a separate
+   * GET (M7). The selector writes via PATCH /me/capacity (caller-scoped only — MN5).
+   */
+  callerCapacityTier: CapacityTier | null;
+}
+
+// ─── Weekly recap lens DTO (mirrors ChoreRecapDtos.cs EXACTLY) ───────────────
+// Served at GET /api/chores/recap?weeks=N. JSON keys are camelCase. The `current`
+// week is the SAME content the Discord digest posts (same headline/distribution/
+// falling-behind/up-for-grabs). `trend` is week-over-week totals, oldest→newest.
+//
+// ⚠ MN9: `weekStartLocal` is a date-only string ("YYYY-MM-DD") already resolved in
+//   the household timezone server-side. NEVER `new Date('YYYY-MM-DD')` on it — render
+//   the string, or parse parts manually. `sharePct` is PERCENT 0..100 (render direct).
+
+/** One member's line in the current-week distribution (no userId/mention — neutral). */
+export interface RecapMemberLineDto {
+  displayName: string;
+  points: number;
+  /** PERCENT 0..100 (e.g. 41.7). Render directly — no client `* 100`. */
+  sharePct: number;
+}
+
+/** The current week's assembled recap — identical to the Discord digest content. */
+export interface RecapWeekDto {
+  /** Local Monday of the week, "YYYY-MM-DD" (household tz; MN9 — do not Date-parse). */
+  weekStartLocal: string;
+  /** Collective, non-punitive headline. */
+  headline: string;
+  totalCompletions: number;
+  totalPoints: number;
+  distribution: RecapMemberLineDto[];
+  /** Names of chores Overdue/DueToday (attention list, not blame). */
+  fallingBehind: string[];
+  upForGrabsCount: number;
+}
+
+/** One week's totals in the week-over-week trend (totals only — no per-member split). */
+export interface RecapTrendPointDto {
+  /** Local Monday of the week, "YYYY-MM-DD" (household tz; MN9 — do not Date-parse). */
+  weekStartLocal: string;
+  totalCompletions: number;
+  totalPoints: number;
+  /** True for the in-progress current week (the last, partial bar). */
+  isCurrent: boolean;
+}
+
+/** Full recap payload: the current week + the week-over-week trend (oldest→newest). */
+export interface ChoreRecapDto {
+  current: RecapWeekDto;
+  trend: RecapTrendPointDto[];
+}
+
+// ─── Digest settings (WP-11 — mirrors WP-06 frozen contract EXACTLY) ─────────
+//
+// Wire casing: camelCase enum strings via JsonStringEnumConverter(CamelCase).
+// The GET never returns the webhook URL (MN7) — only a hasWebhook flag + hint.
+// The PUT tri-state webhookAction drives whether the secret is kept/replaced/cleared.
+
+/** camelCase — enum via JsonStringEnumConverter(CamelCase). Only 'weekly' for now; union-extensible. */
+export type DigestCadence = 'weekly';
+
+/** camelCase — enum via JsonStringEnumConverter(CamelCase). */
+export type DigestDay =
+  | 'sunday'
+  | 'monday'
+  | 'tuesday'
+  | 'wednesday'
+  | 'thursday'
+  | 'friday'
+  | 'saturday';
+
+/**
+ * Tri-state webhook action for PUT /api/chores/digest-settings.
+ * 'keep' = leave stored URL unchanged (default when input untouched).
+ * 'set'  = replace with the provided webhookUrl.
+ * 'clear' = remove the stored URL.
+ */
+export type WebhookAction = 'keep' | 'set' | 'clear';
+
+/**
+ * Safe view returned by GET /api/chores/digest-settings.
+ * ⚠ The webhook URL is NEVER in this response (MN7) — only hasWebhook + a
+ * masked hint. Do NOT fetch or render the stored URL anywhere client-side.
+ */
+export interface DigestSettingsView {
+  enabled: boolean;
+  cadence: DigestCadence;
+  sendDayOfWeek: DigestDay;
+  sendHourLocal: number;
+  /** True when a webhook URL is stored (encrypted at rest). */
+  hasWebhook: boolean;
+  /** A masked hint (e.g. "…xyz") to help the user identify the stored URL; null when no webhook. */
+  webhookHint: string | null;
+  /** ISO-8601 UTC timestamp of the last sent digest; null when never sent. */
+  lastSentAt: string | null;
+}
+
+/**
+ * PUT body for /api/chores/digest-settings.
+ * webhookAction controls the tri-state: 'keep' (default), 'set' (+ webhookUrl), 'clear'.
+ * ⚠ Never log webhookUrl client-side; never put it in a query string (MN7).
+ */
+export interface DigestSettingsUpdate {
+  enabled: boolean;
+  cadence: DigestCadence;
+  sendDayOfWeek: DigestDay;
+  sendHourLocal: number;
+  webhookAction: WebhookAction;
+  /** Required when webhookAction is 'set'. Not sent otherwise. */
+  webhookUrl?: string;
+}
+
+// ─── Shell context (read from the #chores-root data-attributes) ─────────────
+
+export interface ShellContext {
+  householdId: number;
+  userId: number;
+  userName: string;
+}

--- a/frontend/app/src/lib/connections/App.svelte
+++ b/frontend/app/src/lib/connections/App.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  // Root of the connections island (#connections-root). Reads the ShellContext from
+  // the root data-attrs (passed by main.ts), loads the active invite + connected
+  // list ONCE, then drives the invite state machine via the shared store. No writes
+  // happen on load; no liveness/poll (parity — Connections.razor doesn't poll).
+  import { untrack } from 'svelte';
+  import type { ShellContext } from './lib/types';
+  import { connectionsStore as store } from './lib/connectionsStore.svelte';
+  import InviteShare from './lib/components/InviteShare.svelte';
+  import CodeEntry from './lib/components/CodeEntry.svelte';
+  import ConnectedList from './lib/components/ConnectedList.svelte';
+  import DisconnectDialog from './lib/components/DisconnectDialog.svelte';
+
+  let { ctx }: { ctx: ShellContext } = $props();
+
+  async function load(): Promise<void> {
+    await store.load();
+  }
+
+  // ⚠ Loop safety (memory svelte5-setup-effect-async-loader-loop): the one-time
+  // setup effect calls load(), whose sync prefix reads THEN writes store state.
+  // Wrapping the whole body in untrack() gives the effect zero reactive deps so it
+  // runs exactly once. There is no liveness here (parity — the page doesn't poll).
+  $effect(() => {
+    untrack(() => {
+      void ctx; // shell context available; the store calls /api directly (household resolved server-side)
+      void load();
+    });
+  });
+</script>
+
+<div class="con-page">
+  <h1 class="con-title">Family Connections</h1>
+
+  {#if !store.loaded && store.loading}
+    <div class="con-loading">Loading…</div>
+  {:else if !store.loaded && store.error}
+    <div class="con-inline-error" role="alert">
+      <span>{store.error}</span>
+      <button type="button" class="con-retry" onclick={() => void load()}>Retry</button>
+    </div>
+  {:else}
+    <InviteShare />
+    <CodeEntry />
+    <ConnectedList />
+  {/if}
+</div>
+
+<DisconnectDialog />

--- a/frontend/app/src/lib/connections/lib/api.ts
+++ b/frontend/app/src/lib/connections/lib/api.ts
@@ -1,0 +1,90 @@
+import type {
+  ConnectionsDto,
+  InviteDto,
+  ValidateResultDto,
+  AcceptResultDto,
+} from './types';
+
+const BASE = '/api/settings/connections';
+
+/**
+ * Thrown on any non-2xx response. `status` lets callers react to a rejection.
+ *
+ * ⚠ Carried from the other islands: the app re-executes empty-body API 4xx
+ * through a Blazor `/not-found` page, so a server-side "not found" can arrive
+ * as an empty 400 (a bare DELETE 404 even surfaces as 405). The connections
+ * endpoints return outcome envelopes (200) for the expected validate/accept flow
+ * results, so a 4xx here is a genuine error (or 401) — treat ANY 4xx as a
+ * non-retryable client rejection.
+ */
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+
+  /** A non-retryable client rejection (validation / not found / conflict). Any 4xx. */
+  get isClientRejection(): boolean {
+    return this.status >= 400 && this.status < 500;
+  }
+}
+
+async function request<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    credentials: 'include',
+    headers: { Accept: 'application/json', ...(init?.headers ?? {}) },
+    ...init,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    let message = text || res.statusText;
+    // The endpoints return { message } on 4xx — surface it for the toast.
+    try {
+      const parsed = JSON.parse(text);
+      if (parsed && typeof parsed.message === 'string') message = parsed.message;
+    } catch { /* not JSON — use the raw text */ }
+    throw new ApiError(res.status, message);
+  }
+  if (res.status === 204) return undefined as T;
+  return (await res.json()) as T;
+}
+
+function jsonBody(body: unknown): RequestInit {
+  return {
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  };
+}
+
+/** #1 The active invite (or null) + connected households, in one payload. */
+export async function getConnections(): Promise<ConnectionsDto> {
+  return request<ConnectionsDto>(`${BASE}/`);
+}
+
+/** #2 Generate a new invite (replaces any prior active one) → the code (201). */
+export async function generateInvite(): Promise<InviteDto> {
+  return request<InviteDto>(`${BASE}/invite`, { method: 'POST' });
+}
+
+/** #3 Cancel the active invite → 204 (idempotent). */
+export async function cancelInvite(): Promise<void> {
+  await request<void>(`${BASE}/invite`, { method: 'DELETE' });
+}
+
+/** #4 Validate a code WITHOUT connecting → 200 outcome envelope. */
+export async function validateCode(code: string): Promise<ValidateResultDto> {
+  return request<ValidateResultDto>(`${BASE}/validate`, { method: 'POST', ...jsonBody({ code }) });
+}
+
+/** #5 Accept a code (establish the connection) → 200 outcome envelope. */
+export async function acceptCode(code: string): Promise<AcceptResultDto> {
+  return request<AcceptResultDto>(`${BASE}/accept`, { method: 'POST', ...jsonBody({ code }) });
+}
+
+/** #6 Disconnect a connected household → 204 (idempotent; M1 enforced server-side). */
+export async function disconnect(householdId: number): Promise<void> {
+  await request<void>(`${BASE}/connected/${householdId}`, { method: 'DELETE' });
+}

--- a/frontend/app/src/lib/connections/lib/components/CodeEntry.svelte
+++ b/frontend/app/src/lib/connections/lib/components/CodeEntry.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+  // Enter-a-code section (parity Connections.razor:84-151): input (uppercase/strip/
+  // max-6) + Submit → validate; on valid, a pre-connection confirm → Connect/Cancel.
+  // On accept failure the store returns here with codeError (review R-B3).
+  import { connectionsStore as store } from '../connectionsStore.svelte';
+
+  function onInput(e: Event) {
+    store.setCode((e.currentTarget as HTMLInputElement).value);
+  }
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter' && store.canSubmit) void store.validate();
+  }
+</script>
+
+<section class="con-card">
+  <h2 class="con-card-title">Enter a Code</h2>
+  <p class="con-card-sub">Got a code from someone? Enter it below.</p>
+
+  {#if !store.showConfirm}
+    <div class="con-entry-row">
+      <input
+        class="con-code-input"
+        type="text"
+        autocomplete="off"
+        autocapitalize="characters"
+        spellcheck="false"
+        maxlength="6"
+        aria-label="Invite Code"
+        placeholder="ABC123"
+        value={store.enteredCode}
+        oninput={onInput}
+        onkeydown={onKeydown}
+        disabled={store.validating}
+      />
+      <button type="button" class="con-btn-primary" onclick={() => store.validate()} disabled={!store.canSubmit}>
+        {#if store.validating}<span class="con-spinner"></span>{/if}
+        Submit
+      </button>
+    </div>
+
+    {#if store.codeError}
+      <div class="con-alert con-alert-warning" role="alert" style="margin-top: 12px;">{store.codeError}</div>
+    {/if}
+  {:else}
+    <div class="con-alert con-alert-info" style="margin-bottom: 16px;">
+      Connecting with <strong>{store.pendingHouseholdName}</strong> lets both families browse each other's recipes.
+      They can see your recipes but can't change them. You can disconnect anytime.
+    </div>
+    <div class="con-actions">
+      <button type="button" class="con-btn-outline" onclick={() => store.cancelConfirm()} disabled={store.accepting}>
+        Cancel
+      </button>
+      <button type="button" class="con-btn-primary" onclick={() => store.accept()} disabled={store.accepting}>
+        {#if store.accepting}<span class="con-spinner"></span>{/if}
+        Connect
+      </button>
+    </div>
+  {/if}
+</section>

--- a/frontend/app/src/lib/connections/lib/components/ConnectedList.svelte
+++ b/frontend/app/src/lib/connections/lib/components/ConnectedList.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  // Connected-families section (parity Connections.razor:153-188): list each
+  // connected household with its connected-date + a Stop Sharing button (opens the
+  // disconnect-confirm dialog), or an empty hint.
+  import { connectionsStore as store } from '../connectionsStore.svelte';
+  import { formatConnectedDate } from '../dates';
+</script>
+
+<section class="con-card">
+  <h2 class="con-card-title">Your Connected Families</h2>
+
+  {#if store.connected.length === 0}
+    <p class="con-empty">
+      You haven't connected with any families yet. Create an invite code or enter one to get started.
+    </p>
+  {:else}
+    <ul class="con-list">
+      {#each store.connected as family (family.householdId)}
+        <li class="con-row">
+          <div>
+            <div class="con-row-name">{family.householdName}</div>
+            <div class="con-row-date">Connected {formatConnectedDate(family.connectedAt)}</div>
+          </div>
+          <button type="button" class="con-btn-danger" onclick={() => store.askDisconnect(family)}>
+            🔗 Stop Sharing
+          </button>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</section>

--- a/frontend/app/src/lib/connections/lib/components/DisconnectDialog.svelte
+++ b/frontend/app/src/lib/connections/lib/components/DisconnectDialog.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+  // Disconnect-confirm dialog (parity Connections.razor:192-220): the household name
+  // + 3 consequence bullets + a Stop Sharing (danger) action with a busy spinner.
+  // Driven by store.disconnectTarget (a native <dialog> showModal/close).
+  import { connectionsStore as store } from '../connectionsStore.svelte';
+
+  let dialogEl: HTMLDialogElement | null = $state(null);
+  const open = $derived(store.disconnectTarget !== null);
+
+  $effect(() => {
+    if (!dialogEl) return;
+    if (open && !dialogEl.open) {
+      dialogEl.showModal();
+    } else if (!open && dialogEl.open) {
+      dialogEl.close();
+    }
+  });
+</script>
+
+<dialog bind:this={dialogEl} onclose={() => store.cancelDisconnect()} class="con-dialog">
+  {#if store.disconnectTarget}
+    <div class="con-dialog-body">
+      <h2 class="con-dialog-title">Stop sharing with {store.disconnectTarget.householdName}?</h2>
+      <ul class="con-dialog-list">
+        <li><span class="con-mark con-mark-no">✕</span> You'll no longer be able to browse their recipes</li>
+        <li><span class="con-mark con-mark-no">✕</span> They'll no longer be able to browse yours</li>
+        <li><span class="con-mark con-mark-yes">✓</span> Recipes you've already copied will stay in your collection</li>
+      </ul>
+      <div class="con-actions con-dialog-actions">
+        <button type="button" class="con-btn-outline" onclick={() => store.cancelDisconnect()} disabled={store.disconnecting}>
+          Cancel
+        </button>
+        <button type="button" class="con-btn-danger-filled" onclick={() => store.confirmDisconnect()} disabled={store.disconnecting}>
+          {#if store.disconnecting}<span class="con-spinner"></span>{/if}
+          Stop Sharing
+        </button>
+      </div>
+    </div>
+  {/if}
+</dialog>
+
+<style>
+  .con-dialog[open] {
+    position: fixed;
+    inset: 0;
+    margin: auto;
+    border: none;
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text);
+    padding: 0;
+    width: min(420px, calc(100vw - 32px));
+    box-shadow: var(--shadow-4);
+  }
+  .con-dialog::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+  }
+  .con-dialog-body {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding: 24px;
+  }
+  .con-dialog-title {
+    margin: 0;
+    font-size: 1.125rem;
+    font-weight: 500;
+  }
+  .con-dialog-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    font-size: 0.9rem;
+    color: var(--color-text-muted);
+  }
+  .con-dialog-list li {
+    display: flex;
+    gap: 10px;
+    align-items: flex-start;
+  }
+  .con-mark {
+    flex-shrink: 0;
+    font-weight: 700;
+  }
+  .con-mark-no {
+    color: var(--color-error);
+  }
+  .con-mark-yes {
+    color: var(--color-success);
+  }
+  .con-dialog-actions {
+    justify-content: flex-end;
+    margin-top: 4px;
+  }
+</style>

--- a/frontend/app/src/lib/connections/lib/components/InviteShare.svelte
+++ b/frontend/app/src/lib/connections/lib/components/InviteShare.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  // Share section (parity Connections.razor:32-82): generate a code, show it with
+  // expiry + copy + cancel, or the "Create Invite Code" button when there's none.
+  import { connectionsStore as store } from '../connectionsStore.svelte';
+  import { formatExpiry } from '../dates';
+</script>
+
+<section class="con-card">
+  <h2 class="con-card-title">Share Your Recipes</h2>
+  <p class="con-card-sub">
+    Share this code with your family or friends — they'll enter it in their app to start sharing recipes together.
+  </p>
+
+  {#if store.generating}
+    <div class="con-share"><span class="con-spinner" aria-label="Creating invite"></span></div>
+  {:else if store.activeInvite}
+    <div class="con-share">
+      <div class="con-code">{store.activeInvite.code}</div>
+      <button type="button" class="con-btn-outline" onclick={() => store.copyCode()}>📋 Copy Code</button>
+      <div class="con-expiry">Expires {formatExpiry(store.activeInvite.expiresAt)}</div>
+      <button type="button" class="con-btn-danger" onclick={() => store.cancelActiveInvite()}>Cancel Invite</button>
+    </div>
+  {:else}
+    <button type="button" class="con-btn-primary" onclick={() => store.generate()}>Create Invite Code</button>
+  {/if}
+</section>

--- a/frontend/app/src/lib/connections/lib/connectionsStore.svelte.ts
+++ b/frontend/app/src/lib/connections/lib/connectionsStore.svelte.ts
@@ -1,0 +1,246 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Connections view store (#connections-root). Source of truth for the active
+// invite, the connected-households list, AND the invite-flow state machine
+// (generate → enter code → validate → pre-connection confirm → accept; plus the
+// disconnect-confirm flow). Faithful port of Connections.razor's @code block.
+//
+// ⚠ Svelte 5 rune rule (global CORRECTION): never `export` a reassigned `$state`.
+// We wrap the mutable state in a class instance and export the instance.
+//
+// Parity-first ⇒ versionless / last-write-wins. The page does NOT poll (no
+// liveness). Every mutation `await`s then refreshes; a `loadSeq` guard drops a
+// stale reload that resolves after a newer one (memory fca-island-async-race-guards).
+// There is no autosave/draft here (all actions are explicit buttons), so the
+// flush-before-delete guard from that memory does not apply.
+//
+// Error surfacing parity: validate failures + accept failures render INLINE as
+// codeError (a warning under the code input); generate/cancel/disconnect/copy
+// failures surface as toasts. The validate/accept endpoints return a 200 outcome
+// envelope, so a business "no" is `isValid:false` / `success:false`, not a throw.
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { InviteDto, ConnectedDto } from './types';
+import {
+  ApiError,
+  getConnections,
+  generateInvite,
+  cancelInvite,
+  validateCode,
+  acceptCode,
+  disconnect,
+} from './api';
+import { showToast } from '$lib/shared/toast-store.svelte';
+
+/**
+ * Faithful port of Connections.razor's MapValidationError (:403-415). The service
+ * returns prose error strings ("You cannot connect to your own household.") that
+ * don't match these code labels, so today this falls through to the default and
+ * passes the service message through — the port preserves that exact behavior.
+ */
+export function mapValidationError(error: string | null | undefined): string {
+  switch ((error ?? '').toLowerCase()) {
+    case 'self_connection':
+    case 'self-connection':
+    case 'self':
+      return 'This is your own invite code. Share it with another family to connect.';
+    case 'already_connected':
+    case 'already-connected':
+    case 'already connected':
+      return "You're already connected with this family!";
+    case 'expired':
+      return 'This code has expired. Ask them to create a new one.';
+    case 'invalid':
+    case 'not_found':
+    case 'not found':
+      return "We couldn't find that code. Check the code and try again.";
+    default:
+      return error || "We couldn't find that code. Check the code and try again.";
+  }
+}
+
+class ConnectionsStore {
+  // ── Loaded data ──
+  activeInvite = $state<InviteDto | null>(null);
+  connected = $state<ConnectedDto[]>([]);
+  loading = $state(true);
+  error = $state<string | null>(null);
+
+  // ── Share-section flow ──
+  generating = $state(false);
+
+  // ── Enter-a-code flow ──
+  enteredCode = $state('');
+  validating = $state(false);
+  codeError = $state<string | null>(null);
+  showConfirm = $state(false);
+  pendingHouseholdName = $state<string | null>(null);
+  accepting = $state(false);
+
+  // ── Disconnect flow ──
+  disconnectTarget = $state<ConnectedDto | null>(null);
+  disconnecting = $state(false);
+
+  /**
+   * True once the FIRST load resolved. Gates the skeleton so reloads don't reflash it, AND lets the App keep
+   * the sections mounted on a later reload error (a refresh failure must not swap the whole view back to the
+   * error state — the dashboard pattern).
+   */
+  loaded = $state(false);
+  /** Monotonic load id — a slower older response must not overwrite a newer one. */
+  private seq = 0;
+
+  /** Whether the Submit button is enabled (parity: exactly 6 chars + not mid-validate). */
+  get canSubmit(): boolean {
+    return this.enteredCode.length === 6 && !this.validating;
+  }
+
+  /** Load the active invite + connected list. Spinner only on the FIRST load; reloads refresh in place. */
+  async load(): Promise<void> {
+    const s = ++this.seq;
+    try {
+      if (!this.loaded) this.loading = true;
+      this.error = null;
+      const dto = await getConnections();
+      if (s !== this.seq) return; // a newer load superseded this one
+      this.activeInvite = dto.activeInvite;
+      this.connected = dto.connected;
+      this.loaded = true;
+    } catch (e) {
+      if (s !== this.seq) return;
+      this.error = describe(e, 'load connections');
+    } finally {
+      if (s === this.seq) this.loading = false;
+    }
+  }
+
+  // ── Share section ───────────────────────────────────────────────────────────
+
+  async generate(): Promise<void> {
+    this.generating = true;
+    try {
+      this.activeInvite = await generateInvite();
+    } catch (e) {
+      showToast({ message: describe(e, 'create invite'), kind: 'error' });
+    } finally {
+      this.generating = false;
+    }
+  }
+
+  async cancelActiveInvite(): Promise<void> {
+    try {
+      await cancelInvite();
+      this.activeInvite = null;
+    } catch (e) {
+      showToast({ message: describe(e, 'cancel invite'), kind: 'error' });
+    }
+  }
+
+  /** Copy the active code to the clipboard, with the parity "select manually" fallback. */
+  async copyCode(): Promise<void> {
+    const code = this.activeInvite?.code;
+    if (!code) return;
+    try {
+      await navigator.clipboard.writeText(code);
+      showToast({ message: 'Code copied to clipboard', kind: 'success' });
+    } catch {
+      showToast({ message: 'Unable to copy — please select the code manually', kind: 'error' });
+    }
+  }
+
+  // ── Enter-a-code section ──────────────────────────────────────────────────────
+
+  /** Port of OnCodeTextChanged (:361-370): uppercase, strip non-alphanumerics, cap at 6, clear the error. */
+  setCode(raw: string): void {
+    this.enteredCode = [...raw.toUpperCase()]
+      .filter((c) => /[A-Z0-9]/.test(c))
+      .slice(0, 6)
+      .join('');
+    this.codeError = null;
+  }
+
+  async validate(): Promise<void> {
+    if (this.enteredCode.length !== 6) return;
+    this.validating = true;
+    this.codeError = null;
+    try {
+      const res = await validateCode(this.enteredCode);
+      if (res.isValid) {
+        this.pendingHouseholdName = res.householdName;
+        this.showConfirm = true;
+      } else {
+        this.codeError = mapValidationError(res.error);
+      }
+    } catch (e) {
+      this.codeError = `Something went wrong. Please try again. (${describe(e, 'validate code')})`;
+    } finally {
+      this.validating = false;
+    }
+  }
+
+  cancelConfirm(): void {
+    this.showConfirm = false;
+    this.pendingHouseholdName = null;
+  }
+
+  async accept(): Promise<void> {
+    this.accepting = true;
+    try {
+      const res = await acceptCode(this.enteredCode);
+      if (res.success) {
+        showToast({
+          message: `You're now connected with ${res.connectedHouseholdName}! Browse their recipes from your Recipes page.`,
+          kind: 'success',
+        });
+        this.showConfirm = false;
+        this.pendingHouseholdName = null;
+        this.enteredCode = '';
+        await this.load(); // refresh the connected list
+      } else {
+        // Accept failure returns to the ENTRY view with the mapped error (review R-B3).
+        this.codeError = mapValidationError(res.error);
+        this.showConfirm = false;
+      }
+    } catch (e) {
+      showToast({ message: describe(e, 'connect'), kind: 'error' });
+      this.showConfirm = false;
+    } finally {
+      this.accepting = false;
+    }
+  }
+
+  // ── Disconnect section ────────────────────────────────────────────────────────
+
+  askDisconnect(household: ConnectedDto): void {
+    this.disconnectTarget = household;
+  }
+
+  cancelDisconnect(): void {
+    this.disconnectTarget = null;
+  }
+
+  async confirmDisconnect(): Promise<void> {
+    const target = this.disconnectTarget;
+    if (!target) return;
+    this.disconnecting = true;
+    try {
+      await disconnect(target.householdId);
+      showToast({ message: `Stopped sharing with ${target.householdName}`, kind: 'success' });
+      await this.load();
+    } catch (e) {
+      if (e instanceof ApiError) await this.load(); // reconcile to truth on a 4xx
+      showToast({ message: describe(e, 'disconnect'), kind: 'error' });
+    } finally {
+      this.disconnectTarget = null;
+      this.disconnecting = false;
+    }
+  }
+}
+
+function describe(e: unknown, action: string): string {
+  if (e instanceof ApiError) return e.message || `Couldn't ${action} (HTTP ${e.status}).`;
+  if (e instanceof Error) return e.message;
+  return `Couldn't ${action}.`;
+}
+
+/** The single shared connections-view store instance (export the instance, not the runes). */
+export const connectionsStore = new ConnectionsStore();

--- a/frontend/app/src/lib/connections/lib/dates.ts
+++ b/frontend/app/src/lib/connections/lib/dates.ts
@@ -1,0 +1,35 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Date helpers for the connections island. Both dates on the wire (invite
+// expiresAt, connected connectedAt) are FULL ISO-8601 instants (UTC) — review X5.
+// We parse the full instant (new Date(iso) handles the offset correctly) and
+// format in the user's local timezone. This is NOT the noon-UTC date-only case
+// (that trick is only for bare "YYYY-MM-DD"); never new Date('YYYY-MM-DD') here.
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Relative-until-or-absolute expiry text — a faithful port of Connections.razor's
+ * GetExpiryText (:350-357). Rendered as "Expires {this}" in the share card:
+ *   < 1 min   → "in less than a minute"
+ *   < 60 min  → "in N minutes"
+ *   < 24 hr   → "in N hours"
+ *   else      → "on Mon D, YYYY" (local)
+ * Integer truncation matches the C# (int) cast.
+ */
+export function formatExpiry(iso: string): string {
+  const expires = new Date(iso);
+  if (Number.isNaN(expires.getTime())) return '';
+  const remainingMs = expires.getTime() - Date.now();
+  const minutes = remainingMs / 60_000;
+  if (minutes < 1) return 'in less than a minute';
+  if (minutes < 60) return `in ${Math.floor(minutes)} minutes`;
+  const hours = remainingMs / 3_600_000;
+  if (hours < 24) return `in ${Math.floor(hours)} hours`;
+  return `on ${expires.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}`;
+}
+
+/** "Jun 20, 2026" connected-date — parity Connections.razor:173 ("MMM d, yyyy" local), or "" when invalid. */
+export function formatConnectedDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+}

--- a/frontend/app/src/lib/connections/lib/types.ts
+++ b/frontend/app/src/lib/connections/lib/types.ts
@@ -1,0 +1,54 @@
+// ─────────────────────────────────────────────────────────────────────────
+// TS mirror of the /api/settings/connections contract (M9 lockstep). Source of truth:
+//   - Services/Dtos/SettingsConnectionDtos.cs (the C# records — connection-scoped
+//     names there to avoid colliding with the recipes ConnectedHouseholdDto; here
+//     they are island-local)
+//   - tests/.../Fixtures/Settings/connections.json (byte-locked tripwire)
+//   - Endpoints/SettingsConnectionsEndpoints.cs (request DTOs)
+//
+// ⚠ CASING: all keys camelCase. No enums.
+// ⚠ DATES (review X5): `expiresAt` / `connectedAt` are FULL ISO-8601 instants (UTC) —
+//   render them local via new Date(iso) (NEVER new Date('YYYY-MM-DD')). See dates.ts.
+// ─────────────────────────────────────────────────────────────────────────
+
+/** The per-page context the Razor host hands the island via data- attributes. */
+export interface ShellContext {
+  householdId: number;
+  userId: number;
+  userName: string;
+}
+
+/** The household's single active invite. */
+export interface InviteDto {
+  code: string;
+  /** full ISO-8601 instant (UTC). */
+  expiresAt: string;
+}
+
+/** One connected household. */
+export interface ConnectedDto {
+  householdId: number;
+  householdName: string;
+  /** full ISO-8601 instant (UTC). */
+  connectedAt: string;
+}
+
+/** The Connections view aggregate (GET /). `activeInvite` is null when none. */
+export interface ConnectionsDto {
+  activeInvite: InviteDto | null;
+  connected: ConnectedDto[];
+}
+
+/** Validate outcome envelope (200, never a 4xx — review §8). */
+export interface ValidateResultDto {
+  isValid: boolean;
+  householdName: string | null;
+  error: string | null;
+}
+
+/** Accept outcome envelope (200). On failure the island returns to the entry view (review R-B3). */
+export interface AcceptResultDto {
+  success: boolean;
+  connectedHouseholdName: string | null;
+  error: string | null;
+}

--- a/frontend/app/src/lib/dashboard/App.svelte
+++ b/frontend/app/src/lib/dashboard/App.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+  // Root of the dashboard island. Reads the ShellContext from #dashboard-root
+  // data-attrs (passed by main.ts), loads the read-only aggregate once, and
+  // refreshes via liveness (20s visible + refocus). No writes — the only state
+  // the island mutates is its own loaded `data`.
+  import { untrack } from 'svelte';
+  import type { ShellContext } from './lib/types';
+  import { dashboardStore as store } from './lib/dashboardStore.svelte';
+  import { startLiveness, type LivenessHandle } from './lib/liveness';
+  import { showToast } from '$lib/shared/toast-store.svelte';
+  import { formatLongDate, formatShortDate } from './lib/dates';
+  import ChoreCard from './lib/components/ChoreCard.svelte';
+  import ShoppingCard from './lib/components/ShoppingCard.svelte';
+  import MealsCard from './lib/components/MealsCard.svelte';
+  import QuickActions from './lib/components/QuickActions.svelte';
+
+  let { ctx }: { ctx: ShellContext } = $props();
+
+  let liveness: LivenessHandle | null = null;
+
+  async function load(): Promise<void> {
+    await store.load();
+  }
+
+  // Background refresh: keep the last good data and surface a calm toast on failure.
+  async function reconcile(): Promise<void> {
+    const hadData = store.data !== null;
+    await store.load();
+    if (store.error && hadData) {
+      showToast({ message: 'Could not refresh — showing the last update.', kind: 'error' });
+    }
+  }
+
+  // ⚠ Loop safety (memory svelte5-setup-effect-async-loader-loop): the one-time
+  // setup effect calls load(), whose sync prefix reads THEN writes store state.
+  // Wrapping the whole body in untrack() gives the effect zero reactive deps so
+  // it runs exactly once; liveness + refocus drive every later refresh.
+  $effect(() => {
+    untrack(() => {
+      store.init(ctx);
+      void load();
+      liveness = startLiveness(() => void reconcile());
+    });
+    return () => {
+      liveness?.stop();
+      liveness = null;
+    };
+  });
+</script>
+
+<div class="db-container">
+  {#if store.loading && !store.data}
+    <div class="db-loading">Loading your dashboard…</div>
+  {:else if store.error && !store.data}
+    <div class="db-inline-error" role="alert">
+      <span>Couldn't load the dashboard.</span>
+      <button type="button" class="db-retry" onclick={() => void load()}>Retry</button>
+    </div>
+  {:else if store.data}
+    <div class="db-welcome">
+      <h1 class="db-welcome-title">Welcome back, {store.data.greetingName}! 👋</h1>
+      <p class="db-welcome-sub">{store.data.householdName} • {formatLongDate(store.data.today)}</p>
+    </div>
+
+    <div class="db-grid">
+      <ChoreCard chores={store.data.chores} attention={store.choreAttention} />
+      <ShoppingCard shopping={store.data.shopping} progress={store.shoppingProgress} />
+      <MealsCard groups={store.mealsByType} dateLabel={formatShortDate(store.data.today)} />
+    </div>
+
+    <QuickActions />
+  {/if}
+</div>

--- a/frontend/app/src/lib/dashboard/lib/api.ts
+++ b/frontend/app/src/lib/dashboard/lib/api.ts
@@ -1,0 +1,43 @@
+import type { DashboardDto } from './types';
+
+const BASE = '/api/dashboard';
+
+/**
+ * Thrown on any non-2xx response. The dashboard is READ-ONLY (one GET), so any
+ * 4xx is simply a non-retryable rejection — the store keeps its last good data
+ * and surfaces a calm toast. (Carried from the other islands: the app can
+ * re-execute empty-body 404s as empty 400s — `isClientRejection` covers any 4xx.)
+ */
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+
+  get isClientRejection(): boolean {
+    return this.status >= 400 && this.status < 500;
+  }
+}
+
+async function request<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    // Same-origin cookie auth — the host page is already authenticated.
+    credentials: 'include',
+    headers: { Accept: 'application/json', ...(init?.headers ?? {}) },
+    ...init,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new ApiError(res.status, text || res.statusText);
+  }
+  if (res.status === 204) return undefined as T;
+  return (await res.json()) as T;
+}
+
+/** The whole dashboard aggregate (greeting + household + chores + shopping + today's meals). */
+export async function getDashboard(): Promise<DashboardDto> {
+  return request<DashboardDto>(BASE);
+}

--- a/frontend/app/src/lib/dashboard/lib/components/ChoreCard.svelte
+++ b/frontend/app/src/lib/dashboard/lib/components/ChoreCard.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  // Chores summary card — parity with Home.razor lines 27-103. Read-only; the
+  // arrow + empty CTA both navigate to /chores (full-document anchor nav).
+  import type { DashboardChoreSummaryDto } from '../types';
+
+  let { chores, attention }: { chores: DashboardChoreSummaryDto; attention: number } = $props();
+</script>
+
+<div class="db-card">
+  <div class="db-card-header">
+    <div class="db-card-avatar" aria-hidden="true">🧹</div>
+    <div class="db-card-headings">
+      <h2 class="db-card-title">Chores</h2>
+      <p class="db-card-status">
+        {#if chores.activeTotal === 0}
+          No chores yet
+        {:else if attention > 0}
+          {attention} need attention
+        {:else}
+          All caught up
+        {/if}
+      </p>
+    </div>
+    <a class="db-card-arrow" href="/chores" aria-label="Go to chores">→</a>
+  </div>
+
+  <div class="db-card-body">
+    {#if chores.activeTotal === 0}
+      <p class="db-empty">No chores set up yet</p>
+      <div class="db-empty-action">
+        <a class="db-link" href="/chores">Set up the chore board</a>
+      </div>
+    {:else if attention === 0 && chores.upForGrabs === 0}
+      <p class="db-empty">All caught up — nothing needs attention 🎉</p>
+    {:else}
+      <div>
+        {#if chores.overdue > 0}
+          <div class="db-stat-row">
+            <span class="db-stat-icon db-stat-overdue" aria-hidden="true">⚠️</span>
+            <span><b>{chores.overdue}</b> overdue</span>
+          </div>
+        {/if}
+        {#if chores.dueToday > 0}
+          <div class="db-stat-row">
+            <span class="db-stat-icon db-stat-due" aria-hidden="true">📅</span>
+            <span><b>{chores.dueToday}</b> due today</span>
+          </div>
+        {/if}
+        {#if chores.upForGrabs > 0}
+          <div class="db-stat-row">
+            <span class="db-stat-icon" aria-hidden="true">✋</span>
+            <span><b>{chores.upForGrabs}</b> up for grabs</span>
+          </div>
+        {/if}
+      </div>
+    {/if}
+  </div>
+</div>

--- a/frontend/app/src/lib/dashboard/lib/components/MealsCard.svelte
+++ b/frontend/app/src/lib/dashboard/lib/components/MealsCard.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  // Today's meals card — parity with Home.razor lines 158-206. Meals are
+  // pre-grouped by meal type (server-ordered); each group shows its meals.
+  import type { MealType } from '../types';
+  import type { MealGroup } from '../dashboardStore.svelte';
+
+  let { groups, dateLabel }: { groups: MealGroup[]; dateLabel: string } = $props();
+
+  // Parity with Home.razor GetMealTypeIcon (Material icons → emoji equivalents).
+  const MEAL_ICONS: Record<MealType, string> = {
+    breakfast: '🍳',
+    lunch: '🥪',
+    dinner: '🍽️',
+    snack: '🍦',
+  };
+
+  const label = (t: MealType) => t.charAt(0).toUpperCase() + t.slice(1);
+</script>
+
+<div class="db-card">
+  <div class="db-card-header">
+    <div class="db-card-avatar" aria-hidden="true">📅</div>
+    <div class="db-card-headings">
+      <h2 class="db-card-title">Today's Meals</h2>
+      <p class="db-card-status">{dateLabel}</p>
+    </div>
+    <a class="db-card-arrow" href="/meal-plan" aria-label="Go to meal plan">→</a>
+  </div>
+
+  <div class="db-card-body">
+    {#if groups.length === 0}
+      <p class="db-empty">No meals planned for today</p>
+      <div class="db-empty-action">
+        <a class="db-link" href="/meal-plan">Plan something</a>
+      </div>
+    {:else}
+      {#each groups as group (group.mealType)}
+        <div class="db-meal-group">
+          <div class="db-meal-group-head">
+            <span aria-hidden="true">{MEAL_ICONS[group.mealType]}</span>
+            <span>{label(group.mealType)}</span>
+          </div>
+          {#each group.meals as meal, i (i)}
+            <div class="db-meal-item">{meal.displayName}</div>
+          {/each}
+        </div>
+      {/each}
+    {/if}
+  </div>
+</div>

--- a/frontend/app/src/lib/dashboard/lib/components/QuickActions.svelte
+++ b/frontend/app/src/lib/dashboard/lib/components/QuickActions.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  // Quick-action buttons — parity with Home.razor lines 209-263. Each href is a
+  // base-relative SPA route ($app/paths base); SvelteKit intercepts the anchor
+  // for client-side nav. The /recipes/new shape matches the recipes routes (WP-07).
+  import { base } from '$app/paths';
+
+  const ACTIONS = [
+    { href: '/recipes/new', icon: '➕', label: 'New Recipe' },
+    { href: '/recipes', icon: '📖', label: 'Browse Recipes' },
+    { href: '/meal-plan', icon: '🗓️', label: 'This Week' },
+    { href: '/chores', icon: '🧹', label: 'Chores' },
+    { href: '/settings/users', icon: '👤', label: 'Invite Family' },
+  ];
+</script>
+
+<section class="db-quick">
+  <h2 class="db-quick-title">Quick Actions</h2>
+  <div class="db-quick-grid">
+    {#each ACTIONS as action (action.href)}
+      <a class="db-quick-btn" href={`${base}${action.href}`}>
+        <span aria-hidden="true">{action.icon}</span>
+        <span>{action.label}</span>
+      </a>
+    {/each}
+  </div>
+</section>

--- a/frontend/app/src/lib/dashboard/lib/components/ShoppingCard.svelte
+++ b/frontend/app/src/lib/dashboard/lib/components/ShoppingCard.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  // Shopping list summary card — parity with Home.razor lines 106-155.
+  import type { DashboardShoppingSummaryDto } from '../types';
+
+  let { shopping, progress }: { shopping: DashboardShoppingSummaryDto; progress: number } = $props();
+</script>
+
+<div class="db-card">
+  <div class="db-card-header">
+    <div class="db-card-avatar" aria-hidden="true">🛒</div>
+    <div class="db-card-headings">
+      <h2 class="db-card-title">Shopping List</h2>
+      <p class="db-card-status">
+        {#if shopping.remaining > 0}
+          {shopping.remaining} items remaining
+        {:else}
+          All done!
+        {/if}
+      </p>
+    </div>
+    <a class="db-card-arrow" href="/shopping-list" aria-label="Go to shopping list">→</a>
+  </div>
+
+  <div class="db-card-body">
+    {#if shopping.total === 0}
+      <p class="db-empty">Shopping list is empty</p>
+      <div class="db-empty-action">
+        <a class="db-link" href="/shopping-list">Generate from meal plan</a>
+      </div>
+    {:else}
+      <div class="db-progress" role="progressbar" aria-valuenow={progress} aria-valuemin="0" aria-valuemax="100">
+        <div class="db-progress-fill" style="width: {progress}%"></div>
+      </div>
+      <p class="db-progress-caption">
+        {shopping.checked} of {shopping.total} items checked
+      </p>
+    {/if}
+  </div>
+</div>

--- a/frontend/app/src/lib/dashboard/lib/dashboardStore.svelte.ts
+++ b/frontend/app/src/lib/dashboard/lib/dashboardStore.svelte.ts
@@ -1,0 +1,76 @@
+import type { DashboardDto, DashboardMealDto, MealType, ShellContext } from './types';
+import { getDashboard } from './api';
+
+/** A meal-type group for the Today's Meals card (preserves the server's MealType ordering). */
+export interface MealGroup {
+  mealType: MealType;
+  meals: DashboardMealDto[];
+}
+
+/**
+ * The dashboard island store (Svelte-5 rune rule: export the class INSTANCE, never a
+ * reassigned `$state`). Read-only — one aggregate GET, then liveness/refocus reconcile.
+ * No writes ⇒ no optimistic/draft machinery; the one race guard is `#seq` (a slow earlier
+ * load that resolves after a newer one is dropped).
+ */
+export class DashboardStore {
+  data = $state<DashboardDto | null>(null);
+  loading = $state(true);
+  error = $state<string | null>(null);
+  currentUserId = $state(0);
+
+  // Monotonic load guard — only the newest load's response is applied.
+  #seq = 0;
+
+  /** "needs attention" = overdue + due-today (display logic, not a wire field). */
+  choreAttention = $derived(this.data ? this.data.chores.overdue + this.data.chores.dueToday : 0);
+
+  /** Shopping progress percent (0 when nothing to buy). */
+  shoppingProgress = $derived.by(() => {
+    const s = this.data?.shopping;
+    if (!s || s.total <= 0) return 0;
+    return Math.round((s.checked / s.total) * 100);
+  });
+
+  /** Today's meals grouped by type, preserving the server's MealType order (parity: GroupBy(MealType)). */
+  mealsByType = $derived.by(() => {
+    const groups: MealGroup[] = [];
+    for (const meal of this.data?.todaysMeals ?? []) {
+      let g = groups.find((x) => x.mealType === meal.mealType);
+      if (!g) {
+        g = { mealType: meal.mealType, meals: [] };
+        groups.push(g);
+      }
+      g.meals.push(meal);
+    }
+    return groups;
+  });
+
+  init(ctx: ShellContext): void {
+    this.currentUserId = ctx.userId;
+  }
+
+  /** Load the aggregate. Guarded so an out-of-order (stale) response is ignored. */
+  async load(): Promise<void> {
+    const seq = ++this.#seq;
+    try {
+      const d = await getDashboard();
+      if (seq !== this.#seq) return; // superseded by a newer load
+      this.data = d;
+      this.error = null;
+    } catch (e) {
+      if (seq !== this.#seq) return;
+      // Keep the last good data (no blank-out) and surface a calm error.
+      this.error = e instanceof Error ? e.message : 'Failed to load the dashboard.';
+    } finally {
+      if (seq === this.#seq) this.loading = false;
+    }
+  }
+
+  /** Liveness tick + error reconcile — just re-load; the seq guard drops stale ticks. */
+  reconcile(): void {
+    void this.load();
+  }
+}
+
+export const dashboardStore = new DashboardStore();

--- a/frontend/app/src/lib/dashboard/lib/dates.ts
+++ b/frontend/app/src/lib/dashboard/lib/dates.ts
@@ -1,0 +1,35 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Tiny display-only date formatters for the dashboard's two labels (the
+// welcome banner's long date + the meals card's short date). The dashboard has
+// NO week math (unlike meal-plan) — it only formats the server-echoed `today`.
+//
+// ⚠ MN4 / global CORRECTION: never `new Date("YYYY-MM-DD")` — that parses as
+//   UTC midnight, which renders the PREVIOUS day in US timezones. We parse the
+//   components and build the date at NOON-UTC, which is the same calendar day in
+//   every timezone, then format with the user's locale.
+// ─────────────────────────────────────────────────────────────────────────
+
+/** Parse a "YYYY-MM-DD" into a Date pinned at noon UTC (tz-stable calendar day). */
+function parseIsoNoon(iso: string): Date {
+  const [y, m, d] = iso.split('-').map(Number);
+  return new Date(Date.UTC(y, m - 1, d, 12));
+}
+
+/** "Wednesday, June 24" — the welcome-banner date (parity with Home.razor "dddd, MMMM d"). */
+export function formatLongDate(iso: string): string {
+  return parseIsoNoon(iso).toLocaleDateString(undefined, {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
+/** "Jun 24" — the meals-card date (parity with Home.razor "MMM d"). */
+export function formatShortDate(iso: string): string {
+  return parseIsoNoon(iso).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+}

--- a/frontend/app/src/lib/dashboard/lib/liveness.ts
+++ b/frontend/app/src/lib/dashboard/lib/liveness.ts
@@ -1,0 +1,73 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Liveness — lightweight collaboration refresh for the dashboard island.
+//
+// A change made by another household member should appear within ~20s while
+// the tab is VISIBLE, and immediately when the tab regains focus. We do this
+// with a plain interval + `visibilitychange`, NOT Blazor's DataNotifier /
+// PresenceService / PollingService (those are SignalR-circuit-bound — MN2).
+//
+// The poll PAUSES while the tab is hidden (D11): no interval ticks fire when
+// `document.hidden` is true, and on re-show we refetch once immediately, then
+// resume the interval. This keeps background tabs quiet.
+// ─────────────────────────────────────────────────────────────────────────
+
+const POLL_INTERVAL_MS = 20_000;
+
+export interface LivenessHandle {
+  /** Tear down the interval + visibility listener. Call on unmount. */
+  stop(): void;
+}
+
+/**
+ * Start polling. `refresh` is the board reload (App.svelte's loader). It is
+ * only invoked while the document is visible. Returns a handle whose `stop()`
+ * removes the interval + listener.
+ */
+export function startLiveness(refresh: () => void): LivenessHandle {
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  function tick() {
+    // Guard: never poll while hidden (the interval is cleared on hide, but this
+    // is belt-and-suspenders in case a tick is queued at the moment of hiding).
+    if (document.visibilityState === 'visible') {
+      refresh();
+    }
+  }
+
+  function startInterval() {
+    if (timer != null) return;
+    timer = setInterval(tick, POLL_INTERVAL_MS);
+  }
+
+  function stopInterval() {
+    if (timer != null) {
+      clearInterval(timer);
+      timer = null;
+    }
+  }
+
+  function handleVisibility() {
+    if (document.visibilityState === 'visible') {
+      // Re-show: refetch immediately, then resume the interval.
+      refresh();
+      startInterval();
+    } else {
+      // Hidden: pause polling entirely.
+      stopInterval();
+    }
+  }
+
+  document.addEventListener('visibilitychange', handleVisibility);
+
+  // Begin polling only if we start visible.
+  if (document.visibilityState === 'visible') {
+    startInterval();
+  }
+
+  return {
+    stop() {
+      stopInterval();
+      document.removeEventListener('visibilitychange', handleVisibility);
+    },
+  };
+}

--- a/frontend/app/src/lib/dashboard/lib/types.ts
+++ b/frontend/app/src/lib/dashboard/lib/types.ts
@@ -1,0 +1,52 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Dashboard island TS contract. MIRRORS the server DTOs in
+// src/FamilyCoordinationApp/Services/Dtos/DashboardDtos.cs — kept in lockstep
+// with tests/.../Fixtures/Dashboard/dashboard.json (DashboardDtoContractTests
+// is the tripwire). A field rename / casing change here means the same change
+// in that DTO + fixture (M9).
+//
+// ⚠ CASING: MealType is a real enum on the server DTO → it arrives as a
+//   camelCase string ("breakfast"/"lunch"/"dinner"/"snack"). `today` is a
+//   DateOnly → "YYYY-MM-DD"; format it for DISPLAY at noon-UTC, never
+//   `new Date("YYYY-MM-DD")` (UTC-midnight parse = wrong day in US tz).
+// ─────────────────────────────────────────────────────────────────────────
+
+export type MealType = 'breakfast' | 'lunch' | 'dinner' | 'snack';
+
+/** The four Home chore-card counts (mirrors ChoreHomeStats.Result). */
+export interface DashboardChoreSummaryDto {
+  activeTotal: number;
+  overdue: number;
+  dueToday: number;
+  upForGrabs: number;
+}
+
+/** Shopping totals summed across all active (non-archived) lists. */
+export interface DashboardShoppingSummaryDto {
+  remaining: number;
+  checked: number;
+  total: number;
+}
+
+/** One of today's planned meals — type + resolved display name. */
+export interface DashboardMealDto {
+  mealType: MealType;
+  displayName: string;
+}
+
+/** The whole dashboard read-aggregate (one round-trip). */
+export interface DashboardDto {
+  greetingName: string;
+  householdName: string;
+  today: string; // "YYYY-MM-DD"
+  chores: DashboardChoreSummaryDto;
+  shopping: DashboardShoppingSummaryDto;
+  todaysMeals: DashboardMealDto[];
+}
+
+/** Shell context the Razor host hands the island via root data-attrs. */
+export interface ShellContext {
+  householdId: number;
+  userId: number;
+  userName: string;
+}

--- a/frontend/app/src/lib/meal-plan/App.svelte
+++ b/frontend/app/src/lib/meal-plan/App.svelte
@@ -1,0 +1,280 @@
+<script lang="ts">
+  import { untrack } from 'svelte';
+  import type { MealPlanEntryDto, MealType, ShellContext } from './lib/types';
+  import { mealPlanStore } from './lib/state.svelte';
+  import { startLiveness, type LivenessHandle } from './lib/liveness';
+  import { weekdayShort, monthDay, todayMonday } from './lib/dates';
+  import WeekNav from './lib/components/WeekNav.svelte';
+  import CalendarGrid from './lib/components/CalendarGrid.svelte';
+  import DayList from './lib/components/DayList.svelte';
+  import RecipePickerSheet, { type PickerResult } from './lib/components/RecipePickerSheet.svelte';
+  import RecipeDetailSheet from './lib/components/RecipeDetailSheet.svelte';
+  import ConfirmDialog from '$lib/shared/ConfirmDialog.svelte';
+
+  // ───────────────────────────────────────────────────────────────────────
+  // Root of the meal-plan island. Reads the ShellContext from #meal-plan-root
+  // data-attrs, fetches the current week's board into the shared store, and
+  // renders WeekNav + (CalendarGrid on md+ / DayList on sm-). Every slot is a
+  // client-side grouping of the one board payload (store.entriesByDayMeal).
+  // Versionless — add + remove only; on any 4xx/network the store reconciles.
+  // No `new Date('YYYY-MM-DD')` anywhere — week stepping goes through dates.ts.
+  // ───────────────────────────────────────────────────────────────────────
+
+  interface Props {
+    ctx: ShellContext;
+  }
+
+  let { ctx }: Props = $props();
+
+  const store = mealPlanStore;
+
+  let liveness: LivenessHandle | null = null;
+
+  // Responsive split mirrors the Blazor MudHidden breakpoint (Sm = 960px). We
+  // watch matchMedia rather than relying on CSS alone so we only mount one tree.
+  let isDesktop = $state(true);
+  let mediaQuery: MediaQueryList | null = null;
+  function syncMedia(): void {
+    if (mediaQuery) isDesktop = mediaQuery.matches;
+  }
+
+  // ── Picker (add) state ────────────────────────────────────────────────────
+  let pickerOpen = $state(false);
+  let pickerSlot = $state<{ date: string; mealType: MealType } | null>(null);
+  let pickerSlotLabel = $derived(
+    pickerSlot
+      ? `${weekdayShort(pickerSlot.date)} ${monthDay(pickerSlot.date)} — ${mealLabel(pickerSlot.mealType)}`
+      : '',
+  );
+
+  // ── Detail / custom-meal view state ───────────────────────────────────────
+  let detailOpen = $state(false);
+  let detailMode = $state<'recipe' | 'custom'>('recipe');
+  let detailRecipeId = $state<number | null>(null);
+  let detailRecipeName = $state('');
+  let detailCustomEntry = $state<MealPlanEntryDto | null>(null);
+
+  // ── Remove-confirm state ──────────────────────────────────────────────────
+  let confirmOpen = $state(false);
+  let confirmEntry = $state<MealPlanEntryDto | null>(null);
+  let confirmMessage = $derived(
+    confirmEntry ? `Remove this meal from ${monthDay(confirmEntry.date)}?` : '',
+  );
+
+  function mealLabel(m: MealType): string {
+    return m.charAt(0).toUpperCase() + m.slice(1);
+  }
+
+  async function loadBoard(): Promise<void> {
+    await store.loadBoard();
+  }
+
+  // ── Slot handlers ──────────────────────────────────────────────────────────
+  function handleSlotAdd(date: string, mealType: MealType): void {
+    pickerSlot = { date, mealType };
+    pickerOpen = true;
+  }
+
+  async function handlePickerConfirm(result: PickerResult): Promise<void> {
+    const slot = pickerSlot;
+    if (!slot) return;
+    pickerOpen = false;
+    pickerSlot = null;
+    await store.addEntry({
+      date: slot.date,
+      mealType: slot.mealType,
+      recipeId: result.recipeId ?? null,
+      customMealName: result.customMealName ?? null,
+      notes: result.notes ?? null,
+    });
+  }
+
+  function handleViewRecipe(entry: MealPlanEntryDto): void {
+    if (!entry.recipe) return;
+    detailMode = 'recipe';
+    detailRecipeId = entry.recipe.recipeId;
+    detailRecipeName = entry.recipe.name;
+    detailCustomEntry = null;
+    detailOpen = true;
+  }
+
+  function handleViewCustom(entry: MealPlanEntryDto): void {
+    detailMode = 'custom';
+    detailCustomEntry = entry;
+    detailRecipeId = null;
+    detailOpen = true;
+  }
+
+  function handleRemove(entry: MealPlanEntryDto): void {
+    confirmEntry = entry;
+    confirmOpen = true;
+  }
+
+  async function handleConfirmRemove(): Promise<void> {
+    const entry = confirmEntry;
+    confirmOpen = false;
+    confirmEntry = null;
+    if (entry) await store.removeEntry(entry.mealPlanId, entry.entryId);
+  }
+
+  $effect(() => {
+    // One-time mount setup. MUST run exactly once — `loadBoard()` synchronously
+    // reads `store.board`/`store.weekStart` (the spinner-on-first-load check), and
+    // its async `setBoard` REWRITES them, so WITHOUT untrack the effect would
+    // subscribe to the very state it updates → an infinite fetch→setBoard→re-run
+    // loop (~tens of req/s). `untrack` gives the body no reactive deps, so it runs
+    // once; liveness + the matchMedia listener drive all later refreshes.
+    untrack(() => {
+      store.init(ctx);
+      store.setRefresh(loadBoard);
+
+      mediaQuery = window.matchMedia('(min-width: 960px)');
+      syncMedia();
+      mediaQuery.addEventListener('change', syncMedia);
+
+      loadBoard();
+      // Liveness: ~20s poll while visible + immediate refetch on refocus; pauses
+      // while hidden. NOT Blazor DataNotifier/PollingService (MN2).
+      liveness = startLiveness(() => store.reconcile());
+    });
+
+    return () => {
+      liveness?.stop();
+      liveness = null;
+      mediaQuery?.removeEventListener('change', syncMedia);
+      mediaQuery = null;
+    };
+  });
+</script>
+
+<div class="mp-container">
+  <header class="mp-header">
+    <h1 class="mp-title">Meal Plan</h1>
+    <span class="mp-user">{ctx.userName}</span>
+  </header>
+
+  <WeekNav
+    weekStart={store.weekStart}
+    onPrev={() => store.changeWeek(-1)}
+    onNext={() => store.changeWeek(1)}
+    onToday={() => store.changeWeek(todayMonday())}
+  />
+
+  {#if store.error}
+    <div class="mp-inline-error" role="alert">
+      <span>{store.error}</span>
+      <button type="button" class="mp-retry" onclick={loadBoard}>Retry</button>
+    </div>
+  {/if}
+
+  {#if store.loading && !store.board}
+    <div class="mp-loading">Loading the meal plan…</div>
+  {:else if store.board}
+    {#if isDesktop}
+      <CalendarGrid
+        weekStart={store.weekStart}
+        onSlotAdd={handleSlotAdd}
+        onRemove={handleRemove}
+        onViewRecipe={handleViewRecipe}
+        onViewCustom={handleViewCustom}
+      />
+    {:else}
+      <DayList
+        weekStart={store.weekStart}
+        onSlotAdd={handleSlotAdd}
+        onRemove={handleRemove}
+        onViewRecipe={handleViewRecipe}
+        onViewCustom={handleViewCustom}
+      />
+    {/if}
+  {:else if !store.loading}
+    <div class="mp-empty">No meal plan data.</div>
+  {/if}
+</div>
+
+<RecipePickerSheet
+  open={pickerOpen}
+  slotLabel={pickerSlotLabel}
+  onClose={() => {
+    pickerOpen = false;
+    pickerSlot = null;
+  }}
+  onConfirm={handlePickerConfirm}
+/>
+
+<RecipeDetailSheet
+  open={detailOpen}
+  mode={detailMode}
+  recipeId={detailRecipeId}
+  recipeName={detailRecipeName}
+  customEntry={detailCustomEntry}
+  onClose={() => (detailOpen = false)}
+/>
+
+<ConfirmDialog
+  open={confirmOpen}
+  title="Remove Meal"
+  message={confirmMessage}
+  onCancel={() => {
+    confirmOpen = false;
+    confirmEntry = null;
+  }}
+  onConfirm={handleConfirmRemove}
+/>
+
+<style>
+  .mp-container {
+    max-width: 1280px;
+    margin: 0 auto;
+    padding: 24px 16px 96px;
+  }
+  .mp-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 16px;
+  }
+  .mp-title {
+    margin: 0;
+    font-size: 2.125rem;
+    font-weight: 400;
+    color: var(--color-text);
+  }
+  .mp-user {
+    color: var(--color-text-muted);
+    font-size: 0.875rem;
+  }
+  .mp-loading,
+  .mp-empty {
+    padding: 48px 16px;
+    text-align: center;
+    color: var(--color-text-muted);
+  }
+  .mp-inline-error {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 16px;
+    margin-bottom: 16px;
+    background: rgba(229, 57, 53, 0.08);
+    border-left: 4px solid var(--color-error);
+    border-radius: var(--radius-sm);
+    color: var(--color-error);
+    font-size: 0.875rem;
+  }
+  .mp-retry {
+    font: inherit;
+    border: none;
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+    padding: 4px 12px;
+    background: transparent;
+    color: var(--color-error);
+    font-weight: 500;
+  }
+  .mp-retry:hover {
+    background: rgba(229, 57, 53, 0.12);
+  }
+</style>

--- a/frontend/app/src/lib/meal-plan/lib/api.ts
+++ b/frontend/app/src/lib/meal-plan/lib/api.ts
@@ -1,0 +1,114 @@
+import type {
+  MealPlanBoardDto,
+  MealPlanEntryDto,
+  MealRecipeSummaryDto,
+  RecipeDetailDto,
+  MealType,
+  RecipeType,
+} from './types';
+
+const BASE = '/api/meal-plan';
+
+/**
+ * Thrown on any non-2xx response. `status` lets callers react to a rejection.
+ *
+ * ⚠ WP-08 finding (carried from chores/shopping-list): the app re-executes
+ * empty-body API 404s through a Blazor `/not-found` page, so a server-side
+ * "not found" can arrive on the wire as an empty **400**, not 404. Since the
+ * meal-plan island is VERSIONLESS (no 409 concurrency dance), the rule is even
+ * simpler: treat ANY 4xx as a non-retryable client rejection → refetch the
+ * week + calm toast. There is no retry branch.
+ */
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+
+  /**
+   * A non-retryable client rejection: validation / not found (which may surface
+   * as an empty 400 per the WP-08 re-execution behavior). Any 4xx.
+   */
+  get isClientRejection(): boolean {
+    return this.status >= 400 && this.status < 500;
+  }
+}
+
+async function request<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    // Same-origin cookie auth — the host page is already authenticated.
+    credentials: 'include',
+    headers: { Accept: 'application/json', ...(init?.headers ?? {}) },
+    ...init,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new ApiError(res.status, text || res.statusText);
+  }
+  if (res.status === 204) return undefined as T;
+  return (await res.json()) as T;
+}
+
+function jsonBody(body: unknown): RequestInit {
+  return {
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  };
+}
+
+// ─── Board read ─────────────────────────────────────────────────────────────
+// The server re-snaps `weekStart` to that week's Monday and echoes it back as
+// `weekStartDate`, so client stepping is display-only (the server is the
+// authority on the week boundary). A "YYYY-MM-DD" is always sent.
+
+export async function getBoard(weekStart: string): Promise<MealPlanBoardDto> {
+  return request<MealPlanBoardDto>(`${BASE}/board?weekStart=${encodeURIComponent(weekStart)}`);
+}
+
+// ─── Entries (add / remove — versionless) ────────────────────────────────────
+
+/** Body for POST /entries — supply EXACTLY one of recipeId / customMealName. */
+export interface AddEntryBody {
+  /** "YYYY-MM-DD" — the slot's calendar position (server derives the week). */
+  date: string;
+  mealType: MealType;
+  recipeId?: number | null;
+  customMealName?: string | null;
+  notes?: string | null;
+}
+
+/** Add a meal to a slot → the created entry (201). */
+export async function addEntry(body: AddEntryBody): Promise<MealPlanEntryDto> {
+  return request<MealPlanEntryDto>(`${BASE}/entries`, { method: 'POST', ...jsonBody(body) });
+}
+
+/** Remove an entry. DELETE → 204 (no body); a missing entry → 404/empty-400. */
+export async function removeEntry(mealPlanId: number, entryId: number): Promise<void> {
+  await request<void>(`${BASE}/entries/${mealPlanId}/${entryId}`, { method: 'DELETE' });
+}
+
+// ─── Recipes (picker search / quick-create / detail) ─────────────────────────
+
+/** Picker autocomplete. Empty `q` ⇒ all (matches the current MinCharacters=0). */
+export async function searchRecipes(q: string): Promise<MealRecipeSummaryDto[]> {
+  return request<MealRecipeSummaryDto[]>(`${BASE}/recipes?q=${encodeURIComponent(q)}`);
+}
+
+/** Body for POST /recipes — quick-create a bare recipe (details added later). */
+export interface QuickCreateRecipeBody {
+  name: string;
+  recipeType: RecipeType;
+}
+
+/** "New Recipe" tab → the created recipe summary (201). The caller then adds an entry with the new id. */
+export async function quickCreateRecipe(body: QuickCreateRecipeBody): Promise<MealRecipeSummaryDto> {
+  return request<MealRecipeSummaryDto>(`${BASE}/recipes`, { method: 'POST', ...jsonBody(body) });
+}
+
+/** Recipe-detail modal (read-only, lazy on view-click → keeps the board lean). */
+export async function getRecipeDetail(recipeId: number): Promise<RecipeDetailDto> {
+  return request<RecipeDetailDto>(`${BASE}/recipes/${recipeId}`);
+}

--- a/frontend/app/src/lib/meal-plan/lib/components/CalendarGrid.svelte
+++ b/frontend/app/src/lib/meal-plan/lib/components/CalendarGrid.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+  // ───────────────────────────────────────────────────────────────────────
+  // Desktop calendar grid (md+). Mirrors the Blazor WeeklyCalendarView: a
+  // 60px label column + 7 day columns; header row of weekday + date (today
+  // highlighted); meal rows for Breakfast / Lunch / Dinner ONLY. Snack stays
+  // implicit (the enum has it, but the grid never renders a Snack row — only
+  // reachable if data carries one, matching the current page).
+  // ───────────────────────────────────────────────────────────────────────
+  import type { MealPlanEntryDto, MealType } from '../types';
+  import { mealPlanStore, MEAL_ROWS } from '../state.svelte';
+  import { weekDays, weekdayShort, monthDay, isToday } from '../dates';
+  import MealSlot from './MealSlot.svelte';
+
+  interface Props {
+    weekStart: string;
+    onSlotAdd: (date: string, mealType: MealType) => void;
+    onRemove: (entry: MealPlanEntryDto) => void;
+    onViewRecipe: (entry: MealPlanEntryDto) => void;
+    onViewCustom: (entry: MealPlanEntryDto) => void;
+  }
+
+  let { weekStart, onSlotAdd, onRemove, onViewRecipe, onViewCustom }: Props = $props();
+
+  const store = mealPlanStore;
+  let days = $derived(weekDays(weekStart));
+
+  const MEAL_LABELS: Record<MealType, string> = {
+    breakfast: 'Breakfast',
+    lunch: 'Lunch',
+    dinner: 'Dinner',
+    snack: 'Snack',
+  };
+</script>
+
+<div class="mp-grid">
+  <div class="mp-grid-corner"></div>
+  {#each days as day (day)}
+    <div class="mp-day-header" class:today={isToday(day)}>
+      <span class="mp-day-name">{weekdayShort(day)}</span>
+      <span class="mp-day-date">{monthDay(day)}</span>
+    </div>
+  {/each}
+
+  {#each MEAL_ROWS as mealType (mealType)}
+    <div class="mp-meal-label">
+      <span>{MEAL_LABELS[mealType]}</span>
+    </div>
+    {#each days as day (day)}
+      <div class="mp-grid-cell">
+        <MealSlot
+          entries={store.entriesFor(day, mealType)}
+          onAdd={() => onSlotAdd(day, mealType)}
+          {onRemove}
+          {onViewRecipe}
+          {onViewCustom}
+        />
+      </div>
+    {/each}
+  {/each}
+</div>
+
+<style>
+  .mp-grid {
+    display: grid;
+    grid-template-columns: 60px repeat(7, minmax(0, 1fr));
+    gap: 4px;
+    width: 100%;
+  }
+  .mp-day-header {
+    text-align: center;
+    padding: 8px 4px;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    border-radius: var(--radius-sm);
+  }
+  .mp-day-header.today {
+    background: var(--color-primary);
+  }
+  .mp-day-header.today .mp-day-name,
+  .mp-day-header.today .mp-day-date {
+    color: #fff;
+  }
+  .mp-day-name {
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: var(--color-text);
+  }
+  .mp-day-date {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .mp-meal-label {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    writing-mode: vertical-rl;
+    text-orientation: mixed;
+    transform: rotate(180deg);
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .mp-grid-cell {
+    min-width: 0;
+    overflow: hidden;
+  }
+</style>

--- a/frontend/app/src/lib/meal-plan/lib/components/DayList.svelte
+++ b/frontend/app/src/lib/meal-plan/lib/components/DayList.svelte
@@ -1,0 +1,147 @@
+<script lang="ts">
+  // ───────────────────────────────────────────────────────────────────────
+  // Mobile day list (sm-). Mirrors the Blazor WeeklyListView: one expandable
+  // section per day (native <details>), with the weekday + date, a "Today"
+  // chip, and a "N meals" count in the summary; expanding shows B/L/D rows.
+  // Today's section is expanded by default and left-accented.
+  // ───────────────────────────────────────────────────────────────────────
+  import type { MealPlanEntryDto, MealType } from '../types';
+  import { mealPlanStore, MEAL_ROWS } from '../state.svelte';
+  import { weekDays, weekdayLong, monthDay, isToday } from '../dates';
+  import MealSlot from './MealSlot.svelte';
+
+  interface Props {
+    weekStart: string;
+    onSlotAdd: (date: string, mealType: MealType) => void;
+    onRemove: (entry: MealPlanEntryDto) => void;
+    onViewRecipe: (entry: MealPlanEntryDto) => void;
+    onViewCustom: (entry: MealPlanEntryDto) => void;
+  }
+
+  let { weekStart, onSlotAdd, onRemove, onViewRecipe, onViewCustom }: Props = $props();
+
+  const store = mealPlanStore;
+  let days = $derived(weekDays(weekStart));
+
+  const MEAL_LABELS: Record<MealType, string> = {
+    breakfast: 'Breakfast',
+    lunch: 'Lunch',
+    dinner: 'Dinner',
+    snack: 'Snack',
+  };
+</script>
+
+<div class="mp-daylist">
+  {#each days as day (day)}
+    {@const today = isToday(day)}
+    <details class="mp-day-panel" class:today open={today}>
+      <summary class="mp-day-summary">
+        <span class="mp-day-summary-main">
+          <span class="mp-day-summary-name">{weekdayLong(day)}</span>
+          <span class="mp-day-summary-date">{monthDay(day)}</span>
+        </span>
+        {#if today}
+          <span class="mp-day-summary-chip">Today</span>
+        {/if}
+        <span class="mp-day-summary-count">{store.dayCount(day)} meals</span>
+      </summary>
+      <div class="mp-day-body">
+        {#each MEAL_ROWS as mealType (mealType)}
+          <div class="mp-day-row">
+            <span class="mp-day-row-label">{MEAL_LABELS[mealType]}</span>
+            <div class="mp-day-row-slot">
+              <MealSlot
+                entries={store.entriesFor(day, mealType)}
+                onAdd={() => onSlotAdd(day, mealType)}
+                {onRemove}
+                {onViewRecipe}
+                {onViewCustom}
+              />
+            </div>
+          </div>
+        {/each}
+      </div>
+    </details>
+  {/each}
+</div>
+
+<style>
+  .mp-daylist {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .mp-day-panel {
+    background: var(--color-surface);
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-1);
+    overflow: hidden;
+  }
+  .mp-day-panel.today {
+    border-left: 3px solid var(--color-primary);
+  }
+  .mp-day-summary {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 14px 16px;
+    cursor: pointer;
+    list-style: none;
+  }
+  .mp-day-summary::-webkit-details-marker {
+    display: none;
+  }
+  .mp-day-summary-main {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    flex: 1;
+    min-width: 0;
+  }
+  .mp-day-summary-name {
+    font-size: 1rem;
+    font-weight: 500;
+    color: var(--color-text);
+  }
+  .mp-day-summary-date {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .mp-day-summary-chip {
+    font-size: 0.6875rem;
+    font-weight: 500;
+    color: #fff;
+    background: var(--color-primary);
+    border-radius: 12px;
+    padding: 2px 10px;
+    flex-shrink: 0;
+  }
+  .mp-day-summary-count {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    flex-shrink: 0;
+  }
+  .mp-day-body {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 0 16px 14px;
+  }
+  .mp-day-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+  }
+  .mp-day-row-label {
+    width: 80px;
+    flex-shrink: 0;
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--color-text-muted);
+    padding-top: 8px;
+  }
+  .mp-day-row-slot {
+    flex: 1;
+    min-width: 0;
+  }
+</style>

--- a/frontend/app/src/lib/meal-plan/lib/components/MealSlot.svelte
+++ b/frontend/app/src/lib/meal-plan/lib/components/MealSlot.svelte
@@ -1,0 +1,295 @@
+<script lang="ts">
+  // ───────────────────────────────────────────────────────────────────────
+  // One meal slot (a day × meal-type cell). Mirrors the Blazor MealSlot:
+  //   • EMPTY  → a dashed box with a ＋ that opens the picker.
+  //   • ENTRIES → a card per entry:
+  //       – recipe: image (or a book placeholder) + name + a type chip
+  //         (hidden for `main`, matching the Blazor RecipeType.Main guard);
+  //         clicking it opens the recipe detail sheet.
+  //       – custom meal: a restaurant icon + name + notes; clicking opens the
+  //         custom-meal notes view (RecipeDetailSheet's custom mode).
+  //     each entry has a × remove; below the entries an "add side/dessert" row
+  //     re-opens the picker for the same slot.
+  // ───────────────────────────────────────────────────────────────────────
+  import type { MealPlanEntryDto } from '../types';
+  import { recipeTypeLabel } from '../recipeType';
+
+  interface Props {
+    entries: MealPlanEntryDto[];
+    /** Open the picker for this slot (＋ / add side-dessert). */
+    onAdd: () => void;
+    /** Remove an entry (confirms in the parent). */
+    onRemove: (entry: MealPlanEntryDto) => void;
+    /** View a recipe entry's detail. */
+    onViewRecipe: (entry: MealPlanEntryDto) => void;
+    /** View a custom-meal entry's notes. */
+    onViewCustom: (entry: MealPlanEntryDto) => void;
+  }
+
+  let { entries, onAdd, onRemove, onViewRecipe, onViewCustom }: Props = $props();
+
+  let hasEntries = $derived(entries.length > 0);
+</script>
+
+{#if !hasEntries}
+  <button type="button" class="mp-slot mp-slot-empty" aria-label="Add a meal" onclick={onAdd}>
+    <svg viewBox="0 0 24 24" width="28" height="28" aria-hidden="true">
+      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" fill="currentColor" />
+    </svg>
+  </button>
+{:else}
+  <div class="mp-slot mp-slot-filled">
+    <div class="mp-slot-entries">
+      {#each entries as entry (entry.entryId)}
+        {#if entry.recipe}
+          <div class="mp-entry">
+            <button
+              type="button"
+              class="mp-entry-main"
+              onclick={() => onViewRecipe(entry)}
+              title={entry.recipe.name}
+            >
+              {#if entry.recipe.imagePath}
+                <img src={entry.recipe.imagePath} alt={entry.recipe.name} class="mp-entry-image" />
+              {:else}
+                <span class="mp-entry-placeholder" aria-label="Recipe (no image)">
+                  <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+                    <path
+                      d="M18 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 18H6V4h7v7l2.5-1.5L17 11V4h1v16z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </span>
+              {/if}
+              <span class="mp-entry-details">
+                <span class="mp-entry-name">{entry.recipe.name}</span>
+                {#if entry.recipe.recipeType !== 'main'}
+                  <span class="mp-entry-chip">{recipeTypeLabel(entry.recipe.recipeType)}</span>
+                {/if}
+              </span>
+            </button>
+            <button
+              type="button"
+              class="mp-entry-remove"
+              aria-label="Remove this meal"
+              onclick={() => onRemove(entry)}
+            >
+              <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
+                <path
+                  d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </div>
+        {:else if entry.customMealName}
+          <div class="mp-entry">
+            <button
+              type="button"
+              class="mp-entry-main"
+              onclick={() => onViewCustom(entry)}
+              title={entry.notes ? `${entry.customMealName}\n\nNotes: ${entry.notes}` : entry.customMealName}
+            >
+              <span class="mp-entry-custom-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" width="18" height="18">
+                  <path
+                    d="M11 9H9V2H7v7H5V2H3v7c0 2.12 1.66 3.84 3.75 3.97V22h2.5v-9.03C11.34 12.84 13 11.12 13 9V2h-2v7zm5-3v8h2.5v8H21V2c-2.76 0-5 2.24-5 4z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </span>
+              <span class="mp-entry-details">
+                <span class="mp-entry-name">{entry.customMealName}</span>
+                {#if entry.notes}
+                  <span class="mp-entry-notes">{entry.notes}</span>
+                {/if}
+              </span>
+            </button>
+            <button
+              type="button"
+              class="mp-entry-remove"
+              aria-label="Remove this meal"
+              onclick={() => onRemove(entry)}
+            >
+              <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
+                <path
+                  d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </div>
+        {/if}
+      {/each}
+
+      <button type="button" class="mp-slot-add-more" onclick={onAdd}>
+        <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
+          <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" fill="currentColor" />
+        </svg>
+        Add side/dessert
+      </button>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .mp-slot {
+    min-height: 80px;
+    width: 100%;
+    border-radius: var(--radius-sm);
+  }
+
+  .mp-slot-empty {
+    display: grid;
+    place-items: center;
+    border: 2px dashed var(--color-line-strong);
+    background: transparent;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    padding: 0;
+    transition: background-color 0.2s ease;
+  }
+  .mp-slot-empty:hover {
+    background: var(--color-action-hover);
+  }
+
+  .mp-slot-filled {
+    background: var(--color-surface);
+    box-shadow: var(--shadow-2);
+  }
+  .mp-slot-entries {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 8px;
+  }
+
+  .mp-entry {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    border-radius: var(--radius-sm);
+    position: relative;
+    transition: background-color 0.2s ease;
+  }
+  .mp-entry:hover {
+    background: var(--color-action-hover);
+  }
+
+  .mp-entry-main {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex: 1;
+    min-width: 0;
+    text-align: left;
+    font: inherit;
+    color: inherit;
+    background: transparent;
+    border: none;
+    padding: 6px 8px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+  }
+
+  .mp-entry-image,
+  .mp-entry-placeholder,
+  .mp-entry-custom-icon {
+    width: 40px;
+    height: 40px;
+    border-radius: var(--radius-sm);
+    flex-shrink: 0;
+  }
+  .mp-entry-image {
+    object-fit: cover;
+  }
+  .mp-entry-placeholder {
+    display: grid;
+    place-items: center;
+    background: var(--color-secondary);
+    color: #fff;
+  }
+  .mp-entry-custom-icon {
+    display: grid;
+    place-items: center;
+    background: var(--color-primary);
+    color: #fff;
+  }
+
+  .mp-entry-details {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .mp-entry-name {
+    line-height: 1.2;
+    font-size: 0.875rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .mp-entry-chip {
+    align-self: flex-start;
+    font-size: 0.65rem;
+    line-height: 1;
+    padding: 3px 6px;
+    border-radius: 9px;
+    color: var(--color-text-muted);
+    border: 1px solid var(--color-line);
+  }
+  .mp-entry-notes {
+    font-size: 0.75rem;
+    font-style: italic;
+    color: var(--color-text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .mp-entry-remove {
+    flex-shrink: 0;
+    display: grid;
+    place-items: center;
+    width: 32px;
+    height: 32px;
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.2s ease, color 0.15s, background-color 0.15s;
+  }
+  .mp-entry:hover .mp-entry-remove,
+  .mp-entry-remove:focus-visible {
+    opacity: 1;
+  }
+  .mp-entry-remove:hover {
+    color: var(--color-error);
+    background: var(--color-action-hover);
+  }
+
+  .mp-slot-add-more {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    font: inherit;
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    padding: 6px;
+    border: 1px dashed var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: transparent;
+    cursor: pointer;
+    margin-top: 4px;
+    opacity: 0.6;
+    transition: opacity 0.2s ease, background-color 0.15s;
+  }
+  .mp-slot-add-more:hover {
+    opacity: 1;
+    background: var(--color-action-hover);
+  }
+</style>

--- a/frontend/app/src/lib/meal-plan/lib/components/RecipeDetailSheet.svelte
+++ b/frontend/app/src/lib/meal-plan/lib/components/RecipeDetailSheet.svelte
@@ -1,0 +1,368 @@
+<script lang="ts">
+  // ───────────────────────────────────────────────────────────────────────
+  // Recipe detail (read-only) — replaces the Blazor RecipeDetailDialog. Also
+  // hosts the custom-meal notes view (the Blazor page used a MessageBox for
+  // that; we fold it in here per the spec). Two modes:
+  //   • mode='recipe'  → lazy getRecipeDetail(recipeId): image, prep/cook/
+  //     servings chips, ingredients (qty unit name (notes)), instructions via
+  //     {@html} (server-sanitized — NO client markdown lib).
+  //   • mode='custom'  → the entry's name + notes + date/meal context.
+  // ───────────────────────────────────────────────────────────────────────
+  import type { MealPlanEntryDto, RecipeDetailDto, RecipeIngredientDto } from '../types';
+  import { getRecipeDetail, ApiError } from '../api';
+  import { dayLong } from '../dates';
+
+  type Mode = 'recipe' | 'custom';
+
+  interface Props {
+    open: boolean;
+    mode: Mode;
+    /** The recipe id to load (mode='recipe'). */
+    recipeId: number | null;
+    /** Fallback title while the recipe loads (the entry's recipe name). */
+    recipeName: string;
+    /** The custom-meal entry (mode='custom'). */
+    customEntry: MealPlanEntryDto | null;
+    onClose: () => void;
+  }
+
+  let { open, mode, recipeId, recipeName, customEntry, onClose }: Props = $props();
+
+  let dialogEl: HTMLDialogElement | null = $state(null);
+  let detail = $state<RecipeDetailDto | null>(null);
+  let loading = $state(false);
+  let error = $state<string | null>(null);
+
+  // Track the id we last fetched so re-opening the same recipe reuses it, but a
+  // different recipe refetches. Reset on a custom-mode open.
+  let loadedId = $state<number | null>(null);
+
+  async function load(id: number): Promise<void> {
+    loading = true;
+    error = null;
+    try {
+      detail = await getRecipeDetail(id);
+      loadedId = id;
+    } catch (e) {
+      error =
+        e instanceof ApiError
+          ? `Couldn't load this recipe (HTTP ${e.status}).`
+          : "Couldn't load this recipe right now.";
+    } finally {
+      loading = false;
+    }
+  }
+
+  $effect(() => {
+    if (!dialogEl) return;
+    if (open && !dialogEl.open) {
+      if (mode === 'recipe' && recipeId != null && recipeId !== loadedId) {
+        detail = null;
+        void load(recipeId);
+      }
+      dialogEl.showModal();
+    } else if (!open && dialogEl.open) {
+      dialogEl.close();
+    }
+  });
+
+  function formatIngredient(ing: RecipeIngredientDto): string {
+    const parts: string[] = [];
+    if (ing.quantity != null) {
+      // Trim trailing zeros (mirrors the Blazor "0.##").
+      parts.push(String(Number(ing.quantity.toFixed(2))));
+    }
+    if (ing.unit) parts.push(ing.unit);
+    parts.push(ing.name);
+    if (ing.notes) parts.push(`(${ing.notes})`);
+    return parts.join(' ');
+  }
+
+  let title = $derived(
+    mode === 'custom' ? (customEntry?.customMealName ?? 'Custom meal') : (detail?.name ?? recipeName),
+  );
+  let hasMeta = $derived(
+    detail != null &&
+      (detail.prepTimeMinutes != null ||
+        detail.cookTimeMinutes != null ||
+        detail.servings != null),
+  );
+</script>
+
+<dialog bind:this={dialogEl} onclose={onClose} class="mp-dialog">
+  {#if open}
+    <header class="mp-dialog-head">
+      <h2>{title}</h2>
+      <button type="button" class="mp-dialog-x" aria-label="Close" onclick={onClose}>
+        <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true">
+          <path
+            d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+            fill="currentColor"
+          />
+        </svg>
+      </button>
+    </header>
+
+    <div class="mp-dialog-body">
+      {#if mode === 'custom'}
+        <div class="mp-custom-view">
+          {#if customEntry?.notes}
+            <div class="mp-custom-notes">
+              <span class="mp-custom-label">Notes</span>
+              <p class="mp-custom-notes-text">{customEntry.notes}</p>
+            </div>
+          {/if}
+          {#if customEntry}
+            <p class="mp-custom-context">{dayLong(customEntry.date)}</p>
+          {/if}
+          {#if !customEntry?.notes}
+            <p class="mp-empty-note">No notes for this meal.</p>
+          {/if}
+        </div>
+      {:else if loading}
+        <div class="mp-detail-loading">Loading recipe…</div>
+      {:else if error}
+        <div class="mp-detail-error" role="alert">
+          <span>{error}</span>
+          {#if recipeId != null}
+            <button type="button" class="mp-retry" onclick={() => recipeId != null && load(recipeId)}>
+              Retry
+            </button>
+          {/if}
+        </div>
+      {:else if detail}
+        {#if detail.imagePath}
+          <img src={detail.imagePath} alt={detail.name} class="mp-detail-image" />
+        {/if}
+
+        {#if hasMeta}
+          <div class="mp-detail-chips">
+            {#if detail.prepTimeMinutes != null}
+              <span class="mp-detail-chip">Prep: {detail.prepTimeMinutes} min</span>
+            {/if}
+            {#if detail.cookTimeMinutes != null}
+              <span class="mp-detail-chip">Cook: {detail.cookTimeMinutes} min</span>
+            {/if}
+            {#if detail.servings != null}
+              <span class="mp-detail-chip">Servings: {detail.servings}</span>
+            {/if}
+          </div>
+        {/if}
+
+        {#if detail.ingredients.length > 0}
+          <h3 class="mp-detail-subhead">Ingredients</h3>
+          <ul class="mp-detail-ingredients">
+            {#each detail.ingredients as ing (ing.sortOrder)}
+              <li>{formatIngredient(ing)}</li>
+            {/each}
+          </ul>
+        {/if}
+
+        {#if detail.instructionsHtml.trim()}
+          <h3 class="mp-detail-subhead">Instructions</h3>
+          <!-- Server-sanitized HTML (MarkdownHelper.ToSafeHtml). No client markdown lib. -->
+          <div class="mp-detail-instructions">{@html detail.instructionsHtml}</div>
+        {/if}
+      {/if}
+    </div>
+
+    <footer class="mp-dialog-actions">
+      <button type="button" class="mp-btn-ghost" onclick={onClose}>Close</button>
+    </footer>
+  {/if}
+</dialog>
+
+<style>
+  /* Gate layout to [open] so the closed dialog never paints a click-eating overlay. */
+  .mp-dialog[open] {
+    position: fixed;
+    inset: 0;
+    margin: auto;
+    border: none;
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text);
+    padding: 0;
+    width: min(620px, calc(100vw - 32px));
+    max-height: calc(100vh - 32px);
+    box-shadow: var(--shadow-4);
+    display: flex;
+    flex-direction: column;
+  }
+  .mp-dialog::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+  }
+  .mp-dialog-head {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 16px 16px 12px 24px;
+    border-bottom: 1px solid var(--color-line);
+  }
+  .mp-dialog-head h2 {
+    margin: 0;
+    flex: 1;
+    min-width: 0;
+    font-size: 1.25rem;
+    font-weight: 500;
+    overflow-wrap: anywhere;
+  }
+  .mp-dialog-x {
+    flex-shrink: 0;
+    display: grid;
+    place-items: center;
+    width: 36px;
+    height: 36px;
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+  }
+  .mp-dialog-x:hover {
+    background: var(--color-action-hover);
+    color: var(--color-text);
+  }
+  .mp-dialog-body {
+    overflow-y: auto;
+    padding: 16px 24px;
+    flex: 1;
+  }
+  .mp-dialog-actions {
+    display: flex;
+    justify-content: flex-end;
+    padding: 12px 24px calc(16px + env(safe-area-inset-bottom, 0px));
+    border-top: 1px solid var(--color-line);
+  }
+
+  .mp-detail-image {
+    width: 100%;
+    height: 200px;
+    object-fit: cover;
+    border-radius: var(--radius-sm);
+    margin-bottom: 16px;
+  }
+  .mp-detail-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 16px;
+  }
+  .mp-detail-chip {
+    font-size: 0.8125rem;
+    padding: 4px 12px;
+    border-radius: 14px;
+    background: var(--color-action-hover);
+    color: var(--color-text);
+  }
+  .mp-detail-subhead {
+    margin: 16px 0 8px;
+    font-size: 1rem;
+    font-weight: 500;
+  }
+  .mp-detail-ingredients {
+    margin: 0;
+    padding-left: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 0.9375rem;
+  }
+  .mp-detail-instructions {
+    line-height: 1.6;
+    font-size: 0.9375rem;
+  }
+  .mp-detail-instructions :global(ol),
+  .mp-detail-instructions :global(ul) {
+    margin-left: 1.5rem;
+    margin-bottom: 1rem;
+  }
+  .mp-detail-instructions :global(li) {
+    margin-bottom: 0.5rem;
+  }
+  .mp-detail-instructions :global(p) {
+    margin: 0 0 0.75rem;
+  }
+
+  .mp-detail-loading {
+    padding: 32px 0;
+    text-align: center;
+    color: var(--color-text-muted);
+  }
+  .mp-detail-error {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 12px 16px;
+    background: rgba(229, 57, 53, 0.08);
+    border-left: 4px solid var(--color-error);
+    border-radius: var(--radius-sm);
+    color: var(--color-error);
+    font-size: 0.875rem;
+  }
+  .mp-retry {
+    font: inherit;
+    border: none;
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+    padding: 4px 12px;
+    background: transparent;
+    color: var(--color-error);
+    font-weight: 500;
+  }
+  .mp-retry:hover {
+    background: rgba(229, 57, 53, 0.12);
+  }
+
+  /* ── Custom-meal notes view ──────────────────────────────────────────── */
+  .mp-custom-view {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .mp-custom-notes {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .mp-custom-label {
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-text-muted);
+  }
+  .mp-custom-notes-text {
+    margin: 0;
+    font-size: 0.9375rem;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+  }
+  .mp-custom-context {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+  .mp-empty-note {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+
+  .mp-btn-ghost {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    border: none;
+    cursor: pointer;
+    min-height: 44px;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+    background: transparent;
+    color: var(--color-primary);
+  }
+  .mp-btn-ghost:hover {
+    background: var(--color-action-hover);
+  }
+</style>

--- a/frontend/app/src/lib/meal-plan/lib/components/RecipePickerSheet.svelte
+++ b/frontend/app/src/lib/meal-plan/lib/components/RecipePickerSheet.svelte
@@ -1,0 +1,536 @@
+<script lang="ts">
+  // ───────────────────────────────────────────────────────────────────────
+  // Recipe picker — replaces the Blazor RecipePickerDialog (MudDialog). A
+  // bottom sheet from a slot's ＋, with 3 segmented modes + a shared Notes field:
+  //   • Search   — debounced searchRecipes(q), image+name rows, pick one.
+  //   • Custom   — a free-text meal name (+ the shared notes).
+  //   • New      — name + RecipeType select → quickCreateRecipe → then add the
+  //                entry with the new recipeId (two calls — mirrors today's flow).
+  // On confirm the parent runs store.addEntry(...) for the open slot.
+  //
+  // Empty `q` ⇒ all (MinCharacters=0 parity). No date math here — the slot's
+  // date/mealType are passed straight through by the parent.
+  // ───────────────────────────────────────────────────────────────────────
+  import type { MealRecipeSummaryDto, RecipeType } from '../types';
+  import { searchRecipes, quickCreateRecipe, ApiError } from '../api';
+  import { RECIPE_TYPES, recipeTypeLabel } from '../recipeType';
+
+  type Mode = 'search' | 'custom' | 'new';
+
+  /** What the parent needs to add the entry once the sheet confirms. */
+  export interface PickerResult {
+    recipeId?: number;
+    customMealName?: string;
+    notes?: string | null;
+  }
+
+  interface Props {
+    open: boolean;
+    /** A human label for the slot being filled, e.g. "Mon — Dinner". */
+    slotLabel: string;
+    onClose: () => void;
+    onConfirm: (result: PickerResult) => void | Promise<void>;
+  }
+
+  let { open, slotLabel, onClose, onConfirm }: Props = $props();
+
+  let dialogEl: HTMLDialogElement | null = $state(null);
+
+  let mode = $state<Mode>('search');
+  let notes = $state('');
+
+  // ── Search mode ──────────────────────────────────────────────────────────
+  let query = $state('');
+  let results = $state<MealRecipeSummaryDto[]>([]);
+  let searching = $state(false);
+  /** True when the last search request FAILED (vs. genuinely returned nothing) — drives an honest error row. */
+  let searchError = $state(false);
+  let selectedRecipe = $state<MealRecipeSummaryDto | null>(null);
+  let searchToken = 0; // guards out-of-order debounced responses
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // ── Custom mode ──────────────────────────────────────────────────────────
+  let customMealName = $state('');
+
+  // ── New-recipe mode ──────────────────────────────────────────────────────
+  let newRecipeName = $state('');
+  let newRecipeType = $state<RecipeType>('main');
+  let creating = $state(false);
+
+  let localError = $state<string | null>(null);
+  let submitting = $state(false);
+
+  const MODES: { id: Mode; label: string }[] = [
+    { id: 'search', label: 'Pick Recipe' },
+    { id: 'custom', label: 'Custom Meal' },
+    { id: 'new', label: 'New Recipe' },
+  ];
+
+  function reset(): void {
+    mode = 'search';
+    notes = '';
+    query = '';
+    results = [];
+    searching = false;
+    searchError = false;
+    selectedRecipe = null;
+    customMealName = '';
+    newRecipeName = '';
+    newRecipeType = 'main';
+    creating = false;
+    localError = null;
+    submitting = false;
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+      debounceTimer = null;
+    }
+  }
+
+  async function runSearch(q: string): Promise<void> {
+    const token = ++searchToken;
+    searching = true;
+    searchError = false;
+    try {
+      const found = await searchRecipes(q);
+      // Drop a stale response (a newer keystroke superseded this one).
+      if (token === searchToken) results = found;
+    } catch {
+      // A failed search is NOT "no results" — surface it distinctly (council R1).
+      if (token === searchToken) {
+        results = [];
+        searchError = true;
+      }
+    } finally {
+      if (token === searchToken) searching = false;
+    }
+  }
+
+  function onQueryInput(): void {
+    selectedRecipe = null;
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => void runSearch(query), 300);
+  }
+
+  $effect(() => {
+    if (!dialogEl) return;
+    if (open && !dialogEl.open) {
+      reset();
+      dialogEl.showModal();
+      // Prime the list with all recipes (MinCharacters=0 parity).
+      void runSearch('');
+    } else if (!open && dialogEl.open) {
+      dialogEl.close();
+    }
+  });
+
+  let canConfirm = $derived(
+    mode === 'search'
+      ? selectedRecipe != null
+      : mode === 'custom'
+        ? customMealName.trim().length > 0
+        : newRecipeName.trim().length > 0,
+  );
+
+  async function confirm(): Promise<void> {
+    if (!canConfirm || submitting) return;
+    localError = null;
+    const trimmedNotes = notes.trim() || null;
+
+    if (mode === 'search' && selectedRecipe) {
+      submitting = true;
+      try {
+        await onConfirm({ recipeId: selectedRecipe.recipeId, notes: trimmedNotes });
+      } finally {
+        submitting = false;
+      }
+      return;
+    }
+
+    if (mode === 'custom') {
+      const trimmed = customMealName.trim();
+      if (!trimmed) return;
+      submitting = true;
+      try {
+        await onConfirm({ customMealName: trimmed, notes: trimmedNotes });
+      } finally {
+        submitting = false;
+      }
+      return;
+    }
+
+    // mode === 'new': quick-create the recipe, then add the entry with its id.
+    const name = newRecipeName.trim();
+    if (!name) return;
+    creating = true;
+    submitting = true;
+    try {
+      const created = await quickCreateRecipe({ name, recipeType: newRecipeType });
+      await onConfirm({ recipeId: created.recipeId, notes: trimmedNotes });
+    } catch (e) {
+      localError =
+        e instanceof ApiError
+          ? "Couldn't create that recipe — please try again."
+          : "Couldn't create that recipe right now.";
+    } finally {
+      creating = false;
+      submitting = false;
+    }
+  }
+
+  function pick(recipe: MealRecipeSummaryDto): void {
+    selectedRecipe = selectedRecipe?.recipeId === recipe.recipeId ? null : recipe;
+  }
+</script>
+
+<dialog bind:this={dialogEl} onclose={onClose} class="mp-sheet">
+  <div class="mp-sheet-inner">
+    <header class="mp-sheet-head">
+      <h2>Select Meal</h2>
+      {#if slotLabel}
+        <span class="mp-sheet-slot">{slotLabel}</span>
+      {/if}
+    </header>
+
+    <div class="mp-sheet-body">
+      <div class="mp-segmented" role="group" aria-label="Meal source">
+        {#each MODES as m (m.id)}
+          <button
+            type="button"
+            class="mp-seg"
+            class:active={mode === m.id}
+            aria-pressed={mode === m.id}
+            onclick={() => (mode = m.id)}
+          >
+            {m.label}
+          </button>
+        {/each}
+      </div>
+
+      {#if mode === 'search'}
+        <label class="mp-field">
+          <span class="mp-field-label">Search recipes</span>
+          <input
+            type="text"
+            bind:value={query}
+            oninput={onQueryInput}
+            autocomplete="off"
+            placeholder="Type to search…"
+          />
+        </label>
+        <div class="mp-results" role="listbox" aria-label="Recipes">
+          {#if searching && results.length === 0}
+            <p class="mp-results-empty">Searching…</p>
+          {:else if searchError}
+            <p class="mp-results-empty">Couldn't load recipes — please try again.</p>
+          {:else if results.length === 0}
+            <p class="mp-results-empty">No recipes found.</p>
+          {:else}
+            {#each results as recipe (recipe.recipeId)}
+              <button
+                type="button"
+                class="mp-result"
+                class:selected={selectedRecipe?.recipeId === recipe.recipeId}
+                role="option"
+                aria-selected={selectedRecipe?.recipeId === recipe.recipeId}
+                onclick={() => pick(recipe)}
+              >
+                {#if recipe.imagePath}
+                  <img src={recipe.imagePath} alt={recipe.name} class="mp-result-image" />
+                {:else}
+                  <span class="mp-result-placeholder" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" width="18" height="18">
+                      <path
+                        d="M11 9H9V2H7v7H5V2H3v7c0 2.12 1.66 3.84 3.75 3.97V22h2.5v-9.03C11.34 12.84 13 11.12 13 9V2h-2v7zm5-3v8h2.5v8H21V2c-2.76 0-5 2.24-5 4z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                  </span>
+                {/if}
+                <span class="mp-result-name">{recipe.name}</span>
+              </button>
+            {/each}
+          {/if}
+        </div>
+      {:else if mode === 'custom'}
+        <label class="mp-field">
+          <span class="mp-field-label">Custom meal name</span>
+          <input
+            type="text"
+            bind:value={customMealName}
+            autocomplete="off"
+            placeholder="e.g. Leftovers, Eating out, Takeout"
+          />
+        </label>
+      {:else}
+        <p class="mp-hint">Quick-add a recipe. You can add ingredients and details later.</p>
+        <label class="mp-field">
+          <span class="mp-field-label">Recipe name</span>
+          <input
+            type="text"
+            bind:value={newRecipeName}
+            autocomplete="off"
+            placeholder="e.g. Mom's Lasagna"
+          />
+        </label>
+        <label class="mp-field">
+          <span class="mp-field-label">Type</span>
+          <select bind:value={newRecipeType} class="mp-select">
+            {#each RECIPE_TYPES as t (t)}
+              <option value={t}>{recipeTypeLabel(t)}</option>
+            {/each}
+          </select>
+        </label>
+      {/if}
+
+      <label class="mp-field">
+        <span class="mp-field-label">Notes (optional)</span>
+        <textarea
+          bind:value={notes}
+          rows="2"
+          placeholder="e.g. Make extra for tomorrow, use up leftover chicken"
+        ></textarea>
+      </label>
+
+      {#if localError}
+        <p class="mp-sheet-error" role="alert">{localError}</p>
+      {/if}
+    </div>
+
+    <footer class="mp-sheet-actions">
+      <button type="button" class="mp-btn-ghost" onclick={onClose} disabled={submitting}>
+        Cancel
+      </button>
+      <button type="button" class="mp-btn-primary" onclick={confirm} disabled={!canConfirm || submitting}>
+        {#if mode === 'new'}
+          {creating ? 'Creating…' : 'Create & Add'}
+        {:else}
+          {submitting ? 'Adding…' : 'Add'}
+        {/if}
+      </button>
+    </footer>
+  </div>
+</dialog>
+
+<style>
+  .mp-sheet {
+    border: none;
+    padding: 0;
+    background: var(--color-surface);
+    color: var(--color-text);
+    box-shadow: var(--shadow-4);
+    width: min(520px, 100vw);
+    max-height: 90vh;
+    /* Bottom sheet on mobile; centered card on wide screens. */
+    margin: auto auto 0;
+    border-radius: var(--radius-md) var(--radius-md) 0 0;
+  }
+  @media (min-width: 600px) {
+    .mp-sheet {
+      margin: auto;
+      border-radius: var(--radius-md);
+    }
+  }
+  .mp-sheet::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+  }
+  .mp-sheet-inner {
+    display: flex;
+    flex-direction: column;
+    max-height: 90vh;
+  }
+  .mp-sheet-head {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    padding: 20px 24px 8px;
+  }
+  .mp-sheet-head h2 {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 500;
+  }
+  .mp-sheet-slot {
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+  }
+  .mp-sheet-body {
+    overflow-y: auto;
+    padding: 8px 24px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .mp-segmented {
+    display: flex;
+    gap: 6px;
+  }
+  .mp-seg {
+    flex: 1;
+    font: inherit;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    border: 1px solid var(--color-line-strong);
+    background: transparent;
+    color: var(--color-text-muted);
+    padding: 8px 10px;
+    min-height: 40px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: background-color 0.15s, color 0.15s, border-color 0.15s;
+  }
+  .mp-seg.active {
+    background: var(--color-primary);
+    border-color: var(--color-primary);
+    color: #fff;
+  }
+  .mp-seg:hover:not(.active) {
+    background: var(--color-action-hover);
+    color: var(--color-text);
+  }
+
+  .mp-field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .mp-field-label {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--color-text-muted);
+  }
+  .mp-field input[type='text'],
+  .mp-select,
+  .mp-field textarea {
+    font: inherit;
+    color: inherit;
+    padding: 10px 12px;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    min-height: 44px;
+  }
+  .mp-field textarea {
+    resize: vertical;
+    min-height: 60px;
+  }
+  .mp-field input[type='text']:focus,
+  .mp-select:focus,
+  .mp-field textarea:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -1px;
+    border-color: var(--color-primary);
+  }
+
+  .mp-results {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    max-height: 280px;
+    overflow-y: auto;
+  }
+  .mp-results-empty {
+    margin: 0;
+    padding: 16px 4px;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+  .mp-result {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    text-align: left;
+    font: inherit;
+    color: inherit;
+    background: transparent;
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-sm);
+    padding: 8px 12px;
+    min-height: 56px;
+    cursor: pointer;
+    transition: background-color 0.15s, border-color 0.15s;
+  }
+  .mp-result:hover {
+    background: var(--color-action-hover);
+    border-color: var(--color-line-strong);
+  }
+  .mp-result.selected {
+    border-color: var(--color-primary);
+    background: var(--color-action-hover);
+  }
+  .mp-result-image,
+  .mp-result-placeholder {
+    width: 40px;
+    height: 40px;
+    border-radius: var(--radius-sm);
+    flex-shrink: 0;
+  }
+  .mp-result-image {
+    object-fit: cover;
+  }
+  .mp-result-placeholder {
+    display: grid;
+    place-items: center;
+    background: var(--color-action-hover);
+    color: var(--color-text-muted);
+  }
+  .mp-result-name {
+    flex: 1;
+    min-width: 0;
+    font-size: 0.9375rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .mp-hint {
+    margin: 0;
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+  }
+  .mp-sheet-error {
+    margin: 0;
+    font-size: 0.875rem;
+    color: var(--color-error);
+  }
+
+  .mp-sheet-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 16px 24px calc(20px + env(safe-area-inset-bottom, 0px));
+    border-top: 1px solid var(--color-line);
+  }
+  .mp-btn-ghost,
+  .mp-btn-primary {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    border: none;
+    cursor: pointer;
+    min-height: 44px;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+  }
+  .mp-btn-ghost {
+    background: transparent;
+    color: var(--color-primary);
+  }
+  .mp-btn-ghost:hover:not(:disabled) {
+    background: var(--color-action-hover);
+  }
+  .mp-btn-primary {
+    background: var(--color-primary);
+    color: #fff;
+    box-shadow: var(--shadow-1);
+  }
+  .mp-btn-primary:hover:not(:disabled) {
+    background: var(--color-primary-hover);
+  }
+  .mp-btn-primary:disabled,
+  .mp-btn-ghost:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+</style>

--- a/frontend/app/src/lib/meal-plan/lib/components/WeekNav.svelte
+++ b/frontend/app/src/lib/meal-plan/lib/components/WeekNav.svelte
@@ -1,0 +1,144 @@
+<script lang="ts">
+  // ───────────────────────────────────────────────────────────────────────
+  // Week navigation — mirrors the Blazor MealPlanNavigation: prev / next
+  // chevrons, the centered week-range label, a "This week" chip when on the
+  // current week, and a "Jump to Today" button (disabled on the current week).
+  //
+  // Stepping is DISPLAY-ONLY (the server re-snaps the week to Monday on every
+  // board GET). No `new Date('YYYY-MM-DD')` — the label comes from dates.ts.
+  // ───────────────────────────────────────────────────────────────────────
+  import { weekRangeLabel, todayMonday } from '../dates';
+
+  interface Props {
+    /** The week's Monday "YYYY-MM-DD". */
+    weekStart: string;
+    onPrev: () => void;
+    onNext: () => void;
+    onToday: () => void;
+  }
+
+  let { weekStart, onPrev, onNext, onToday }: Props = $props();
+
+  let isCurrentWeek = $derived(weekStart === todayMonday());
+  let rangeLabel = $derived(weekRangeLabel(weekStart));
+</script>
+
+<nav class="mp-nav" aria-label="Week navigation">
+  <div class="mp-nav-header">
+    <button type="button" class="mp-nav-chevron" aria-label="Previous week" onclick={onPrev}>
+      <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+        <path d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z" fill="currentColor" />
+      </svg>
+    </button>
+
+    <div class="mp-nav-center">
+      <h2 class="mp-nav-range">{rangeLabel}</h2>
+      {#if isCurrentWeek}
+        <span class="mp-nav-chip">This week</span>
+      {/if}
+    </div>
+
+    <button type="button" class="mp-nav-chevron" aria-label="Next week" onclick={onNext}>
+      <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+        <path d="M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z" fill="currentColor" />
+      </svg>
+    </button>
+  </div>
+
+  <div class="mp-nav-actions">
+    <button
+      type="button"
+      class="mp-nav-today"
+      onclick={onToday}
+      disabled={isCurrentWeek}
+    >
+      <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+        <path
+          d="M19 3h-1V1h-2v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2V5a2 2 0 0 0-2-2zm0 16H5V8h14v11zM7 10h5v5H7z"
+          fill="currentColor"
+        />
+      </svg>
+      Jump to Today
+    </button>
+  </div>
+</nav>
+
+<style>
+  .mp-nav {
+    margin-bottom: 24px;
+  }
+  .mp-nav-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+  }
+  .mp-nav-center {
+    flex: 1;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+  }
+  .mp-nav-range {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 400;
+    color: var(--color-text);
+  }
+  .mp-nav-chip {
+    display: inline-block;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: #fff;
+    background: var(--color-primary);
+    border-radius: 12px;
+    padding: 2px 10px;
+  }
+  .mp-nav-chevron {
+    display: grid;
+    place-items: center;
+    width: 44px;
+    height: 44px;
+    border: none;
+    border-radius: 50%;
+    background: transparent;
+    color: var(--color-primary);
+    cursor: pointer;
+    flex-shrink: 0;
+    transition: background-color 0.15s;
+  }
+  .mp-nav-chevron:hover {
+    background: var(--color-action-hover);
+  }
+  .mp-nav-actions {
+    display: flex;
+    justify-content: center;
+    margin-top: 12px;
+  }
+  .mp-nav-today {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font: inherit;
+    font-size: 0.875rem;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+    color: var(--color-primary);
+    background: transparent;
+    border: none;
+    border-radius: var(--radius-sm);
+    padding: 8px 16px;
+    min-height: 40px;
+    cursor: pointer;
+    transition: background-color 0.15s;
+  }
+  .mp-nav-today:hover:not(:disabled) {
+    background: var(--color-action-hover);
+  }
+  .mp-nav-today:disabled {
+    color: var(--color-text-disabled);
+    cursor: not-allowed;
+  }
+</style>

--- a/frontend/app/src/lib/meal-plan/lib/dates.ts
+++ b/frontend/app/src/lib/meal-plan/lib/dates.ts
@@ -1,0 +1,130 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Week helpers for the meal-plan island.
+//
+// ⚠ GLOBAL PROJECT RULE / MN4: NEVER `new Date('YYYY-MM-DD')`. The string form
+// parses as UTC midnight, which renders as the PREVIOUS day in US timezones —
+// a wrong-week bug. We instead:
+//   • parse a "YYYY-MM-DD" by SPLITTING on '-' into integer parts, and
+//   • build dates with `Date.UTC(y, m, d, 12)` — NOON UTC, far enough from
+//     either midnight that no DST shift can cross a day boundary — then read
+//     the UTC parts back. Stepping by whole weeks is exact this way.
+//
+// All of this is DISPLAY-ONLY: the server re-snaps `weekStart` to that week's
+// Monday on every board GET, so client stepping can never corrupt the boundary.
+// ─────────────────────────────────────────────────────────────────────────
+
+const WEEKDAY_SHORT = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const MONTH_SHORT = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+];
+
+/** Parse a "YYYY-MM-DD" string into [year, month(1-12), day] integers. No Date built. */
+function parseParts(dateStr: string): [number, number, number] {
+  const [y, m, d] = dateStr.split('-').map((s) => Number(s));
+  return [y, m, d];
+}
+
+/** A noon-UTC Date for "YYYY-MM-DD" — DST-safe for whole-day/-week math only. */
+function utcNoon(dateStr: string): Date {
+  const [y, m, d] = parseParts(dateStr);
+  return new Date(Date.UTC(y, m - 1, d, 12));
+}
+
+/** Format a noon-UTC Date back to "YYYY-MM-DD" (reads UTC parts — never local). */
+function formatUtc(date: Date): string {
+  const y = date.getUTCFullYear();
+  const m = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const d = String(date.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * The Monday of the week containing `dateStr` ("YYYY-MM-DD"). Mirrors the
+ * server's GetWeekStartDate: `diff = (7 + (dow - Monday)) % 7`, then subtract.
+ * The server re-snaps anyway; this keeps the client label correct between GETs.
+ */
+export function mondayOf(dateStr: string): string {
+  const d = utcNoon(dateStr);
+  // getUTCDay(): Sunday=0 … Saturday=6. Monday=1.
+  const diff = (7 + (d.getUTCDay() - 1)) % 7;
+  d.setUTCDate(d.getUTCDate() - diff);
+  return formatUtc(d);
+}
+
+/** A "YYYY-MM-DD" `n` weeks from `mondayStr` (n may be negative). */
+export function addWeeks(mondayStr: string, n: number): string {
+  const d = utcNoon(mondayStr);
+  d.setUTCDate(d.getUTCDate() + n * 7);
+  return formatUtc(d);
+}
+
+/** Monday of the LOCAL current week, as "YYYY-MM-DD". The one place we read "today". */
+export function todayMonday(): string {
+  const now = new Date();
+  // Build today's string from LOCAL parts (the household's calendar day), then
+  // snap to Monday via the UTC-noon helpers. No `new Date('YYYY-MM-DD')`.
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, '0');
+  const d = String(now.getDate()).padStart(2, '0');
+  return mondayOf(`${y}-${m}-${d}`);
+}
+
+/** The 7 "YYYY-MM-DD" day strings of the week starting at `mondayStr`. */
+export function weekDays(mondayStr: string): string[] {
+  const base = utcNoon(mondayStr);
+  const out: string[] = [];
+  for (let i = 0; i < 7; i++) {
+    const d = new Date(base.getTime());
+    d.setUTCDate(d.getUTCDate() + i);
+    out.push(formatUtc(d));
+  }
+  return out;
+}
+
+/** Short weekday label, e.g. "Mon" (for a "YYYY-MM-DD"). */
+export function weekdayShort(dateStr: string): string {
+  return WEEKDAY_SHORT[utcNoon(dateStr).getUTCDay()];
+}
+
+/** Full weekday label, e.g. "Monday". */
+export function weekdayLong(dateStr: string): string {
+  const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+  return days[utcNoon(dateStr).getUTCDay()];
+}
+
+/** "MMM d" label, e.g. "Jun 23". */
+export function monthDay(dateStr: string): string {
+  const d = utcNoon(dateStr);
+  return `${MONTH_SHORT[d.getUTCMonth()]} ${d.getUTCDate()}`;
+}
+
+/** Full day label, e.g. "Monday, June 23". */
+export function dayLong(dateStr: string): string {
+  const months = [
+    'January', 'February', 'March', 'April', 'May', 'June',
+    'July', 'August', 'September', 'October', 'November', 'December',
+  ];
+  const d = utcNoon(dateStr);
+  return `${weekdayLong(dateStr)}, ${months[d.getUTCMonth()]} ${d.getUTCDate()}`;
+}
+
+/**
+ * Week-range label, e.g. "Jun 23 – Jun 29, 2025" (matches the Blazor
+ * MealPlanNavigation's "MMM d - MMM d, yyyy"). `mondayStr` is the week's Monday.
+ */
+export function weekRangeLabel(mondayStr: string): string {
+  const endDate = utcNoon(mondayStr);
+  endDate.setUTCDate(endDate.getUTCDate() + 6);
+  const endStr = formatUtc(endDate);
+  return `${monthDay(mondayStr)} – ${monthDay(endStr)}, ${endDate.getUTCFullYear()}`;
+}
+
+/** Is `dateStr` the local current day? (drives the "today" highlight). */
+export function isToday(dateStr: string): boolean {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, '0');
+  const d = String(now.getDate()).padStart(2, '0');
+  return dateStr === `${y}-${m}-${d}`;
+}

--- a/frontend/app/src/lib/meal-plan/lib/liveness.ts
+++ b/frontend/app/src/lib/meal-plan/lib/liveness.ts
@@ -1,0 +1,73 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Liveness — lightweight collaboration refresh for the meal-plan island.
+//
+// A change made by another household member should appear within ~20s while
+// the tab is VISIBLE, and immediately when the tab regains focus. We do this
+// with a plain interval + `visibilitychange`, NOT Blazor's DataNotifier /
+// PresenceService / PollingService (those are SignalR-circuit-bound — MN2).
+//
+// The poll PAUSES while the tab is hidden (D11): no interval ticks fire when
+// `document.hidden` is true, and on re-show we refetch once immediately, then
+// resume the interval. This keeps background tabs quiet.
+// ─────────────────────────────────────────────────────────────────────────
+
+const POLL_INTERVAL_MS = 20_000;
+
+export interface LivenessHandle {
+  /** Tear down the interval + visibility listener. Call on unmount. */
+  stop(): void;
+}
+
+/**
+ * Start polling. `refresh` is the board reload (App.svelte's loader). It is
+ * only invoked while the document is visible. Returns a handle whose `stop()`
+ * removes the interval + listener.
+ */
+export function startLiveness(refresh: () => void): LivenessHandle {
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  function tick() {
+    // Guard: never poll while hidden (the interval is cleared on hide, but this
+    // is belt-and-suspenders in case a tick is queued at the moment of hiding).
+    if (document.visibilityState === 'visible') {
+      refresh();
+    }
+  }
+
+  function startInterval() {
+    if (timer != null) return;
+    timer = setInterval(tick, POLL_INTERVAL_MS);
+  }
+
+  function stopInterval() {
+    if (timer != null) {
+      clearInterval(timer);
+      timer = null;
+    }
+  }
+
+  function handleVisibility() {
+    if (document.visibilityState === 'visible') {
+      // Re-show: refetch immediately, then resume the interval.
+      refresh();
+      startInterval();
+    } else {
+      // Hidden: pause polling entirely.
+      stopInterval();
+    }
+  }
+
+  document.addEventListener('visibilitychange', handleVisibility);
+
+  // Begin polling only if we start visible.
+  if (document.visibilityState === 'visible') {
+    startInterval();
+  }
+
+  return {
+    stop() {
+      stopInterval();
+      document.removeEventListener('visibilitychange', handleVisibility);
+    },
+  };
+}

--- a/frontend/app/src/lib/meal-plan/lib/recipeType.ts
+++ b/frontend/app/src/lib/meal-plan/lib/recipeType.ts
@@ -1,0 +1,33 @@
+// Display labels for the RecipeType union (mirrors the Blazor GetRecipeTypeLabel
+// in RecipePickerDialog) + the picker's select option order.
+import type { RecipeType } from './types';
+
+export const RECIPE_TYPE_LABELS: Record<RecipeType, string> = {
+  main: 'Main Dish',
+  side: 'Side Dish',
+  appetizer: 'Appetizer',
+  dessert: 'Dessert',
+  beverage: 'Beverage',
+  sauce: 'Sauce/Condiment',
+  breakfast: 'Breakfast',
+  snack: 'Snack',
+  other: 'Other',
+};
+
+/** The select option order — matches the C# enum declaration order. */
+export const RECIPE_TYPES: RecipeType[] = [
+  'main',
+  'side',
+  'appetizer',
+  'dessert',
+  'beverage',
+  'sauce',
+  'breakfast',
+  'snack',
+  'other',
+];
+
+/** Short chip label shown on a slot card (the type chip is hidden for `main`). */
+export function recipeTypeLabel(type: RecipeType): string {
+  return RECIPE_TYPE_LABELS[type] ?? type;
+}

--- a/frontend/app/src/lib/meal-plan/lib/state.svelte.ts
+++ b/frontend/app/src/lib/meal-plan/lib/state.svelte.ts
@@ -1,0 +1,205 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Board store — the single source of truth for the meal-plan island.
+//
+// One `MealPlanBoardDto` (the current week) is fetched and held here. The
+// calendar grid + day list are CLIENT-SIDE groupings of that one payload via
+// `entriesByDayMeal`.
+//
+// ⚠ Svelte 5 rune rule (global CORRECTION): never `export` a reassigned
+// `$state`/`$derived` from a module. We wrap the mutable state in a class
+// instance and export the instance — the runes live as `$state`/`$derived`
+// fields on the object, which is the supported pattern.
+//
+// Parity-first ⇒ VERSIONLESS / last-write-wins. The only ops are add + remove;
+// there is no xmin token, no 409 branch. On any 4xx/network error we reconcile
+// (re-GET the current week) + surface a calm toast. NO `new Date('YYYY-MM-DD')`
+// anywhere — week stepping goes through lib/dates.ts (MN4).
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { MealPlanBoardDto, MealPlanEntryDto, MealType, ShellContext } from './types';
+import { ApiError, addEntry, getBoard, removeEntry, type AddEntryBody } from './api';
+import { addWeeks, mondayOf, todayMonday } from './dates';
+import { showToast } from '$lib/shared/toast-store.svelte';
+
+/** The board's three rendered meal rows (Snack is implicit — only shown if data exists). */
+export const MEAL_ROWS: MealType[] = ['breakfast', 'lunch', 'dinner'];
+
+class MealPlanStore {
+  /** The week's Monday "YYYY-MM-DD". Client stepping is display-only — the server re-snaps on GET. */
+  weekStart = $state<string>(todayMonday());
+  /** The one fetched payload for `weekStart`. null until the first load resolves. */
+  board = $state<MealPlanBoardDto | null>(null);
+  loading = $state(true);
+  /** Human-readable error message; null when healthy. */
+  error = $state<string | null>(null);
+  /** This household member's userId — set once on init from the shell context. */
+  currentUserId = $state(0);
+
+  /**
+   * The board refetch hook, wired by App.svelte (`store.setRefresh(loadBoard)`).
+   * Shared by liveness AND the error-reconcile path so a post-mutation refetch
+   * reuses the exact same loader.
+   */
+  private refresh: (() => Promise<void>) | null = null;
+
+  /**
+   * Slot lookup: `${date}|${mealType}` → the entries in that slot. Empty map
+   * until the board loads. A slot with no entries simply isn't a key.
+   */
+  entriesByDayMeal = $derived.by(() => {
+    const map = new Map<string, MealPlanEntryDto[]>();
+    for (const e of this.board?.entries ?? []) {
+      const key = `${e.date}|${e.mealType}`;
+      const bucket = map.get(key);
+      if (bucket) bucket.push(e);
+      else map.set(key, [e]);
+    }
+    return map;
+  });
+
+  /** Entries for one slot (empty array when none). */
+  entriesFor(date: string, mealType: MealType): MealPlanEntryDto[] {
+    return this.entriesByDayMeal.get(`${date}|${mealType}`) ?? [];
+  }
+
+  /** Count of all entries on a given day (for the mobile day-list "N meals" label). */
+  dayCount(date: string): number {
+    return (this.board?.entries ?? []).filter((e) => e.date === date).length;
+  }
+
+  /** Seed the viewing user's id (drives "you"-style affordances if ever needed). */
+  init(ctx: ShellContext): void {
+    this.currentUserId = ctx.userId;
+  }
+
+  /** Wire the board refetch (App.svelte's loader). Used for liveness + error reconcile. */
+  setRefresh(refresh: () => Promise<void>): void {
+    this.refresh = refresh;
+  }
+
+  /** Replace the board payload (the server echoes the snapped Monday — adopt it). */
+  setBoard(next: MealPlanBoardDto): void {
+    this.board = next;
+    // Adopt the server's authoritative Monday so the label can't drift from the
+    // data (e.g. if the client and server disagreed on the week boundary).
+    this.weekStart = next.weekStartDate;
+    this.error = null;
+  }
+
+  /** Re-GET the current week. Shared by liveness + error reconcile. */
+  async reconcile(): Promise<void> {
+    if (this.refresh) await this.refresh();
+  }
+
+  /**
+   * Fetch the board for the CURRENT `weekStart`. App.svelte wires this as the
+   * loader (and as the liveness/reconcile refresh). Keeps the spinner only for
+   * the first load; liveness refreshes are silent.
+   */
+  async loadBoard(): Promise<void> {
+    try {
+      if (this.board == null) this.loading = true;
+      this.error = null;
+      this.setBoard(await getBoard(this.weekStart));
+    } catch (e) {
+      if (e instanceof ApiError) {
+        this.error = `Failed to load the meal plan (HTTP ${e.status}).`;
+      } else {
+        this.error = e instanceof Error ? e.message : String(e);
+      }
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  /**
+   * Step the week. A number = relative weeks (−1 prev / +1 next); a string =
+   * an explicit target date (snapped to its Monday — used by "jump to today").
+   * Recomputes `weekStart` via dates.ts then refetches.
+   */
+  async changeWeek(deltaOrMonday: number | string): Promise<void> {
+    this.weekStart =
+      typeof deltaOrMonday === 'number'
+        ? addWeeks(this.weekStart, deltaOrMonday)
+        : mondayOf(deltaOrMonday);
+    await this.loadBoard();
+  }
+
+  /**
+   * Add a meal to a slot. Add is infrequent, so we AWAIT the POST then merge the
+   * returned authoritative entry into `board.entries` (no temp id). On any
+   * 4xx/network error: reconcile (re-GET the week) + a calm toast.
+   */
+  async addEntry(body: AddEntryBody): Promise<void> {
+    if (!this.board) return;
+    // Capture the week the add targets. If the user navigates to another week while the POST is in flight,
+    // we must NOT merge this (off-week) entry into the now-current board (council R1). It is persisted
+    // server-side and will appear when its week is viewed.
+    const targetWeek = this.weekStart;
+    try {
+      const created = await addEntry(body);
+      if (!this.board || this.weekStart !== targetWeek) return;
+      // The POST may have GetOrCreated the week's plan, so the board's
+      // mealPlanId could have been null — adopt the entry's plan id.
+      if (this.board.mealPlanId == null) {
+        this.board.mealPlanId = created.mealPlanId;
+      }
+      this.board.entries = [...this.board.entries, created];
+    } catch (e) {
+      await this.reconcile();
+      const msg =
+        e instanceof ApiError
+          ? "Couldn't add that meal — the plan was refreshed."
+          : "Couldn't add that meal right now.";
+      showToast({ message: msg, kind: 'info' });
+    }
+  }
+
+  /**
+   * Remove an entry — optimistic splice, then DELETE. On any error reconcile +
+   * calm toast. A missing entry (already removed by someone else) → 404/empty-400
+   * → the refetch shows the true state.
+   */
+  async removeEntry(mealPlanId: number, entryId: number): Promise<void> {
+    if (!this.board) return;
+    const idx = this.board.entries.findIndex(
+      (e) => e.mealPlanId === mealPlanId && e.entryId === entryId,
+    );
+    if (idx < 0) return;
+    const removed = this.board.entries[idx];
+    // Optimistic splice.
+    this.board.entries = this.board.entries.filter(
+      (e) => !(e.mealPlanId === mealPlanId && e.entryId === entryId),
+    );
+    try {
+      await removeEntry(mealPlanId, entryId);
+    } catch (e) {
+      if (e instanceof ApiError) {
+        // Any 4xx (incl. the empty-400-from-404 quirk) — resync to truth.
+        await this.reconcile();
+        showToast({ message: 'That meal changed — the plan was refreshed.', kind: 'info' });
+      } else {
+        // Network/5xx: the refetch may not have restored it; put it back AT ITS ORIGINAL INDEX (council R1 —
+        // appending would reorder the slot's entries on a failed delete).
+        if (
+          this.board &&
+          !this.board.entries.some(
+            (x) => x.mealPlanId === mealPlanId && x.entryId === entryId,
+          )
+        ) {
+          const restored = [...this.board.entries];
+          restored.splice(Math.min(idx, restored.length), 0, removed);
+          this.board.entries = restored;
+        }
+        showToast({ message: 'Something went wrong. Please try again.', kind: 'error' });
+      }
+    }
+  }
+}
+
+/**
+ * The single shared store instance. Components import this and read its
+ * `$state`/`$derived` fields reactively. We export the INSTANCE (not the runes
+ * themselves) so the rune-export rule is respected.
+ */
+export const mealPlanStore = new MealPlanStore();

--- a/frontend/app/src/lib/meal-plan/lib/types.ts
+++ b/frontend/app/src/lib/meal-plan/lib/types.ts
@@ -1,0 +1,91 @@
+// ─────────────────────────────────────────────────────────────────────────
+// TS mirror of the meal-plan board DTO contract (M9 four-way lockstep with
+// Services/Dtos/MealPlanDtos.cs ↔ Fixtures/MealPlanBoard/board.json ↔
+// MealPlanBoardDtoContractTests). A shape/casing change updates all four.
+//
+// ⚠ CASING: `MealType` / `RecipeType` are real enum TYPES on the C# DTO → they
+//   serialize as camelCase string unions via the globally-registered
+//   JsonStringEnumConverter(CamelCase). `DateOnly` serializes as "YYYY-MM-DD".
+//
+// ⚠ DATES: every `date` / `weekStartDate` below is a "YYYY-MM-DD" STRING.
+//   NEVER `new Date('YYYY-MM-DD')` for logic — UTC-parsing shifts the day
+//   backward in US timezones (global CORRECTION / MN4). Use lib/dates.ts, which
+//   parses by splitting on '-' and steps weeks via Date.UTC(...,12).
+//
+// Versionless / last-write-wins: parity ops are add + remove only, so there is
+// NO version/xmin token anywhere on this contract.
+// ─────────────────────────────────────────────────────────────────────────
+
+export type MealType = 'breakfast' | 'lunch' | 'dinner' | 'snack';
+
+export type RecipeType =
+  | 'main'
+  | 'side'
+  | 'appetizer'
+  | 'dessert'
+  | 'beverage'
+  | 'sauce'
+  | 'breakfast'
+  | 'snack'
+  | 'other';
+
+/** The lightweight recipe shape a slot card renders (the board payload stays lean). */
+export interface MealRecipeSummaryDto {
+  recipeId: number;
+  name: string;
+  imagePath: string | null;
+  recipeType: RecipeType;
+}
+
+/** One planned meal. Exactly one of `recipe` / `customMealName` is set. */
+export interface MealPlanEntryDto {
+  mealPlanId: number;
+  entryId: number;
+  /** "YYYY-MM-DD" — the slot's calendar position. NEVER new Date() it for logic. */
+  date: string;
+  mealType: MealType;
+  recipe: MealRecipeSummaryDto | null;
+  customMealName: string | null;
+  notes: string | null;
+}
+
+/** The week board: the Monday it covers, the plan id (null when none yet), and its entries. */
+export interface MealPlanBoardDto {
+  /** "YYYY-MM-DD" — the Monday, echoed by the server. */
+  weekStartDate: string;
+  mealPlanId: number | null;
+  entries: MealPlanEntryDto[];
+}
+
+/** One ingredient line, pre-ordered by `sortOrder`. */
+export interface RecipeIngredientDto {
+  quantity: number | null;
+  unit: string | null;
+  name: string;
+  notes: string | null;
+  sortOrder: number;
+}
+
+/**
+ * Read-only recipe detail for the in-island view modal. `instructionsHtml` is
+ * server-sanitized (MarkdownHelper.ToSafeHtml) so the island ships no Markdown
+ * library — render via {@html}.
+ */
+export interface RecipeDetailDto {
+  recipeId: number;
+  name: string;
+  imagePath: string | null;
+  recipeType: RecipeType;
+  prepTimeMinutes: number | null;
+  cookTimeMinutes: number | null;
+  servings: number | null;
+  instructionsHtml: string;
+  ingredients: RecipeIngredientDto[];
+}
+
+/** The shell context the Razor host hands the island via root data-attrs. */
+export interface ShellContext {
+  householdId: number;
+  userId: number;
+  userName: string;
+}

--- a/frontend/app/src/lib/presence.svelte.ts
+++ b/frontend/app/src/lib/presence.svelte.ts
@@ -1,0 +1,106 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Presence store for the de-Blazored SvelteKit shell.
+//
+// Replaces the Blazor circuit heartbeat (D3): every 30s it POSTs a heartbeat
+// (recording the caller's current SPA path) and polls GET /api/presence/users
+// for the header's online-users avatar row. `online` is a client-derived sync
+// indicator — true while the last /api call succeeded, false when it failed
+// (e.g. the network dropped). Same-origin cookie auth (credentials: 'include').
+//
+// The staleness decay (Online→Away→Offline) is driven server-side by the
+// /api/presence/users handler calling PresenceService.UpdatePresence() — this
+// client only reflects what the endpoint returns.
+//
+// ⚠ Svelte 5 rune rule: $state lives in private fields on a singleton class;
+// callers read reactive values through getters (never a re-exported reassigned
+// $state). Reading `presence.users` / `presence.online` in markup tracks them.
+// ─────────────────────────────────────────────────────────────────────────
+
+/** One active user in the header roster (caller excluded server-side). */
+export interface PresenceUser {
+  userId: number;
+  displayName: string;
+  initials: string | null;
+  pictureUrl: string | null;
+  /** Serialized lowercase by the backend's camelCase enum converter. */
+  status: 'online' | 'away';
+}
+
+const HEARTBEAT_MS = 30_000;
+
+class PresenceStore {
+  #users = $state<PresenceUser[]>([]);
+  #online = $state(true);
+  #timer: ReturnType<typeof setInterval> | null = null;
+  #started = false;
+
+  /** The active users to show in the header (excludes the caller). */
+  get users(): readonly PresenceUser[] {
+    return this.#users;
+  }
+
+  /** True while the last /api/presence call succeeded; drives the sync indicator. */
+  get online(): boolean {
+    return this.#online;
+  }
+
+  /**
+   * Begin the 30s heartbeat + roster poll. Idempotent — calling twice is a
+   * no-op, so mounting from the header (the single always-present consumer) is
+   * safe. Fires one tick immediately so the row/indicator populate on load.
+   */
+  start(): void {
+    if (this.#started) return;
+    this.#started = true;
+    void this.#tick();
+    this.#timer = setInterval(() => void this.#tick(), HEARTBEAT_MS);
+  }
+
+  /** Stop polling (header teardown). */
+  stop(): void {
+    if (this.#timer !== null) clearInterval(this.#timer);
+    this.#timer = null;
+    this.#started = false;
+  }
+
+  async #tick(): Promise<void> {
+    await this.#heartbeat();
+    await this.#loadUsers();
+  }
+
+  async #heartbeat(): Promise<void> {
+    try {
+      const res = await fetch('/api/presence/heartbeat', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          page: typeof window !== 'undefined' ? window.location.pathname : null,
+        }),
+      });
+      this.#online = res.ok;
+    } catch {
+      this.#online = false;
+    }
+  }
+
+  async #loadUsers(): Promise<void> {
+    try {
+      const res = await fetch('/api/presence/users', {
+        credentials: 'include',
+        headers: { Accept: 'application/json' },
+      });
+      if (!res.ok) {
+        this.#online = false;
+        return;
+      }
+      this.#online = true;
+      this.#users = (await res.json()) as PresenceUser[];
+    } catch {
+      this.#online = false;
+    }
+  }
+}
+
+/** The canonical, app-wide presence singleton. Import and read reactively. */
+export const presence = new PresenceStore();

--- a/frontend/app/src/lib/recipes/EditApp.svelte
+++ b/frontend/app/src/lib/recipes/EditApp.svelte
@@ -1,0 +1,306 @@
+<script lang="ts">
+  // ───────────────────────────────────────────────────────────────────────
+  // Root of the recipes EDIT view (#recipes-edit-root, data-view="edit").
+  // ctx.recipeId is null for /recipes/new, set for /recipes/edit/{id}. Loads the
+  // recipe (or draft, or blank) into the edit store and renders the form
+  // sections, ingredient entry/list (dnd), instructions, autosave indicator, and
+  // Save/Cancel/Delete. Single-user form ⇒ NO liveness.
+  //
+  // ⚠ Loop safety (spec §10): the one-time setup $effect is wrapped ENTIRELY in
+  // untrack() — store.load() reads then writes store $state, so without untrack
+  // the effect would loop. untrack gives it zero reactive deps (runs once).
+  //
+  // Nav-lock: a `beforeunload` handler warns on unsaved changes (replaces the
+  // Blazor NavigationLock). Save/Cancel/Delete clear `dirty` before navigating,
+  // so only an unsaved manual nav-away prompts.
+  // ───────────────────────────────────────────────────────────────────────
+  import { untrack } from 'svelte';
+  import type { ShellContext } from './lib/types';
+  import { recipeEditStore } from './lib/recipeEditStore.svelte';
+  import BasicInfoSection from './lib/components/BasicInfoSection.svelte';
+  import ImageSection from './lib/components/ImageSection.svelte';
+  import IngredientEntry from './lib/components/IngredientEntry.svelte';
+  import IngredientList from './lib/components/IngredientList.svelte';
+  import BulkPasteDialog from './lib/components/BulkPasteDialog.svelte';
+  import ImagePickerDialog from './lib/components/ImagePickerDialog.svelte';
+  import ConfirmDialog from '$lib/shared/ConfirmDialog.svelte';
+
+  interface Props {
+    ctx: ShellContext;
+  }
+
+  let { ctx }: Props = $props();
+
+  const store = recipeEditStore;
+
+  let bulkOpen = $state(false);
+  let pickerOpen = $state(false);
+  let deleteOpen = $state(false);
+
+  function handleBeforeUnload(e: BeforeUnloadEvent): void {
+    if (store.dirty) {
+      e.preventDefault();
+      e.returnValue = '';
+    }
+  }
+
+  $effect(() => {
+    untrack(() => {
+      store.init(ctx);
+      store.load(ctx.recipeId); // reads then writes store $state — MUST be inside untrack
+      window.addEventListener('beforeunload', handleBeforeUnload);
+    });
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+      store.teardown();
+    };
+  });
+</script>
+
+<div class="rc-container">
+  <header class="rc-header">
+    <h1 class="rc-title">{store.isEdit ? 'Edit Recipe' : 'New Recipe'}</h1>
+    {#if store.isEdit}
+      <button type="button" class="rc-btn-danger-outline" onclick={() => (deleteOpen = true)}>Delete</button>
+    {/if}
+  </header>
+
+  {#if store.loading}
+    <div class="rc-loading-bar"><span></span></div>
+  {:else}
+    {#if store.error}
+      <div class="rc-inline-error" role="alert">{store.error}</div>
+    {/if}
+
+    <BasicInfoSection />
+
+    <ImageSection onChooseExisting={() => (pickerOpen = true)} />
+
+    <section class="rc-paper">
+      <h2 class="rc-section-title">Ingredients</h2>
+      <IngredientEntry
+        categories={store.categories}
+        onAdd={(i) => store.addIngredient(i)}
+        onBulkOpen={() => (bulkOpen = true)}
+      />
+      <IngredientList
+        ingredients={store.ingredients}
+        onReorder={(rows) => store.reorder(rows)}
+        onEdit={(id) => store.editIngredient(id)}
+        onRemove={(id) => store.removeIngredient(id)}
+      />
+    </section>
+
+    <section class="rc-paper">
+      <h2 class="rc-section-title">Instructions</h2>
+      <textarea
+        class="rc-input rc-instructions"
+        rows="10"
+        bind:value={store.form.instructions}
+        oninput={() => store.onEdit()}
+        placeholder="Supports Markdown formatting"
+      ></textarea>
+    </section>
+
+    <div class="rc-footer">
+      <div class="rc-autosave" aria-live="polite">
+        {#if store.autosaveStatus === 'saving'}
+          <span class="rc-spinner" aria-hidden="true"></span>
+          <span class="rc-autosave-text">Saving draft…</span>
+        {:else if store.autosaveStatus === 'saved'}
+          <span class="rc-autosave-saved">✓ Draft saved</span>
+        {/if}
+      </div>
+
+      <div class="rc-footer-actions">
+        <button type="button" class="rc-btn-ghost" onclick={() => store.cancel()}>Cancel</button>
+        <button type="button" class="rc-btn-solid" onclick={() => store.save()} disabled={store.saving}>
+          {store.saving ? 'Saving…' : store.isEdit ? 'Save Changes' : 'Create Recipe'}
+        </button>
+      </div>
+    </div>
+  {/if}
+</div>
+
+<BulkPasteDialog
+  open={bulkOpen}
+  categories={store.categories}
+  onClose={() => (bulkOpen = false)}
+  onImport={(rows) => store.addBulk(rows)}
+/>
+
+<ImagePickerDialog
+  open={pickerOpen}
+  currentImage={store.form.imagePath}
+  onClose={() => (pickerOpen = false)}
+  onSelect={(path) => store.setImage(path)}
+/>
+
+<ConfirmDialog
+  open={deleteOpen}
+  danger
+  title="Delete Recipe"
+  message={`Are you sure you want to delete "${store.form.name}"? This action cannot be undone.`}
+  onCancel={() => (deleteOpen = false)}
+  onConfirm={() => {
+    deleteOpen = false;
+    store.delete();
+  }}
+/>
+
+<style>
+  .rc-container {
+    max-width: 880px;
+    margin: 0 auto;
+    padding: 24px 16px 96px;
+  }
+  .rc-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 16px;
+  }
+  .rc-title {
+    margin: 0;
+    font-size: 2.125rem;
+    font-weight: 400;
+    color: var(--color-text);
+  }
+  .rc-paper {
+    background: var(--color-surface);
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-1);
+    padding: 16px;
+    margin-bottom: 16px;
+  }
+  .rc-section-title {
+    margin: 0 0 12px;
+    font-size: 1.125rem;
+    font-weight: 500;
+  }
+  .rc-input {
+    font: inherit;
+    padding: 10px 12px;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text);
+    width: 100%;
+  }
+  .rc-input:focus {
+    outline: none;
+    border-color: var(--color-primary);
+  }
+  .rc-instructions {
+    resize: vertical;
+    min-height: 200px;
+  }
+  .rc-loading-bar {
+    height: 4px;
+    background: var(--color-action-hover);
+    border-radius: 2px;
+    overflow: hidden;
+    margin: 24px 0;
+  }
+  .rc-loading-bar span {
+    display: block;
+    height: 100%;
+    width: 40%;
+    background: var(--color-primary);
+    animation: rc-indeterminate 1.2s ease-in-out infinite;
+  }
+  @keyframes rc-indeterminate {
+    0% {
+      transform: translateX(-100%);
+    }
+    100% {
+      transform: translateX(350%);
+    }
+  }
+  .rc-inline-error {
+    padding: 10px 16px;
+    margin-bottom: 16px;
+    background: rgba(229, 57, 53, 0.08);
+    border-left: 4px solid var(--color-error);
+    border-radius: var(--radius-sm);
+    color: var(--color-error);
+    font-size: 0.875rem;
+  }
+  .rc-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+  .rc-autosave {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 24px;
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+  }
+  .rc-autosave-saved {
+    color: var(--color-success);
+  }
+  .rc-spinner {
+    width: 14px;
+    height: 14px;
+    border: 2px solid var(--color-line-strong);
+    border-top-color: var(--color-primary);
+    border-radius: 50%;
+    animation: rc-spin 0.8s linear infinite;
+  }
+  @keyframes rc-spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+  .rc-footer-actions {
+    display: flex;
+    gap: 8px;
+    margin-left: auto;
+  }
+  .rc-btn-ghost,
+  .rc-btn-solid,
+  .rc-btn-danger-outline {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    min-height: 40px;
+    font-weight: 500;
+  }
+  .rc-btn-ghost {
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
+  }
+  .rc-btn-ghost:hover {
+    background: var(--color-action-hover);
+  }
+  .rc-btn-solid {
+    border: none;
+    background: var(--color-primary);
+    color: #fff;
+  }
+  .rc-btn-solid:hover:not(:disabled) {
+    background: var(--color-primary-hover);
+  }
+  .rc-btn-solid:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+  .rc-btn-danger-outline {
+    border: 1px solid var(--color-error);
+    background: transparent;
+    color: var(--color-error);
+  }
+  .rc-btn-danger-outline:hover {
+    background: rgba(229, 57, 53, 0.08);
+  }
+</style>

--- a/frontend/app/src/lib/recipes/ListApp.svelte
+++ b/frontend/app/src/lib/recipes/ListApp.svelte
@@ -1,0 +1,435 @@
+<script lang="ts">
+  // ───────────────────────────────────────────────────────────────────────
+  // Root of the recipes LIST view (#recipes-list-root, data-view="list").
+  // Reads ShellContext from the root data-attrs, loads the grid into the shared
+  // list store, and renders the connected-household selector, search + favorites,
+  // the card grid, the detail drawer, the import + delete dialogs, and toasts.
+  // Liveness re-runs the current query while the tab is visible (collaboration).
+  //
+  // ⚠ Loop safety (spec §10): the one-time setup $effect is wrapped ENTIRELY in
+  // untrack() — load()/loadConnections() read then write store $state, so without
+  // untrack the effect would subscribe to the state it writes → an infinite
+  // fetch→write→re-run loop. untrack gives it zero reactive deps (runs once);
+  // liveness + user actions drive every later refresh.
+  // ───────────────────────────────────────────────────────────────────────
+  import { untrack } from 'svelte';
+  import { base } from '$app/paths';
+  import { goto } from '$app/navigation';
+  import type { RecipeListItemDto, ShellContext } from './lib/types';
+  import { recipeListStore } from './lib/recipeListStore.svelte';
+  import { copyConnectedRecipe } from './lib/api';
+  import { startLiveness, type LivenessHandle } from './lib/liveness';
+  import { showToast } from '$lib/shared/toast-store.svelte';
+  import RecipeCard from './lib/components/RecipeCard.svelte';
+  import ConnectedHouseholdSelector from './lib/components/ConnectedHouseholdSelector.svelte';
+  import RecipeDetailDrawer from './lib/components/RecipeDetailDrawer.svelte';
+  import ImportDialog from './lib/components/ImportDialog.svelte';
+  import ConfirmDialog from '$lib/shared/ConfirmDialog.svelte';
+
+  interface Props {
+    ctx: ShellContext;
+    /** When true (the /recipes/import route), the import dialog opens on mount. */
+    openImport?: boolean;
+    /** Called when the import dialog closes — the /recipes/import route navigates back to /recipes. */
+    onImportClose?: () => void;
+  }
+
+  let { ctx, openImport = false, onImportClose }: Props = $props();
+
+  const store = recipeListStore;
+
+  let liveness: LivenessHandle | null = null;
+
+  // Search is debounced locally (300ms) before hitting the server (mirrors the
+  // Blazor MudTextField DebounceInterval). Kept separate from store.query so the
+  // input stays responsive between debounce ticks.
+  let searchValue = $state('');
+  let searchTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // Drawer / dialogs.
+  let drawerOpen = $state(false);
+  let drawerRecipe = $state<RecipeListItemDto | null>(null);
+  let importOpen = $state(openImport);
+  let deleteOpen = $state(false);
+  let deleteTarget = $state<RecipeListItemDto | null>(null);
+
+  async function load(): Promise<void> {
+    await store.load();
+  }
+
+  function onSearchInput(value: string): void {
+    searchValue = value;
+    if (searchTimer) clearTimeout(searchTimer);
+    searchTimer = setTimeout(() => void store.search(searchValue), 300);
+  }
+
+  async function onSelectHousehold(id: number | null): Promise<void> {
+    searchValue = '';
+    closeDrawer();
+    await store.setConnected(id);
+  }
+
+  function openDrawer(recipe: RecipeListItemDto): void {
+    drawerRecipe = recipe;
+    drawerOpen = true;
+  }
+
+  function closeDrawer(): void {
+    drawerOpen = false;
+    // Keep drawerRecipe so the panel content doesn't flash during the close slide.
+  }
+
+  function handleEdit(recipeId: number): void {
+    void goto(`${base}/recipes/edit/${recipeId}`);
+  }
+
+  function handleAddRecipe(): void {
+    void goto(`${base}/recipes/new`);
+  }
+
+  function handleAddToMealPlan(name: string): void {
+    showToast({ message: `Add '${name}' to meal plan — feature in development.`, kind: 'info' });
+  }
+
+  async function handleCopy(recipeId: number): Promise<void> {
+    if (store.selectedConnectedId == null) return;
+    try {
+      await copyConnectedRecipe(store.selectedConnectedId, recipeId);
+      showToast({ message: "Recipe copied! It's now in your collection.", kind: 'success' });
+    } catch {
+      showToast({ message: "Couldn't copy that recipe right now.", kind: 'error' });
+    }
+  }
+
+  function requestDelete(recipe: RecipeListItemDto): void {
+    deleteTarget = recipe;
+    deleteOpen = true;
+  }
+
+  async function confirmDelete(): Promise<void> {
+    const target = deleteTarget;
+    deleteOpen = false;
+    deleteTarget = null;
+    if (!target) return;
+    closeDrawer();
+    await store.deleteRecipe(target.recipeId);
+  }
+
+  function onImported(recipeId: number): void {
+    void goto(`${base}/recipes/edit/${recipeId}`);
+  }
+
+  // Empty-state copy mirrors Recipes.razor:120-195.
+  let emptyTitle = $derived(
+    store.isViewingConnected
+      ? 'No shared recipes'
+      : store.showFavoritesOnly
+        ? 'No favorites yet'
+        : 'No recipes yet',
+  );
+  let emptyHint = $derived(
+    store.isViewingConnected
+      ? store.query.trim()
+        ? `No recipes found matching "${store.query}"`
+        : "This family hasn't added any recipes yet"
+      : store.showFavoritesOnly
+        ? 'Tap the heart on a recipe to add it to your favorites'
+        : store.query.trim()
+          ? `No recipes found matching "${store.query}"`
+          : 'Start building your family recipe collection',
+  );
+
+  $effect(() => {
+    untrack(() => {
+      store.init(ctx);
+      store.setRefresh(load);
+      load(); // reads then writes store $state — MUST be inside untrack
+      store.loadConnections();
+      // Liveness: ~20s poll while visible + immediate refetch on refocus.
+      liveness = startLiveness(() => store.reconcile());
+    });
+
+    return () => {
+      liveness?.stop();
+      liveness = null;
+      if (searchTimer) clearTimeout(searchTimer);
+      searchTimer = null;
+    };
+  });
+</script>
+
+<div class="rc-container">
+  <header class="rc-header">
+    <h1 class="rc-title">Recipes</h1>
+    {#if !store.isViewingConnected}
+      <div class="rc-header-actions">
+        <button type="button" class="rc-btn-outline" onclick={() => (importOpen = true)}>
+          Import from URL
+        </button>
+        <button type="button" class="rc-btn-solid" onclick={handleAddRecipe}>Add Recipe</button>
+      </div>
+    {/if}
+  </header>
+
+  {#if store.connections.length > 0}
+    <ConnectedHouseholdSelector
+      connections={store.connections}
+      selectedId={store.selectedConnectedId}
+      onSelect={onSelectHousehold}
+    />
+  {/if}
+
+  <div class="rc-controls">
+    <input
+      type="search"
+      class="rc-search"
+      placeholder="Search by name, ingredients, or type"
+      value={searchValue}
+      oninput={(e) => onSearchInput(e.currentTarget.value)}
+    />
+    {#if !store.isViewingConnected}
+      <button
+        type="button"
+        class="rc-fav-chip"
+        class:rc-fav-chip-on={store.showFavoritesOnly}
+        aria-pressed={store.showFavoritesOnly}
+        onclick={() => store.toggleFavoritesFilter()}
+      >
+        {store.showFavoritesOnly ? '♥' : '♡'} Favorites
+      </button>
+    {/if}
+  </div>
+
+  {#if store.error}
+    <div class="rc-inline-error" role="alert">
+      <span>{store.error}</span>
+      <button type="button" class="rc-retry" onclick={load}>Retry</button>
+    </div>
+  {/if}
+
+  {#if store.loading}
+    <div class="rc-grid">
+      {#each Array(6) as _, i (i)}
+        <div class="rc-skeleton"></div>
+      {/each}
+    </div>
+  {:else if store.displayed.length === 0}
+    <div class="rc-empty">
+      <h2 class="rc-empty-title">{emptyTitle}</h2>
+      <p class="rc-empty-hint">{emptyHint}</p>
+      {#if !store.isViewingConnected && !store.showFavoritesOnly && !store.query.trim()}
+        <button type="button" class="rc-btn-solid" onclick={handleAddRecipe}>Add Your First Recipe</button>
+      {/if}
+    </div>
+  {:else}
+    <div class="rc-grid">
+      {#each store.displayed as recipe (recipe.recipeId)}
+        <RecipeCard
+          {recipe}
+          isFavorite={!store.isViewingConnected && store.favoriteIds.has(recipe.recipeId)}
+          isReadOnly={store.isViewingConnected}
+          sharedFromName={store.isViewingConnected ? store.selectedConnectedName : null}
+          onClick={openDrawer}
+          onToggleFavorite={(r) => store.toggleFavorite(r.recipeId)}
+        />
+      {/each}
+    </div>
+  {/if}
+</div>
+
+<RecipeDetailDrawer
+  open={drawerOpen}
+  summary={drawerRecipe}
+  connectedId={store.selectedConnectedId}
+  isReadOnly={store.isViewingConnected}
+  connectedName={store.selectedConnectedName}
+  onClose={closeDrawer}
+  onEdit={handleEdit}
+  onDelete={requestDelete}
+  onCopy={handleCopy}
+  onAddToMealPlan={handleAddToMealPlan}
+/>
+
+<ImportDialog
+  open={importOpen}
+  onClose={() => {
+    importOpen = false;
+    onImportClose?.();
+  }}
+  {onImported}
+/>
+
+<ConfirmDialog
+  open={deleteOpen}
+  danger
+  title="Delete Recipe"
+  message={deleteTarget
+    ? `Are you sure you want to delete "${deleteTarget.name}"? This action cannot be undone.`
+    : ''}
+  onCancel={() => {
+    deleteOpen = false;
+    deleteTarget = null;
+  }}
+  onConfirm={confirmDelete}
+/>
+
+<style>
+  .rc-container {
+    max-width: 1280px;
+    margin: 0 auto;
+    padding: 24px 16px 96px;
+  }
+  .rc-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-bottom: 16px;
+  }
+  .rc-title {
+    margin: 0;
+    font-size: 2.125rem;
+    font-weight: 400;
+    color: var(--color-text);
+  }
+  .rc-header-actions {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .rc-controls {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    flex-wrap: wrap;
+    margin-bottom: 16px;
+  }
+  .rc-search {
+    flex: 1;
+    min-width: 200px;
+    font: inherit;
+    padding: 10px 14px;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text);
+  }
+  .rc-search:focus {
+    outline: none;
+    border-color: var(--color-primary);
+  }
+  .rc-fav-chip {
+    font: inherit;
+    font-size: 0.8125rem;
+    padding: 8px 16px;
+    border-radius: 18px;
+    border: 1px solid var(--color-line-strong);
+    background: transparent;
+    color: var(--color-text);
+    cursor: pointer;
+  }
+  .rc-fav-chip:hover {
+    background: var(--color-action-hover);
+  }
+  .rc-fav-chip-on {
+    background: var(--color-error);
+    border-color: var(--color-error);
+    color: #fff;
+  }
+  .rc-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 16px;
+    align-items: stretch;
+  }
+  .rc-skeleton {
+    height: 320px;
+    border-radius: var(--radius-md);
+    background: linear-gradient(
+      90deg,
+      var(--color-action-hover) 25%,
+      var(--color-divider) 37%,
+      var(--color-action-hover) 63%
+    );
+    background-size: 400% 100%;
+    animation: rc-shimmer 1.4s ease infinite;
+  }
+  @keyframes rc-shimmer {
+    0% {
+      background-position: 100% 50%;
+    }
+    100% {
+      background-position: 0 50%;
+    }
+  }
+  .rc-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    min-height: 360px;
+    gap: 8px;
+  }
+  .rc-empty-title {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 400;
+  }
+  .rc-empty-hint {
+    margin: 0 0 12px;
+    color: var(--color-text-muted);
+  }
+  .rc-inline-error {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 16px;
+    margin-bottom: 16px;
+    background: rgba(229, 57, 53, 0.08);
+    border-left: 4px solid var(--color-error);
+    border-radius: var(--radius-sm);
+    color: var(--color-error);
+    font-size: 0.875rem;
+  }
+  .rc-retry {
+    font: inherit;
+    border: none;
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+    padding: 4px 12px;
+    background: transparent;
+    color: var(--color-error);
+    font-weight: 500;
+  }
+  .rc-retry:hover {
+    background: rgba(229, 57, 53, 0.12);
+  }
+  .rc-btn-solid,
+  .rc-btn-outline {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    min-height: 40px;
+    font-weight: 500;
+  }
+  .rc-btn-solid {
+    border: none;
+    background: var(--color-primary);
+    color: #fff;
+  }
+  .rc-btn-solid:hover {
+    background: var(--color-primary-hover);
+  }
+  .rc-btn-outline {
+    border: 1px solid var(--color-secondary);
+    background: transparent;
+    color: var(--color-secondary);
+  }
+  .rc-btn-outline:hover {
+    background: var(--color-action-hover);
+  }
+</style>

--- a/frontend/app/src/lib/recipes/lib/api.ts
+++ b/frontend/app/src/lib/recipes/lib/api.ts
@@ -1,0 +1,187 @@
+import type {
+  RecipeListDto,
+  RecipeFullDto,
+  RecipeWriteRequest,
+  ParsedIngredientDto,
+  CategoryDto,
+  ConnectedHouseholdDto,
+  RecipeImportResultDto,
+  RecipeDraftData,
+  SaveDraftRequest,
+} from './types';
+
+const BASE = '/api/recipes';
+
+/**
+ * Thrown on any non-2xx response. `status` lets callers react to a rejection.
+ *
+ * ⚠ Carried from chores/shopping-list/meal-plan: the app re-executes empty-body
+ * API 404s through a Blazor `/not-found` page, so a server-side "not found" can
+ * arrive on the wire as an empty **400** (a bare DELETE 404 even surfaces as
+ * 405). Every recipes endpoint therefore returns a NON-EMPTY body on not-found,
+ * and the island treats ANY 4xx as a non-retryable client rejection → reconcile
+ * (refetch the list) + a calm toast. There is no retry branch (versionless).
+ */
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+
+  /** A non-retryable client rejection (validation / not found, incl. the empty-400 quirk). Any 4xx. */
+  get isClientRejection(): boolean {
+    return this.status >= 400 && this.status < 500;
+  }
+}
+
+async function request<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    // Same-origin cookie auth — the host page is already authenticated.
+    credentials: 'include',
+    headers: { Accept: 'application/json', ...(init?.headers ?? {}) },
+    ...init,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new ApiError(res.status, text || res.statusText);
+  }
+  // 204 No-Content (delete, save-draft, and the "no draft" GET) ⇒ undefined.
+  if (res.status === 204) return undefined as T;
+  return (await res.json()) as T;
+}
+
+function jsonBody(body: unknown): RequestInit {
+  return {
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  };
+}
+
+// ─── List + detail ────────────────────────────────────────────────────────
+
+/** #1 Own household's recipe grid + this user's favorite ids. Empty `q` ⇒ all. */
+export async function listRecipes(q: string): Promise<RecipeListDto> {
+  return request<RecipeListDto>(`${BASE}?q=${encodeURIComponent(q)}`);
+}
+
+/** #2 Full recipe (read drawer + edit load — superset). 404 → ApiError. */
+export async function getRecipe(recipeId: number): Promise<RecipeFullDto> {
+  return request<RecipeFullDto>(`${BASE}/${recipeId}`);
+}
+
+/** #3 Create → the saved recipe (201). */
+export async function createRecipe(body: RecipeWriteRequest): Promise<RecipeFullDto> {
+  return request<RecipeFullDto>(`${BASE}`, { method: 'POST', ...jsonBody(body) });
+}
+
+/** #4 Update (replaces ingredients wholesale) → the re-fetched recipe. */
+export async function updateRecipe(recipeId: number, body: RecipeWriteRequest): Promise<RecipeFullDto> {
+  return request<RecipeFullDto>(`${BASE}/${recipeId}`, { method: 'PUT', ...jsonBody(body) });
+}
+
+/** #5 Soft-delete → 204. A missing recipe → 404/empty-400. */
+export async function deleteRecipe(recipeId: number): Promise<void> {
+  await request<void>(`${BASE}/${recipeId}`, { method: 'DELETE' });
+}
+
+/** #6 Toggle favorite → the new state. */
+export async function toggleFavorite(recipeId: number): Promise<{ isFavorite: boolean }> {
+  return request<{ isFavorite: boolean }>(`${BASE}/${recipeId}/favorite`, { method: 'POST' });
+}
+
+// ─── Ingredient entry helpers ───────────────────────────────────────────────
+
+/** #7 Ingredient-name autocomplete. `<2` chars ⇒ [] (server guards). */
+export async function ingredientSuggestions(prefix: string): Promise<string[]> {
+  return request<string[]>(`${BASE}/ingredient-suggestions?prefix=${encodeURIComponent(prefix)}`);
+}
+
+/** #8 Server NL-parse one ingredient line (parse-on-blur). Empty text → 400. */
+export async function parseIngredient(text: string): Promise<ParsedIngredientDto> {
+  return request<ParsedIngredientDto>(`${BASE}/parse-ingredient`, { method: 'POST', ...jsonBody({ text }) });
+}
+
+/** #9 Bulk-paste preview — parse each non-blank line in one round-trip. */
+export async function parseIngredients(lines: string[]): Promise<ParsedIngredientDto[]> {
+  return request<ParsedIngredientDto[]>(`${BASE}/parse-ingredients`, { method: 'POST', ...jsonBody({ lines }) });
+}
+
+/** #10 Household categories for the entry category select. */
+export async function getCategories(): Promise<CategoryDto[]> {
+  return request<CategoryDto[]>(`${BASE}/categories`);
+}
+
+// ─── Images ─────────────────────────────────────────────────────────────────
+
+/**
+ * #11 Multipart upload → the stored path. NOT JSON — send FormData and let the
+ * browser set the multipart boundary (do not set Content-Type). 10 MB +
+ * jpg/png/gif/webp validated server-side (else 400).
+ */
+export async function uploadImage(file: File): Promise<{ imagePath: string }> {
+  const form = new FormData();
+  form.append('file', file);
+  return request<{ imagePath: string }>(`${BASE}/images`, { method: 'POST', body: form });
+}
+
+/** #12 Household image paths for the picker grid. */
+export async function listImages(): Promise<string[]> {
+  return request<string[]>(`${BASE}/images`);
+}
+
+// ─── Import ─────────────────────────────────────────────────────────────────
+
+/**
+ * #13 Scrape→create. On success returns the SAVED recipe id (then nav to edit).
+ * On a duplicate returns existingRecipeId/Name (unless `force`). On failure,
+ * errorType + partialData for the "Add Manually" fallback. May take ≤60s (Polly)
+ * — do NOT add a shorter client timeout.
+ */
+export async function importRecipe(url: string, force = false): Promise<RecipeImportResultDto> {
+  return request<RecipeImportResultDto>(`${BASE}/import`, { method: 'POST', ...jsonBody({ url, force }) });
+}
+
+// ─── Connected households ─────────────────────────────────────────────────────
+
+/** #14 Connected households for the selector. */
+export async function getConnections(): Promise<ConnectedHouseholdDto[]> {
+  return request<ConnectedHouseholdDto[]>(`${BASE}/connections`);
+}
+
+/** #15 A connected household's shared recipes (read-only; favoriteRecipeIds always []). 403 if not connected. */
+export async function listConnectedRecipes(chId: number, q: string): Promise<RecipeListDto> {
+  return request<RecipeListDto>(`${BASE}/connected/${chId}?q=${encodeURIComponent(q)}`);
+}
+
+/** #16 Read-only detail of a connected recipe (author stripped). 403 if not connected. */
+export async function getConnectedRecipe(chId: number, recipeId: number): Promise<RecipeFullDto> {
+  return request<RecipeFullDto>(`${BASE}/connected/${chId}/${recipeId}`);
+}
+
+/** #17 Copy a connected recipe into my household → the new recipe id (201). */
+export async function copyConnectedRecipe(chId: number, recipeId: number): Promise<{ recipeId: number }> {
+  return request<{ recipeId: number }>(`${BASE}/connected/${chId}/${recipeId}/copy`, { method: 'POST' });
+}
+
+// ─── Drafts (autosave) ────────────────────────────────────────────────────────
+
+/** #18 Load a draft. `recipeId` omitted ⇒ the new-recipe draft. 204 (no draft) ⇒ null. */
+export async function getDraft(recipeId?: number | null): Promise<RecipeDraftData | null> {
+  const qs = recipeId != null ? `?recipeId=${recipeId}` : '';
+  const draft = await request<RecipeDraftData | undefined>(`${BASE}/draft${qs}`);
+  return draft ?? null;
+}
+
+/** #19 Save a draft (flat body: recipeId + draft fields) → 204. */
+export async function saveDraft(body: SaveDraftRequest): Promise<void> {
+  await request<void>(`${BASE}/draft`, { method: 'PUT', ...jsonBody(body) });
+}
+
+/** #20 Delete a draft → 204 (idempotent). `recipeId` omitted ⇒ the new-recipe draft. */
+export async function deleteDraft(recipeId?: number | null): Promise<void> {
+  const qs = recipeId != null ? `?recipeId=${recipeId}` : '';
+  await request<void>(`${BASE}/draft${qs}`, { method: 'DELETE' });
+}

--- a/frontend/app/src/lib/recipes/lib/avatar.ts
+++ b/frontend/app/src/lib/recipes/lib/avatar.ts
@@ -1,0 +1,9 @@
+// Initials fallback for an author avatar when there's no picture URL. The server
+// sends only createdByName + createdByPictureUrl (User has no color field), so the
+// island derives initials client-side (mirrors User.Initials: first + last word).
+export function initials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return '?';
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}

--- a/frontend/app/src/lib/recipes/lib/components/BasicInfoSection.svelte
+++ b/frontend/app/src/lib/recipes/lib/components/BasicInfoSection.svelte
@@ -1,0 +1,191 @@
+<script lang="ts">
+  // Basic-info form section (mirrors RecipeEdit.razor:73-131): name (required),
+  // description, prep/cook/servings, source URL, and the recipe-type select.
+  // Also shows the "Imported from {domain}" notice for an edited imported recipe.
+  import { recipeEditStore } from '../recipeEditStore.svelte';
+  import { RECIPE_TYPES, recipeTypeLabel } from '../recipeType';
+
+  const store = recipeEditStore;
+
+  function domainOf(url: string): string {
+    try {
+      return new URL(url).host.replace(/^www\./, '');
+    } catch {
+      return url;
+    }
+  }
+
+  function isSafeUrl(url: string): boolean {
+    try {
+      const u = new URL(url);
+      return u.protocol === 'http:' || u.protocol === 'https:';
+    } catch {
+      return false;
+    }
+  }
+</script>
+
+<section class="rc-paper">
+  {#if store.isEdit && store.form.sourceUrl.trim()}
+    <div class="rc-import-note">
+      <span aria-hidden="true">☁</span>
+      <span>
+        Imported from
+        {#if isSafeUrl(store.form.sourceUrl)}
+          <a href={store.form.sourceUrl} target="_blank" rel="noopener noreferrer"
+            >{domainOf(store.form.sourceUrl)}</a
+          >
+        {:else}
+          {domainOf(store.form.sourceUrl)}
+        {/if}
+      </span>
+    </div>
+  {/if}
+
+  <h2 class="rc-section-title">Basic Info</h2>
+
+  <label class="rc-field">
+    <span class="rc-field-label">Recipe Name <span class="rc-req">*</span></span>
+    <input
+      type="text"
+      class="rc-input"
+      bind:value={store.form.name}
+      oninput={() => store.onEdit()}
+      required
+    />
+  </label>
+
+  <label class="rc-field">
+    <span class="rc-field-label">Description</span>
+    <textarea
+      class="rc-input rc-textarea"
+      rows="2"
+      bind:value={store.form.description}
+      oninput={() => store.onEdit()}
+      placeholder="Brief introduction to the recipe"
+    ></textarea>
+  </label>
+
+  <div class="rc-row3">
+    <label class="rc-field">
+      <span class="rc-field-label">Prep Time (min)</span>
+      <input
+        type="number"
+        class="rc-input"
+        min="0"
+        bind:value={store.form.prepTimeMinutes}
+        oninput={() => store.onEdit()}
+      />
+    </label>
+    <label class="rc-field">
+      <span class="rc-field-label">Cook Time (min)</span>
+      <input
+        type="number"
+        class="rc-input"
+        min="0"
+        bind:value={store.form.cookTimeMinutes}
+        oninput={() => store.onEdit()}
+      />
+    </label>
+    <label class="rc-field">
+      <span class="rc-field-label">Servings</span>
+      <input
+        type="number"
+        class="rc-input"
+        min="1"
+        bind:value={store.form.servings}
+        oninput={() => store.onEdit()}
+      />
+    </label>
+  </div>
+
+  <label class="rc-field">
+    <span class="rc-field-label">Source URL (optional)</span>
+    <input
+      type="url"
+      class="rc-input"
+      bind:value={store.form.sourceUrl}
+      oninput={() => store.onEdit()}
+      placeholder="Link to original recipe"
+    />
+  </label>
+
+  <label class="rc-field">
+    <span class="rc-field-label">Recipe Type</span>
+    <select class="rc-input" bind:value={store.form.recipeType} onchange={() => store.onEdit()}>
+      {#each RECIPE_TYPES as type (type)}
+        <option value={type}>{recipeTypeLabel(type)}</option>
+      {/each}
+    </select>
+  </label>
+</section>
+
+<style>
+  .rc-paper {
+    background: var(--color-surface);
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-1);
+    padding: 16px;
+    margin-bottom: 16px;
+  }
+  .rc-section-title {
+    margin: 0 0 12px;
+    font-size: 1.125rem;
+    font-weight: 500;
+  }
+  .rc-import-note {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 14px;
+    margin-bottom: 16px;
+    border-radius: var(--radius-sm);
+    background: rgba(30, 136, 229, 0.08);
+    border-left: 4px solid var(--color-info);
+    font-size: 0.875rem;
+  }
+  .rc-import-note a {
+    color: var(--color-info);
+  }
+  .rc-field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-bottom: 12px;
+  }
+  .rc-field-label {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .rc-req {
+    color: var(--color-error);
+  }
+  .rc-input {
+    font: inherit;
+    padding: 10px 12px;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text);
+    width: 100%;
+  }
+  .rc-input:focus {
+    outline: none;
+    border-color: var(--color-primary);
+  }
+  .rc-textarea {
+    resize: vertical;
+    min-height: 60px;
+  }
+  .rc-row3 {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 12px;
+  }
+  @media (max-width: 600px) {
+    .rc-row3 {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/frontend/app/src/lib/recipes/lib/components/BulkPasteDialog.svelte
+++ b/frontend/app/src/lib/recipes/lib/components/BulkPasteDialog.svelte
@@ -1,0 +1,309 @@
+<script lang="ts">
+  // Bulk-paste dialog (mirrors BulkPasteDialog.razor): a multi-line textarea →
+  // POST /parse-ingredients (one round-trip) → a preview list (qty/unit/name/notes
+  // + an incomplete-parse warning) → import all into the edit form.
+  import type { NewIngredientInput } from '../recipeEditStore.svelte';
+  import type { ParsedIngredientDto } from '../types';
+  import { parseIngredients } from '../api';
+
+  interface Props {
+    open: boolean;
+    categories: string[];
+    onClose: () => void;
+    onImport: (rows: NewIngredientInput[]) => void;
+  }
+
+  let { open, categories, onClose, onImport }: Props = $props();
+
+  let dialogEl: HTMLDialogElement | null = $state(null);
+  let pastedText = $state('');
+  let parsed = $state<ParsedIngredientDto[]>([]);
+  let parsing = $state(false);
+  let parseTimer: ReturnType<typeof setTimeout> | null = null;
+
+  $effect(() => {
+    if (!dialogEl) return;
+    if (open && !dialogEl.open) dialogEl.showModal();
+    else if (!open && dialogEl.open) dialogEl.close();
+  });
+
+  function findCategory(suggested: string): string {
+    const match = categories.find((c) => c.toLowerCase() === suggested.toLowerCase());
+    return match ?? categories[0] ?? 'Pantry';
+  }
+
+  function onText(value: string): void {
+    pastedText = value;
+    if (parseTimer) clearTimeout(parseTimer);
+    const lines = value
+      .split(/\r?\n/)
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0);
+    if (lines.length === 0) {
+      parsed = [];
+      return;
+    }
+    parseTimer = setTimeout(async () => {
+      parsing = true;
+      try {
+        parsed = await parseIngredients(lines);
+      } catch {
+        parsed = [];
+      } finally {
+        parsing = false;
+      }
+    }, 300);
+  }
+
+  function removeRow(index: number): void {
+    parsed = parsed.filter((_, i) => i !== index);
+  }
+
+  function reset(): void {
+    pastedText = '';
+    parsed = [];
+    parsing = false;
+  }
+
+  function handleClose(): void {
+    reset();
+    onClose();
+  }
+
+  function importAll(): void {
+    const rows: NewIngredientInput[] = parsed.map((p) => ({
+      name: p.name,
+      quantity: p.quantity,
+      unit: p.unit,
+      category: findCategory(p.suggestedCategory),
+      notes: p.notes,
+    }));
+    onImport(rows);
+    reset();
+    onClose();
+  }
+</script>
+
+<dialog bind:this={dialogEl} onclose={handleClose} class="rc-dialog">
+  {#if open}
+    <header class="rc-dialog-head">
+      <h2>Bulk Paste Ingredients</h2>
+      <button type="button" class="rc-dialog-x" aria-label="Close" onclick={handleClose}>×</button>
+    </header>
+
+    <div class="rc-dialog-body">
+      <p class="rc-bulk-intro">
+        Paste multiple ingredients (one per line). Each line is parsed into structured fields.
+      </p>
+      <textarea
+        class="rc-input rc-bulk-textarea"
+        rows="8"
+        placeholder="2 cups flour&#10;1/2 lb chicken, boneless&#10;3 cloves garlic, minced"
+        value={pastedText}
+        oninput={(e) => onText(e.currentTarget.value)}
+      ></textarea>
+
+      {#if parsing}
+        <p class="rc-bulk-status">Parsing…</p>
+      {:else if parsed.length > 0}
+        <p class="rc-bulk-status">Parsed Ingredients ({parsed.length})</p>
+        <div class="rc-bulk-list">
+          {#each parsed as p, i (i)}
+            <div class="rc-bulk-row">
+              <div class="rc-bulk-row-head">
+                <span class="rc-bulk-name">{p.name}</span>
+                <button type="button" class="rc-bulk-del" aria-label="Remove" onclick={() => removeRow(i)}
+                  >×</button
+                >
+              </div>
+              <div class="rc-bulk-fields">
+                <span><strong>Qty:</strong> {p.quantity ?? '—'}</span>
+                <span><strong>Unit:</strong> {p.unit ?? '—'}</span>
+              </div>
+              {#if p.notes}
+                <div class="rc-bulk-note"><strong>Notes:</strong> {p.notes}</div>
+              {/if}
+              {#if !p.isComplete}
+                <div class="rc-bulk-warn">Incomplete parse — review and edit after import.</div>
+              {/if}
+            </div>
+          {/each}
+        </div>
+      {/if}
+    </div>
+
+    <footer class="rc-dialog-actions">
+      <button type="button" class="rc-btn-ghost" onclick={handleClose}>Cancel</button>
+      <button type="button" class="rc-btn-solid" onclick={importAll} disabled={parsed.length === 0}>
+        Import {parsed.length} Ingredient{parsed.length !== 1 ? 's' : ''}
+      </button>
+    </footer>
+  {/if}
+</dialog>
+
+<style>
+  .rc-dialog[open] {
+    position: fixed;
+    inset: 0;
+    margin: auto;
+    border: none;
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text);
+    padding: 0;
+    width: min(600px, calc(100vw - 32px));
+    max-height: calc(100vh - 32px);
+    box-shadow: var(--shadow-4);
+    display: flex;
+    flex-direction: column;
+  }
+  .rc-dialog::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+  }
+  .rc-dialog-head {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 16px 16px 12px 24px;
+    border-bottom: 1px solid var(--color-line);
+  }
+  .rc-dialog-head h2 {
+    margin: 0;
+    flex: 1;
+    font-size: 1.25rem;
+    font-weight: 500;
+  }
+  .rc-dialog-x {
+    flex-shrink: 0;
+    width: 36px;
+    height: 36px;
+    display: grid;
+    place-items: center;
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
+    border-radius: var(--radius-sm);
+    font-size: 1.4rem;
+    line-height: 1;
+    cursor: pointer;
+  }
+  .rc-dialog-x:hover {
+    background: var(--color-action-hover);
+    color: var(--color-text);
+  }
+  .rc-dialog-body {
+    overflow-y: auto;
+    padding: 16px 24px;
+    flex: 1;
+  }
+  .rc-bulk-intro {
+    margin: 0 0 12px;
+    font-size: 0.9375rem;
+  }
+  .rc-input {
+    font: inherit;
+    padding: 10px 12px;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text);
+    width: 100%;
+  }
+  .rc-input:focus {
+    outline: none;
+    border-color: var(--color-primary);
+  }
+  .rc-bulk-textarea {
+    resize: vertical;
+    min-height: 140px;
+  }
+  .rc-bulk-status {
+    margin: 16px 0 8px;
+    font-size: 0.875rem;
+    font-weight: 500;
+  }
+  .rc-bulk-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    max-height: 360px;
+    overflow-y: auto;
+  }
+  .rc-bulk-row {
+    padding: 8px 12px;
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-sm);
+    background: var(--color-background);
+  }
+  .rc-bulk-row-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+  }
+  .rc-bulk-name {
+    font-weight: 500;
+  }
+  .rc-bulk-del {
+    border: none;
+    background: transparent;
+    color: var(--color-error);
+    font-size: 1.2rem;
+    line-height: 1;
+    cursor: pointer;
+  }
+  .rc-bulk-fields {
+    display: flex;
+    gap: 16px;
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+    margin-top: 4px;
+  }
+  .rc-bulk-note {
+    font-size: 0.8125rem;
+    margin-top: 4px;
+  }
+  .rc-bulk-warn {
+    margin-top: 6px;
+    padding: 6px 10px;
+    border-radius: var(--radius-sm);
+    background: rgba(251, 140, 0, 0.12);
+    color: var(--color-warning);
+    font-size: 0.8125rem;
+  }
+  .rc-dialog-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 12px 24px calc(16px + env(safe-area-inset-bottom, 0px));
+    border-top: 1px solid var(--color-line);
+  }
+  .rc-btn-ghost,
+  .rc-btn-solid {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    border: none;
+    cursor: pointer;
+    min-height: 44px;
+    font-weight: 500;
+  }
+  .rc-btn-ghost {
+    background: transparent;
+    color: var(--color-text-muted);
+  }
+  .rc-btn-ghost:hover {
+    background: var(--color-action-hover);
+  }
+  .rc-btn-solid {
+    background: var(--color-primary);
+    color: #fff;
+  }
+  .rc-btn-solid:hover:not(:disabled) {
+    background: var(--color-primary-hover);
+  }
+  .rc-btn-solid:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+</style>

--- a/frontend/app/src/lib/recipes/lib/components/ConnectedHouseholdSelector.svelte
+++ b/frontend/app/src/lib/recipes/lib/components/ConnectedHouseholdSelector.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+  // "My Recipes" + a chip per connected household + a "manage connections" link.
+  // Mirrors Recipes.razor:55-79. Shown only when connections exist.
+  import type { ConnectedHouseholdDto } from '../types';
+
+  interface Props {
+    connections: ConnectedHouseholdDto[];
+    selectedId: number | null;
+    onSelect: (id: number | null) => void;
+  }
+
+  let { connections, selectedId, onSelect }: Props = $props();
+</script>
+
+<div class="rc-selector">
+  <button
+    type="button"
+    class="rc-chip"
+    class:rc-chip-active={selectedId == null}
+    onclick={() => onSelect(null)}
+  >
+    My Recipes
+  </button>
+  {#each connections as hh (hh.householdId)}
+    <button
+      type="button"
+      class="rc-chip"
+      class:rc-chip-active={selectedId === hh.householdId}
+      onclick={() => onSelect(hh.householdId)}
+    >
+      {hh.householdName}
+    </button>
+  {/each}
+  <a
+    class="rc-manage"
+    href="/settings/connections"
+    title="Manage family connections"
+    aria-label="Manage family connections">＋</a
+  >
+</div>
+
+<style>
+  .rc-selector {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-bottom: 16px;
+  }
+  .rc-chip {
+    font: inherit;
+    font-size: 0.8125rem;
+    padding: 6px 14px;
+    border-radius: 16px;
+    border: 1px solid var(--color-line-strong);
+    background: transparent;
+    color: var(--color-text);
+    cursor: pointer;
+  }
+  .rc-chip:hover {
+    background: var(--color-action-hover);
+  }
+  .rc-chip-active {
+    background: var(--color-primary);
+    border-color: var(--color-primary);
+    color: #fff;
+  }
+  .rc-chip-active:hover {
+    background: var(--color-primary-hover);
+  }
+  .rc-manage {
+    display: grid;
+    place-items: center;
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    color: var(--color-primary);
+    text-decoration: none;
+    font-size: 1.1rem;
+    line-height: 1;
+  }
+  .rc-manage:hover {
+    background: var(--color-action-hover);
+  }
+</style>

--- a/frontend/app/src/lib/recipes/lib/components/ImagePickerDialog.svelte
+++ b/frontend/app/src/lib/recipes/lib/components/ImagePickerDialog.svelte
@@ -1,0 +1,248 @@
+<script lang="ts">
+  // Household image picker (mirrors ImagePickerDialog.razor): a grid of the
+  // household's uploaded images (GET /images), click to select, confirm to apply.
+  import { listImages, ApiError } from '../api';
+
+  interface Props {
+    open: boolean;
+    currentImage: string | null;
+    onClose: () => void;
+    onSelect: (path: string) => void;
+  }
+
+  let { open, currentImage, onClose, onSelect }: Props = $props();
+
+  let dialogEl: HTMLDialogElement | null = $state(null);
+  let images = $state<string[]>([]);
+  let loading = $state(false);
+  let error = $state<string | null>(null);
+  let selected = $state<string | null>(null);
+  // Re-fetch once per open (the grid can change between opens).
+  let loadedWhileOpen = false;
+
+  $effect(() => {
+    if (!dialogEl) return;
+    if (open && !dialogEl.open) {
+      dialogEl.showModal();
+      if (!loadedWhileOpen) {
+        loadedWhileOpen = true;
+        selected = currentImage;
+        void load();
+      }
+    } else if (!open && dialogEl.open) {
+      dialogEl.close();
+    }
+    if (!open) loadedWhileOpen = false;
+  });
+
+  async function load(): Promise<void> {
+    loading = true;
+    error = null;
+    try {
+      images = await listImages();
+    } catch (e) {
+      error = e instanceof ApiError ? `Couldn't load images (HTTP ${e.status}).` : "Couldn't load images.";
+    } finally {
+      loading = false;
+    }
+  }
+
+  function toggle(image: string): void {
+    selected = selected === image ? null : image;
+  }
+
+  function confirm(): void {
+    if (selected) {
+      onSelect(selected);
+      onClose();
+    }
+  }
+</script>
+
+<dialog bind:this={dialogEl} onclose={onClose} class="rc-dialog">
+  {#if open}
+    <header class="rc-dialog-head">
+      <h2>Select Image</h2>
+      <button type="button" class="rc-dialog-x" aria-label="Close" onclick={onClose}>×</button>
+    </header>
+
+    <div class="rc-dialog-body">
+      {#if loading}
+        <div class="rc-picker-status">Loading images…</div>
+      {:else if error}
+        <div class="rc-picker-error" role="alert">{error}</div>
+      {:else if images.length === 0}
+        <div class="rc-picker-status">No images found. Upload an image first using the file picker.</div>
+      {:else}
+        <p class="rc-picker-intro">Click an image to select it. These are all images uploaded for your household.</p>
+        <div class="rc-picker-grid">
+          {#each images as image (image)}
+            <button
+              type="button"
+              class="rc-picker-item"
+              class:rc-picker-selected={selected === image}
+              onclick={() => toggle(image)}
+              aria-pressed={selected === image}
+            >
+              <img src={image} alt="Recipe option" />
+              {#if selected === image}
+                <span class="rc-picker-check" aria-hidden="true">✓</span>
+              {/if}
+            </button>
+          {/each}
+        </div>
+      {/if}
+    </div>
+
+    <footer class="rc-dialog-actions">
+      <button type="button" class="rc-btn-ghost" onclick={onClose}>Cancel</button>
+      <button type="button" class="rc-btn-solid" onclick={confirm} disabled={!selected}>Select Image</button>
+    </footer>
+  {/if}
+</dialog>
+
+<style>
+  .rc-dialog[open] {
+    position: fixed;
+    inset: 0;
+    margin: auto;
+    border: none;
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text);
+    padding: 0;
+    width: min(640px, calc(100vw - 32px));
+    max-height: calc(100vh - 32px);
+    box-shadow: var(--shadow-4);
+    display: flex;
+    flex-direction: column;
+  }
+  .rc-dialog::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+  }
+  .rc-dialog-head {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 16px 16px 12px 24px;
+    border-bottom: 1px solid var(--color-line);
+  }
+  .rc-dialog-head h2 {
+    margin: 0;
+    flex: 1;
+    font-size: 1.25rem;
+    font-weight: 500;
+  }
+  .rc-dialog-x {
+    flex-shrink: 0;
+    width: 36px;
+    height: 36px;
+    display: grid;
+    place-items: center;
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
+    border-radius: var(--radius-sm);
+    font-size: 1.4rem;
+    line-height: 1;
+    cursor: pointer;
+  }
+  .rc-dialog-x:hover {
+    background: var(--color-action-hover);
+    color: var(--color-text);
+  }
+  .rc-dialog-body {
+    overflow-y: auto;
+    padding: 16px 24px;
+    flex: 1;
+  }
+  .rc-picker-intro {
+    margin: 0 0 12px;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+  .rc-picker-status {
+    padding: 24px 0;
+    text-align: center;
+    color: var(--color-text-muted);
+  }
+  .rc-picker-error {
+    padding: 12px 16px;
+    border-left: 4px solid var(--color-error);
+    background: rgba(229, 57, 53, 0.08);
+    color: var(--color-error);
+    border-radius: var(--radius-sm);
+    font-size: 0.875rem;
+  }
+  .rc-picker-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 12px;
+  }
+  .rc-picker-item {
+    position: relative;
+    padding: 0;
+    aspect-ratio: 1;
+    border-radius: 8px;
+    overflow: hidden;
+    cursor: pointer;
+    border: 3px solid transparent;
+    background: var(--color-action-hover);
+  }
+  .rc-picker-item:hover {
+    border-color: var(--color-primary);
+  }
+  .rc-picker-selected {
+    border-color: var(--color-success);
+  }
+  .rc-picker-item img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+  .rc-picker-check {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    background: rgba(0, 0, 0, 0.3);
+    color: var(--color-success);
+    font-size: 2rem;
+  }
+  .rc-dialog-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 12px 24px calc(16px + env(safe-area-inset-bottom, 0px));
+    border-top: 1px solid var(--color-line);
+  }
+  .rc-btn-ghost,
+  .rc-btn-solid {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    border: none;
+    cursor: pointer;
+    min-height: 44px;
+    font-weight: 500;
+  }
+  .rc-btn-ghost {
+    background: transparent;
+    color: var(--color-text-muted);
+  }
+  .rc-btn-ghost:hover {
+    background: var(--color-action-hover);
+  }
+  .rc-btn-solid {
+    background: var(--color-primary);
+    color: #fff;
+  }
+  .rc-btn-solid:hover:not(:disabled) {
+    background: var(--color-primary-hover);
+  }
+  .rc-btn-solid:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+</style>

--- a/frontend/app/src/lib/recipes/lib/components/ImageSection.svelte
+++ b/frontend/app/src/lib/recipes/lib/components/ImageSection.svelte
@@ -1,0 +1,133 @@
+<script lang="ts">
+  // Image form section (mirrors RecipeEdit.razor:133-177): preview + remove,
+  // file upload (multipart via the store), and "Choose Existing" (opens the
+  // household image picker, hosted by EditApp).
+  import { recipeEditStore } from '../recipeEditStore.svelte';
+
+  interface Props {
+    onChooseExisting: () => void;
+  }
+
+  let { onChooseExisting }: Props = $props();
+
+  const store = recipeEditStore;
+
+  let fileInput: HTMLInputElement | null = $state(null);
+
+  async function onFileChange(e: Event): Promise<void> {
+    const input = e.currentTarget as HTMLInputElement;
+    const file = input.files?.[0];
+    if (file) await store.uploadImage(file);
+    input.value = ''; // allow re-selecting the same file
+  }
+</script>
+
+<section class="rc-paper">
+  <h2 class="rc-section-title">Image</h2>
+
+  {#if store.form.imagePath}
+    <div class="rc-image-preview">
+      <img src={store.form.imagePath} alt="Recipe" />
+      <button type="button" class="rc-image-remove" aria-label="Remove image" onclick={() => store.removeImage()}
+        >×</button
+      >
+    </div>
+  {/if}
+
+  <div class="rc-image-actions">
+    <button type="button" class="rc-btn-outline" onclick={() => fileInput?.click()}>
+      {store.form.imagePath ? 'Change Image' : 'Upload Image'}
+    </button>
+    <button type="button" class="rc-btn-outline rc-secondary" onclick={onChooseExisting}>
+      Choose Existing
+    </button>
+    <input
+      bind:this={fileInput}
+      type="file"
+      accept="image/*"
+      class="rc-file-hidden"
+      onchange={onFileChange}
+    />
+  </div>
+  <p class="rc-image-hint">Max 10 MB. Supported: JPG, PNG, GIF, WebP</p>
+</section>
+
+<style>
+  .rc-paper {
+    background: var(--color-surface);
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-1);
+    padding: 16px;
+    margin-bottom: 16px;
+  }
+  .rc-section-title {
+    margin: 0 0 12px;
+    font-size: 1.125rem;
+    font-weight: 500;
+  }
+  .rc-image-preview {
+    position: relative;
+    display: inline-block;
+    margin-bottom: 12px;
+  }
+  .rc-image-preview img {
+    width: 300px;
+    max-width: 100%;
+    height: 200px;
+    object-fit: cover;
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-2);
+    display: block;
+  }
+  .rc-image-remove {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    width: 28px;
+    height: 28px;
+    display: grid;
+    place-items: center;
+    border: none;
+    border-radius: 50%;
+    background: rgba(0, 0, 0, 0.55);
+    color: #fff;
+    font-size: 1.2rem;
+    line-height: 1;
+    cursor: pointer;
+  }
+  .rc-image-remove:hover {
+    background: rgba(0, 0, 0, 0.75);
+  }
+  .rc-image-actions {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .rc-file-hidden {
+    display: none;
+  }
+  .rc-image-hint {
+    margin: 6px 0 0;
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .rc-btn-outline {
+    font: inherit;
+    padding: 10px 18px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--color-primary);
+    background: transparent;
+    color: var(--color-primary);
+    cursor: pointer;
+    min-height: 40px;
+    font-weight: 500;
+  }
+  .rc-btn-outline:hover {
+    background: var(--color-action-hover);
+  }
+  .rc-secondary {
+    border-color: var(--color-secondary);
+    color: var(--color-secondary);
+  }
+</style>

--- a/frontend/app/src/lib/recipes/lib/components/ImportDialog.svelte
+++ b/frontend/app/src/lib/recipes/lib/components/ImportDialog.svelte
@@ -1,0 +1,334 @@
+<script lang="ts">
+  // Import-from-URL dialog (mirrors ImportRecipeDialog.razor): URL field, a
+  // supported-sites note, a spinner (YouTube variant warns it's slower), duplicate
+  // detection ("View Existing" / "Import Anyway"=force), and an error → "Add
+  // Manually" fallback. On success the parent navigates to /recipes/edit/{id}.
+  import { base } from '$app/paths';
+  import { goto } from '$app/navigation';
+  import { importRecipe, ApiError } from '../api';
+
+  interface Props {
+    open: boolean;
+    onClose: () => void;
+    onImported: (recipeId: number) => void;
+  }
+
+  let { open, onClose, onImported }: Props = $props();
+
+  let dialogEl: HTMLDialogElement | null = $state(null);
+  let url = $state('');
+  let importing = $state(false);
+  let error = $state<string | null>(null);
+  let existingId = $state<number | null>(null);
+  let showManual = $state(false);
+
+  let isYouTube = $derived(/youtube\.com|youtu\.be/i.test(url));
+
+  $effect(() => {
+    if (!dialogEl) return;
+    if (open && !dialogEl.open) {
+      dialogEl.showModal();
+    } else if (!open && dialogEl.open) {
+      dialogEl.close();
+    }
+  });
+
+  function reset(): void {
+    url = '';
+    importing = false;
+    error = null;
+    existingId = null;
+    showManual = false;
+  }
+
+  function handleClose(): void {
+    reset();
+    onClose();
+  }
+
+  async function doImport(force = false): Promise<void> {
+    if (!url.trim() || importing) return;
+    importing = true;
+    error = null;
+    showManual = false;
+    existingId = null;
+    try {
+      const res = await importRecipe(url.trim(), force);
+      if (res.success && res.recipeId != null) {
+        onImported(res.recipeId);
+        return;
+      }
+      if (res.existingRecipeId != null) {
+        existingId = res.existingRecipeId;
+        error = res.errorMessage ?? 'This recipe has already been imported.';
+        return;
+      }
+      error = res.errorMessage ?? 'Import failed for unknown reason.';
+      // Offer manual entry unless the URL itself was invalid.
+      showManual = res.errorType !== 'InvalidUrl';
+    } catch (e) {
+      error =
+        e instanceof ApiError
+          ? `Import failed (HTTP ${e.status}).`
+          : 'An error occurred during import.';
+      showManual = true;
+    } finally {
+      importing = false;
+    }
+  }
+
+  function viewExisting(): void {
+    if (existingId != null) void goto(`${base}/recipes/edit/${existingId}`);
+  }
+
+  function importAnyway(): void {
+    void doImport(true);
+  }
+
+  function addManually(): void {
+    void goto(`${base}/recipes/new`);
+  }
+</script>
+
+<dialog bind:this={dialogEl} onclose={handleClose} class="rc-dialog">
+  {#if open}
+    <header class="rc-dialog-head">
+      <h2>Import Recipe</h2>
+      <button type="button" class="rc-dialog-x" aria-label="Close" onclick={handleClose}>×</button>
+    </header>
+
+    <div class="rc-dialog-body">
+      <p class="rc-import-intro">Paste a recipe URL to import. Tested and working with:</p>
+      <p class="rc-import-sites">✓ AllRecipes • BBC Good Food • NYT Cooking • Serious Eats • YouTube</p>
+
+      <label class="rc-field">
+        <span class="rc-field-label">Recipe URL</span>
+        <input
+          type="url"
+          class="rc-input"
+          placeholder="https://www.allrecipes.com/recipe/..."
+          bind:value={url}
+          disabled={importing}
+        />
+      </label>
+
+      {#if importing}
+        <div class="rc-import-progress">
+          <span class="rc-spinner" aria-hidden="true"></span>
+          <span>
+            {isYouTube
+              ? 'Extracting recipe from video… This may take a moment.'
+              : 'Importing recipe…'}
+          </span>
+        </div>
+      {/if}
+
+      {#if error}
+        <div class="rc-import-alert" class:rc-alert-info={existingId != null}>
+          <p class="rc-alert-msg">{error}</p>
+          {#if existingId != null}
+            <div class="rc-alert-actions">
+              <button type="button" class="rc-text-btn" onclick={viewExisting}>View Existing</button>
+              <button type="button" class="rc-text-btn" onclick={importAnyway}>Import Anyway</button>
+            </div>
+          {:else if showManual}
+            <button type="button" class="rc-text-btn" onclick={addManually}>Add Recipe Manually</button>
+          {/if}
+        </div>
+      {/if}
+    </div>
+
+    <footer class="rc-dialog-actions">
+      <button type="button" class="rc-btn-ghost" onclick={handleClose} disabled={importing}>Cancel</button>
+      <button
+        type="button"
+        class="rc-btn-solid"
+        onclick={() => doImport(false)}
+        disabled={importing || !url.trim()}
+      >
+        Import
+      </button>
+    </footer>
+  {/if}
+</dialog>
+
+<style>
+  .rc-dialog[open] {
+    position: fixed;
+    inset: 0;
+    margin: auto;
+    border: none;
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text);
+    padding: 0;
+    width: min(520px, calc(100vw - 32px));
+    max-height: calc(100vh - 32px);
+    box-shadow: var(--shadow-4);
+    display: flex;
+    flex-direction: column;
+  }
+  .rc-dialog::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+  }
+  .rc-dialog-head {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 16px 16px 12px 24px;
+    border-bottom: 1px solid var(--color-line);
+  }
+  .rc-dialog-head h2 {
+    margin: 0;
+    flex: 1;
+    font-size: 1.25rem;
+    font-weight: 500;
+  }
+  .rc-dialog-x {
+    flex-shrink: 0;
+    width: 36px;
+    height: 36px;
+    display: grid;
+    place-items: center;
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
+    border-radius: var(--radius-sm);
+    font-size: 1.4rem;
+    line-height: 1;
+    cursor: pointer;
+  }
+  .rc-dialog-x:hover {
+    background: var(--color-action-hover);
+    color: var(--color-text);
+  }
+  .rc-dialog-body {
+    overflow-y: auto;
+    padding: 16px 24px;
+    flex: 1;
+  }
+  .rc-import-intro {
+    margin: 0 0 8px;
+    font-size: 0.9375rem;
+  }
+  .rc-import-sites {
+    margin: 0 0 16px;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+  .rc-field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .rc-field-label {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .rc-input {
+    font: inherit;
+    padding: 10px 12px;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text);
+  }
+  .rc-input:focus {
+    outline: none;
+    border-color: var(--color-primary);
+  }
+  .rc-import-progress {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-top: 16px;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+  .rc-spinner {
+    width: 18px;
+    height: 18px;
+    border: 2px solid var(--color-line-strong);
+    border-top-color: var(--color-primary);
+    border-radius: 50%;
+    animation: rc-spin 0.8s linear infinite;
+  }
+  @keyframes rc-spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+  .rc-import-alert {
+    margin-top: 16px;
+    padding: 12px 16px;
+    border-radius: var(--radius-sm);
+    border-left: 4px solid var(--color-warning);
+    background: rgba(251, 140, 0, 0.08);
+  }
+  .rc-alert-info {
+    border-left-color: var(--color-info);
+    background: rgba(30, 136, 229, 0.08);
+  }
+  .rc-alert-msg {
+    margin: 0;
+    font-size: 0.875rem;
+  }
+  .rc-alert-actions {
+    display: flex;
+    gap: 12px;
+    margin-top: 8px;
+  }
+  .rc-text-btn {
+    font: inherit;
+    background: transparent;
+    border: none;
+    color: var(--color-primary);
+    cursor: pointer;
+    font-size: 0.875rem;
+    font-weight: 500;
+    margin-top: 8px;
+    padding: 0;
+  }
+  .rc-alert-actions .rc-text-btn {
+    margin-top: 0;
+  }
+  .rc-text-btn:hover {
+    text-decoration: underline;
+  }
+  .rc-dialog-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 12px 24px calc(16px + env(safe-area-inset-bottom, 0px));
+    border-top: 1px solid var(--color-line);
+  }
+  .rc-btn-ghost,
+  .rc-btn-solid {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    border: none;
+    cursor: pointer;
+    min-height: 44px;
+    font-weight: 500;
+  }
+  .rc-btn-ghost {
+    background: transparent;
+    color: var(--color-text-muted);
+  }
+  .rc-btn-ghost:hover:not(:disabled) {
+    background: var(--color-action-hover);
+  }
+  .rc-btn-solid {
+    background: var(--color-primary);
+    color: #fff;
+  }
+  .rc-btn-solid:hover:not(:disabled) {
+    background: var(--color-primary-hover);
+  }
+  .rc-btn-solid:disabled,
+  .rc-btn-ghost:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+</style>

--- a/frontend/app/src/lib/recipes/lib/components/IngredientEntry.svelte
+++ b/frontend/app/src/lib/recipes/lib/components/IngredientEntry.svelte
@@ -1,0 +1,309 @@
+<script lang="ts">
+  // Ingredient entry (mirrors IngredientEntry.razor): a raw NL input that parses
+  // on Enter/Tab/blur via POST /parse-ingredient, revealing editable qty / unit /
+  // name / category / notes fields. Unit autocomplete is a static list; the
+  // ingredient-name autocomplete pulls server suggestions (≥2 chars). A "Bulk
+  // Paste" button opens the bulk dialog (hosted by EditApp).
+  import type { NewIngredientInput } from '../recipeEditStore.svelte';
+  import { parseIngredient, ingredientSuggestions } from '../api';
+  import { showToast } from '$lib/shared/toast-store.svelte';
+
+  interface Props {
+    categories: string[];
+    onAdd: (input: NewIngredientInput) => void;
+    onBulkOpen: () => void;
+  }
+
+  let { categories, onAdd, onBulkOpen }: Props = $props();
+
+  const UNITS = [
+    'cup', 'cups', 'tbsp', 'tsp', 'oz', 'lb', 'lbs', 'g', 'kg', 'ml', 'l',
+    'clove', 'cloves', 'can', 'cans', 'bunch', 'slice', 'slices', 'piece', 'pieces',
+  ];
+
+  let rawInput = $state('');
+  let showParsed = $state(false);
+  let quantity = $state('');
+  let unit = $state('');
+  let name = $state('');
+  let category = $state('Pantry');
+  let notes = $state('');
+  let parsing = $state(false);
+
+  let nameSuggestions = $state<string[]>([]);
+  let suggestTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function findCategory(suggested: string): string {
+    const match = categories.find((c) => c.toLowerCase() === suggested.toLowerCase());
+    return match ?? categories[0] ?? 'Pantry';
+  }
+
+  async function parseInput(): Promise<void> {
+    if (!rawInput.trim() || parsing) return;
+    parsing = true;
+    try {
+      const parsed = await parseIngredient(rawInput);
+      quantity = parsed.quantity != null ? String(parsed.quantity) : '';
+      unit = parsed.unit ?? '';
+      name = parsed.name;
+      notes = parsed.notes ?? '';
+      category = findCategory(parsed.suggestedCategory);
+      showParsed = true;
+    } catch {
+      showToast({ message: "Couldn't parse that ingredient.", kind: 'error' });
+    } finally {
+      parsing = false;
+    }
+  }
+
+  async function add(): Promise<void> {
+    if (!showParsed) {
+      await parseInput();
+      if (!showParsed) return;
+    }
+    if (!name.trim()) return;
+    const q = quantity.trim() === '' ? null : Number(quantity);
+    onAdd({
+      name: name.trim(),
+      quantity: q != null && !Number.isNaN(q) ? q : null,
+      unit: unit.trim() === '' ? null : unit.trim(),
+      category,
+      notes: notes.trim() === '' ? null : notes.trim(),
+    });
+    reset();
+  }
+
+  function reset(): void {
+    rawInput = '';
+    showParsed = false;
+    quantity = '';
+    unit = '';
+    name = '';
+    category = categories[0] ?? 'Pantry';
+    notes = '';
+    nameSuggestions = [];
+  }
+
+  function handleKeyDown(e: KeyboardEvent): void {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      if (showParsed) void add();
+      else if (rawInput.trim()) void parseInput();
+    } else if (e.key === 'Tab' && !showParsed && rawInput.trim()) {
+      void parseInput();
+    }
+  }
+
+  function handleRawBlur(): void {
+    if (!showParsed && rawInput.trim()) void parseInput();
+  }
+
+  function onNameInput(value: string): void {
+    name = value;
+    if (suggestTimer) clearTimeout(suggestTimer);
+    if (value.trim().length < 2) {
+      nameSuggestions = [];
+      return;
+    }
+    suggestTimer = setTimeout(async () => {
+      try {
+        nameSuggestions = await ingredientSuggestions(value.trim());
+      } catch {
+        nameSuggestions = [];
+      }
+    }, 300);
+  }
+</script>
+
+<section class="rc-paper">
+  <div class="rc-entry-head">
+    <h3 class="rc-entry-title">Add Ingredients</h3>
+    <button type="button" class="rc-text-btn" onclick={onBulkOpen}>⧉ Bulk Paste</button>
+  </div>
+
+  <div class="rc-raw-row">
+    <input
+      type="text"
+      class="rc-input"
+      placeholder="Add ingredient (e.g., '2 cups flour' or '1/2 lb chicken, boneless')"
+      bind:value={rawInput}
+      onkeydown={handleKeyDown}
+      onblur={handleRawBlur}
+    />
+    <button type="button" class="rc-icon-add" aria-label="Parse / add" onclick={add}>＋</button>
+  </div>
+
+  {#if showParsed}
+    <div class="rc-parsed-grid">
+      <label class="rc-field rc-col-qty">
+        <span class="rc-field-label">Quantity</span>
+        <input type="text" class="rc-input" bind:value={quantity} />
+      </label>
+      <label class="rc-field rc-col-unit">
+        <span class="rc-field-label">Unit</span>
+        <input type="text" class="rc-input" list="rc-unit-list" bind:value={unit} />
+        <datalist id="rc-unit-list">
+          {#each UNITS as u (u)}
+            <option value={u}></option>
+          {/each}
+        </datalist>
+      </label>
+      <label class="rc-field rc-col-name">
+        <span class="rc-field-label">Ingredient</span>
+        <input
+          type="text"
+          class="rc-input"
+          list="rc-name-list"
+          value={name}
+          oninput={(e) => onNameInput(e.currentTarget.value)}
+        />
+        <datalist id="rc-name-list">
+          {#each nameSuggestions as s (s)}
+            <option value={s}></option>
+          {/each}
+        </datalist>
+      </label>
+      <label class="rc-field rc-col-cat">
+        <span class="rc-field-label">Category</span>
+        <select class="rc-input" bind:value={category}>
+          {#each categories as cat (cat)}
+            <option value={cat}>{cat}</option>
+          {/each}
+        </select>
+      </label>
+      <div class="rc-col-add">
+        <button type="button" class="rc-btn-solid" onclick={add}>Add</button>
+      </div>
+      <label class="rc-field rc-col-notes">
+        <span class="rc-field-label">Notes (optional)</span>
+        <input type="text" class="rc-input" bind:value={notes} />
+      </label>
+    </div>
+  {/if}
+</section>
+
+<style>
+  .rc-paper {
+    background: var(--color-surface);
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-1);
+    padding: 16px;
+    margin-bottom: 16px;
+  }
+  .rc-entry-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 12px;
+  }
+  .rc-entry-title {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 500;
+  }
+  .rc-text-btn {
+    font: inherit;
+    background: transparent;
+    border: none;
+    color: var(--color-primary);
+    cursor: pointer;
+    font-size: 0.875rem;
+    font-weight: 500;
+  }
+  .rc-text-btn:hover {
+    text-decoration: underline;
+  }
+  .rc-raw-row {
+    display: flex;
+    gap: 8px;
+    align-items: stretch;
+  }
+  .rc-input {
+    font: inherit;
+    padding: 10px 12px;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text);
+    width: 100%;
+  }
+  .rc-input:focus {
+    outline: none;
+    border-color: var(--color-primary);
+  }
+  .rc-icon-add {
+    flex-shrink: 0;
+    width: 44px;
+    border: 1px solid var(--color-primary);
+    background: transparent;
+    color: var(--color-primary);
+    border-radius: var(--radius-sm);
+    font-size: 1.3rem;
+    line-height: 1;
+    cursor: pointer;
+  }
+  .rc-icon-add:hover {
+    background: var(--color-action-hover);
+  }
+  .rc-parsed-grid {
+    display: grid;
+    grid-template-columns: repeat(12, 1fr);
+    gap: 12px;
+    margin-top: 12px;
+  }
+  .rc-field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .rc-field-label {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .rc-col-qty {
+    grid-column: span 2;
+  }
+  .rc-col-unit {
+    grid-column: span 2;
+  }
+  .rc-col-name {
+    grid-column: span 4;
+  }
+  .rc-col-cat {
+    grid-column: span 2;
+  }
+  .rc-col-add {
+    grid-column: span 2;
+    display: flex;
+    align-items: flex-end;
+  }
+  .rc-col-notes {
+    grid-column: span 12;
+  }
+  @media (max-width: 700px) {
+    .rc-col-qty,
+    .rc-col-unit,
+    .rc-col-name,
+    .rc-col-cat,
+    .rc-col-add,
+    .rc-col-notes {
+      grid-column: span 12;
+    }
+  }
+  .rc-btn-solid {
+    font: inherit;
+    width: 100%;
+    padding: 10px 16px;
+    border: none;
+    border-radius: var(--radius-sm);
+    background: var(--color-primary);
+    color: #fff;
+    cursor: pointer;
+    min-height: 44px;
+    font-weight: 500;
+  }
+  .rc-btn-solid:hover {
+    background: var(--color-primary-hover);
+  }
+</style>

--- a/frontend/app/src/lib/recipes/lib/components/IngredientList.svelte
+++ b/frontend/app/src/lib/recipes/lib/components/IngredientList.svelte
@@ -1,0 +1,197 @@
+<script lang="ts">
+  // Ingredient list (mirrors IngredientList.razor): drag-reorder via
+  // svelte-dnd-action (the chores pattern), edit (remove + re-add), and
+  // delete-with-undo (the undo lives on the toast). Quantities use the EXACT
+  // formatter (formatExactQuantity — entered values are precise).
+  import type { IngredientRow } from '../recipeEditStore.svelte';
+  import { formatExactQuantity } from '../quantity';
+  import { dndzone, type DndEvent } from 'svelte-dnd-action';
+
+  interface Props {
+    ingredients: IngredientRow[];
+    onReorder: (rows: IngredientRow[]) => void;
+    onEdit: (id: number) => void;
+    onRemove: (id: number) => void;
+  }
+
+  let { ingredients, onReorder, onEdit, onRemove }: Props = $props();
+
+  // Local copy svelte-dnd-action mutates during a drag; resynced from the source
+  // whenever we're NOT dragging (chores pattern — avoids fighting the library).
+  let rows = $state<IngredientRow[]>([]);
+  let dragging = $state(false);
+  $effect(() => {
+    if (!dragging) rows = [...ingredients];
+  });
+
+  function handleConsider(e: CustomEvent<DndEvent<IngredientRow>>): void {
+    dragging = true;
+    rows = e.detail.items;
+  }
+  function handleFinalize(e: CustomEvent<DndEvent<IngredientRow>>): void {
+    rows = e.detail.items;
+    onReorder([...rows]);
+    dragging = false;
+  }
+
+  function formatLine(ing: IngredientRow): string {
+    const parts: string[] = [];
+    if (ing.quantity != null) parts.push(formatExactQuantity(ing.quantity));
+    if (ing.unit) parts.push(ing.unit);
+    parts.push(ing.name);
+    return parts.join(' ');
+  }
+
+  function categoryColor(category: string): string {
+    switch (category) {
+      case 'Meat':
+        return 'var(--color-error)';
+      case 'Produce':
+        return 'var(--color-success)';
+      case 'Dairy':
+        return 'var(--color-warning)';
+      case 'Spices':
+        return 'var(--color-secondary)';
+      case 'Frozen':
+        return 'var(--color-info)';
+      case 'Beverages':
+        return 'var(--color-primary)';
+      default:
+        return 'var(--color-text-muted)';
+    }
+  }
+</script>
+
+<h3 class="rc-list-title">Ingredients ({ingredients.length})</h3>
+
+{#if ingredients.length === 0}
+  <div class="rc-list-empty">No ingredients yet. Use the form above to add ingredients.</div>
+{:else}
+  <ul
+    class="rc-ing-list"
+    use:dndzone={{ items: rows, flipDurationMs: 150, dropTargetStyle: {}, delayTouchStart: 250 }}
+    onconsider={handleConsider}
+    onfinalize={handleFinalize}
+  >
+    {#each rows as ing (ing.id)}
+      <li class="rc-ing-item">
+        <div class="rc-ing-main">
+          <span class="rc-ing-grip" aria-hidden="true">⠿</span>
+          <div class="rc-ing-text">
+            <span class="rc-ing-line">{formatLine(ing)}</span>
+            {#if ing.notes}
+              <span class="rc-ing-notes">{ing.notes}</span>
+            {/if}
+          </div>
+        </div>
+        <div class="rc-ing-actions">
+          <span class="rc-cat-chip" style="--chip-color: {categoryColor(ing.category)}">{ing.category}</span>
+          <button type="button" class="rc-ing-btn" aria-label="Edit ingredient" onclick={() => onEdit(ing.id)}
+            >✎</button
+          >
+          <button
+            type="button"
+            class="rc-ing-btn rc-ing-del"
+            aria-label="Delete ingredient"
+            onclick={() => onRemove(ing.id)}>🗑</button
+          >
+        </div>
+      </li>
+    {/each}
+  </ul>
+{/if}
+
+<style>
+  .rc-list-title {
+    margin: 0 0 8px;
+    font-size: 1rem;
+    font-weight: 500;
+  }
+  .rc-list-empty {
+    padding: 12px 16px;
+    border-radius: var(--radius-sm);
+    background: rgba(30, 136, 229, 0.08);
+    border-left: 4px solid var(--color-info);
+    font-size: 0.875rem;
+    color: var(--color-text);
+  }
+  .rc-ing-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-height: 60px;
+  }
+  .rc-ing-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 12px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-1);
+    cursor: grab;
+  }
+  .rc-ing-item:active {
+    cursor: grabbing;
+  }
+  .rc-ing-main {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+  }
+  .rc-ing-grip {
+    color: var(--color-text-disabled);
+    cursor: grab;
+  }
+  .rc-ing-text {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+  .rc-ing-line {
+    overflow-wrap: anywhere;
+  }
+  .rc-ing-notes {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .rc-ing-actions {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+  }
+  .rc-cat-chip {
+    font-size: 0.6875rem;
+    font-weight: 500;
+    padding: 2px 10px;
+    border-radius: 12px;
+    border: 1px solid var(--chip-color);
+    color: var(--chip-color);
+    white-space: nowrap;
+  }
+  .rc-ing-btn {
+    width: 32px;
+    height: 32px;
+    display: grid;
+    place-items: center;
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    font-size: 0.95rem;
+  }
+  .rc-ing-btn:hover {
+    background: var(--color-action-hover);
+  }
+  .rc-ing-del:hover {
+    color: var(--color-error);
+  }
+</style>

--- a/frontend/app/src/lib/recipes/lib/components/RecipeCard.svelte
+++ b/frontend/app/src/lib/recipes/lib/components/RecipeCard.svelte
@@ -1,0 +1,253 @@
+<script lang="ts">
+  // One recipe card in the grid. Mirrors RecipeCard.razor: image/placeholder,
+  // type chip (hidden for `main`), "imported" cloud icon, favorite heart (hidden
+  // when read-only/connected), title, author (pic-or-initials, or "Deleted user"),
+  // optional connected-household attribution, and the first-3 ingredient preview.
+  import type { RecipeListItemDto } from '../types';
+  import { recipeTypeShort, recipeTypeColor } from '../recipeType';
+  import { initials } from '../avatar';
+
+  interface Props {
+    recipe: RecipeListItemDto;
+    isFavorite: boolean;
+    isReadOnly: boolean;
+    sharedFromName: string | null;
+    onClick: (recipe: RecipeListItemDto) => void;
+    onToggleFavorite: (recipe: RecipeListItemDto) => void;
+  }
+
+  let { recipe, isFavorite, isReadOnly, sharedFromName, onClick, onToggleFavorite }: Props = $props();
+
+  let preview = $derived(
+    recipe.ingredientCount === 0
+      ? null
+      : recipe.ingredientPreview.join(', ') +
+          (recipe.ingredientCount > 3 ? `, +${recipe.ingredientCount - 3} more` : ''),
+  );
+
+  function handleFavorite(e: MouseEvent): void {
+    e.stopPropagation(); // don't open the drawer when tapping the heart
+    onToggleFavorite(recipe);
+  }
+</script>
+
+<button type="button" class="rc-card" onclick={() => onClick(recipe)}>
+  <div class="rc-card-image">
+    <img
+      src={recipe.imagePath ?? '/images/recipe-placeholder.svg'}
+      alt={recipe.name}
+      loading="lazy"
+    />
+    {#if !isReadOnly}
+      <span
+        class="rc-fav"
+        class:rc-fav-on={isFavorite}
+        role="button"
+        tabindex="0"
+        aria-label={isFavorite ? 'Remove from favorites' : 'Add to favorites'}
+        aria-pressed={isFavorite}
+        onclick={handleFavorite}
+        onkeydown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleFavorite(e as unknown as MouseEvent);
+          }
+        }}
+      >
+        {isFavorite ? '♥' : '♡'}
+      </span>
+    {/if}
+  </div>
+
+  <div class="rc-card-body">
+    <div class="rc-card-title-row">
+      <span class="rc-card-title">{recipe.name}</span>
+      <span class="rc-card-badges">
+        {#if recipe.recipeType !== 'main'}
+          <span class="rc-type-chip" style="--chip-color: {recipeTypeColor(recipe.recipeType)}">
+            {recipeTypeShort(recipe.recipeType)}
+          </span>
+        {/if}
+        {#if recipe.hasSourceUrl}
+          <span class="rc-imported" title="Imported from web" aria-label="Imported from web">☁</span>
+        {/if}
+      </span>
+    </div>
+
+    <div class="rc-card-author">
+      {#if recipe.createdByName}
+        {#if recipe.createdByPictureUrl}
+          <img class="rc-avatar" src={recipe.createdByPictureUrl} alt={recipe.createdByName} />
+        {:else}
+          <span class="rc-avatar rc-avatar-initials">{initials(recipe.createdByName)}</span>
+        {/if}
+        <span class="rc-author-name">{recipe.createdByName}</span>
+      {:else}
+        <span class="rc-avatar rc-avatar-initials" aria-hidden="true">∅</span>
+        <span class="rc-author-name rc-author-deleted">Deleted user</span>
+      {/if}
+    </div>
+
+    {#if sharedFromName}
+      <div class="rc-attribution">From {sharedFromName}</div>
+    {/if}
+
+    <div class="rc-card-ingredients">
+      {#if preview}
+        {preview}
+      {:else}
+        <span class="rc-no-ingredients">No ingredients</span>
+      {/if}
+    </div>
+  </div>
+</button>
+
+<style>
+  .rc-card {
+    font: inherit;
+    text-align: left;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    background: var(--color-surface);
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-1);
+    cursor: pointer;
+    padding: 0;
+    overflow: hidden;
+    color: var(--color-text);
+    transition:
+      transform 0.2s ease,
+      box-shadow 0.2s ease;
+  }
+  .rc-card:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-4);
+  }
+  .rc-card-image {
+    position: relative;
+    flex-shrink: 0;
+    height: 200px;
+    background: var(--color-action-hover);
+  }
+  .rc-card-image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+  .rc-fav {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    display: grid;
+    place-items: center;
+    width: 34px;
+    height: 34px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.92);
+    color: var(--color-text-muted);
+    font-size: 1.1rem;
+    line-height: 1;
+    cursor: pointer;
+    backdrop-filter: blur(4px);
+  }
+  .rc-fav:hover {
+    background: #fff;
+  }
+  .rc-fav-on {
+    color: var(--color-error);
+  }
+  .rc-card-body {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 120px;
+    padding: 16px;
+  }
+  .rc-card-title-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    margin-bottom: 8px;
+    min-height: 48px;
+  }
+  .rc-card-title {
+    flex: 1;
+    font-size: 1.125rem;
+    font-weight: 500;
+    line-height: 1.3;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+  .rc-card-badges {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+  }
+  .rc-type-chip {
+    font-size: 0.6875rem;
+    font-weight: 500;
+    padding: 2px 8px;
+    border-radius: 12px;
+    border: 1px solid var(--chip-color);
+    color: var(--chip-color);
+    white-space: nowrap;
+  }
+  .rc-imported {
+    color: var(--color-secondary);
+    font-size: 0.9rem;
+  }
+  .rc-card-author {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+  }
+  .rc-avatar {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    object-fit: cover;
+    flex-shrink: 0;
+  }
+  .rc-avatar-initials {
+    display: grid;
+    place-items: center;
+    background: var(--color-primary-soft);
+    color: #fff;
+    font-size: 0.625rem;
+    font-weight: 600;
+  }
+  .rc-author-name {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .rc-author-deleted {
+    font-style: italic;
+  }
+  .rc-attribution {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    margin-bottom: 4px;
+  }
+  .rc-card-ingredients {
+    margin-top: auto;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+  .rc-no-ingredients {
+    font-style: italic;
+  }
+</style>

--- a/frontend/app/src/lib/recipes/lib/components/RecipeDetailDrawer.svelte
+++ b/frontend/app/src/lib/recipes/lib/components/RecipeDetailDrawer.svelte
@@ -1,0 +1,572 @@
+<script lang="ts">
+  // Read-only detail slide-out (mirrors the Blazor MudDrawer at Recipes.razor:223-416).
+  // Lazy-fetches the full recipe on open — getRecipe (#2) for own recipes,
+  // getConnectedRecipe (#16) in connected mode. Hosts the live servings scaler
+  // (client-side rescale via quantity.ts), instructions via {@html} (server-
+  // sanitized), source link (safe-url guarded), and the action buttons.
+  import type { RecipeFullDto, RecipeIngredientFullDto, RecipeListItemDto } from '../types';
+  import { getRecipe, getConnectedRecipe, ApiError } from '../api';
+  import { initials } from '../avatar';
+  import {
+    formatScaledQuantity,
+    getScaledQuantity,
+    getScalingFactor,
+    getScalingLabel,
+  } from '../quantity';
+
+  interface Props {
+    open: boolean;
+    /** The card the drawer was opened from (fallback title + delete name). */
+    summary: RecipeListItemDto | null;
+    /** Connected household id when viewing a connected recipe (else null). */
+    connectedId: number | null;
+    isReadOnly: boolean;
+    connectedName: string | null;
+    onClose: () => void;
+    onEdit: (recipeId: number) => void;
+    onDelete: (summary: RecipeListItemDto) => void;
+    onCopy: (recipeId: number) => Promise<void>;
+    onAddToMealPlan: (name: string) => void;
+  }
+
+  let {
+    open,
+    summary,
+    connectedId,
+    isReadOnly,
+    connectedName,
+    onClose,
+    onEdit,
+    onDelete,
+    onCopy,
+    onAddToMealPlan,
+  }: Props = $props();
+
+  let detail = $state<RecipeFullDto | null>(null);
+  let loading = $state(false);
+  let error = $state<string | null>(null);
+  let scaledServings = $state(1);
+  let copying = $state(false);
+  // The `${connectedId}:${recipeId}` we last fetched — reopening the same recipe reuses it.
+  let loadedKey: string | null = null;
+
+  function keyFor(s: RecipeListItemDto): string {
+    return `${connectedId ?? ''}:${s.recipeId}`;
+  }
+
+  async function load(s: RecipeListItemDto): Promise<void> {
+    loading = true;
+    error = null;
+    try {
+      const full =
+        connectedId == null
+          ? await getRecipe(s.recipeId)
+          : await getConnectedRecipe(connectedId, s.recipeId);
+      detail = full;
+      scaledServings = full.servings ?? 1;
+      loadedKey = keyFor(s);
+    } catch (e) {
+      error =
+        e instanceof ApiError
+          ? `Couldn't load this recipe (HTTP ${e.status}).`
+          : "Couldn't load this recipe right now.";
+    } finally {
+      loading = false;
+    }
+  }
+
+  // Reactive lazy-load on open / recipe change (mirrors meal-plan RecipeDetailSheet).
+  // Guarded by the key so it settles after one load — NOT an unbounded loop.
+  $effect(() => {
+    if (open && summary && keyFor(summary) !== loadedKey) {
+      detail = null;
+      void load(summary);
+    }
+  });
+
+  let factor = $derived(detail ? getScalingFactor(detail.servings, scaledServings) : 1);
+  let title = $derived(detail?.name ?? summary?.name ?? '');
+  let hasTimeMeta = $derived(
+    detail != null && (detail.prepTimeMinutes != null || detail.cookTimeMinutes != null),
+  );
+  // Sort once when the detail changes (not on every render — e.g. each servings tick).
+  let sortedIngredients = $derived(
+    detail ? detail.ingredients.slice().sort((a, b) => a.sortOrder - b.sortOrder) : [],
+  );
+
+  function ingredientLine(ing: RecipeIngredientFullDto): string {
+    const parts: string[] = [];
+    if (ing.quantity != null) {
+      parts.push(formatScaledQuantity(getScaledQuantity(ing.quantity, factor)));
+    }
+    if (ing.unit) parts.push(ing.unit);
+    parts.push(ing.name);
+    if (ing.notes) parts.push(`(${ing.notes})`);
+    return parts.join(' ');
+  }
+
+  function isSafeUrl(url: string | null): boolean {
+    if (!url) return false;
+    try {
+      const u = new URL(url);
+      return u.protocol === 'http:' || u.protocol === 'https:';
+    } catch {
+      return false;
+    }
+  }
+
+  function increaseServings(): void {
+    scaledServings++;
+  }
+  function decreaseServings(): void {
+    if (scaledServings > 1) scaledServings--;
+  }
+  function resetServings(): void {
+    scaledServings = detail?.servings ?? 1;
+  }
+
+  async function handleCopy(): Promise<void> {
+    if (!detail) return;
+    copying = true;
+    try {
+      await onCopy(detail.recipeId);
+    } finally {
+      copying = false;
+    }
+  }
+</script>
+
+{#if open}
+  <button type="button" class="rc-drawer-scrim" aria-label="Close panel" onclick={onClose}></button>
+{/if}
+
+<aside class="rc-drawer" class:rc-drawer-open={open} aria-hidden={!open}>
+  <header class="rc-drawer-head">
+    <h2 class="rc-drawer-title">{title}</h2>
+    <button type="button" class="rc-drawer-x" aria-label="Close panel" onclick={onClose}>×</button>
+  </header>
+
+  <div class="rc-drawer-body">
+    {#if loading}
+      <div class="rc-drawer-loading">Loading recipe…</div>
+    {:else if error}
+      <div class="rc-drawer-error" role="alert">
+        <span>{error}</span>
+        {#if summary}
+          <button type="button" class="rc-retry" onclick={() => summary && load(summary)}>Retry</button>
+        {/if}
+      </div>
+    {:else if detail}
+      {#if detail.imagePath}
+        <div class="rc-detail-image">
+          <img src={detail.imagePath} alt={detail.name} />
+        </div>
+      {/if}
+
+      <div class="rc-detail-author">
+        {#if detail.createdByName}
+          {#if detail.createdByPictureUrl}
+            <img class="rc-avatar" src={detail.createdByPictureUrl} alt={detail.createdByName} />
+          {:else}
+            <span class="rc-avatar rc-avatar-initials">{initials(detail.createdByName)}</span>
+          {/if}
+          <span class="rc-detail-author-name">Added by {detail.createdByName}</span>
+        {:else}
+          <span class="rc-avatar rc-avatar-initials" aria-hidden="true">∅</span>
+          <span class="rc-detail-author-name rc-italic">Added by deleted user</span>
+        {/if}
+      </div>
+
+      {#if isReadOnly && connectedName}
+        <p class="rc-detail-from">From {connectedName}</p>
+      {/if}
+
+      {#if hasTimeMeta}
+        <div class="rc-detail-chips">
+          {#if detail.prepTimeMinutes != null}
+            <span class="rc-detail-chip rc-chip-info">Prep: {detail.prepTimeMinutes} min</span>
+          {/if}
+          {#if detail.cookTimeMinutes != null}
+            <span class="rc-detail-chip rc-chip-warn">Cook: {detail.cookTimeMinutes} min</span>
+          {/if}
+        </div>
+      {/if}
+
+      {#if detail.servings != null}
+        <div class="rc-scaler">
+          <span class="rc-scaler-label">🍽 Servings:</span>
+          <button
+            type="button"
+            class="rc-step"
+            aria-label="Decrease servings"
+            onclick={decreaseServings}
+            disabled={scaledServings <= 1}>−</button
+          >
+          <strong class="rc-scaler-count">{scaledServings}</strong>
+          <button type="button" class="rc-step" aria-label="Increase servings" onclick={increaseServings}>+</button>
+          {#if scaledServings !== detail.servings}
+            <span class="rc-scaler-badge">{getScalingLabel(factor)}</span>
+            <button type="button" class="rc-text-btn" onclick={resetServings}>Reset</button>
+          {/if}
+        </div>
+      {/if}
+
+      {#if detail.description}
+        <p class="rc-detail-description">{detail.description}</p>
+      {/if}
+
+      {#if detail.ingredients.length > 0}
+        <h3 class="rc-detail-subhead">Ingredients</h3>
+        <ul class="rc-detail-ingredients">
+          {#each sortedIngredients as ing (ing.ingredientId)}
+            <li>{ingredientLine(ing)}</li>
+          {/each}
+        </ul>
+      {/if}
+
+      {#if detail.instructionsHtml.trim()}
+        <h3 class="rc-detail-subhead">Instructions</h3>
+        <!-- Server-sanitized HTML (MarkdownHelper.ToSafeHtml). No client markdown lib. -->
+        <div class="rc-detail-instructions">{@html detail.instructionsHtml}</div>
+      {/if}
+
+      {#if isSafeUrl(detail.sourceUrl)}
+        <div class="rc-detail-source">
+          <span aria-hidden="true">🔗</span>
+          <a href={detail.sourceUrl} target="_blank" rel="noopener noreferrer">View Original Recipe</a>
+        </div>
+      {/if}
+    {/if}
+  </div>
+
+  {#if detail}
+    <footer class="rc-drawer-actions">
+      {#if isReadOnly}
+        <button type="button" class="rc-btn-solid rc-full" onclick={handleCopy} disabled={copying}>
+          {copying ? 'Copying…' : 'Copy to My Recipes'}
+        </button>
+      {:else}
+        <button type="button" class="rc-btn-solid rc-full" onclick={() => detail && onEdit(detail.recipeId)}>
+          Edit Recipe
+        </button>
+        <button type="button" class="rc-btn-outline rc-full" onclick={() => detail && onAddToMealPlan(detail.name)}>
+          Add to Meal Plan
+        </button>
+        <button type="button" class="rc-btn-text-danger rc-full" onclick={() => summary && onDelete(summary)}>
+          Delete Recipe
+        </button>
+      {/if}
+    </footer>
+  {/if}
+</aside>
+
+<style>
+  .rc-drawer-scrim {
+    position: fixed;
+    inset: 0;
+    border: none;
+    padding: 0;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 1299;
+    cursor: default;
+  }
+  .rc-drawer {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: min(800px, 90vw);
+    background: var(--color-surface);
+    color: var(--color-text);
+    box-shadow: var(--shadow-4);
+    z-index: 1300;
+    display: flex;
+    flex-direction: column;
+    transform: translateX(100%);
+    transition: transform 0.25s ease;
+    visibility: hidden;
+  }
+  .rc-drawer-open {
+    transform: translateX(0);
+    visibility: visible;
+  }
+  .rc-drawer-head {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 16px 16px 12px 24px;
+    border-bottom: 1px solid var(--color-line);
+  }
+  .rc-drawer-title {
+    flex: 1;
+    min-width: 0;
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 400;
+    overflow-wrap: anywhere;
+  }
+  .rc-drawer-x {
+    flex-shrink: 0;
+    width: 40px;
+    height: 40px;
+    display: grid;
+    place-items: center;
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
+    border-radius: var(--radius-sm);
+    font-size: 1.5rem;
+    line-height: 1;
+    cursor: pointer;
+  }
+  .rc-drawer-x:hover {
+    background: var(--color-action-hover);
+    color: var(--color-text);
+  }
+  .rc-drawer-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 16px 24px;
+  }
+  .rc-detail-image {
+    width: 100%;
+    height: 250px;
+    margin-bottom: 16px;
+    border-radius: 8px;
+    overflow: hidden;
+  }
+  .rc-detail-image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+  .rc-detail-author {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 12px;
+  }
+  .rc-avatar {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    object-fit: cover;
+    flex-shrink: 0;
+  }
+  .rc-avatar-initials {
+    display: grid;
+    place-items: center;
+    background: var(--color-primary-soft);
+    color: #fff;
+    font-size: 0.6875rem;
+    font-weight: 600;
+  }
+  .rc-detail-author-name {
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+  .rc-italic {
+    font-style: italic;
+  }
+  .rc-detail-from {
+    margin: 0 0 12px;
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .rc-detail-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 16px;
+  }
+  .rc-detail-chip {
+    font-size: 0.8125rem;
+    padding: 4px 12px;
+    border-radius: 14px;
+    background: var(--color-action-hover);
+    color: var(--color-text);
+  }
+  .rc-chip-info {
+    color: var(--color-info);
+    border: 1px solid var(--color-info);
+    background: transparent;
+  }
+  .rc-chip-warn {
+    color: var(--color-warning);
+    border: 1px solid var(--color-warning);
+    background: transparent;
+  }
+  .rc-scaler {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 16px;
+    flex-wrap: wrap;
+  }
+  .rc-scaler-label {
+    font-size: 0.875rem;
+    color: var(--color-success);
+  }
+  .rc-step {
+    width: 28px;
+    height: 28px;
+    display: grid;
+    place-items: center;
+    border: 1px solid var(--color-line-strong);
+    background: transparent;
+    color: var(--color-text);
+    border-radius: 50%;
+    cursor: pointer;
+    font-size: 1.1rem;
+    line-height: 1;
+  }
+  .rc-step:hover:not(:disabled) {
+    background: var(--color-action-hover);
+  }
+  .rc-step:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+  .rc-scaler-count {
+    min-width: 24px;
+    text-align: center;
+  }
+  .rc-scaler-badge {
+    font-size: 0.75rem;
+    padding: 2px 10px;
+    border-radius: 12px;
+    border: 1px solid var(--color-info);
+    color: var(--color-info);
+  }
+  .rc-text-btn {
+    font: inherit;
+    background: transparent;
+    border: none;
+    color: var(--color-primary);
+    cursor: pointer;
+    font-size: 0.8125rem;
+  }
+  .rc-text-btn:hover {
+    text-decoration: underline;
+  }
+  .rc-detail-description {
+    margin: 0 0 16px;
+    line-height: 1.5;
+  }
+  .rc-detail-subhead {
+    margin: 16px 0 8px;
+    font-size: 1.125rem;
+    font-weight: 500;
+  }
+  .rc-detail-ingredients {
+    margin: 0 0 16px;
+    padding-left: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 0.9375rem;
+  }
+  .rc-detail-instructions {
+    line-height: 1.6;
+    margin-bottom: 16px;
+  }
+  .rc-detail-instructions :global(ol),
+  .rc-detail-instructions :global(ul) {
+    margin-left: 1.5rem;
+    margin-bottom: 1rem;
+  }
+  .rc-detail-instructions :global(li) {
+    margin-bottom: 0.5rem;
+  }
+  .rc-detail-instructions :global(p) {
+    margin: 0 0 0.75rem;
+  }
+  .rc-detail-source {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 16px;
+    font-size: 0.875rem;
+  }
+  .rc-detail-source a {
+    color: var(--color-secondary);
+  }
+  .rc-drawer-loading {
+    padding: 48px 0;
+    text-align: center;
+    color: var(--color-text-muted);
+  }
+  .rc-drawer-error {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 12px 16px;
+    background: rgba(229, 57, 53, 0.08);
+    border-left: 4px solid var(--color-error);
+    border-radius: var(--radius-sm);
+    color: var(--color-error);
+    font-size: 0.875rem;
+  }
+  .rc-retry {
+    font: inherit;
+    border: none;
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+    padding: 4px 12px;
+    background: transparent;
+    color: var(--color-error);
+    font-weight: 500;
+  }
+  .rc-drawer-actions {
+    flex-shrink: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 16px 24px calc(16px + env(safe-area-inset-bottom, 0px));
+    border-top: 1px solid var(--color-line);
+    background: var(--color-surface);
+  }
+  .rc-full {
+    width: 100%;
+  }
+  .rc-btn-solid,
+  .rc-btn-outline,
+  .rc-btn-text-danger {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    min-height: 44px;
+    font-weight: 500;
+  }
+  .rc-btn-solid {
+    border: none;
+    background: var(--color-primary);
+    color: #fff;
+  }
+  .rc-btn-solid:hover:not(:disabled) {
+    background: var(--color-primary-hover);
+  }
+  .rc-btn-solid:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+  .rc-btn-outline {
+    border: 1px solid var(--color-secondary);
+    background: transparent;
+    color: var(--color-secondary);
+  }
+  .rc-btn-outline:hover {
+    background: var(--color-action-hover);
+  }
+  .rc-btn-text-danger {
+    border: none;
+    background: transparent;
+    color: var(--color-error);
+  }
+  .rc-btn-text-danger:hover {
+    background: rgba(229, 57, 53, 0.08);
+  }
+</style>

--- a/frontend/app/src/lib/recipes/lib/liveness.ts
+++ b/frontend/app/src/lib/recipes/lib/liveness.ts
@@ -1,0 +1,77 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Liveness — lightweight collaboration refresh for the recipes LIST view.
+//
+// A recipe added/edited/deleted by another household member should appear
+// within ~20s while the tab is VISIBLE, and immediately when the tab regains
+// focus. We do this with a plain interval + `visibilitychange`, NOT Blazor's
+// DataNotifier / PresenceService / PollingService (those are SignalR-circuit-
+// bound — the exact failure mode the strangler removes).
+//
+// The poll PAUSES while the tab is hidden: no interval ticks fire when
+// `document.hidden` is true, and on re-show we refetch once immediately, then
+// resume the interval. This keeps background tabs quiet.
+//
+// Wired ONLY in ListApp — the edit form is single-user (autosave-drafts is its
+// persistence path); a poll there would clobber in-progress edits.
+// ─────────────────────────────────────────────────────────────────────────
+
+const POLL_INTERVAL_MS = 20_000;
+
+export interface LivenessHandle {
+  /** Tear down the interval + visibility listener. Call on unmount. */
+  stop(): void;
+}
+
+/**
+ * Start polling. `refresh` is the list reload (ListApp's reconcile). It is only
+ * invoked while the document is visible. Returns a handle whose `stop()` removes
+ * the interval + listener.
+ */
+export function startLiveness(refresh: () => void): LivenessHandle {
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  function tick() {
+    // Guard: never poll while hidden (the interval is cleared on hide, but this
+    // is belt-and-suspenders in case a tick is queued at the moment of hiding).
+    if (document.visibilityState === 'visible') {
+      refresh();
+    }
+  }
+
+  function startInterval() {
+    if (timer != null) return;
+    timer = setInterval(tick, POLL_INTERVAL_MS);
+  }
+
+  function stopInterval() {
+    if (timer != null) {
+      clearInterval(timer);
+      timer = null;
+    }
+  }
+
+  function handleVisibility() {
+    if (document.visibilityState === 'visible') {
+      // Re-show: refetch immediately, then resume the interval.
+      refresh();
+      startInterval();
+    } else {
+      // Hidden: pause polling entirely.
+      stopInterval();
+    }
+  }
+
+  document.addEventListener('visibilitychange', handleVisibility);
+
+  // Begin polling only if we start visible.
+  if (document.visibilityState === 'visible') {
+    startInterval();
+  }
+
+  return {
+    stop() {
+      stopInterval();
+      document.removeEventListener('visibilitychange', handleVisibility);
+    },
+  };
+}

--- a/frontend/app/src/lib/recipes/lib/quantity.ts
+++ b/frontend/app/src/lib/recipes/lib/quantity.ts
@@ -1,0 +1,102 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Quantity formatting + servings-scaling math. Client-only (no endpoint).
+//
+// ⚠ TWO DISTINCT FORMATTERS — do NOT merge them (spec §6 / §11.10):
+//   • formatScaledQuantity — the DRAWER's *scaled* values. Uses RANGE
+//     thresholds (Recipes.razor FormatQuantity, :897-905) because a scaled
+//     value is fuzzy (e.g. 0.333… → "⅓"). Unicode-fraction glyphs.
+//   • formatExactQuantity — the ingredient-LIST display. Uses EXACT-equality
+//     checks (IngredientList.razor FormatQuantity, :106-132) because entered
+//     values are precise. ASCII "1/2"-style fractions + mixed numbers.
+// They differ on purpose; porting from intuition diverges.
+// ─────────────────────────────────────────────────────────────────────────
+
+// Unicode fraction glyphs used by the scaled formatter.
+const QUARTER = '¼'; // ¼
+const THIRD = '⅓'; // ⅓
+const HALF = '½'; // ½
+const TWO_THIRDS = '⅔'; // ⅔
+const THREE_QUARTERS = '¾'; // ¾
+const TIMES = '×'; // ×
+
+/** Mirror C# "0.##": round to ≤2 decimals, trim trailing zeros. */
+function formatDecimal(n: number): string {
+  const rounded = Math.round(n * 100) / 100;
+  return String(rounded);
+}
+
+/**
+ * Format a SCALED quantity for the detail drawer (range thresholds — the value
+ * is the product of user scaling, so it's approximate). Ports
+ * Recipes.razor:887-912 exactly.
+ */
+export function formatScaledQuantity(qty: number): string {
+  if (qty === Math.floor(qty)) {
+    return String(Math.trunc(qty));
+  }
+
+  const fractionalPart = qty - Math.floor(qty);
+  const wholePart = Math.floor(qty);
+
+  let fraction: string | null = null;
+  if (fractionalPart >= 0.2 && fractionalPart < 0.3) fraction = QUARTER;
+  else if (fractionalPart >= 0.3 && fractionalPart < 0.4) fraction = THIRD;
+  else if (fractionalPart >= 0.45 && fractionalPart < 0.55) fraction = HALF;
+  else if (fractionalPart >= 0.6 && fractionalPart < 0.7) fraction = TWO_THIRDS;
+  else if (fractionalPart >= 0.7 && fractionalPart < 0.8) fraction = THREE_QUARTERS;
+
+  if (fraction != null) {
+    return wholePart > 0 ? `${wholePart} ${fraction}` : fraction;
+  }
+
+  return formatDecimal(qty);
+}
+
+/**
+ * Format an EXACT entered quantity for the ingredient list (exact-equality
+ * fractions + mixed numbers). Ports IngredientList.razor:106-132 exactly.
+ */
+export function formatExactQuantity(qty: number): string {
+  // Common fractions (exact).
+  if (qty === 0.25) return '1/4';
+  if (qty === 0.5) return '1/2';
+  if (qty === 0.75) return '3/4';
+  if (qty === 0.33 || qty === 1 / 3) return '1/3';
+  if (qty === 0.67 || qty === 2 / 3) return '2/3';
+
+  // Mixed fractions.
+  const whole = Math.trunc(qty);
+  const frac = qty - whole;
+
+  if (frac === 0) return formatDecimal(whole);
+
+  if (whole > 0) {
+    if (frac === 0.25) return `${whole} 1/4`;
+    if (frac === 0.5) return `${whole} 1/2`;
+    if (frac === 0.75) return `${whole} 3/4`;
+    if (frac === 0.33 || Math.abs(frac - 1 / 3) < 0.01) return `${whole} 1/3`;
+    if (frac === 0.67 || Math.abs(frac - 2 / 3) < 0.01) return `${whole} 2/3`;
+  }
+
+  // Decimal fallback.
+  return formatDecimal(qty);
+}
+
+/** Scaling factor = scaledServings / baseServings (1 when base is null/0). */
+export function getScalingFactor(baseServings: number | null, scaledServings: number): number {
+  if (baseServings == null || baseServings === 0) return 1;
+  return scaledServings / baseServings;
+}
+
+/** Apply a scaling factor to one quantity. */
+export function getScaledQuantity(original: number, factor: number): number {
+  return original * factor;
+}
+
+/** The "×2" / "½×" / "1.5×" badge for the drawer. Ports Recipes.razor:930-937. */
+export function getScalingLabel(factor: number): string {
+  if (factor === 2) return `2${TIMES}`;
+  if (factor === 0.5) return `${HALF}${TIMES}`;
+  if (factor === 1.5) return `1.5${TIMES}`;
+  return `${formatDecimal(factor)}${TIMES}`;
+}

--- a/frontend/app/src/lib/recipes/lib/recipeEditStore.svelte.ts
+++ b/frontend/app/src/lib/recipes/lib/recipeEditStore.svelte.ts
@@ -1,0 +1,533 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Edit-view store — the source of truth for the recipe edit form
+// (#recipes-edit-root). Owns ONLY edit-view files (spec §6 store split) so
+// WP-5 / WP-6 never collide.
+//
+// ⚠ Svelte 5 rune rule: export the class INSTANCE, not reassigned $state.
+//
+// Mirrors RecipeEdit.razor: draft-first load (restore + toast, else recipe-or-
+// blank), 2s-debounce autosave drafts, ingredient add/bulk/remove(undo)/reorder,
+// image upload/remove/pick, and Save/Cancel/Delete. Versionless / last-write-wins
+// (D5): on any 4xx during save/delete we surface a calm "this recipe changed"
+// and return to the list (§8). Single-user form ⇒ NO liveness (autosave is the
+// persistence path).
+// ─────────────────────────────────────────────────────────────────────────
+
+import type {
+  RecipeDraftData,
+  RecipeFullDto,
+  RecipeType,
+  RecipeWriteRequest,
+  SaveDraftRequest,
+  ShellContext,
+} from './types';
+import {
+  ApiError,
+  getRecipe,
+  getDraft,
+  saveDraft,
+  deleteDraft,
+  createRecipe,
+  updateRecipe,
+  deleteRecipe,
+  uploadImage,
+  getCategories,
+} from './api';
+import { base } from '$app/paths';
+import { showToast } from '$lib/shared/toast-store.svelte';
+
+/** The bound form model (text fields are strings; trimmed/null-on-save). */
+export interface RecipeEditModel {
+  name: string;
+  description: string;
+  instructions: string;
+  sourceUrl: string;
+  prepTimeMinutes: number | null;
+  cookTimeMinutes: number | null;
+  servings: number | null;
+  recipeType: RecipeType;
+  imagePath: string | null;
+}
+
+/** One ingredient row. `id` is a stable client uid for keying + svelte-dnd-action. */
+export interface IngredientRow {
+  id: number;
+  ingredientId: number;
+  quantity: number | null;
+  unit: string | null;
+  name: string;
+  category: string;
+  notes: string | null;
+  groupName: string | null;
+  sortOrder: number;
+}
+
+/** A structured ingredient produced by the entry / bulk-paste (pre-row). */
+export interface NewIngredientInput {
+  name: string;
+  quantity: number | null;
+  unit: string | null;
+  category: string;
+  notes: string | null;
+  groupName?: string | null;
+}
+
+type AutosaveStatus = 'none' | 'saving' | 'saved';
+
+const AUTOSAVE_DELAY_MS = 2000;
+const SAVED_CLEAR_MS = 3000;
+
+function blankForm(): RecipeEditModel {
+  return {
+    name: '',
+    description: '',
+    instructions: '',
+    sourceUrl: '',
+    prepTimeMinutes: null,
+    cookTimeMinutes: null,
+    servings: null,
+    recipeType: 'main',
+    imagePath: null,
+  };
+}
+
+class RecipeEditStore {
+  form = $state<RecipeEditModel>(blankForm());
+  ingredients = $state<IngredientRow[]>([]);
+  categories = $state<string[]>([]);
+  loading = $state(true);
+  saving = $state(false);
+  deleting = $state(false);
+  dirty = $state(false);
+  autosaveStatus = $state<AutosaveStatus>('none');
+  error = $state<string | null>(null);
+
+  /** The recipe id (null = new). Set from the shell context. */
+  recipeId = $state<number | null>(null);
+  currentUserId = $state(0);
+
+  isEdit = $derived(this.recipeId != null);
+
+  private uidSeq = 1;
+  private autosaveTimer: ReturnType<typeof setTimeout> | null = null;
+  private savedClearTimer: ReturnType<typeof setTimeout> | null = null;
+  /** The in-flight draft-save (if any) — save()/delete() await it before deleteDraft so a late
+   *  autosave can't re-create the draft we just cleared (council race fix). */
+  private autosaveInFlight: Promise<void> | null = null;
+
+  init(ctx: ShellContext): void {
+    this.currentUserId = ctx.userId;
+    this.recipeId = ctx.recipeId;
+  }
+
+  /**
+   * Load draft-first (restore + toast), else the existing recipe (edit) or blank
+   * defaults (new). Mirrors RecipeEdit.razor LoadRecipeOrDraft. Also loads the
+   * household categories for the entry select.
+   */
+  async load(recipeId: number | null): Promise<void> {
+    this.recipeId = recipeId;
+    this.loading = true;
+    this.error = null;
+    try {
+      const draft = await getDraft(recipeId);
+      if (draft) {
+        this.applyDraft(draft);
+        showToast({ message: 'Restored from draft', kind: 'info' });
+      } else if (recipeId != null) {
+        const full = await getRecipe(recipeId);
+        this.applyFull(full);
+      } else {
+        // New recipe defaults (RecipeEdit.razor:352-357).
+        this.form = { ...blankForm(), recipeType: 'main', servings: 4 };
+        this.ingredients = [];
+      }
+      this.dirty = false;
+    } catch (e) {
+      if (recipeId != null && e instanceof ApiError) {
+        // Missing / cross-household recipe → calm message + back to the list.
+        showToast({ message: 'Recipe not found.', kind: 'error' });
+        this.navigateToList();
+        return;
+      }
+      this.error = e instanceof Error ? e.message : String(e);
+    } finally {
+      this.loading = false;
+    }
+    // Categories are non-critical — load after the form is up.
+    void this.loadCategories();
+  }
+
+  private async loadCategories(): Promise<void> {
+    try {
+      const cats = await getCategories();
+      this.categories = cats.map((c) => c.name);
+    } catch {
+      this.categories = [];
+    }
+  }
+
+  private applyDraft(d: RecipeDraftData): void {
+    this.form = {
+      name: d.name,
+      description: d.description ?? '',
+      instructions: d.instructions ?? '',
+      sourceUrl: d.sourceUrl ?? '',
+      prepTimeMinutes: d.prepTimeMinutes,
+      cookTimeMinutes: d.cookTimeMinutes,
+      servings: d.servings,
+      // Drafts don't persist recipeType (DraftService.RecipeDraftData has no type) —
+      // mirrors Blazor restoring a draft into a default-Main recipe.
+      recipeType: 'main',
+      imagePath: d.imagePath,
+    };
+    this.ingredients = d.ingredients.map((i) => this.toRow(i, 0));
+  }
+
+  private applyFull(f: RecipeFullDto): void {
+    this.form = {
+      name: f.name,
+      description: f.description ?? '',
+      instructions: f.instructions ?? '',
+      sourceUrl: f.sourceUrl ?? '',
+      prepTimeMinutes: f.prepTimeMinutes,
+      cookTimeMinutes: f.cookTimeMinutes,
+      servings: f.servings,
+      recipeType: f.recipeType,
+      imagePath: f.imagePath,
+    };
+    this.ingredients = f.ingredients
+      .slice()
+      .sort((a, b) => a.sortOrder - b.sortOrder)
+      .map((i) => this.toRow(i, i.ingredientId));
+  }
+
+  private toRow(
+    i: {
+      quantity: number | null;
+      unit: string | null;
+      name: string;
+      category: string;
+      notes: string | null;
+      groupName: string | null;
+      sortOrder: number;
+    },
+    ingredientId: number,
+  ): IngredientRow {
+    return {
+      id: this.uidSeq++,
+      ingredientId,
+      quantity: i.quantity,
+      unit: i.unit,
+      name: i.name,
+      category: i.category,
+      notes: i.notes,
+      groupName: i.groupName,
+      sortOrder: i.sortOrder,
+    };
+  }
+
+  // ── Field edits → dirty + autosave ─────────────────────────────────────────
+
+  /** Call on any form-field edit: marks dirty + (re)schedules the draft autosave. */
+  onEdit(): void {
+    this.dirty = true;
+    this.autosaveStatus = 'none';
+    this.scheduleAutosave();
+  }
+
+  private scheduleAutosave(): void {
+    if (this.autosaveTimer) clearTimeout(this.autosaveTimer);
+    this.autosaveTimer = setTimeout(() => void this.runAutosave(), AUTOSAVE_DELAY_MS);
+  }
+
+  private async runAutosave(): Promise<void> {
+    // Skip if: the draft endpoint requires a non-blank name, OR a save/delete is underway (that path
+    // owns the draft lifecycle and will deleteDraft — autosaving now would resurrect it).
+    if (!this.form.name.trim() || this.saving || this.deleting) {
+      this.autosaveStatus = 'none';
+      return;
+    }
+    this.autosaveStatus = 'saving';
+    const inFlight = (async () => {
+      try {
+        await saveDraft(this.buildDraftBody());
+        this.autosaveStatus = 'saved';
+        if (this.savedClearTimer) clearTimeout(this.savedClearTimer);
+        this.savedClearTimer = setTimeout(() => {
+          if (this.autosaveStatus === 'saved') this.autosaveStatus = 'none';
+        }, SAVED_CLEAR_MS);
+      } catch {
+        this.autosaveStatus = 'none';
+        showToast({ message: "Couldn't save draft.", kind: 'info' });
+      }
+    })();
+    this.autosaveInFlight = inFlight;
+    await inFlight;
+    if (this.autosaveInFlight === inFlight) this.autosaveInFlight = null;
+  }
+
+  /**
+   * Cancel a pending autosave timer and wait out any in-flight draft save. save()/delete() call this
+   * before deleteDraft so a late autosave PUT can't land after the delete and re-create the draft.
+   */
+  private async flushAutosave(): Promise<void> {
+    if (this.autosaveTimer) {
+      clearTimeout(this.autosaveTimer);
+      this.autosaveTimer = null;
+    }
+    if (this.autosaveInFlight) {
+      try {
+        await this.autosaveInFlight;
+      } catch {
+        /* the autosave handles its own errors */
+      }
+    }
+  }
+
+  // ── Ingredients ────────────────────────────────────────────────────────────
+
+  addIngredient(input: NewIngredientInput): void {
+    this.ingredients = [...this.ingredients, this.newRow(input, this.ingredients.length)];
+    this.onEdit();
+  }
+
+  addBulk(inputs: NewIngredientInput[]): void {
+    let order = this.ingredients.length;
+    const rows = inputs.map((i) => this.newRow(i, order++));
+    this.ingredients = [...this.ingredients, ...rows];
+    this.onEdit();
+  }
+
+  private newRow(input: NewIngredientInput, sortOrder: number): IngredientRow {
+    return {
+      id: this.uidSeq++,
+      ingredientId: 0,
+      quantity: input.quantity,
+      unit: input.unit,
+      name: input.name,
+      category: input.category,
+      notes: input.notes,
+      groupName: input.groupName ?? null,
+      sortOrder,
+    };
+  }
+
+  /** Remove an ingredient with a 5s "Undo" toast (mirrors IngredientList delete-with-undo). */
+  removeIngredient(id: number): void {
+    const index = this.ingredients.findIndex((r) => r.id === id);
+    if (index < 0) return;
+    const removed = this.ingredients[index];
+    this.ingredients = this.resequence(this.ingredients.filter((r) => r.id !== id));
+    this.onEdit();
+    showToast({
+      message: 'Ingredient deleted',
+      kind: 'info',
+      durationMs: 5000,
+      action: {
+        label: 'Undo',
+        onClick: () => this.restoreIngredient(removed, index),
+      },
+    });
+  }
+
+  private restoreIngredient(row: IngredientRow, index: number): void {
+    const next = this.ingredients.slice();
+    next.splice(Math.min(index, next.length), 0, row);
+    this.ingredients = this.resequence(next);
+    this.onEdit();
+    showToast({ message: 'Ingredient restored', kind: 'success' });
+  }
+
+  /**
+   * "Edit" an ingredient — parity with Blazor's remove-and-re-add flow
+   * (IngredientList.razor:451-456). Inline editing is a harvested follow-up quest.
+   */
+  editIngredient(id: number): void {
+    this.ingredients = this.resequence(this.ingredients.filter((r) => r.id !== id));
+    this.onEdit();
+    showToast({ message: 'Re-add the ingredient with your changes.', kind: 'info' });
+  }
+
+  /** Apply a drag-reorder (svelte-dnd-action finalize gives the new row order). */
+  reorder(rows: IngredientRow[]): void {
+    this.ingredients = this.resequence(rows);
+    this.onEdit();
+  }
+
+  /** Recompute sortOrder 0..n in list order. */
+  private resequence(rows: IngredientRow[]): IngredientRow[] {
+    return rows.map((r, i) => ({ ...r, sortOrder: i }));
+  }
+
+  // ── Image ──────────────────────────────────────────────────────────────────
+
+  async uploadImage(file: File): Promise<void> {
+    try {
+      const { imagePath } = await uploadImage(file);
+      this.form.imagePath = imagePath;
+      this.onEdit();
+      showToast({ message: 'Image uploaded', kind: 'success' });
+    } catch (e) {
+      const msg =
+        e instanceof ApiError && e.status === 400
+          ? 'That image was rejected (max 10 MB; JPG/PNG/GIF/WebP).'
+          : "Couldn't upload that image.";
+      showToast({ message: msg, kind: 'error' });
+    }
+  }
+
+  removeImage(): void {
+    this.form.imagePath = null;
+    this.onEdit();
+  }
+
+  setImage(path: string): void {
+    this.form.imagePath = path;
+    this.onEdit();
+  }
+
+  // ── Save / Delete / Cancel ───────────────────────────────────────────────────
+
+  async save(): Promise<void> {
+    const name = this.form.name.trim();
+    if (!name) {
+      showToast({ message: 'Recipe name is required.', kind: 'error' });
+      return;
+    }
+    this.saving = true; // set first: a timer-fired autosave now bails on the saving guard
+    await this.flushAutosave(); // wait out any in-flight draft save before we deleteDraft
+    this.error = null;
+    try {
+      const body = this.buildWriteRequest();
+      if (this.recipeId != null) {
+        await updateRecipe(this.recipeId, body);
+      } else {
+        await createRecipe(body);
+      }
+      await this.safeDeleteDraft();
+      this.dirty = false; // suppress the beforeunload nav-lock before navigating
+      this.navigateToList();
+    } catch (e) {
+      if (e instanceof ApiError) {
+        // 4xx incl. the empty-400-from-404 quirk → concurrent delete / last-write-wins.
+        this.error = 'This recipe changed since you opened it.';
+        this.dirty = false;
+        showToast({ message: 'This recipe changed — returning to the list.', kind: 'info' });
+        this.navigateToList();
+      } else {
+        showToast({ message: 'Something went wrong saving. Please try again.', kind: 'error' });
+      }
+    } finally {
+      this.saving = false;
+    }
+  }
+
+  async delete(): Promise<void> {
+    if (this.recipeId == null) return;
+    this.deleting = true; // set first: a timer-fired autosave now bails on the deleting guard
+    await this.flushAutosave(); // wait out any in-flight draft save before we deleteDraft
+    try {
+      await deleteRecipe(this.recipeId);
+      await this.safeDeleteDraft();
+      this.dirty = false;
+      showToast({ message: 'Recipe deleted', kind: 'success' });
+      this.navigateToList();
+    } catch (e) {
+      if (e instanceof ApiError) {
+        // Already gone — just return to the list.
+        this.dirty = false;
+        showToast({ message: 'That recipe was already removed.', kind: 'info' });
+        this.navigateToList();
+      } else {
+        showToast({ message: "Couldn't delete that recipe right now.", kind: 'error' });
+      }
+    } finally {
+      this.deleting = false;
+    }
+  }
+
+  cancel(): void {
+    this.dirty = false; // explicit discard — no nav-lock prompt
+    this.navigateToList();
+  }
+
+  private async safeDeleteDraft(): Promise<void> {
+    try {
+      await deleteDraft(this.recipeId);
+    } catch {
+      /* draft cleanup is best-effort */
+    }
+  }
+
+  private navigateToList(): void {
+    window.location.assign(`${base}/recipes`);
+  }
+
+  /** Clear timers on unmount (EditApp's effect cleanup). */
+  teardown(): void {
+    if (this.autosaveTimer) clearTimeout(this.autosaveTimer);
+    if (this.savedClearTimer) clearTimeout(this.savedClearTimer);
+    this.autosaveTimer = null;
+    this.savedClearTimer = null;
+  }
+
+  // ── Mappers (form → wire) ────────────────────────────────────────────────────
+
+  private buildWriteRequest(): RecipeWriteRequest {
+    return {
+      name: this.form.name.trim(),
+      description: nullIfBlank(this.form.description),
+      instructions: nullIfBlank(this.form.instructions),
+      sourceUrl: nullIfBlank(this.form.sourceUrl),
+      servings: this.form.servings,
+      prepTimeMinutes: this.form.prepTimeMinutes,
+      cookTimeMinutes: this.form.cookTimeMinutes,
+      recipeType: this.form.recipeType,
+      imagePath: this.form.imagePath,
+      ingredients: this.ingredients.map((r, i) => ({
+        name: r.name.trim(),
+        quantity: r.quantity,
+        unit: nullIfBlank(r.unit),
+        category: r.category?.trim() || this.fallbackCategory(),
+        notes: nullIfBlank(r.notes),
+        groupName: nullIfBlank(r.groupName),
+        sortOrder: i,
+      })),
+    };
+  }
+
+  private buildDraftBody(): SaveDraftRequest {
+    return {
+      recipeId: this.recipeId,
+      name: this.form.name.trim(),
+      description: nullIfBlank(this.form.description),
+      instructions: nullIfBlank(this.form.instructions),
+      imagePath: this.form.imagePath,
+      sourceUrl: nullIfBlank(this.form.sourceUrl),
+      servings: this.form.servings,
+      prepTimeMinutes: this.form.prepTimeMinutes,
+      cookTimeMinutes: this.form.cookTimeMinutes,
+      ingredients: this.ingredients.map((r, i) => ({
+        name: r.name.trim(),
+        quantity: r.quantity,
+        unit: nullIfBlank(r.unit),
+        category: r.category?.trim() || this.fallbackCategory(),
+        notes: nullIfBlank(r.notes),
+        groupName: nullIfBlank(r.groupName),
+        sortOrder: i,
+      })),
+    };
+  }
+
+  private fallbackCategory(): string {
+    return this.categories[0] ?? 'Pantry';
+  }
+}
+
+function nullIfBlank(s: string | null | undefined): string | null {
+  return s == null || s.trim() === '' ? null : s.trim();
+}
+
+/** The single shared edit-view store instance (export the instance, not the runes). */
+export const recipeEditStore = new RecipeEditStore();

--- a/frontend/app/src/lib/recipes/lib/recipeListStore.svelte.ts
+++ b/frontend/app/src/lib/recipes/lib/recipeListStore.svelte.ts
@@ -1,0 +1,209 @@
+// ─────────────────────────────────────────────────────────────────────────
+// List-view store — the source of truth for the recipes grid (#recipes-list-root).
+//
+// ⚠ Svelte 5 rune rule (global CORRECTION): never `export` a reassigned
+// `$state`/`$derived` from a module. We wrap the mutable state in a class
+// instance and export the instance — the runes live as fields on the object.
+//
+// Parity-first ⇒ versionless / last-write-wins. Search is SERVER-side + debounced
+// (D9); the favorites filter is CLIENT-side over the loaded set; favoriteRecipeIds
+// arrive with the same payload (one round-trip). On any 4xx/network error we
+// reconcile (re-run the current query) + a calm toast. Liveness re-runs the
+// current query while the tab is visible.
+//
+// Owns ONLY list-view files (spec §6 store split) — the edit view has its own
+// store (recipeEditStore.svelte.ts), so WP-5 / WP-6 never collide.
+// ─────────────────────────────────────────────────────────────────────────
+
+import type {
+  ConnectedHouseholdDto,
+  RecipeListItemDto,
+  ShellContext,
+} from './types';
+import {
+  ApiError,
+  listRecipes,
+  listConnectedRecipes,
+  toggleFavorite as apiToggleFavorite,
+  deleteRecipe as apiDeleteRecipe,
+  getConnections,
+} from './api';
+import { showToast } from '$lib/shared/toast-store.svelte';
+
+class RecipeListStore {
+  /** The active search term (server-filtered, debounced by the view). */
+  query = $state('');
+  /** The loaded card set (own household OR a connected household). */
+  recipes = $state<RecipeListItemDto[]>([]);
+  /** This user's favorite recipe ids (own household only — empty for connected). */
+  favoriteIds = $state<Set<number>>(new Set());
+  /** Client-side "favorites only" filter chip (own household only). */
+  showFavoritesOnly = $state(false);
+  /** null = my recipes; a household id = viewing that connected household (read-only). */
+  selectedConnectedId = $state<number | null>(null);
+  /** Connected households for the selector (empty ⇒ no selector shown). */
+  connections = $state<ConnectedHouseholdDto[]>([]);
+  loading = $state(true);
+  error = $state<string | null>(null);
+  currentUserId = $state(0);
+
+  /** True once the first load has resolved — gates the skeleton so search/liveness don't reflash it. */
+  private hasLoaded = false;
+  /** Monotonic load id — search / connected-switch / liveness / reconcile all call load(); a slower
+   *  older response must NOT overwrite a newer one, so each load only applies if it's still the latest. */
+  private loadSeq = 0;
+  /** The list refetch hook (ListApp's loader), shared by liveness + error reconcile. */
+  private refresh: (() => Promise<void>) | null = null;
+
+  /** Viewing a connected household? (favorites + per-card heart hide when true.) */
+  isViewingConnected = $derived(this.selectedConnectedId != null);
+
+  /** The connected household's name (attribution) — null when viewing my recipes. */
+  selectedConnectedName = $derived(
+    this.selectedConnectedId == null
+      ? null
+      : (this.connections.find((c) => c.householdId === this.selectedConnectedId)?.householdName ?? null),
+  );
+
+  /** The cards actually rendered — applies the client-side favorites filter (own household only). */
+  displayed = $derived.by(() =>
+    this.showFavoritesOnly && this.selectedConnectedId == null
+      ? this.recipes.filter((r) => this.favoriteIds.has(r.recipeId))
+      : this.recipes,
+  );
+
+  init(ctx: ShellContext): void {
+    this.currentUserId = ctx.userId;
+  }
+
+  setRefresh(refresh: () => Promise<void>): void {
+    this.refresh = refresh;
+  }
+
+  /** Re-run the current query. Shared by liveness + error reconcile. */
+  async reconcile(): Promise<void> {
+    if (this.refresh) await this.refresh();
+  }
+
+  /**
+   * Load the current view: own recipes (#1) when no connected household is
+   * selected, else the connected household's shared recipes (#15, same shape,
+   * favorites always empty). Spinner only on the FIRST load — search + liveness
+   * refresh in place (no skeleton reflash).
+   */
+  async load(): Promise<void> {
+    const seq = ++this.loadSeq;
+    try {
+      if (!this.hasLoaded) this.loading = true;
+      this.error = null;
+      if (this.selectedConnectedId == null) {
+        const dto = await listRecipes(this.query);
+        if (seq !== this.loadSeq) return; // a newer load superseded this one
+        this.recipes = dto.recipes;
+        this.favoriteIds = new Set(dto.favoriteRecipeIds);
+      } else {
+        const dto = await listConnectedRecipes(this.selectedConnectedId, this.query);
+        if (seq !== this.loadSeq) return;
+        this.recipes = dto.recipes;
+        this.favoriteIds = new Set();
+      }
+      this.hasLoaded = true;
+    } catch (e) {
+      if (seq !== this.loadSeq) return; // don't surface an error from a superseded load
+      this.error =
+        e instanceof ApiError
+          ? `Failed to load recipes (HTTP ${e.status}).`
+          : e instanceof Error
+            ? e.message
+            : String(e);
+    } finally {
+      if (seq === this.loadSeq) this.loading = false;
+    }
+  }
+
+  /** Load the connected-household selector chips (non-critical: failure ⇒ no selector). */
+  async loadConnections(): Promise<void> {
+    try {
+      this.connections = await getConnections();
+    } catch {
+      this.connections = [];
+    }
+  }
+
+  /** Set the new search term and reload (the view debounces before calling this). */
+  async search(q: string): Promise<void> {
+    this.query = q;
+    await this.load();
+  }
+
+  /**
+   * Switch between "My Recipes" (null) and a connected household. Resets the
+   * search + favorites filter (mirrors the Blazor OnHouseholdSelectionChanged),
+   * then reloads.
+   */
+  async setConnected(id: number | null): Promise<void> {
+    this.selectedConnectedId = id;
+    this.query = '';
+    this.showFavoritesOnly = false;
+    await this.load();
+  }
+
+  toggleFavoritesFilter(): void {
+    this.showFavoritesOnly = !this.showFavoritesOnly;
+  }
+
+  /**
+   * Toggle a favorite (own household only). Optimistic Set toggle, then POST and
+   * reconcile to the server's authoritative state; on error revert + (4xx) refetch.
+   */
+  async toggleFavorite(id: number): Promise<void> {
+    if (this.selectedConnectedId != null) return;
+    const had = this.favoriteIds.has(id);
+    this.favoriteIds = toggled(this.favoriteIds, id, !had);
+    try {
+      const res = await apiToggleFavorite(id);
+      this.favoriteIds = toggled(this.favoriteIds, id, res.isFavorite);
+    } catch (e) {
+      this.favoriteIds = toggled(this.favoriteIds, id, had); // revert
+      if (e instanceof ApiError) {
+        await this.reconcile();
+        showToast({ message: 'That recipe changed — the list was refreshed.', kind: 'info' });
+      } else {
+        showToast({ message: "Couldn't update that favorite right now.", kind: 'error' });
+      }
+    }
+  }
+
+  /**
+   * Delete a recipe (own household only). Optimistic removal from the grid, then
+   * DELETE; on a 4xx (incl. the empty-400-from-404 quirk) reconcile to truth, on
+   * network/5xx restore the card.
+   */
+  async deleteRecipe(id: number): Promise<void> {
+    const prev = this.recipes;
+    this.recipes = this.recipes.filter((r) => r.recipeId !== id);
+    try {
+      await apiDeleteRecipe(id);
+      showToast({ message: 'Recipe deleted.', kind: 'success' });
+    } catch (e) {
+      if (e instanceof ApiError) {
+        await this.reconcile();
+        showToast({ message: 'That recipe changed — the list was refreshed.', kind: 'info' });
+      } else {
+        this.recipes = prev;
+        showToast({ message: "Couldn't delete that recipe right now.", kind: 'error' });
+      }
+    }
+  }
+}
+
+/** Return a NEW Set with `id` present (`on`) or absent — keeps the $state reassignment reactive. */
+function toggled(set: ReadonlySet<number>, id: number, on: boolean): Set<number> {
+  const next = new Set(set);
+  if (on) next.add(id);
+  else next.delete(id);
+  return next;
+}
+
+/** The single shared list-view store instance (export the instance, not the runes). */
+export const recipeListStore = new RecipeListStore();

--- a/frontend/app/src/lib/recipes/lib/recipeType.ts
+++ b/frontend/app/src/lib/recipes/lib/recipeType.ts
@@ -1,0 +1,65 @@
+// Display labels for the RecipeType union (mirrors the Blazor GetRecipeTypeLabel
+// in RecipeEdit / RecipeCard) + the type-select option order (the C# enum order).
+import type { RecipeType } from './types';
+
+export const RECIPE_TYPE_LABELS: Record<RecipeType, string> = {
+  main: 'Main Dish',
+  side: 'Side Dish',
+  appetizer: 'Appetizer',
+  dessert: 'Dessert',
+  beverage: 'Beverage',
+  sauce: 'Sauce/Condiment',
+  breakfast: 'Breakfast',
+  snack: 'Snack',
+  other: 'Other',
+};
+
+/** The select option order — matches the C# enum declaration order. */
+export const RECIPE_TYPES: RecipeType[] = [
+  'main',
+  'side',
+  'appetizer',
+  'dessert',
+  'beverage',
+  'sauce',
+  'breakfast',
+  'snack',
+  'other',
+];
+
+export function recipeTypeLabel(type: RecipeType): string {
+  return RECIPE_TYPE_LABELS[type] ?? type;
+}
+
+/** Short chip labels for the card (mirrors RecipeCard.razor GetTypeLabel; `main` chip is hidden). */
+const RECIPE_TYPE_SHORT: Record<RecipeType, string> = {
+  main: 'Main',
+  side: 'Side',
+  appetizer: 'Appetizer',
+  dessert: 'Dessert',
+  beverage: 'Beverage',
+  sauce: 'Sauce',
+  breakfast: 'Breakfast',
+  snack: 'Snack',
+  other: 'Other',
+};
+
+export function recipeTypeShort(type: RecipeType): string {
+  return RECIPE_TYPE_SHORT[type] ?? type;
+}
+
+/** Chip accent color per type (mirrors RecipeCard.razor GetTypeColor). */
+export function recipeTypeColor(type: RecipeType): string {
+  switch (type) {
+    case 'dessert':
+      return 'var(--color-secondary)';
+    case 'beverage':
+      return 'var(--color-info)';
+    case 'breakfast':
+      return 'var(--color-warning)';
+    case 'appetizer':
+      return 'var(--color-primary-soft)';
+    default:
+      return 'var(--color-text-muted)';
+  }
+}

--- a/frontend/app/src/lib/recipes/lib/types.ts
+++ b/frontend/app/src/lib/recipes/lib/types.ts
@@ -1,0 +1,203 @@
+// ─────────────────────────────────────────────────────────────────────────
+// TS mirror of the /api/recipes contract (M9 lockstep). Source of truth:
+//   - Services/Dtos/RecipeDtos.cs (the C# records)
+//   - tests/.../Fixtures/RecipeList/list.json + Fixtures/RecipeFull/recipe.json
+//     (the contract-test tripwires — these keys/casing are byte-locked)
+//   - Endpoints/RecipesEndpoints.cs (request DTOs)
+//   - Services/DraftService.cs (RecipeDraftData / IngredientDraftData)
+//
+// ⚠ CASING: all keys are camelCase. `RecipeType` is a real C# enum on the DTO →
+//   it serializes as a camelCase STRING via JsonStringEnumConverter(CamelCase)
+//   ("main", "side", …). `decimal?`/`int?` serialize as number-or-null.
+// ─────────────────────────────────────────────────────────────────────────
+
+export type RecipeType =
+  | 'main'
+  | 'side'
+  | 'appetizer'
+  | 'dessert'
+  | 'beverage'
+  | 'sauce'
+  | 'breakfast'
+  | 'snack'
+  | 'other';
+
+// ── List (Fixtures/RecipeList/list.json) ───────────────────────────────────
+
+export interface RecipeListItemDto {
+  recipeId: number;
+  name: string;
+  recipeType: RecipeType;
+  imagePath: string | null;
+  /** bool, NOT the url — the card only shows the "imported" cloud icon. */
+  hasSourceUrl: boolean;
+  /** null when connected (privacy) or the author was deleted. */
+  createdByName: string | null;
+  /** User has PictureUrl + Initials, NO color → card renders pic-or-initials. */
+  createdByPictureUrl: string | null;
+  /** First 3 ingredient names (ordered by sort order). */
+  ingredientPreview: string[];
+  /** Total count — for the "+N more" suffix. */
+  ingredientCount: number;
+}
+
+export interface RecipeListDto {
+  recipes: RecipeListItemDto[];
+  /** Own-household only; always [] for a connected household. */
+  favoriteRecipeIds: number[];
+}
+
+// ── Full (read drawer + edit form superset, D3) (Fixtures/RecipeFull/recipe.json) ──
+
+export interface RecipeIngredientFullDto {
+  ingredientId: number;
+  quantity: number | null;
+  unit: string | null;
+  name: string;
+  category: string;
+  notes: string | null;
+  groupName: string | null;
+  sortOrder: number;
+}
+
+export interface RecipeFullDto {
+  recipeId: number;
+  name: string;
+  recipeType: RecipeType;
+  description: string | null;
+  /** RAW markdown — for the edit textarea. */
+  instructions: string | null;
+  /** Server-sanitized HTML — for the read drawer's {@html}. */
+  instructionsHtml: string;
+  imagePath: string | null;
+  sourceUrl: string | null;
+  prepTimeMinutes: number | null;
+  cookTimeMinutes: number | null;
+  servings: number | null;
+  /** Both null when connected (includeAuthor:false) / deleted user. */
+  createdByName: string | null;
+  createdByPictureUrl: string | null;
+  /** Attribution for copied recipes. */
+  sharedFromHouseholdName: string | null;
+  ingredients: RecipeIngredientFullDto[];
+}
+
+// ── Parse / categories / connections / import ──────────────────────────────
+
+export interface ParsedIngredientDto {
+  quantity: number | null;
+  unit: string | null;
+  name: string;
+  notes: string | null;
+  isComplete: boolean;
+  suggestedCategory: string;
+}
+
+export interface CategoryDto {
+  name: string;
+}
+
+export interface ConnectedHouseholdDto {
+  householdId: number;
+  householdName: string;
+}
+
+export interface PartialRecipeDataDto {
+  name: string | null;
+  description: string | null;
+  instructions: string | null;
+  ingredientStrings: string[] | null;
+  imageUrl: string | null;
+  prepTimeMinutes: number | null;
+  cookTimeMinutes: number | null;
+  servings: number | null;
+}
+
+export interface RecipeImportResultDto {
+  success: boolean;
+  /** The SAVED recipe id on success. */
+  recipeId: number | null;
+  errorMessage: string | null;
+  /** The RecipeImportErrorType name (e.g. "NetworkError"). */
+  errorType: string | null;
+  existingRecipeId: number | null;
+  existingRecipeName: string | null;
+  partialData: PartialRecipeDataDto | null;
+}
+
+// ── Drafts (mirror DraftService.RecipeDraftData / IngredientDraftData) ──────
+// Reused as BOTH the GET /draft response AND (flattened with recipeId) the PUT body.
+
+export interface IngredientDraftData {
+  name: string;
+  quantity: number | null;
+  unit: string | null;
+  category: string;
+  notes: string | null;
+  groupName: string | null;
+  sortOrder: number;
+}
+
+export interface RecipeDraftData {
+  name: string;
+  description: string | null;
+  instructions: string | null;
+  imagePath: string | null;
+  sourceUrl: string | null;
+  servings: number | null;
+  prepTimeMinutes: number | null;
+  cookTimeMinutes: number | null;
+  ingredients: IngredientDraftData[];
+}
+
+// ── Write request (POST/PUT body — Endpoints RecipeWriteRequest) ────────────
+
+export interface RecipeIngredientWrite {
+  name: string;
+  quantity: number | null;
+  unit: string | null;
+  category: string;
+  notes: string | null;
+  groupName: string | null;
+  sortOrder: number;
+}
+
+export interface RecipeWriteRequest {
+  name: string;
+  description: string | null;
+  instructions: string | null;
+  sourceUrl: string | null;
+  servings: number | null;
+  prepTimeMinutes: number | null;
+  cookTimeMinutes: number | null;
+  recipeType: RecipeType;
+  imagePath: string | null;
+  ingredients: RecipeIngredientWrite[];
+}
+
+/** PUT /draft body — FLAT (recipeId + the draft fields). recipeId omitted ⇒ new-recipe draft. */
+export interface SaveDraftRequest {
+  recipeId: number | null;
+  name: string;
+  description: string | null;
+  instructions: string | null;
+  imagePath: string | null;
+  sourceUrl: string | null;
+  servings: number | null;
+  prepTimeMinutes: number | null;
+  cookTimeMinutes: number | null;
+  ingredients: IngredientDraftData[];
+}
+
+// ── Shell context (read from the root data-attrs) ──────────────────────────
+
+export type IslandView = 'list' | 'edit';
+
+export interface ShellContext {
+  householdId: number;
+  userId: number;
+  userName: string;
+  view: IslandView;
+  /** Set only for editing an existing recipe (null for /recipes/new). */
+  recipeId: number | null;
+}

--- a/frontend/app/src/lib/settings/CategoriesApp.svelte
+++ b/frontend/app/src/lib/settings/CategoriesApp.svelte
@@ -1,0 +1,359 @@
+<script lang="ts">
+  // Categories view (#settings-categories-root). Parity with Categories.razor:
+  // add form, active list with drag-reorder (svelte-dnd-action), edit dialog,
+  // soft-delete with an "in use" confirm, and a deleted-list with restore.
+  import { onMount } from 'svelte';
+  import { dndzone, type DndEvent } from 'svelte-dnd-action';
+  import type { ShellContext, CategoryDto, CategoryWriteRequest } from './lib/types';
+  import { categoriesStore } from './lib/categoriesStore.svelte';
+  import { formatDeletedDate } from './lib/dates';
+  import { showToast } from '$lib/shared/toast-store.svelte';
+  import CategoryEditDialog from './lib/components/CategoryEditDialog.svelte';
+  import ConfirmDialog from '$lib/shared/ConfirmDialog.svelte';
+
+  // ctx is provided by the Razor host; the store calls /api directly (household resolved server-side).
+  let { ctx }: { ctx: ShellContext } = $props();
+
+  const store = categoriesStore;
+
+  // One-time load — onMount is not reactive, so it can't form the setup-effect fetch loop.
+  onMount(() => {
+    void ctx; // host context available; not needed by the store
+    void store.load();
+  });
+
+  // Add form.
+  let newName = $state('');
+  let newEmoji = $state('');
+  let newColor = $state('#808080');
+
+  async function add() {
+    if (!newName.trim()) {
+      showToast({ message: 'Category name is required.', kind: 'error' });
+      return;
+    }
+    const body: CategoryWriteRequest = { name: newName.trim(), iconEmoji: newEmoji.trim() || null, color: newColor };
+    if (await store.add(body)) {
+      newName = '';
+      newEmoji = '';
+      newColor = '#808080';
+    }
+  }
+
+  // Drag-reorder: a local copy svelte-dnd-action mutates during a drag, resynced
+  // from the store whenever we're NOT dragging (the chores/recipes pattern).
+  let rows = $state<CategoryDto[]>([]);
+  let dragging = $state(false);
+  $effect(() => {
+    if (!dragging) rows = [...store.active];
+  });
+  function handleConsider(e: CustomEvent<DndEvent<CategoryDto>>) {
+    dragging = true;
+    rows = e.detail.items;
+  }
+  function handleFinalize(e: CustomEvent<DndEvent<CategoryDto>>) {
+    rows = e.detail.items;
+    dragging = false;
+    void store.reorder(rows.map((c) => c.categoryId));
+  }
+
+  // Edit dialog.
+  let editing = $state<CategoryDto | null>(null);
+  function openEdit(c: CategoryDto) {
+    editing = c;
+  }
+  async function saveEdit(body: CategoryWriteRequest) {
+    const target = editing;
+    if (!target) return;
+    editing = null;
+    await store.update(target.categoryId, body);
+  }
+
+  // Delete confirm (with the in-use round-trip, parity).
+  let confirmCategory = $state<CategoryDto | null>(null);
+  let confirmMessage = $state('');
+  async function askDelete(c: CategoryDto) {
+    const inUse = await store.checkInUse(c.categoryId);
+    confirmMessage = inUse
+      ? `"${c.name}" is used by ingredients in your recipes. You can still delete it, but those ingredients keep their category.`
+      : `Delete the "${c.name}" category?`;
+    confirmCategory = c;
+  }
+  async function confirmDelete() {
+    const target = confirmCategory;
+    confirmCategory = null;
+    if (target) await store.remove(target.categoryId);
+  }
+</script>
+
+<div class="set-page">
+  <h1 class="set-title">Manage Categories</h1>
+  <p class="set-subtitle">Customize ingredient categories for your household. Drag to reorder to match your store layout.</p>
+
+  {#if store.loading}
+    <div class="set-skeleton">Loading…</div>
+  {:else if store.error}
+    <div class="set-error">{store.error}</div>
+  {:else}
+    <!-- Add new -->
+    <section class="set-card">
+      <h2 class="set-card-title">Add New Category</h2>
+      <div class="set-add-row">
+        <input class="set-input set-grow" type="text" placeholder="Name" bind:value={newName} onkeydown={(e) => e.key === 'Enter' && add()} />
+        <input class="set-input" type="text" placeholder="Emoji" bind:value={newEmoji} />
+        <input class="set-color" type="color" bind:value={newColor} aria-label="Color" />
+        <button type="button" class="set-btn-primary" onclick={add}>Add</button>
+      </div>
+    </section>
+
+    <!-- Active list (drag-reorder) -->
+    <section class="set-card">
+      <h2 class="set-card-title">Active Categories</h2>
+      {#if rows.length === 0}
+        <div class="set-empty">No categories yet. Add one above.</div>
+      {:else}
+        <ul
+          class="set-list"
+          use:dndzone={{ items: rows, flipDurationMs: 150, dropTargetStyle: {}, delayTouchStart: 250 }}
+          onconsider={handleConsider}
+          onfinalize={handleFinalize}
+        >
+          {#each rows as cat (cat.categoryId)}
+            <li class="set-row">
+              <div class="set-row-main">
+                <span class="set-grip" aria-hidden="true">⠿</span>
+                <span class="set-swatch" style="background-color: {cat.color}"></span>
+                <span class="set-name">{cat.name}</span>
+                {#if cat.isDefault}
+                  <span class="set-chip set-chip-info">Default</span>
+                {/if}
+              </div>
+              <div class="set-row-actions">
+                <button type="button" class="set-icon-btn" aria-label="Edit category" onclick={() => openEdit(cat)}>✎</button>
+                <button type="button" class="set-icon-btn set-danger" aria-label="Delete category" onclick={() => askDelete(cat)}>🗑</button>
+              </div>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </section>
+
+    <!-- Deleted list -->
+    {#if store.deleted.length > 0}
+      <section class="set-card">
+        <h2 class="set-card-title">Deleted Categories</h2>
+        {#each store.deleted as cat (cat.categoryId)}
+          <div class="set-row set-row-muted">
+            <div class="set-row-main">
+              <span class="set-swatch" style="background-color: {cat.color}"></span>
+              <span class="set-name">{cat.name}</span>
+              <span class="set-deleted-note">(deleted {formatDeletedDate(cat.deletedAt)})</span>
+            </div>
+            <button type="button" class="set-btn-text" onclick={() => store.restore(cat.categoryId)}>Restore</button>
+          </div>
+        {/each}
+      </section>
+    {/if}
+  {/if}
+</div>
+
+<CategoryEditDialog open={editing != null} category={editing} onCancel={() => (editing = null)} onSave={saveEdit} />
+<ConfirmDialog
+  open={confirmCategory != null}
+  danger
+  title="Delete Category"
+  message={confirmMessage}
+  confirmLabel="Delete"
+  onCancel={() => (confirmCategory = null)}
+  onConfirm={confirmDelete}
+/>
+
+<style>
+  .set-page {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 24px 16px 96px;
+  }
+  .set-title {
+    margin: 0 0 4px;
+    font-size: 1.5rem;
+    font-weight: 500;
+  }
+  .set-subtitle {
+    margin: 0 0 20px;
+    color: var(--color-text-muted);
+    font-size: 0.875rem;
+  }
+  .set-card {
+    background: var(--color-surface);
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-1);
+    padding: 16px;
+    margin-bottom: 16px;
+  }
+  .set-card-title {
+    margin: 0 0 12px;
+    font-size: 1rem;
+    font-weight: 500;
+  }
+  .set-add-row {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+  .set-input {
+    font: inherit;
+    padding: 10px 12px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--color-line-strong);
+    background: var(--color-surface);
+    color: var(--color-text);
+    min-width: 120px;
+  }
+  .set-input:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -1px;
+  }
+  .set-grow {
+    flex: 1;
+    min-width: 160px;
+  }
+  .set-color {
+    width: 48px;
+    height: 42px;
+    padding: 2px;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    cursor: pointer;
+  }
+  .set-btn-primary {
+    font: inherit;
+    font-weight: 500;
+    padding: 10px 20px;
+    min-height: 42px;
+    border: none;
+    border-radius: var(--radius-sm);
+    background: var(--color-primary);
+    color: #fff;
+    cursor: pointer;
+  }
+  .set-btn-primary:hover {
+    background: var(--color-primary-hover);
+  }
+  .set-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-height: 48px;
+  }
+  .set-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 10px 12px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-1);
+    cursor: grab;
+  }
+  .set-row:active {
+    cursor: grabbing;
+  }
+  .set-row-muted {
+    opacity: 0.65;
+    cursor: default;
+    box-shadow: none;
+  }
+  .set-row-main {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+  }
+  .set-grip {
+    color: var(--color-text-disabled);
+  }
+  .set-swatch {
+    width: 22px;
+    height: 22px;
+    border-radius: 4px;
+    flex-shrink: 0;
+    border: 1px solid var(--color-line);
+  }
+  .set-name {
+    overflow-wrap: anywhere;
+  }
+  .set-deleted-note {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .set-chip {
+    font-size: 0.6875rem;
+    font-weight: 500;
+    padding: 2px 10px;
+    border-radius: 12px;
+    white-space: nowrap;
+  }
+  .set-chip-info {
+    border: 1px solid var(--color-info);
+    color: var(--color-info);
+  }
+  .set-row-actions {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+  }
+  .set-icon-btn {
+    width: 34px;
+    height: 34px;
+    display: grid;
+    place-items: center;
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    font-size: 0.95rem;
+  }
+  .set-icon-btn:hover {
+    background: var(--color-action-hover);
+  }
+  .set-danger:hover {
+    color: var(--color-error);
+  }
+  .set-btn-text {
+    font: inherit;
+    font-weight: 500;
+    background: transparent;
+    border: none;
+    color: var(--color-primary);
+    cursor: pointer;
+    padding: 6px 10px;
+    border-radius: var(--radius-sm);
+  }
+  .set-btn-text:hover {
+    background: var(--color-action-hover);
+  }
+  .set-empty,
+  .set-skeleton,
+  .set-error {
+    padding: 16px;
+    border-radius: var(--radius-sm);
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+  .set-error {
+    background: rgba(229, 57, 53, 0.08);
+    border-left: 4px solid var(--color-error);
+    color: var(--color-text);
+  }
+</style>

--- a/frontend/app/src/lib/settings/UsersApp.svelte
+++ b/frontend/app/src/lib/settings/UsersApp.svelte
@@ -1,0 +1,293 @@
+<script lang="ts">
+  // Manage Users view (#settings-users-root). Parity with WhitelistAdmin.razor:
+  // add-by-email, a member list with "You" + status, and enable/disable/delete.
+  // Button visibility mirrors the server guards (self / last-active / last-user);
+  // the server is the source of truth (review R-A2) — the client gate is cosmetic.
+  import { onMount } from 'svelte';
+  import type { ShellContext, MemberDto } from './lib/types';
+  import { membersStore } from './lib/membersStore.svelte';
+  import ConfirmDialog from '$lib/shared/ConfirmDialog.svelte';
+
+  let { ctx }: { ctx: ShellContext } = $props();
+
+  const store = membersStore;
+
+  onMount(() => {
+    void ctx; // host context available; not needed by the store
+    void store.load();
+  });
+
+  let newEmail = $state('');
+  async function add() {
+    if (!newEmail.trim()) return;
+    if (await store.add(newEmail)) newEmail = '';
+  }
+
+  function isSelf(m: MemberDto): boolean {
+    return m.userId === store.currentUserId;
+  }
+  // Disable is offered only for an active member while more than one remains active.
+  function canDisable(m: MemberDto): boolean {
+    return !isSelf(m) && m.isWhitelisted && store.activeCount > 1;
+  }
+  function canEnable(m: MemberDto): boolean {
+    return !isSelf(m) && !m.isWhitelisted;
+  }
+  // Delete is offered for a non-self member while more than one user remains.
+  function canDelete(m: MemberDto): boolean {
+    return !isSelf(m) && store.members.length > 1;
+  }
+
+  // Delete confirm.
+  let confirmMember = $state<MemberDto | null>(null);
+  let confirmMessage = $state('');
+  function askDelete(m: MemberDto) {
+    confirmMessage =
+      `Permanently delete ${m.displayName ?? m.email} (${m.email})? ` +
+      `This removes their account from the household. Their recipes and feedback are kept. This can't be undone.`;
+    confirmMember = m;
+  }
+  async function confirmDelete() {
+    const target = confirmMember;
+    confirmMember = null;
+    if (target) await store.remove(target.userId);
+  }
+</script>
+
+<div class="set-page">
+  <h1 class="set-title">Manage Family Members</h1>
+
+  {#if store.loading}
+    <div class="set-skeleton">Loading…</div>
+  {:else if store.error}
+    <div class="set-error">{store.error}</div>
+  {:else}
+    <!-- Add member -->
+    <section class="set-card">
+      <h2 class="set-card-title">Add Family Member</h2>
+      <div class="set-add-row">
+        <input
+          class="set-input set-grow"
+          type="email"
+          placeholder="email@example.com"
+          bind:value={newEmail}
+          onkeydown={(e) => e.key === 'Enter' && add()}
+        />
+        <button type="button" class="set-btn-primary" onclick={add}>Add</button>
+      </div>
+    </section>
+
+    <!-- Members -->
+    <section class="set-card">
+      <h2 class="set-card-title">Current Members</h2>
+      <div class="set-members">
+        {#each store.members as m (m.userId)}
+          <div class="set-row set-row-static">
+            <div class="set-member-info">
+              <div class="set-member-line">
+                <span class="set-member-email">{m.email}</span>
+                {#if isSelf(m)}
+                  <span class="set-chip set-chip-info">You</span>
+                {/if}
+                {#if m.isWhitelisted}
+                  <span class="set-chip set-chip-success">Active</span>
+                {:else}
+                  <span class="set-chip set-chip-muted">Disabled</span>
+                {/if}
+              </div>
+              {#if m.displayName}
+                <span class="set-member-name">{m.displayName}</span>
+              {/if}
+            </div>
+            <div class="set-row-actions">
+              {#if isSelf(m)}
+                <span class="set-muted-note">Cannot modify self</span>
+              {:else}
+                {#if canDisable(m)}
+                  <button type="button" class="set-btn-text set-warn" onclick={() => store.toggle(m.userId, false)}>Disable</button>
+                {:else if canEnable(m)}
+                  <button type="button" class="set-btn-text set-ok" onclick={() => store.toggle(m.userId, true)}>Enable</button>
+                {/if}
+                {#if canDelete(m)}
+                  <button type="button" class="set-btn-text set-danger-text" onclick={() => askDelete(m)}>Delete</button>
+                {/if}
+              {/if}
+            </div>
+          </div>
+        {/each}
+      </div>
+    </section>
+  {/if}
+</div>
+
+<ConfirmDialog
+  open={confirmMember != null}
+  danger
+  title="Delete User"
+  message={confirmMessage}
+  confirmLabel="Delete"
+  onCancel={() => (confirmMember = null)}
+  onConfirm={confirmDelete}
+/>
+
+<style>
+  .set-page {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 24px 16px 96px;
+  }
+  .set-title {
+    margin: 0 0 20px;
+    font-size: 1.5rem;
+    font-weight: 500;
+  }
+  .set-card {
+    background: var(--color-surface);
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-1);
+    padding: 16px;
+    margin-bottom: 16px;
+  }
+  .set-card-title {
+    margin: 0 0 12px;
+    font-size: 1rem;
+    font-weight: 500;
+  }
+  .set-add-row {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+  .set-input {
+    font: inherit;
+    padding: 10px 12px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--color-line-strong);
+    background: var(--color-surface);
+    color: var(--color-text);
+    min-width: 120px;
+  }
+  .set-input:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -1px;
+  }
+  .set-grow {
+    flex: 1;
+    min-width: 200px;
+  }
+  .set-btn-primary {
+    font: inherit;
+    font-weight: 500;
+    padding: 10px 20px;
+    min-height: 42px;
+    border: none;
+    border-radius: var(--radius-sm);
+    background: var(--color-primary);
+    color: #fff;
+    cursor: pointer;
+  }
+  .set-btn-primary:hover {
+    background: var(--color-primary-hover);
+  }
+  .set-members {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .set-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 10px 12px;
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-sm);
+  }
+  .set-row-static {
+    background: var(--color-surface);
+  }
+  .set-member-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+  .set-member-line {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .set-member-email {
+    overflow-wrap: anywhere;
+  }
+  .set-member-name {
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+  }
+  .set-chip {
+    font-size: 0.6875rem;
+    font-weight: 500;
+    padding: 2px 10px;
+    border-radius: 12px;
+    white-space: nowrap;
+  }
+  .set-chip-info {
+    border: 1px solid var(--color-info);
+    color: var(--color-info);
+  }
+  .set-chip-success {
+    border: 1px solid var(--color-success);
+    color: var(--color-success);
+  }
+  .set-chip-muted {
+    border: 1px solid var(--color-line-strong);
+    color: var(--color-text-muted);
+  }
+  .set-row-actions {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+  }
+  .set-btn-text {
+    font: inherit;
+    font-weight: 500;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 6px 10px;
+    border-radius: var(--radius-sm);
+    color: var(--color-primary);
+  }
+  .set-btn-text:hover {
+    background: var(--color-action-hover);
+  }
+  .set-warn {
+    color: var(--color-warning);
+  }
+  .set-ok {
+    color: var(--color-success);
+  }
+  .set-danger-text {
+    color: var(--color-error);
+  }
+  .set-muted-note {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .set-skeleton,
+  .set-error {
+    padding: 16px;
+    border-radius: var(--radius-sm);
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+  .set-error {
+    background: rgba(229, 57, 53, 0.08);
+    border-left: 4px solid var(--color-error);
+    color: var(--color-text);
+  }
+</style>

--- a/frontend/app/src/lib/settings/lib/api.ts
+++ b/frontend/app/src/lib/settings/lib/api.ts
@@ -1,0 +1,122 @@
+import type {
+  CategoryListDto,
+  CategoryDto,
+  CategoryWriteRequest,
+  MemberListDto,
+  MemberActionDto,
+  MemberDto,
+} from './types';
+
+const CATEGORIES = '/api/settings/categories';
+const MEMBERS = '/api/settings/members';
+
+/**
+ * Thrown on any non-2xx response. `status` lets callers react to a rejection.
+ *
+ * ⚠ Carried from the other islands: the app re-executes empty-body API 4xx
+ * through a Blazor `/not-found` page, so a server-side "not found" can arrive
+ * as an empty 400 (a bare DELETE 404 even surfaces as 405). Every settings
+ * endpoint returns a NON-EMPTY body on 4xx, and the island treats ANY 4xx as a
+ * non-retryable client rejection → reconcile (refetch) + a calm toast.
+ */
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+
+  /** A non-retryable client rejection (validation / not found / conflict). Any 4xx. */
+  get isClientRejection(): boolean {
+    return this.status >= 400 && this.status < 500;
+  }
+}
+
+async function request<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    credentials: 'include',
+    headers: { Accept: 'application/json', ...(init?.headers ?? {}) },
+    ...init,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    let message = text || res.statusText;
+    // The endpoints return { message } on 4xx — surface it for the toast.
+    try {
+      const parsed = JSON.parse(text);
+      if (parsed && typeof parsed.message === 'string') message = parsed.message;
+    } catch { /* not JSON — use the raw text */ }
+    throw new ApiError(res.status, message);
+  }
+  if (res.status === 204) return undefined as T;
+  return (await res.json()) as T;
+}
+
+function jsonBody(body: unknown): RequestInit {
+  return {
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  };
+}
+
+// ─── Categories ─────────────────────────────────────────────────────────────
+
+/** #1 Active + deleted categories for the household. */
+export async function getCategories(): Promise<CategoryListDto> {
+  return request<CategoryListDto>(`${CATEGORIES}/`);
+}
+
+/** #2 Create → the saved category (201). Empty name → 400. */
+export async function createCategory(body: CategoryWriteRequest): Promise<CategoryDto> {
+  return request<CategoryDto>(`${CATEGORIES}/`, { method: 'POST', ...jsonBody(body) });
+}
+
+/** #3 Update name/emoji/color (sort order preserved) → the updated category. 404 if missing. */
+export async function updateCategory(categoryId: number, body: CategoryWriteRequest): Promise<CategoryDto> {
+  return request<CategoryDto>(`${CATEGORIES}/${categoryId}`, { method: 'PUT', ...jsonBody(body) });
+}
+
+/** #4 Soft-delete → 204 (idempotent). 404 if missing. */
+export async function deleteCategory(categoryId: number): Promise<void> {
+  await request<void>(`${CATEGORIES}/${categoryId}`, { method: 'DELETE' });
+}
+
+/** #5 Restore a soft-deleted category → 204 (idempotent). */
+export async function restoreCategory(categoryId: number): Promise<void> {
+  await request<void>(`${CATEGORIES}/${categoryId}/restore`, { method: 'POST' });
+}
+
+/** #6 Persist a new order (index ⇒ sortOrder) → 204. */
+export async function updateSortOrder(orderedIds: number[]): Promise<void> {
+  await request<void>(`${CATEGORIES}/sort-order`, { method: 'PUT', ...jsonBody({ orderedIds }) });
+}
+
+/** #7 Whether the category's name is used by any ingredient (for the delete confirm). */
+export async function categoryInUse(categoryId: number): Promise<boolean> {
+  const res = await request<{ inUse: boolean }>(`${CATEGORIES}/${categoryId}/in-use`);
+  return res.inUse;
+}
+
+// ─── Members ──────────────────────────────────────────────────────────────────
+
+/** #8 Household members + the caller's id (for "You" + self-gating). */
+export async function getMembers(): Promise<MemberListDto> {
+  return request<MemberListDto>(`${MEMBERS}/`);
+}
+
+/** #9 Add/re-enable by email → outcome envelope (200). Another household ⇒ 409 (ApiError). */
+export async function addMember(email: string): Promise<MemberActionDto> {
+  return request<MemberActionDto>(`${MEMBERS}/`, { method: 'POST', ...jsonBody({ email }) });
+}
+
+/** #10 Enable/disable → the updated member. Self ⇒ 400; last-active ⇒ 409 (ApiError). */
+export async function setWhitelist(userId: number, isWhitelisted: boolean): Promise<MemberDto> {
+  return request<MemberDto>(`${MEMBERS}/${userId}`, { method: 'PUT', ...jsonBody({ isWhitelisted }) });
+}
+
+/** #11 Delete a member → 204. Self ⇒ 400; last-user / has-activity ⇒ 409 (ApiError). */
+export async function deleteMember(userId: number): Promise<void> {
+  await request<void>(`${MEMBERS}/${userId}`, { method: 'DELETE' });
+}

--- a/frontend/app/src/lib/settings/lib/categoriesStore.svelte.ts
+++ b/frontend/app/src/lib/settings/lib/categoriesStore.svelte.ts
@@ -1,0 +1,139 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Categories view store (#settings-categories-root). Source of truth for the
+// active + deleted category lists.
+//
+// ⚠ Svelte 5 rune rule (global CORRECTION): never `export` a reassigned
+// `$state`. We wrap the mutable state in a class instance and export the instance.
+//
+// Parity-first ⇒ versionless / last-write-wins. This view is WRITE-heavy but
+// each surface is simple CRUD: every mutation `await`s then reloads the affected
+// lists; a `loadSeq` guard drops a stale reload that resolves after a newer one
+// (memory fca-island-async-race-guards). No autosave/draft — these are explicit
+// button actions. No liveness (parity: the page doesn't poll).
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { CategoryDto, CategoryWriteRequest } from './types';
+import {
+  ApiError,
+  getCategories,
+  createCategory,
+  updateCategory,
+  deleteCategory,
+  restoreCategory,
+  updateSortOrder,
+  categoryInUse,
+} from './api';
+import { showToast } from '$lib/shared/toast-store.svelte';
+
+class CategoriesStore {
+  active = $state<CategoryDto[]>([]);
+  deleted = $state<CategoryDto[]>([]);
+  loading = $state(true);
+  error = $state<string | null>(null);
+
+  /** True once the first load resolved — gates the skeleton so reloads don't reflash it. */
+  private hasLoaded = false;
+  /** Monotonic load id — a slower older response must not overwrite a newer one. */
+  private seq = 0;
+
+  /** Load both lists. Spinner only on the FIRST load; reloads refresh in place. */
+  async load(): Promise<void> {
+    const s = ++this.seq;
+    try {
+      if (!this.hasLoaded) this.loading = true;
+      this.error = null;
+      const dto = await getCategories();
+      if (s !== this.seq) return; // a newer load superseded this one
+      this.active = dto.active;
+      this.deleted = dto.deleted;
+      this.hasLoaded = true;
+    } catch (e) {
+      if (s !== this.seq) return;
+      this.error = describe(e, 'load categories');
+    } finally {
+      if (s === this.seq) this.loading = false;
+    }
+  }
+
+  async add(body: CategoryWriteRequest): Promise<boolean> {
+    try {
+      const created = await createCategory(body);
+      await this.load();
+      showToast({ message: `Category "${created.name}" created.`, kind: 'success' });
+      return true;
+    } catch (e) {
+      showToast({ message: describe(e, 'create category'), kind: 'error' });
+      return false;
+    }
+  }
+
+  async update(categoryId: number, body: CategoryWriteRequest): Promise<boolean> {
+    try {
+      await updateCategory(categoryId, body);
+      await this.load();
+      showToast({ message: 'Category updated.', kind: 'success' });
+      return true;
+    } catch (e) {
+      if (e instanceof ApiError) await this.load(); // reconcile to truth on 4xx
+      showToast({ message: describe(e, 'update category'), kind: 'error' });
+      return false;
+    }
+  }
+
+  /** Whether the category's name is used by an ingredient (drives the delete confirm copy). */
+  async checkInUse(categoryId: number): Promise<boolean> {
+    try {
+      return await categoryInUse(categoryId);
+    } catch {
+      return false; // non-critical — fall back to the plain confirm
+    }
+  }
+
+  async remove(categoryId: number): Promise<void> {
+    try {
+      await deleteCategory(categoryId);
+      await this.load();
+      showToast({ message: 'Category deleted.', kind: 'success' });
+    } catch (e) {
+      if (e instanceof ApiError) await this.load();
+      showToast({ message: describe(e, 'delete category'), kind: 'error' });
+    }
+  }
+
+  async restore(categoryId: number): Promise<void> {
+    try {
+      await restoreCategory(categoryId);
+      await this.load();
+      showToast({ message: 'Category restored.', kind: 'success' });
+    } catch (e) {
+      if (e instanceof ApiError) await this.load();
+      showToast({ message: describe(e, 'restore category'), kind: 'error' });
+    }
+  }
+
+  /**
+   * Persist a new order (parity: reorder commits immediately). Optimistic local
+   * reorder so the UI is responsive, then persist; on failure reload to restore
+   * the authoritative order + a toast.
+   */
+  async reorder(orderedIds: number[]): Promise<void> {
+    const byId = new Map(this.active.map((c) => [c.categoryId, c]));
+    const next = orderedIds.map((id) => byId.get(id)).filter((c): c is CategoryDto => c != null);
+    if (next.length === this.active.length) this.active = next;
+    try {
+      await updateSortOrder(orderedIds);
+    } catch (e) {
+      await this.load(); // restore the real order
+      showToast({ message: describe(e, 'reorder categories'), kind: 'error' });
+    }
+  }
+}
+
+function describe(e: unknown, action: string): string {
+  if (e instanceof ApiError) return e.message || `Couldn't ${action} (HTTP ${e.status}).`;
+  if (e instanceof Error) return e.message;
+  return `Couldn't ${action}.`;
+}
+
+/** The single shared categories-view store instance (export the instance, not the runes). */
+export const categoriesStore = new CategoriesStore();

--- a/frontend/app/src/lib/settings/lib/components/CategoryEditDialog.svelte
+++ b/frontend/app/src/lib/settings/lib/components/CategoryEditDialog.svelte
@@ -1,0 +1,157 @@
+<script lang="ts">
+  // In-island edit dialog — replaces the Blazor CategoryEditDialog MudDialog.
+  // Parity: plain freeform name + emoji text fields + a color input (the emoji is
+  // freeform text today, e.g. "meat_on_bone"; no emoji picker — that'd be new UX).
+  import type { CategoryDto, CategoryWriteRequest } from '../types';
+
+  interface Props {
+    open: boolean;
+    category: CategoryDto | null;
+    onCancel: () => void;
+    onSave: (body: CategoryWriteRequest) => void;
+  }
+
+  let { open, category, onCancel, onSave }: Props = $props();
+
+  let dialogEl = $state<HTMLDialogElement | null>(null);
+  let name = $state('');
+  let iconEmoji = $state('');
+  let color = $state('#808080');
+
+  // Seed the form from the category when the dialog opens. Reads open/category
+  // (props) and writes the form $state — it does NOT read the form fields, so
+  // there's no self-triggering loop.
+  $effect(() => {
+    if (open && category) {
+      name = category.name;
+      iconEmoji = category.iconEmoji ?? '';
+      color = category.color || '#808080';
+    }
+  });
+
+  $effect(() => {
+    if (!dialogEl) return;
+    if (open && !dialogEl.open) dialogEl.showModal();
+    else if (!open && dialogEl.open) dialogEl.close();
+  });
+
+  function save() {
+    if (!name.trim()) return;
+    onSave({ name: name.trim(), iconEmoji: iconEmoji.trim() || null, color });
+  }
+</script>
+
+<dialog bind:this={dialogEl} onclose={onCancel} class="rc-confirm">
+  {#if open}
+    <div class="rc-confirm-body">
+      <h2>Edit Category</h2>
+      <label class="set-field">
+        <span>Name</span>
+        <input type="text" bind:value={name} class="set-input" />
+      </label>
+      <label class="set-field">
+        <span>Emoji</span>
+        <input type="text" bind:value={iconEmoji} class="set-input" placeholder="e.g., meat_on_bone" />
+      </label>
+      <label class="set-field">
+        <span>Color</span>
+        <input type="color" bind:value={color} class="set-color" />
+      </label>
+      <div class="rc-confirm-actions">
+        <button type="button" class="rc-btn-ghost" onclick={onCancel}>Cancel</button>
+        <button type="button" class="rc-btn-primary" onclick={save} disabled={!name.trim()}>Save</button>
+      </div>
+    </div>
+  {/if}
+</dialog>
+
+<style>
+  .rc-confirm[open] {
+    position: fixed;
+    inset: 0;
+    margin: auto;
+    border: none;
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text);
+    padding: 0;
+    width: min(420px, calc(100vw - 32px));
+    box-shadow: var(--shadow-4);
+  }
+  .rc-confirm::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+  }
+  .rc-confirm-body {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 24px;
+  }
+  .rc-confirm h2 {
+    margin: 0 0 4px;
+    font-size: 1.25rem;
+    font-weight: 500;
+  }
+  .set-field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+  }
+  .set-input {
+    font: inherit;
+    padding: 10px 12px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--color-line-strong);
+    background: var(--color-surface);
+    color: var(--color-text);
+  }
+  .set-input:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -1px;
+  }
+  .set-color {
+    width: 64px;
+    height: 40px;
+    padding: 2px;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    cursor: pointer;
+  }
+  .rc-confirm-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 8px;
+  }
+  .rc-btn-ghost,
+  .rc-btn-primary {
+    font: inherit;
+    padding: 10px 20px;
+    border-radius: var(--radius-sm);
+    border: none;
+    cursor: pointer;
+    min-height: 40px;
+    font-weight: 500;
+  }
+  .rc-btn-ghost {
+    background: transparent;
+    color: var(--color-text-muted);
+  }
+  .rc-btn-ghost:hover {
+    background: var(--color-action-hover);
+  }
+  .rc-btn-primary {
+    background: var(--color-primary);
+    color: #fff;
+  }
+  .rc-btn-primary:hover {
+    background: var(--color-primary-hover);
+  }
+  .rc-btn-primary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+</style>

--- a/frontend/app/src/lib/settings/lib/dates.ts
+++ b/frontend/app/src/lib/settings/lib/dates.ts
@@ -1,0 +1,13 @@
+// Tiny date helper for the settings island. The only date on the wire is
+// Category.deletedAt — a FULL ISO-8601 instant (UTC), review X5. We parse the
+// full instant (new Date(iso) handles the offset correctly) and format it in the
+// user's local timezone. This is NOT the noon-UTC date-only case (that trick is
+// only for bare "YYYY-MM-DD" strings); never use new Date('YYYY-MM-DD') here.
+
+/** "deleted Jun 20"-style short date for a deleted category, or "" when absent/invalid. */
+export function formatDeletedDate(iso: string | null): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}

--- a/frontend/app/src/lib/settings/lib/membersStore.svelte.ts
+++ b/frontend/app/src/lib/settings/lib/membersStore.svelte.ts
@@ -1,0 +1,94 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Manage-Users view store (#settings-users-root). Source of truth for the
+// household member list + the caller's id (for "You" + self-gating).
+//
+// Same discipline as the categories store: untrack one-time load (in the App),
+// `loadSeq` guard, await-then-reload mutations, no liveness. The self / last-active
+// / last-user guards are enforced SERVER-side (the source of truth); the client
+// mirror here is only for button visibility (parity WhitelistAdmin).
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { MemberDto } from './types';
+import { ApiError, getMembers, addMember, setWhitelist, deleteMember } from './api';
+import { showToast } from '$lib/shared/toast-store.svelte';
+
+class MembersStore {
+  members = $state<MemberDto[]>([]);
+  currentUserId = $state(0);
+  loading = $state(true);
+  error = $state<string | null>(null);
+
+  private hasLoaded = false;
+  private seq = 0;
+
+  /** Active (whitelisted) member count — mirrors the server's last-active guard for button visibility. */
+  activeCount = $derived(this.members.filter((m) => m.isWhitelisted).length);
+
+  async load(): Promise<void> {
+    const s = ++this.seq;
+    try {
+      if (!this.hasLoaded) this.loading = true;
+      this.error = null;
+      const dto = await getMembers();
+      if (s !== this.seq) return;
+      this.members = dto.members;
+      this.currentUserId = dto.currentUserId;
+      this.hasLoaded = true;
+    } catch (e) {
+      if (s !== this.seq) return;
+      this.error = describe(e, 'load members');
+    } finally {
+      if (s === this.seq) this.loading = false;
+    }
+  }
+
+  async add(email: string): Promise<boolean> {
+    const trimmed = email.trim();
+    if (!trimmed) return false;
+    try {
+      const res = await addMember(trimmed);
+      await this.load();
+      if (res.outcome === 'created') {
+        showToast({ message: `Added ${res.member.email}.`, kind: 'success' });
+      } else if (res.outcome === 'reenabled') {
+        showToast({ message: `Re-enabled ${res.member.email}.`, kind: 'success' });
+      } else {
+        // alreadyActive — a benign notice, NOT an error (parity: a warning today, review R-A1).
+        showToast({ message: `${res.member.email} already has access.`, kind: 'info' });
+      }
+      return true;
+    } catch (e) {
+      showToast({ message: describe(e, 'add member'), kind: 'error' });
+      return false;
+    }
+  }
+
+  async toggle(userId: number, isWhitelisted: boolean): Promise<void> {
+    try {
+      await setWhitelist(userId, isWhitelisted);
+      await this.load();
+    } catch (e) {
+      if (e instanceof ApiError) await this.load();
+      showToast({ message: describe(e, isWhitelisted ? 'enable member' : 'disable member'), kind: 'error' });
+    }
+  }
+
+  async remove(userId: number): Promise<void> {
+    try {
+      await deleteMember(userId);
+      await this.load();
+      showToast({ message: 'Member removed.', kind: 'success' });
+    } catch (e) {
+      if (e instanceof ApiError) await this.load();
+      showToast({ message: describe(e, 'remove member'), kind: 'error' });
+    }
+  }
+}
+
+function describe(e: unknown, action: string): string {
+  if (e instanceof ApiError) return e.message || `Couldn't ${action} (HTTP ${e.status}).`;
+  if (e instanceof Error) return e.message;
+  return `Couldn't ${action}.`;
+}
+
+export const membersStore = new MembersStore();

--- a/frontend/app/src/lib/settings/lib/types.ts
+++ b/frontend/app/src/lib/settings/lib/types.ts
@@ -1,0 +1,65 @@
+// ─────────────────────────────────────────────────────────────────────────
+// TS mirror of the /api/settings contract (M9 lockstep). Source of truth:
+//   - Services/Dtos/SettingsDtos.cs (the C# records — named Settings* there to
+//     avoid colliding with the recipes/chores DTOs; here they are island-local)
+//   - tests/.../Fixtures/Settings/{categories,members}.json (byte-locked tripwires)
+//   - Endpoints/SettingsEndpoints.cs (request DTOs)
+//
+// ⚠ CASING: all keys camelCase. No enums.
+// ⚠ DATES (review X5): `deletedAt` is a FULL ISO-8601 instant (UTC) or null —
+//   render it local via new Date(iso) (NEVER new Date('YYYY-MM-DD')).
+// ─────────────────────────────────────────────────────────────────────────
+
+/** The per-page context the Razor host hands the island via data- attributes. */
+export interface ShellContext {
+  householdId: number;
+  userId: number;
+  userName: string;
+  view: 'categories' | 'users';
+}
+
+// ── Categories (Fixtures/Settings/categories.json) ──────────────────────────
+
+export interface CategoryDto {
+  categoryId: number;
+  name: string;
+  iconEmoji: string | null;
+  color: string;
+  isDefault: boolean;
+  sortOrder: number;
+  /** full ISO-8601 instant (UTC) for deleted rows, else null. */
+  deletedAt: string | null;
+}
+
+export interface CategoryListDto {
+  active: CategoryDto[];
+  deleted: CategoryDto[];
+}
+
+export interface CategoryWriteRequest {
+  name: string;
+  iconEmoji: string | null;
+  color: string;
+}
+
+// ── Members (Fixtures/Settings/members.json) ────────────────────────────────
+
+export interface MemberDto {
+  userId: number;
+  email: string;
+  displayName: string | null;
+  isWhitelisted: boolean;
+}
+
+export interface MemberListDto {
+  currentUserId: number;
+  members: MemberDto[];
+}
+
+/** Add-member outcome envelope (review R-A1): "alreadyActive" is a WARNING, not an error. */
+export type AddMemberOutcome = 'created' | 'reenabled' | 'alreadyActive';
+
+export interface MemberActionDto {
+  member: MemberDto;
+  outcome: AddMemberOutcome;
+}

--- a/frontend/app/src/lib/shell/Header.svelte
+++ b/frontend/app/src/lib/shell/Header.svelte
@@ -3,10 +3,19 @@
   // presence (placeholder — wired in WP-02), dark-mode toggle, site-admin chip,
   // user name + avatar, logout. Identity comes from the canonical session store;
   // dark mode from the theme store.
+  import { onMount } from 'svelte';
   import { session } from '$lib/session.svelte';
   import { theme } from '$lib/theme.svelte';
+  import { presence } from '$lib/presence.svelte';
   import Icon from './Icon.svelte';
   import UserAvatar from '$lib/shared/UserAvatar.svelte';
+
+  // The header is the single always-present consumer of presence, so it owns the
+  // poller lifecycle: start the 30s heartbeat + roster poll on mount, stop on teardown.
+  onMount(() => {
+    presence.start();
+    return () => presence.stop();
+  });
 </script>
 
 <header class="sh-header">
@@ -15,8 +24,24 @@
   <div class="sh-header-spacer"></div>
 
   <div class="sh-header-actions">
-    <!-- presence placeholder — online-users pill is wired in WP-02 -->
-    <div class="sh-presence" data-presence-slot aria-hidden="true"></div>
+    <!-- Online-users roster + client-derived sync indicator (WP-02). -->
+    <div class="sh-presence">
+      {#each presence.users.slice(0, 5) as u (u.userId)}
+        <span
+          class="sh-presence-avatar"
+          class:sh-presence-away={u.status === 'away'}
+          title={u.status === 'away' ? `${u.displayName} (away)` : u.displayName}
+        >
+          <UserAvatar name={u.displayName} initials={u.initials} pictureUrl={u.pictureUrl} size={24} />
+        </span>
+      {/each}
+      <span
+        class="sh-sync"
+        class:sh-sync-offline={!presence.online}
+        title={presence.online ? 'Synced' : 'Offline — reconnecting…'}
+        aria-label={presence.online ? 'Synced' : 'Offline'}
+      ></span>
+    </div>
 
     <button
       type="button"
@@ -80,6 +105,30 @@
   .sh-presence {
     display: flex;
     align-items: center;
+    gap: 4px;
+  }
+  .sh-presence-avatar {
+    display: inline-flex;
+    border-radius: 50%;
+    margin-left: -6px;
+    box-shadow: 0 0 0 2px var(--color-appbar);
+  }
+  .sh-presence-avatar:first-child {
+    margin-left: 0;
+  }
+  .sh-presence-away {
+    opacity: 0.5;
+  }
+  .sh-sync {
+    width: 8px;
+    height: 8px;
+    margin-left: 6px;
+    border-radius: 50%;
+    background: var(--color-success, #43a047);
+    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.25);
+  }
+  .sh-sync-offline {
+    background: var(--color-text-disabled, #9e9e9e);
   }
   .sh-icon-btn {
     display: inline-flex;

--- a/frontend/app/src/routes/+page.svelte
+++ b/frontend/app/src/routes/+page.svelte
@@ -1,23 +1,27 @@
 <script lang="ts">
+  // SPA index (/app). The app has no content of its own at the root, so it
+  // redirects to the dashboard. The redirect is a client-side goto in onMount —
+  // NOT a +page.ts SSR `redirect` — because the app runs ssr=false (+layout.ts).
+  // replaceState keeps the redirecting index out of the history stack. A minimal
+  // loading body (not an empty page) avoids a blank-white flash during the
+  // one-tick redirect. [R2 — closes the WP-08 Minor]
+  import { onMount } from 'svelte';
   import { base } from '$app/paths';
+  import { goto } from '$app/navigation';
+
+  onMount(() => {
+    void goto(`${base}/dashboard`, { replaceState: true });
+  });
 </script>
 
-<section class="spike-index">
-  <h1>De-Blazor spike</h1>
-  <p>The shopping-list island, rendered as a SvelteKit route over <code>/api</code>.</p>
-  <a class="spike-link" href="{base}/shopping-list">Open shopping list →</a>
-</section>
+<div class="index-loading">
+  <p>Loading…</p>
+</div>
 
 <style>
-  .spike-index {
-    max-width: 640px;
-    margin: 0 auto;
+  .index-loading {
     padding: 48px 16px;
-  }
-  .spike-link {
-    display: inline-block;
-    margin-top: 16px;
-    font-weight: 600;
-    color: var(--color-primary, #2e7d32);
+    text-align: center;
+    color: var(--color-text-muted, #666);
   }
 </style>

--- a/frontend/app/src/routes/chores/+page.svelte
+++ b/frontend/app/src/routes/chores/+page.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  // Chores route. Identity comes from the canonical $lib/session store (booted
+  // once in the shell +layout.svelte) — NOT a per-route /api/me fetch (M8). The
+  // store handles the 401 → /account/login redirect and surfaces load errors
+  // through the shell layout's banner. Chores needs no route params; ctx() with
+  // no args supplies the household/user identity the island reads.
+  import App from '$lib/chores/App.svelte';
+  import { session, ctx } from '$lib/session.svelte';
+</script>
+
+{#if session.ready}
+  <App ctx={ctx()} />
+{:else if session.status !== 'error'}
+  <p class="route-status">Loading…</p>
+{/if}
+
+<style>
+  .route-status {
+    padding: 48px 16px;
+    text-align: center;
+    color: var(--color-text-muted, #666);
+  }
+</style>

--- a/frontend/app/src/routes/dashboard/+page.svelte
+++ b/frontend/app/src/routes/dashboard/+page.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  // Dashboard route (/dashboard → the read-only dashboard island over
+  // GET /api/dashboard). Identity comes from the canonical $lib/session store
+  // (M8) — no per-route /api/me fetch. This is also the SPA's landing surface:
+  // /app redirects here (see routes/+page.svelte).
+  import App from '$lib/dashboard/App.svelte';
+  import { session, ctx } from '$lib/session.svelte';
+</script>
+
+{#if session.ready}
+  <App ctx={ctx()} />
+{:else if session.status !== 'error'}
+  <p class="route-status">Loading…</p>
+{/if}
+
+<style>
+  .route-status {
+    padding: 48px 16px;
+    text-align: center;
+    color: var(--color-text-muted, #666);
+  }
+</style>

--- a/frontend/app/src/routes/meal-plan/+page.svelte
+++ b/frontend/app/src/routes/meal-plan/+page.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  // Meal-plan route. Identity comes from the canonical $lib/session store
+  // (booted once in the shell +layout.svelte) — NOT a per-route /api/me fetch
+  // (M8). Week navigation is island-internal state driving a weekStart query on
+  // /api/meal-plan/board, so there is no browser URL to make base-aware.
+  import App from '$lib/meal-plan/App.svelte';
+  import { session, ctx } from '$lib/session.svelte';
+</script>
+
+{#if session.ready}
+  <App ctx={ctx()} />
+{:else if session.status !== 'error'}
+  <p class="route-status">Loading…</p>
+{/if}
+
+<style>
+  .route-status {
+    padding: 48px 16px;
+    text-align: center;
+    color: var(--color-text-muted, #666);
+  }
+</style>

--- a/frontend/app/src/routes/recipes/+page.svelte
+++ b/frontend/app/src/routes/recipes/+page.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  // Recipes list route (/recipes → ListApp, the island's old data-view="list").
+  // Identity comes from the canonical $lib/session store (M8) — NOT a per-route
+  // /api/me fetch. The recipes island's ShellContext carries a `view`
+  // discriminator (list|edit) + recipeId, so the route builds the ctx literal
+  // directly from session identity rather than the shared ctx() helper.
+  import ListApp from '$lib/recipes/ListApp.svelte';
+  import { session } from '$lib/session.svelte';
+</script>
+
+{#if session.ready}
+  <ListApp
+    ctx={{
+      householdId: session.householdId!,
+      userId: session.userId!,
+      userName: session.userName!,
+      view: 'list',
+      recipeId: null,
+    }}
+  />
+{:else if session.status !== 'error'}
+  <p class="route-status">Loading…</p>
+{/if}
+
+<style>
+  .route-status {
+    padding: 48px 16px;
+    text-align: center;
+    color: var(--color-text-muted, #666);
+  }
+</style>

--- a/frontend/app/src/routes/recipes/edit/[id]/+page.svelte
+++ b/frontend/app/src/routes/recipes/edit/[id]/+page.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  // Recipe edit route (/recipes/edit/{id} → EditApp, the island's data-view="edit").
+  // recipeId comes from the route param (kept in the /recipes/edit/{id} shape the
+  // island already navigates to — do NOT reshape). Identity from $lib/session (M8).
+  import { page } from '$app/state';
+  import EditApp from '$lib/recipes/EditApp.svelte';
+  import { session } from '$lib/session.svelte';
+
+  const recipeId = $derived.by(() => {
+    const n = Number(page.params.id);
+    return Number.isFinite(n) ? n : null;
+  });
+</script>
+
+{#if session.ready}
+  <EditApp
+    ctx={{
+      householdId: session.householdId!,
+      userId: session.userId!,
+      userName: session.userName!,
+      view: 'edit',
+      recipeId,
+    }}
+  />
+{:else if session.status !== 'error'}
+  <p class="route-status">Loading…</p>
+{/if}
+
+<style>
+  .route-status {
+    padding: 48px 16px;
+    text-align: center;
+    color: var(--color-text-muted, #666);
+  }
+</style>

--- a/frontend/app/src/routes/recipes/import/+page.svelte
+++ b/frontend/app/src/routes/recipes/import/+page.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  // Import route (/recipes/import). The island's ImportDialog is a modal opened
+  // from within ListApp — there is no standalone import view — so this route
+  // renders ListApp with the dialog auto-opened on mount. Closing the dialog
+  // returns to /recipes (base-aware); a successful import follows the island's
+  // own base-aware nav to the new/edited recipe. Identity from $lib/session (M8).
+  import { base } from '$app/paths';
+  import { goto } from '$app/navigation';
+  import ListApp from '$lib/recipes/ListApp.svelte';
+  import { session } from '$lib/session.svelte';
+</script>
+
+{#if session.ready}
+  <ListApp
+    openImport
+    onImportClose={() => goto(`${base}/recipes`)}
+    ctx={{
+      householdId: session.householdId!,
+      userId: session.userId!,
+      userName: session.userName!,
+      view: 'list',
+      recipeId: null,
+    }}
+  />
+{:else if session.status !== 'error'}
+  <p class="route-status">Loading…</p>
+{/if}
+
+<style>
+  .route-status {
+    padding: 48px 16px;
+    text-align: center;
+    color: var(--color-text-muted, #666);
+  }
+</style>

--- a/frontend/app/src/routes/recipes/new/+page.svelte
+++ b/frontend/app/src/routes/recipes/new/+page.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  // New-recipe route (/recipes/new → EditApp with a null recipeId, the island's
+  // data-view="edit" + no recipe-id). Identity from $lib/session (M8).
+  import EditApp from '$lib/recipes/EditApp.svelte';
+  import { session } from '$lib/session.svelte';
+</script>
+
+{#if session.ready}
+  <EditApp
+    ctx={{
+      householdId: session.householdId!,
+      userId: session.userId!,
+      userName: session.userName!,
+      view: 'edit',
+      recipeId: null,
+    }}
+  />
+{:else if session.status !== 'error'}
+  <p class="route-status">Loading…</p>
+{/if}
+
+<style>
+  .route-status {
+    padding: 48px 16px;
+    text-align: center;
+    color: var(--color-text-muted, #666);
+  }
+</style>

--- a/frontend/app/src/routes/settings/categories/+page.svelte
+++ b/frontend/app/src/routes/settings/categories/+page.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  // Settings → Categories route (/settings/categories → the settings island's
+  // CategoriesApp, the old data-view="categories"). Identity from the canonical
+  // $lib/session store (M8). The settings island's ShellContext carries a `view`
+  // discriminator, so the route builds the ctx literal from session identity.
+  import CategoriesApp from '$lib/settings/CategoriesApp.svelte';
+  import { session } from '$lib/session.svelte';
+</script>
+
+{#if session.ready}
+  <CategoriesApp
+    ctx={{
+      householdId: session.householdId!,
+      userId: session.userId!,
+      userName: session.userName!,
+      view: 'categories',
+    }}
+  />
+{:else if session.status !== 'error'}
+  <p class="route-status">Loading…</p>
+{/if}
+
+<style>
+  .route-status {
+    padding: 48px 16px;
+    text-align: center;
+    color: var(--color-text-muted, #666);
+  }
+</style>

--- a/frontend/app/src/routes/settings/connections/+page.svelte
+++ b/frontend/app/src/routes/settings/connections/+page.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  // Settings → Connections route (/settings/connections → the connections island's
+  // invite-code flow). Identity from $lib/session (M8); connections' ShellContext
+  // is the plain {householdId,userId,userName} shape, so ctx() supplies it drop-in.
+  import App from '$lib/connections/App.svelte';
+  import { session, ctx } from '$lib/session.svelte';
+</script>
+
+{#if session.ready}
+  <App ctx={ctx()} />
+{:else if session.status !== 'error'}
+  <p class="route-status">Loading…</p>
+{/if}
+
+<style>
+  .route-status {
+    padding: 48px 16px;
+    text-align: center;
+    color: var(--color-text-muted, #666);
+  }
+</style>

--- a/frontend/app/src/routes/settings/feedback/+page.svelte
+++ b/frontend/app/src/routes/settings/feedback/+page.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  // Settings → Feedback route (/settings/feedback → the admin island's FeedbackApp,
+  // the old admin-feedback-root, dual-mode list/triage). Identity from $lib/session
+  // (M8); the admin ShellContext carries a `view` discriminator. The API enforces
+  // site-admin on triage actions — the island renders its own handling.
+  import FeedbackApp from '$lib/admin/FeedbackApp.svelte';
+  import { session } from '$lib/session.svelte';
+</script>
+
+{#if session.ready}
+  <FeedbackApp
+    ctx={{
+      householdId: session.householdId!,
+      userId: session.userId!,
+      userName: session.userName!,
+      view: 'feedback',
+    }}
+  />
+{:else if session.status !== 'error'}
+  <p class="route-status">Loading…</p>
+{/if}
+
+<style>
+  .route-status {
+    padding: 48px 16px;
+    text-align: center;
+    color: var(--color-text-muted, #666);
+  }
+</style>

--- a/frontend/app/src/routes/settings/households/+page.svelte
+++ b/frontend/app/src/routes/settings/households/+page.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  // Settings → Household Requests route (/settings/households → the admin island's
+  // HouseholdsApp, the old admin-households-root). SITE-ADMIN ONLY: the households
+  // nav entry is already gated on session.isSiteAdmin (shell Nav), and a non-admin
+  // who reaches the route gets the API's 403 surfaced as the island's built-in
+  // "Access denied" panel (R-C4) inside the shell — never a blank page. Identity
+  // from $lib/session (M8); the admin ShellContext carries a `view` discriminator.
+  import HouseholdsApp from '$lib/admin/HouseholdsApp.svelte';
+  import { session } from '$lib/session.svelte';
+</script>
+
+{#if session.ready}
+  <HouseholdsApp
+    ctx={{
+      householdId: session.householdId!,
+      userId: session.userId!,
+      userName: session.userName!,
+      view: 'households',
+    }}
+  />
+{:else if session.status !== 'error'}
+  <p class="route-status">Loading…</p>
+{/if}
+
+<style>
+  .route-status {
+    padding: 48px 16px;
+    text-align: center;
+    color: var(--color-text-muted, #666);
+  }
+</style>

--- a/frontend/app/src/routes/settings/users/+page.svelte
+++ b/frontend/app/src/routes/settings/users/+page.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  // Settings → Family Members route (/settings/users → the settings island's
+  // UsersApp, the old data-view="users"). Identity from $lib/session (M8);
+  // ShellContext carries a `view` discriminator, built from session identity.
+  import UsersApp from '$lib/settings/UsersApp.svelte';
+  import { session } from '$lib/session.svelte';
+</script>
+
+{#if session.ready}
+  <UsersApp
+    ctx={{
+      householdId: session.householdId!,
+      userId: session.userId!,
+      userName: session.userName!,
+      view: 'users',
+    }}
+  />
+{:else if session.status !== 'error'}
+  <p class="route-status">Loading…</p>
+{/if}
+
+<style>
+  .route-status {
+    padding: 48px 16px;
+    text-align: center;
+    color: var(--color-text-muted, #666);
+  }
+</style>

--- a/src/FamilyCoordinationApp/Endpoints/PresenceEndpoints.cs
+++ b/src/FamilyCoordinationApp/Endpoints/PresenceEndpoints.cs
@@ -1,0 +1,96 @@
+using System.Security.Claims;
+using FamilyCoordinationApp.Data;
+using FamilyCoordinationApp.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace FamilyCoordinationApp.Endpoints;
+
+/// <summary>
+/// /api/presence/* — exposes the in-memory <see cref="PresenceService"/> over HTTP so the de-Blazored
+/// SvelteKit shell can drive the header's online-users avatar row + a client-derived sync indicator,
+/// replacing the Blazor circuit heartbeat (D3). <c>POST /heartbeat</c> records the caller's activity + the
+/// SPA path they're on; <c>GET /users</c> returns the caller-excluded active users as a typed DTO.
+/// <para>
+/// CRITICAL: <c>GET /users</c> FIRST runs <see cref="PresenceService.UpdatePresence"/> — the
+/// Online→Away→Offline staleness decay that <c>PollingService</c> used to drive on a timer. WP-12 deletes
+/// PollingService, so without this call a user who closed their tab would linger <c>Online</c> forever.
+/// The endpoints only ADD to the backend (M1); the Blazor MainLayout heartbeat + PollingService are
+/// removed in WP-12 after the M5 consumer audit.
+/// </para>
+/// </summary>
+public static class PresenceEndpoints
+{
+    public static IEndpointRouteBuilder MapPresenceEndpoints(this IEndpointRouteBuilder app)
+    {
+        // Same group posture as the other island endpoint groups: cookie auth + no antiforgery token
+        // (the SPA calls these with credentials: 'include' and no CSRF token — same-origin cookie only, M2).
+        var group = app.MapGroup("/api/presence")
+            .RequireAuthorization()
+            .DisableAntiforgery();
+
+        group.MapPost("/heartbeat", Heartbeat);
+        group.MapGet("/users", GetUsers);
+
+        return app;
+    }
+
+    private static async Task<IResult> Heartbeat(
+        HeartbeatRequest request,
+        ClaimsPrincipal principal,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        PresenceService presence,
+        CancellationToken ct)
+    {
+        // PresenceService.Heartbeat needs display name / initials / picture, which UserContextResolver
+        // does not carry — so load the same projection MeEndpoints does (identity from the DB, never the
+        // client). The caller's user id + household come ONLY from their email claim (multi-tenant boundary).
+        var email = principal.FindFirst(ClaimTypes.Email)?.Value;
+        if (string.IsNullOrEmpty(email)) return Results.Unauthorized();
+
+        await using var db = await dbFactory.CreateDbContextAsync(ct);
+        var user = await db.Users
+            .Where(u => u.Email == email)
+            .Select(u => new { u.Id, u.DisplayName, u.Initials, u.PictureUrl })
+            .FirstOrDefaultAsync(ct);
+
+        if (user is null) return Results.Unauthorized();
+
+        presence.Heartbeat(user.Id, user.DisplayName, user.PictureUrl, user.Initials, request.Page);
+        return Results.NoContent();
+    }
+
+    private static async Task<IResult> GetUsers(
+        ClaimsPrincipal principal,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        PresenceService presence,
+        CancellationToken ct)
+    {
+        var caller = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (caller is null) return Results.Unauthorized();
+
+        // Drive the staleness decay PollingService used to run on a timer (WP-12 deletes it), so closed-tab
+        // users age Online→Away→Offline instead of showing Online forever. Idempotent + cheap (in-memory).
+        presence.UpdatePresence();
+
+        // Exclude the caller (they don't need to see themselves in the roster) and project to a typed DTO —
+        // never the raw UserPresence, which would leak LastSeen / CurrentPage. Status is the PresenceStatus
+        // enum, serialized "online"/"away" by the global camelCase JsonStringEnumConverter (Program.cs).
+        var users = presence.GetAllActiveUsers()
+            .Where(p => p.UserId != caller.UserId)
+            .Select(p => new PresenceUserDto(p.UserId, p.DisplayName, p.Initials, p.PictureUrl, p.Status))
+            .ToList();
+
+        return Results.Ok(users);
+    }
+
+    /// <summary>POST body for a heartbeat: the SPA path the caller is currently on (nullable/cosmetic).</summary>
+    public sealed record HeartbeatRequest(string? Page);
+
+    /// <summary>The caller-excluded active-user shape the shell header renders (no LastSeen / CurrentPage).</summary>
+    public sealed record PresenceUserDto(
+        int UserId,
+        string DisplayName,
+        string? Initials,
+        string? PictureUrl,
+        PresenceStatus Status);
+}

--- a/src/FamilyCoordinationApp/Program.cs
+++ b/src/FamilyCoordinationApp/Program.cs
@@ -440,6 +440,7 @@ app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();
 
 app.MapMeEndpoints();
+app.MapPresenceEndpoints();
 app.MapShoppingListEndpoints();
 app.MapChoresEndpoints();
 app.MapRoomsEndpoints();

--- a/tests/FamilyCoordinationApp.Tests/Services/PresenceServiceTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/PresenceServiceTests.cs
@@ -1,0 +1,68 @@
+using FamilyCoordinationApp.Services;
+using FluentAssertions;
+
+namespace FamilyCoordinationApp.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="PresenceService"/> — the in-memory presence tracker the de-Blazored shell's
+/// <c>GET /api/presence/users</c> endpoint (WP-02) reads. That endpoint calls
+/// <see cref="PresenceService.UpdatePresence"/> itself before <see cref="PresenceService.GetAllActiveUsers"/>,
+/// because WP-12 deletes the <c>PollingService</c> that used to drive the Online→Away→Offline staleness decay
+/// on a timer. These tests lock that decay contract so a user who closes their tab ages out of the roster
+/// instead of showing Online forever (the CRITICAL failure WP-02 calls out).
+/// </summary>
+public class PresenceServiceTests
+{
+    [Fact]
+    public void Heartbeat_MarksUserOnline_AndListsThem()
+    {
+        var svc = new PresenceService();
+        svc.Heartbeat(1, "Alice", pictureUrl: null, initials: "AL", currentPage: "/shopping-list");
+
+        var active = svc.GetAllActiveUsers().ToList();
+        active.Should().ContainSingle(u => u.UserId == 1);
+        active.Single(u => u.UserId == 1).Status.Should().Be(PresenceStatus.Online);
+    }
+
+    [Fact]
+    public void GetAllActiveUsers_ReturnsEveryOnlineUser_TheEndpointExcludesTheCaller()
+    {
+        var svc = new PresenceService();
+        svc.Heartbeat(1, "Alice", null, "AL");
+        svc.Heartbeat(2, "Bob", null, "BO");
+
+        // The service returns both; the /users endpoint filters out the caller (Where UserId != caller.UserId).
+        svc.GetAllActiveUsers().Select(u => u.UserId).Should().BeEquivalentTo(new[] { 1, 2 });
+    }
+
+    [Fact]
+    public void UpdatePresence_AgesAStaleUserToOffline_SoTheyDropFromTheRoster()
+    {
+        var svc = new PresenceService();
+        svc.Heartbeat(1, "Alice", null, "AL");
+
+        // Simulate a closed tab: last seen 16 minutes ago (> the 15-min Offline threshold).
+        svc.GetUserPresence(1)!.LastSeen = DateTime.UtcNow.AddMinutes(-16);
+
+        svc.UpdatePresence();
+
+        svc.GetUserPresence(1)!.Status.Should().Be(PresenceStatus.Offline);
+        svc.GetAllActiveUsers().Should().NotContain(u => u.UserId == 1);
+    }
+
+    [Fact]
+    public void UpdatePresence_AgesAnIdleUserToAway_ButKeepsThemInTheRoster()
+    {
+        var svc = new PresenceService();
+        svc.Heartbeat(1, "Alice", null, "AL");
+
+        // Idle 6 minutes (> the 5-min Away threshold, < the 15-min Offline threshold).
+        svc.GetUserPresence(1)!.LastSeen = DateTime.UtcNow.AddMinutes(-6);
+
+        svc.UpdatePresence();
+
+        var alice = svc.GetAllActiveUsers().SingleOrDefault(u => u.UserId == 1);
+        alice.Should().NotBeNull();
+        alice!.Status.Should().Be(PresenceStatus.Away);
+    }
+}


### PR DESCRIPTION
## De-Blazor Wave 3 — Presence + island route fan-out (keystone `ae67f7dc`)

Executes **Wave 3** of the de-Blazor SvelteKit-shell spec (`outputs/workshops/deblazor-sveltekit-shell/`) — 6 work packages, one per commit. All build-out stays behind `/app` (MN8); the live Blazor routes + the old `frontend/{island}` micro-apps are untouched (rollback safety, deleted only in WP-12).

### What landed

| WP | Surface | Routes added |
|----|---------|--------------|
| **WP-05** | chores | `/chores` |
| **WP-06** | meal-plan | `/meal-plan` |
| **WP-07** | recipes | `/recipes`, `/recipes/edit/[id]`, `/recipes/new`, `/recipes/import` |
| **WP-08** | dashboard | `/dashboard` + SPA index (`/app` → `/dashboard`) |
| **WP-09** | settings | `/settings/{categories,users,connections,feedback,households}` |
| **WP-02** | presence | `POST /api/presence/heartbeat`, `GET /api/presence/users` + header wiring |

Each island route follows the three patterns locked in Wave 2 (WP-04):
1. **No island `<Toasts/>`** — the shell `+layout.svelte` mounts the single canonical toast region; every island's `showToast` was rewired to `$lib/shared/toast-store.svelte`.
2. **M8 identity** — routes read identity from the canonical `$lib/session` store (via `ctx()` or a session-built ctx literal for the `view`-carrying islands), never a per-route `/api/me` fetch.
3. **Base-aware nav** — every in-island path write (`recipes` `location.assign`, dashboard quick-actions) is now `${base}/…` (`$app/paths`), via `goto` in components and base-aware `location.assign` in the recipe-edit store (no `$app/navigation` coupling in the lib).

Shared-component swaps validated drop-in: `MemberAvatar` (chores), `ConfirmDialog` (meal-plan/recipes/settings/admin) → `$lib/shared/*`. Destructive confirms whose old dialog defaulted to red (recipes, settings) now pass `danger` explicitly (admin Approve keeps `tone="primary"`; meal-plan's Remove was green, unchanged).

### WP-02 presence

- `PresenceEndpoints.cs` exposes the existing in-memory `PresenceService` over `/api` (cookie auth, no antiforgery — same posture as the other island groups). `GET /users` **calls `PresenceService.UpdatePresence()` itself** before `GetAllActiveUsers()` — the Online→Away→Offline staleness decay that `PollingService` used to drive on a timer (WP-12 deletes it), so a closed tab ages out instead of showing Online forever. Caller is self-excluded; DTO omits `LastSeen`/`CurrentPage`; `Status` serializes `online`/`away` via the global camelCase enum converter.
- `presence.svelte.ts` polls heartbeat + roster every 30s and derives an `online` sync flag from the last call. `Header.svelte` renders the avatar row (`$lib/shared/UserAvatar`) + sync indicator and owns the poller lifecycle.
- New `PresenceServiceTests` (4 tests) lock the decay contract (heartbeat→list, age→Away keeps in roster, age→Offline drops from roster).

### Gates (all green)

- `dotnet build` — 0 errors
- `npm run check` (svelte-check) — **0 errors**, 282 files (2 pre-existing/intentional `state_referenced_locally` warnings: the shopping-list spike baseline + the recipes `openImport` initial-value capture)
- `npm run build` (vite/adapter-static) — built clean
- `dotnet test --filter PresenceServiceTests` — 4/4 passed

### Not in this PR (deliberate)

- **Browser-parity verification (the operator fork).** Route-by-route parity on a rebuilt `:8080` is the deferred fork from the spec's *Decisions needed*. The `:8080` container is stale (predates this branch). Per Link 6's finding: `claude-in-chrome` DOM+psql covers most parity, but **drag-heavy surfaces (chores + meal-plan boards) need a human parity check** — automation can't reliably drive cross-zone drags. Recommend verifying during the Jul 10–20 window before the WP-12 flip.
- Waves 4–5 (peripheral static pages, onboarding, and the flip/delete-Blazor) — keystone `ae67f7dc` stays open.

Spec: `outputs/workshops/deblazor-sveltekit-shell/work-packages/` (WP-02/05/06/07/08/09). Base: `master` (Wave 1 #59 + Wave 2 #60 merged).

https://claude.ai/code/session_013YMHavg5XoW16eMmUmNdD9
