### PR TITLE
fix(review): de-Blazor pre-flip review fixes — 401 body, household-scoped presence, SPA auth-death handling

### DIFF
--- a/frontend/app/src/lib/presence.svelte.ts
+++ b/frontend/app/src/lib/presence.svelte.ts
@@ -33,6 +33,7 @@ class PresenceStore {
   #online = $state(true);
   #timer: ReturnType<typeof setInterval> | null = null;
   #started = false;
+  #ticking = false;
 
   /** The active users to show in the header (excludes the caller). */
   get users(): readonly PresenceUser[] {
@@ -64,8 +65,29 @@ class PresenceStore {
   }
 
   async #tick(): Promise<void> {
-    await this.#heartbeat();
-    await this.#loadUsers();
+    // Re-entrancy guard: if a tick's fetches stall past the interval, skip the
+    // overlapping tick instead of racing two writers over #users/#online.
+    if (this.#ticking) return;
+    this.#ticking = true;
+    try {
+      await this.#heartbeat();
+      await this.#loadUsers();
+    } finally {
+      this.#ticking = false;
+    }
+  }
+
+  /**
+   * A 401/403 mid-session means the cookie died (or access was revoked) — the
+   * network is fine and no retry can fix it, so "reconnecting…" would lie
+   * forever. Stop polling and hand the browser to the same server-side pages
+   * the session store bounces to on boot.
+   */
+  #authDied(status: number): void {
+    this.stop();
+    if (typeof window !== 'undefined') {
+      window.location.href = status === 403 ? '/account/access-denied' : '/account/login';
+    }
   }
 
   async #heartbeat(): Promise<void> {
@@ -78,6 +100,10 @@ class PresenceStore {
           page: typeof window !== 'undefined' ? window.location.pathname : null,
         }),
       });
+      if (res.status === 401 || res.status === 403) {
+        this.#authDied(res.status);
+        return;
+      }
       this.#online = res.ok;
     } catch {
       this.#online = false;
@@ -90,6 +116,10 @@ class PresenceStore {
         credentials: 'include',
         headers: { Accept: 'application/json' },
       });
+      if (res.status === 401 || res.status === 403) {
+        this.#authDied(res.status);
+        return;
+      }
       if (!res.ok) {
         this.#online = false;
         return;

--- a/frontend/app/src/lib/session.svelte.ts
+++ b/frontend/app/src/lib/session.svelte.ts
@@ -40,6 +40,7 @@ interface MeResponse {
 }
 
 const LOGIN_URL = '/account/login';
+const ACCESS_DENIED_URL = '/account/access-denied';
 
 class SessionStore {
   #user = $state<SessionUser | null>(null);
@@ -114,6 +115,16 @@ class SessionStore {
         // Full-page redirect (NOT goto()); NOT base-prefixed (root server route).
         if (typeof window !== 'undefined') {
           window.location.href = LOGIN_URL;
+        }
+        return;
+      }
+
+      if (res.status === 403) {
+        // Authenticated but not authorized (e.g. removed from the whitelist) —
+        // an error screen would dead-end them; the server access-denied page
+        // routes them to request access / sign in as someone else.
+        if (typeof window !== 'undefined') {
+          window.location.href = ACCESS_DENIED_URL;
         }
         return;
       }

--- a/src/FamilyCoordinationApp/Authorization/ApiAwareAuthEvents.cs
+++ b/src/FamilyCoordinationApp/Authorization/ApiAwareAuthEvents.cs
@@ -35,7 +35,13 @@ public static class ApiAwareAuthEvents
         if (context.Request.Path.StartsWithSegments(ApiPrefix))
         {
             context.Response.StatusCode = apiStatusCode;
-            return Task.CompletedTask;
+            // The body must be non-empty: UseStatusCodePagesWithReExecute re-executes any empty-body 4xx
+            // through the GET-only /not-found page with the ORIGINAL method, so a non-GET /api auth failure
+            // would surface as 405 instead of 401/403 (CORRECTIONS: fca-empty-404-surfaces-as-405-on-delete).
+            return context.Response.WriteAsJsonAsync(new
+            {
+                message = apiStatusCode == StatusCodes.Status403Forbidden ? "Forbidden" : "Unauthorized",
+            });
         }
 
         context.Response.Redirect(context.RedirectUri);

--- a/src/FamilyCoordinationApp/Components/Layout/MainLayout.razor
+++ b/src/FamilyCoordinationApp/Components/Layout/MainLayout.razor
@@ -52,7 +52,7 @@
             <Authorized>
                 <div class="d-flex align-center gap-2 gap-md-4">
                     <MudHidden Breakpoint="Breakpoint.SmAndDown">
-                        <OnlineUsers CurrentUserId="@CurrentUserId" />
+                        <OnlineUsers CurrentUserId="@CurrentUserId" CurrentHouseholdId="@CurrentHouseholdId" />
                     </MudHidden>
                     <SyncStatusIndicator />
                     <MudIconButton Icon="@(IsDarkMode ? Icons.Material.Filled.LightMode : Icons.Material.Filled.DarkMode)"
@@ -190,6 +190,9 @@
     // Persisted state to prevent prerender flash
     [PersistentState(AllowUpdates = true)]
     public int CurrentUserId { get; set; }
+
+    [PersistentState(AllowUpdates = true)]
+    public int CurrentHouseholdId { get; set; }
     
     [PersistentState(AllowUpdates = true)]
     public string? CurrentUserPicture { get; set; }
@@ -373,6 +376,7 @@
             if (user != null)
             {
                 CurrentUserId = user.Id;
+                CurrentHouseholdId = user.HouseholdId;
                 CurrentUserPicture = user.PictureUrl;
                 CurrentUserInitials = user.Initials;
                 CurrentUserName = user.DisplayName;
@@ -396,7 +400,7 @@
         if (CurrentUserId > 0)
         {
             var currentPage = new Uri(NavigationManager.Uri).AbsolutePath;
-            PresenceService.Heartbeat(CurrentUserId, CurrentUserName, CurrentUserPicture, CurrentUserInitials, currentPage);
+            PresenceService.Heartbeat(CurrentUserId, CurrentHouseholdId, CurrentUserName, CurrentUserPicture, CurrentUserInitials, currentPage);
         }
     }
 

--- a/src/FamilyCoordinationApp/Components/Shared/OnlineUsers.razor
+++ b/src/FamilyCoordinationApp/Components/Shared/OnlineUsers.razor
@@ -38,6 +38,12 @@
     [Parameter]
     public int CurrentUserId { get; set; }
 
+    /// <summary>
+    /// Caller's household — the roster is household-scoped (multi-tenant boundary).
+    /// </summary>
+    [Parameter]
+    public int CurrentHouseholdId { get; set; }
+
     private List<UserPresence> _onlineUsers = new();
 
     protected override void OnInitialized()
@@ -57,7 +63,7 @@
 
     private void LoadOnlineUsers()
     {
-        _onlineUsers = PresenceService.GetAllActiveUsers()
+        _onlineUsers = PresenceService.GetAllActiveUsers(CurrentHouseholdId)
             .Where(u => u.UserId != CurrentUserId)
             .OrderByDescending(u => u.Status == PresenceStatus.Online)
             .ThenBy(u => u.DisplayName)

--- a/src/FamilyCoordinationApp/Endpoints/PresenceEndpoints.cs
+++ b/src/FamilyCoordinationApp/Endpoints/PresenceEndpoints.cs
@@ -50,12 +50,12 @@ public static class PresenceEndpoints
         await using var db = await dbFactory.CreateDbContextAsync(ct);
         var user = await db.Users
             .Where(u => u.Email == email)
-            .Select(u => new { u.Id, u.DisplayName, u.Initials, u.PictureUrl })
+            .Select(u => new { u.Id, u.HouseholdId, u.DisplayName, u.Initials, u.PictureUrl })
             .FirstOrDefaultAsync(ct);
 
         if (user is null) return Results.Unauthorized();
 
-        presence.Heartbeat(user.Id, user.DisplayName, user.PictureUrl, user.Initials, request.Page);
+        presence.Heartbeat(user.Id, user.HouseholdId, user.DisplayName, user.PictureUrl, user.Initials, request.Page);
         return Results.NoContent();
     }
 
@@ -72,10 +72,10 @@ public static class PresenceEndpoints
         // users age Online→Away→Offline instead of showing Online forever. Idempotent + cheap (in-memory).
         presence.UpdatePresence();
 
-        // Exclude the caller (they don't need to see themselves in the roster) and project to a typed DTO —
+        // Household-scoped (multi-tenant boundary), caller-excluded, and projected to a typed DTO —
         // never the raw UserPresence, which would leak LastSeen / CurrentPage. Status is the PresenceStatus
         // enum, serialized "online"/"away" by the global camelCase JsonStringEnumConverter (Program.cs).
-        var users = presence.GetAllActiveUsers()
+        var users = presence.GetAllActiveUsers(caller.HouseholdId)
             .Where(p => p.UserId != caller.UserId)
             .Select(p => new PresenceUserDto(p.UserId, p.DisplayName, p.Initials, p.PictureUrl, p.Status))
             .ToList();

--- a/src/FamilyCoordinationApp/Pages/Error.cshtml
+++ b/src/FamilyCoordinationApp/Pages/Error.cshtml
@@ -4,24 +4,15 @@
     ViewData["Title"] = "Error";
 }
 <div class="prose">
-    <h1 class="text-danger">Error.</h1>
+    <h1 class="text-danger">Something went wrong.</h1>
     <h2 class="text-danger">An error occurred while processing your request.</h2>
+
+    <p>Please try again. If the problem keeps happening, let the site admin know.</p>
 
     @if (Model.ShowRequestId)
     {
         <p><strong>Request ID:</strong> <code>@Model.RequestId</code></p>
     }
 
-    <h3>Development Mode</h3>
-    <p>
-        Swapping to <strong>Development</strong> environment will display more detailed information
-        about the error that occurred.
-    </p>
-    <p>
-        <strong>The Development environment shouldn't be enabled for deployed applications.</strong>
-        It can result in displaying sensitive information from exceptions to end users. For local
-        debugging, enable the <strong>Development</strong> environment by setting the
-        <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>
-        and restarting the app.
-    </p>
+    <p><a href="/">Back to the app</a></p>
 </div>

--- a/src/FamilyCoordinationApp/Services/PresenceService.cs
+++ b/src/FamilyCoordinationApp/Services/PresenceService.cs
@@ -7,6 +7,8 @@ public enum PresenceStatus { Online, Away, Offline }
 public class UserPresence
 {
     public int UserId { get; set; }
+    /// <summary>Multi-tenant boundary: rosters are only ever served household-scoped.</summary>
+    public int HouseholdId { get; set; }
     public string DisplayName { get; set; } = string.Empty;
     public string? PictureUrl { get; set; }
     public string Initials { get; set; } = string.Empty;
@@ -24,13 +26,14 @@ public class PresenceService
     /// <summary>
     /// Called by components to indicate user activity.
     /// </summary>
-    public void Heartbeat(int userId, string displayName, string? pictureUrl, string initials, string? currentPage = null)
+    public void Heartbeat(int userId, int householdId, string displayName, string? pictureUrl, string initials, string? currentPage = null)
     {
         _presence.AddOrUpdate(
             userId,
             new UserPresence
             {
                 UserId = userId,
+                HouseholdId = householdId,
                 DisplayName = displayName,
                 PictureUrl = pictureUrl,
                 Initials = initials,
@@ -43,6 +46,7 @@ public class PresenceService
                 existing.LastSeen = DateTime.UtcNow;
                 existing.Status = PresenceStatus.Online;
                 existing.CurrentPage = currentPage;
+                existing.HouseholdId = householdId;
                 existing.DisplayName = displayName;
                 existing.PictureUrl = pictureUrl;
                 existing.Initials = initials;
@@ -94,8 +98,12 @@ public class PresenceService
     public IEnumerable<UserPresence> GetOnlineUsers() =>
         _presence.Values.Where(p => p.Status == PresenceStatus.Online);
 
-    public IEnumerable<UserPresence> GetAllActiveUsers() =>
-        _presence.Values.Where(p => p.Status != PresenceStatus.Offline);
+    /// <summary>
+    /// Active (non-Offline) users in ONE household. Presence is a cross-household singleton dictionary,
+    /// so every roster read must be household-scoped — an unscoped roster leaks user PII across tenants.
+    /// </summary>
+    public IEnumerable<UserPresence> GetAllActiveUsers(int householdId) =>
+        _presence.Values.Where(p => p.HouseholdId == householdId && p.Status != PresenceStatus.Offline);
 
     public IEnumerable<UserPresence> GetUsersOnPage(string page) =>
         _presence.Values.Where(p => p.Status == PresenceStatus.Online && p.CurrentPage == page);

--- a/tests/FamilyCoordinationApp.Tests/Authorization/ApiAwareAuthEventsTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Authorization/ApiAwareAuthEventsTests.cs
@@ -18,6 +18,7 @@ public sealed class ApiAwareAuthEventsTests
     {
         var http = new DefaultHttpContext();
         http.Request.Path = path;
+        http.Response.Body = new MemoryStream();
         var scheme = new AuthenticationScheme(
             CookieAuthenticationDefaults.AuthenticationScheme, null, typeof(CookieAuthenticationHandler));
         return new RedirectContext<CookieAuthenticationOptions>(
@@ -35,6 +36,8 @@ public sealed class ApiAwareAuthEventsTests
 
         ctx.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
         ctx.Response.Headers.ContainsKey("Location").Should().BeFalse("an /api auth failure must not 302-redirect");
+        ctx.Response.Body.Length.Should().BeGreaterThan(0,
+            "an empty-body 4xx gets re-executed through the GET-only /not-found page — a non-GET /api call would surface as 405");
     }
 
     [Fact]
@@ -45,6 +48,8 @@ public sealed class ApiAwareAuthEventsTests
         await ApiAwareAuthEvents.StatusForApiElseRedirect(ctx, StatusCodes.Status403Forbidden);
 
         ctx.Response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        ctx.Response.Body.Length.Should().BeGreaterThan(0,
+            "an empty-body 4xx gets re-executed through the GET-only /not-found page — a non-GET /api call would surface as 405");
     }
 
     [Theory]

--- a/tests/FamilyCoordinationApp.Tests/Services/PresenceServiceTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/PresenceServiceTests.cs
@@ -9,7 +9,8 @@ namespace FamilyCoordinationApp.Tests.Services;
 /// <see cref="PresenceService.UpdatePresence"/> itself before <see cref="PresenceService.GetAllActiveUsers"/>,
 /// because WP-12 deletes the <c>PollingService</c> that used to drive the Online→Away→Offline staleness decay
 /// on a timer. These tests lock that decay contract so a user who closes their tab ages out of the roster
-/// instead of showing Online forever (the CRITICAL failure WP-02 calls out).
+/// instead of showing Online forever (the CRITICAL failure WP-02 calls out) — and lock the household scoping
+/// of the roster (multi-tenant boundary: presence is a cross-household singleton dictionary).
 /// </summary>
 public class PresenceServiceTests
 {
@@ -17,9 +18,9 @@ public class PresenceServiceTests
     public void Heartbeat_MarksUserOnline_AndListsThem()
     {
         var svc = new PresenceService();
-        svc.Heartbeat(1, "Alice", pictureUrl: null, initials: "AL", currentPage: "/shopping-list");
+        svc.Heartbeat(1, householdId: 10, "Alice", pictureUrl: null, initials: "AL", currentPage: "/shopping-list");
 
-        var active = svc.GetAllActiveUsers().ToList();
+        var active = svc.GetAllActiveUsers(10).ToList();
         active.Should().ContainSingle(u => u.UserId == 1);
         active.Single(u => u.UserId == 1).Status.Should().Be(PresenceStatus.Online);
     }
@@ -28,18 +29,43 @@ public class PresenceServiceTests
     public void GetAllActiveUsers_ReturnsEveryOnlineUser_TheEndpointExcludesTheCaller()
     {
         var svc = new PresenceService();
-        svc.Heartbeat(1, "Alice", null, "AL");
-        svc.Heartbeat(2, "Bob", null, "BO");
+        svc.Heartbeat(1, 10, "Alice", null, "AL");
+        svc.Heartbeat(2, 10, "Bob", null, "BO");
 
         // The service returns both; the /users endpoint filters out the caller (Where UserId != caller.UserId).
-        svc.GetAllActiveUsers().Select(u => u.UserId).Should().BeEquivalentTo(new[] { 1, 2 });
+        svc.GetAllActiveUsers(10).Select(u => u.UserId).Should().BeEquivalentTo(new[] { 1, 2 });
+    }
+
+    [Fact]
+    public void GetAllActiveUsers_IsHouseholdScoped_NoCrossTenantLeak()
+    {
+        var svc = new PresenceService();
+        svc.Heartbeat(1, 10, "Alice", null, "AL");
+        svc.Heartbeat(2, 20, "Mallory", null, "MA");
+
+        // Multi-tenant boundary: household 10's roster must never contain household 20's users.
+        svc.GetAllActiveUsers(10).Select(u => u.UserId).Should().BeEquivalentTo(new[] { 1 });
+        svc.GetAllActiveUsers(20).Select(u => u.UserId).Should().BeEquivalentTo(new[] { 2 });
+    }
+
+    [Fact]
+    public void Heartbeat_ReheartbeatKeepsHouseholdCurrent()
+    {
+        var svc = new PresenceService();
+        svc.Heartbeat(1, 10, "Alice", null, "AL");
+
+        // A user moved to another household must not linger in the old household's roster.
+        svc.Heartbeat(1, 30, "Alice", null, "AL");
+
+        svc.GetAllActiveUsers(10).Should().BeEmpty();
+        svc.GetAllActiveUsers(30).Select(u => u.UserId).Should().BeEquivalentTo(new[] { 1 });
     }
 
     [Fact]
     public void UpdatePresence_AgesAStaleUserToOffline_SoTheyDropFromTheRoster()
     {
         var svc = new PresenceService();
-        svc.Heartbeat(1, "Alice", null, "AL");
+        svc.Heartbeat(1, 10, "Alice", null, "AL");
 
         // Simulate a closed tab: last seen 16 minutes ago (> the 15-min Offline threshold).
         svc.GetUserPresence(1)!.LastSeen = DateTime.UtcNow.AddMinutes(-16);
@@ -47,21 +73,21 @@ public class PresenceServiceTests
         svc.UpdatePresence();
 
         svc.GetUserPresence(1)!.Status.Should().Be(PresenceStatus.Offline);
-        svc.GetAllActiveUsers().Should().NotContain(u => u.UserId == 1);
+        svc.GetAllActiveUsers(10).Should().NotContain(u => u.UserId == 1);
     }
 
     [Fact]
     public void UpdatePresence_AgesAnIdleUserToAway_ButKeepsThemInTheRoster()
     {
         var svc = new PresenceService();
-        svc.Heartbeat(1, "Alice", null, "AL");
+        svc.Heartbeat(1, 10, "Alice", null, "AL");
 
         // Idle 6 minutes (> the 5-min Away threshold, < the 15-min Offline threshold).
         svc.GetUserPresence(1)!.LastSeen = DateTime.UtcNow.AddMinutes(-6);
 
         svc.UpdatePresence();
 
-        var alice = svc.GetAllActiveUsers().SingleOrDefault(u => u.UserId == 1);
+        var alice = svc.GetAllActiveUsers(10).SingleOrDefault(u => u.UserId == 1);
         alice.Should().NotBeNull();
         alice!.Status.Should().Be(PresenceStatus.Away);
     }


### PR DESCRIPTION
Pre-flip safeguard: findings from the rigorous full-diff review of the de-Blazor change set (917e3aa..Wave 4), fixed before WP-12 cuts over.

## Fixes
- **401→405 trap (high):** `ApiAwareAuthEvents` wrote empty-body 401/403 on `/api`; `UseStatusCodePagesWithReExecute` re-executes empty 4xx through the GET-only `/not-found` page, so every **non-GET** `/api` call with a dead session surfaced as **405** — the SPA session store could never detect expiry on mutating calls. Now writes a JSON body; tests assert non-empty. (Same class as CORRECTIONS `fca-empty-404-surfaces-as-405-on-delete`.)
- **Cross-household presence leak (high):** `GET /api/presence/users` returned every household's active users (name/initials/picture — multi-tenant boundary violation; pre-existing in the Blazor `OnlineUsers` header, first exposed over HTTP by WP-02). `UserPresence` now carries `HouseholdId`; both heartbeat call sites set it; roster reads are household-scoped in the API **and** the Blazor header. New isolation + household-rehome tests.
- **SPA session-death UX (medium):** `/api/me` 403 (de-whitelisted/pending user) now routes to `/account/access-denied` instead of a dead error screen; the presence poller stops and redirects on 401/403 instead of showing "reconnecting…" forever, and skips overlapping ticks.
- **Error page (medium):** replaced the stock `dotnet new` Development-Mode scaffold text (migrated verbatim from `Error.razor`) with user-facing copy.

## Gates
`dotnet build` 0 err · `dotnet test` **800/800** · `svelte-check` 0 err (2 baseline warnings) · `npm run build` ok · `dotnet format` 49 pre-existing whitespace errors (baseline, 0 new)

Review verdict + non-blocker harvest reported in-session. WP-12 (the flip) follows on fresh master once this merges.

https://claude.ai/code/session_01SrvSqxcwtcpiHNKmhj4asU