### PR TITLE
docs: update README + PROJECT stack for the SvelteKit SPA (post de-Blazor flip)

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -59,7 +59,7 @@ The integrated workflow: recipes → meal plan → shopping list. Manual coordin
 
 ## Constraints
 
-- **Tech stack**: Blazor Server (.NET 8), PostgreSQL, Docker — chosen for C# expertise everywhere and built-in SignalR for real-time collaboration
+- **Tech stack**: .NET 10 / ASP.NET Core (`/api`) + SvelteKit SPA (Svelte 5), PostgreSQL, Docker. *(Originally Blazor Server / .NET 8 — chosen for C# expertise everywhere + built-in SignalR; the UI runtime was flipped to a SvelteKit SPA served over `/api` in the de-Blazor migration, 2026-07-04. Real-time collaboration is now `/api` polling + presence, not SignalR. The "Key Decisions" table below is preserved as the original historical record.)*
 - **Deployment**: Must run on [SERVER] (Ubuntu 24.04) via Docker Compose, accessible at your-domain.example.com
 - **Authentication**: Google OAuth only, email whitelist for authorized family members (no public signup)
 - **Real-time**: SignalR over WebSocket for collaborative shopping list editing (must work on mobile with spotty WiFi)

--- a/README.md
+++ b/README.md
@@ -1,75 +1,126 @@
 # Family Coordination App
 
-A Blazor Server application for family meal planning, recipe management, and shopping list coordination.
+A household coordination app — meal planning, recipe management, shopping lists,
+chores, and multi-user family collaboration.
+
+The UI is a **SvelteKit single-page app (Svelte 5)** served at the site root by
+an **ASP.NET Core** backend, which exposes the data layer under `/api` with
+same-origin cookie auth. The only server-rendered pages are a small set of
+static Razor Pages (login, legal, error, and the household-onboarding flow).
+
+> Originally a Blazor Server app; flipped to the SvelteKit SPA in the de-Blazor
+> migration (2026-07-04). Blazor Server and MudBlazor have been removed.
+
+## Architecture
+
+- **Backend** — .NET 10 / ASP.NET Core: minimal-API endpoints under `/api` plus
+  the static Razor Pages. PostgreSQL via EF Core. Multi-tenant: every entity is
+  keyed by `HouseholdId` and every query filters on it.
+- **Frontend** — SvelteKit (Svelte 5, `adapter-static`) in `frontend/app/`,
+  built to a static SPA and served at the site root. The build output is copied
+  into the backend's `wwwroot/` (the `CopyAppSpa` MSBuild target locally, a
+  Docker stage in prod) and served via per-prefix SPA fallbacks in `Program.cs`.
+- **Auth** — Google OAuth + a 30-day sliding cookie (`FamilyApp.Auth`), scoped
+  to an email whitelist.
 
 ## Building and Running
 
-### Local Development
+Requires the .NET 10 SDK, Node 20+, PostgreSQL, and Google OAuth credentials.
 
-Run the application locally using the .NET SDK:
+### Local development
+
+**Fast frontend loop (Vite + hot reload)** — run the backend and the Vite dev
+server side by side:
 
 ```bash
+# Terminal 1 — backend on http://localhost:5077 (Development dev-auth bypass)
+dotnet run --project src/FamilyCoordinationApp/FamilyCoordinationApp.csproj
+
+# Terminal 2 — SvelteKit dev server on http://localhost:5174, proxies /api -> :5077
+cd frontend/app && npm install && npm run dev
+```
+
+Open <http://localhost:5174>.
+
+**Full app from the .NET host (SPA served at root)** — build the SPA first, then
+run the backend. `dotnet run` copies `frontend/app/build/` into `wwwroot/` via
+the `CopyAppSpa` target, but it does **not** build the SPA for you, so the build
+step is required whenever the frontend changes:
+
+```bash
+cd frontend/app && npm install && npm run build
+cd ../..
 dotnet run --project src/FamilyCoordinationApp/FamilyCoordinationApp.csproj
 ```
 
-The application will be available at `http://localhost:5000` (HTTP) or `https://localhost:5001` (HTTPS).
+Open <http://localhost:5077> (the HTTPS profile is `https://localhost:7130` — see
+`src/FamilyCoordinationApp/Properties/launchSettings.json`).
 
-### Docker Build
-
-Due to a known bug in .NET SDK 10.0.102 that prevents standard Docker builds, use the provided build script:
+### Build & test
 
 ```bash
-./docker-build.sh [tag]
+# Backend build
+dotnet build src/FamilyCoordinationApp/FamilyCoordinationApp.csproj
+
+# Tests (xUnit + FluentAssertions + Moq + Bogus)
+dotnet test tests/FamilyCoordinationApp.Tests/FamilyCoordinationApp.Tests.csproj
+
+# Frontend type-check + build
+cd frontend/app && npm install && npm run check && npm run build
 ```
 
-Examples:
-```bash
-# Build with default 'latest' tag
-./docker-build.sh
+### Docker
 
-# Build with specific version tag
-./docker-build.sh v1.0.0
+The production image is a single multi-stage `Dockerfile` — a `node:20-alpine`
+stage builds the SPA, then the .NET publish stage copies it into `wwwroot/`:
+
+```bash
+# Build (same command prod uses)
+docker build -t familyapp:latest .
+
+# Run the app + PostgreSQL
+docker compose up -d          # app is served on http://localhost:8080
 ```
 
-For more details about the Docker build workaround, see [DOCKER-BUILD-WORKAROUND.md](DOCKER-BUILD-WORKAROUND.md).
-
-### Running with Docker
-
-After building the Docker image:
+On local Windows a known .NET SDK 10.0 bug (MSB3552) can break the multi-stage
+build. If you hit it, use the workaround script (local `dotnet publish` +
+`Dockerfile.runtime-only`) — see
+[DOCKER-BUILD-WORKAROUND.md](DOCKER-BUILD-WORKAROUND.md):
 
 ```bash
-# Run standalone
-docker run -d -p 8080:8080 --name familyapp familyapp:latest
-
-# Or with Docker Compose
-docker-compose up -d
+./docker-build.sh [tag]       # default tag: latest
 ```
 
 ## Project Structure
 
-- `src/FamilyCoordinationApp/` - Main application code
-- `tests/FamilyCoordinationApp.Tests/` - Unit and integration tests
-- `Dockerfile.runtime-only` - Docker build configuration (workaround for SDK bug)
-- `docker-build.sh` - Automated Docker build script
+- `src/FamilyCoordinationApp/` — ASP.NET Core backend (`/api` minimal-API
+  endpoints, EF Core data layer, static Razor Pages, auth)
+- `frontend/app/` — the SvelteKit SPA (Svelte 5) — the app's entire UI
+- `tests/FamilyCoordinationApp.Tests/` — unit & integration tests
+- `Dockerfile` — multi-stage production build (SPA + .NET)
+- `Dockerfile.runtime-only` / `docker-build.sh` — local Windows MSB3552 workaround
+- `docker-compose*.yml` — local and production Compose definitions
 
 ## Technology Stack
 
-- .NET 10.0
-- Blazor Server
-- PostgreSQL (via Npgsql)
-- Entity Framework Core 10.0
-- MudBlazor UI components
-- Google OAuth authentication
+- .NET 10 / ASP.NET Core (minimal APIs + static Razor Pages)
+- SvelteKit + Svelte 5 + TypeScript (`adapter-static` SPA)
+- PostgreSQL + Entity Framework Core 10
+- Google OAuth (same-origin cookie auth)
+- Docker
 
 ## Features
 
-- **Recipe Management** - Import from URLs, manual entry, ingredient parsing
-- **Meal Planning** - Weekly calendar with drag-and-drop scheduling
-- **Shopping Lists** - Auto-generated from meal plans with ingredient consolidation
-- **Multi-Household** - Family collaboration with role-based permissions
-- **Google OAuth** - Secure authentication
+- **Recipe Management** — import from URLs (schema.org JSON-LD), manual entry,
+  ingredient parsing
+- **Meal Planning** — weekly calendar with drag-and-drop scheduling
+- **Shopping Lists** — auto-generated from meal plans with ingredient
+  consolidation
+- **Chores** — assignment, rotation, and household equity tracking
+- **Multi-Household** — family collaboration with role-based permissions and
+  household-to-household recipe sharing
+- **Google OAuth** — secure authentication
 
 ## License
 
 MIT License
-


### PR DESCRIPTION
Post-cutover doc pass — the README still presented the app as **Blazor Server / MudBlazor** with wrong local ports and a stale docker-build story. Brings the top-level docs in line with the SvelteKit SPA that shipped in #65.

## README
- Rewrote the intro + new **Architecture** section: SvelteKit SPA (Svelte 5, `adapter-static`) served at the site root by ASP.NET Core over `/api`, same-origin cookie auth, static Razor Pages for login/legal/onboarding
- Corrected **local dev**: the Vite `:5174` proxy loop, and the full `dotnet run` path — noting the SPA must be pre-built (`CopyAppSpa` only *copies* `frontend/app/build/`, it doesn't build it)
- Fixed ports (`:5077` / `:8080`, not 5000/5001)
- Docker: plain `docker build -t familyapp:latest .` as prod parity; the MSB3552 workaround (`docker-build.sh` / `DOCKER-BUILD-WORKAROUND.md`) as the local-Windows fallback
- Refreshed project structure, tech stack, and features (added **Chores**)

## .planning/PROJECT.md
- Fixed the present-tense `Tech stack: Blazor Server (.NET 8)` constraint; noted the flip and that real-time is now `/api` polling + presence, not SignalR
- Left the historical **Key Decisions** table intact

## Intentionally left as-is
The `.planning/phases/**` and `.planning/archive/**` Blazor mentions are historical records of past phase work — not stale current-state claims. Rewriting them would destroy the record.

https://claude.ai/code/session_015Tu5FgtyXRfVMxqQ1qyLzL