### PR TITLE
feat(settings): admin-initiated household invite (push)

### DIFF
--- a/frontend/app/src/lib/admin/HouseholdsApp.svelte
+++ b/frontend/app/src/lib/admin/HouseholdsApp.svelte
@@ -59,6 +59,24 @@
     rejectTarget = null;
     if (r) await store.reject(r.id, reason, r.displayName);
   }
+
+  // Invite a household (admin "push" — create the household + owner directly).
+  let inviteName = $state('');
+  let inviteEmail = $state('');
+  let inviteDisplayName = $state('');
+  const canInvite = $derived(
+    inviteName.trim().length > 0 && inviteEmail.trim().length > 0 && !store.creating,
+  );
+  async function submitInvite(e: SubmitEvent) {
+    e.preventDefault();
+    if (!canInvite) return;
+    const ok = await store.createHousehold(inviteName.trim(), inviteEmail.trim(), inviteDisplayName);
+    if (ok) {
+      inviteName = '';
+      inviteEmail = '';
+      inviteDisplayName = '';
+    }
+  }
 </script>
 
 <div class="adm-page">
@@ -116,6 +134,32 @@
         {/each}
       </div>
     {/if}
+
+    <h2 class="adm-subtitle">Invite a Household</h2>
+    <form class="adm-form" onsubmit={submitInvite}>
+      <p class="adm-form-hint">
+        Create a new household and its owner. They can sign in with Google straight away — no request to approve.
+      </p>
+      <div class="adm-form-grid">
+        <label class="adm-field">
+          <span class="adm-field-label">Household name</span>
+          <input class="adm-input" type="text" bind:value={inviteName} maxlength="200" placeholder="The Smiths" required />
+        </label>
+        <label class="adm-field">
+          <span class="adm-field-label">Owner email</span>
+          <input class="adm-input" type="email" bind:value={inviteEmail} maxlength="256" placeholder="owner@example.com" required />
+        </label>
+        <label class="adm-field">
+          <span class="adm-field-label">Owner name <span class="adm-field-opt">(optional)</span></span>
+          <input class="adm-input" type="text" bind:value={inviteDisplayName} maxlength="200" placeholder="Jane Smith" />
+        </label>
+      </div>
+      <div class="adm-form-actions">
+        <button type="submit" class="adm-btn-primary" disabled={!canInvite}>
+          {store.creating ? 'Creating…' : 'Create household'}
+        </button>
+      </div>
+    </form>
 
     <h2 class="adm-subtitle">Existing Households</h2>
     {#if store.households.length === 0}
@@ -308,6 +352,76 @@
   }
   .adm-danger-text {
     color: var(--color-error);
+  }
+  .adm-form {
+    background: var(--color-surface);
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-1);
+    padding: 16px;
+  }
+  .adm-form-hint {
+    margin: 0 0 14px;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+  .adm-form-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+  @media (min-width: 640px) {
+    .adm-form-grid {
+      grid-template-columns: 1fr 1fr;
+    }
+  }
+  .adm-field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .adm-field-label {
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: var(--color-text-muted);
+  }
+  .adm-field-opt {
+    font-weight: 400;
+  }
+  .adm-input {
+    font: inherit;
+    padding: 9px 12px;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text);
+  }
+  .adm-input:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -1px;
+  }
+  .adm-form-actions {
+    margin-top: 14px;
+    display: flex;
+    justify-content: flex-end;
+  }
+  .adm-btn-primary {
+    font: inherit;
+    font-weight: 500;
+    background: var(--color-primary);
+    color: #fff;
+    border: none;
+    border-radius: var(--radius-sm);
+    padding: 9px 18px;
+    cursor: pointer;
+    min-height: 40px;
+  }
+  .adm-btn-primary:hover:not(:disabled) {
+    background: var(--color-primary-hover);
+  }
+  .adm-btn-primary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
   }
   .adm-table-wrap {
     overflow-x: auto;

--- a/frontend/app/src/lib/admin/lib/api.ts
+++ b/frontend/app/src/lib/admin/lib/api.ts
@@ -1,6 +1,7 @@
 import type { HouseholdRequestsDto, HouseholdSummaryDto, FeedbackListDto } from './types';
 
 const REQUESTS = '/api/settings/household-requests';
+const HOUSEHOLDS = '/api/settings/households';
 const FEEDBACK = '/api/settings/feedback';
 
 /**
@@ -71,6 +72,21 @@ export async function approveRequest(id: number): Promise<HouseholdSummaryDto> {
 /** #3 Reject with an OPTIONAL reason → 204. Already-reviewed ⇒ 409 (ApiError); unknown ⇒ 404. */
 export async function rejectRequest(id: number, reason: string): Promise<void> {
   await request<void>(`${REQUESTS}/${id}/reject`, { method: 'POST', ...jsonBody({ reason }) });
+}
+
+/**
+ * Admin-initiated household create (the "push" invite) → the new household summary (201). Blank/too-long ⇒ 400
+ * (ApiError); an email already belonging to a member ⇒ 409 (ApiError). `ownerDisplayName` is optional.
+ */
+export async function createHousehold(
+  householdName: string,
+  ownerEmail: string,
+  ownerDisplayName?: string,
+): Promise<HouseholdSummaryDto> {
+  return request<HouseholdSummaryDto>(`${HOUSEHOLDS}/`, {
+    method: 'POST',
+    ...jsonBody({ householdName, ownerEmail, ownerDisplayName: ownerDisplayName || null }),
+  });
 }
 
 // ─── Feedback (dual-mode) ───────────────────────────────────────────────────

--- a/frontend/app/src/lib/admin/lib/householdRequestsStore.svelte.ts
+++ b/frontend/app/src/lib/admin/lib/householdRequestsStore.svelte.ts
@@ -13,7 +13,7 @@
 // ─────────────────────────────────────────────────────────────────────────
 
 import type { HouseholdRequestDto, HouseholdSummaryDto } from './types';
-import { ApiError, getHouseholdRequests, approveRequest, rejectRequest } from './api';
+import { ApiError, getHouseholdRequests, approveRequest, rejectRequest, createHousehold } from './api';
 import { showToast } from '$lib/shared/toast-store.svelte';
 
 class HouseholdRequestsStore {
@@ -23,6 +23,8 @@ class HouseholdRequestsStore {
   error = $state<string | null>(null);
   /** True after a 403 on the list GET — the caller is not a site admin (R-C4). */
   accessDenied = $state(false);
+  /** True while an admin create-household POST is in flight (disables the invite form). */
+  creating = $state(false);
 
   private hasLoaded = false;
   private seq = 0;
@@ -70,6 +72,26 @@ class HouseholdRequestsStore {
     } catch (e) {
       if (e instanceof ApiError) await this.load();
       showToast({ message: describe(e, 'reject request'), kind: 'error' });
+    }
+  }
+
+  /**
+   * Admin-initiated household create (the "push" invite). Returns true on success so the form can clear itself.
+   * Validation/collision (400/409) surface as a calm toast; the server is the source of truth, the client reflects it.
+   */
+  async createHousehold(householdName: string, ownerEmail: string, ownerDisplayName: string): Promise<boolean> {
+    if (this.creating) return false;
+    this.creating = true;
+    try {
+      const summary = await createHousehold(householdName, ownerEmail, ownerDisplayName.trim() || undefined);
+      await this.load();
+      showToast({ message: `Created “${summary.name}” — ${ownerEmail} can now sign in.`, kind: 'success' });
+      return true;
+    } catch (e) {
+      showToast({ message: describe(e, 'create household'), kind: 'error' });
+      return false;
+    } finally {
+      this.creating = false;
     }
   }
 }

--- a/src/FamilyCoordinationApp/Endpoints/SettingsAdminEndpoints.cs
+++ b/src/FamilyCoordinationApp/Endpoints/SettingsAdminEndpoints.cs
@@ -43,6 +43,12 @@ public static class SettingsAdminEndpoints
         requests.MapPost("/{id:int}/approve", ApproveRequest);
         requests.MapPost("/{id:int}/reject", RejectRequest);
 
+        // ── Households (site-admin only) — admin-initiated create (the "push" invite) ──
+        var households = app.MapGroup("/api/settings/households")
+            .RequireAuthorization()
+            .DisableAntiforgery();
+        households.MapPost("/", CreateHousehold);
+
         // ── Feedback (dual-mode) ──────────────────────────────────────────────────
         var feedback = app.MapGroup("/api/settings/feedback")
             .RequireAuthorization()
@@ -121,6 +127,52 @@ public static class SettingsAdminEndpoints
             ReviewOutcome.NotFound => Results.NotFound(new { message = "Household request not found." }),
             ReviewOutcome.AlreadyReviewed => Results.Conflict(new { message = "This request has already been reviewed." }),
             _ => Results.NoContent(),
+        };
+    }
+
+    /// <summary>
+    /// #3b POST /api/settings/households — admin-initiated household create (the "push" invite mirroring the
+    /// self-request→approve "pull"). Site-admin only. Validates + caps inputs to the column limits server-side so an
+    /// oversized direct-API value is a clean 400, not a varchar-overflow 500 (parity RejectRequest's 500-char guard).
+    /// 403 / 400 (blank or too long) / 409 (email already a member) / else 201 with the new household summary.
+    /// </summary>
+    private static async Task<IResult> CreateHousehold(
+        CreateHouseholdRequest? req,
+        ClaimsPrincipal principal,
+        ISiteAdminService siteAdmin,
+        IHouseholdRequestService requestService,
+        CancellationToken ct)
+    {
+        if (RequireSiteAdmin(principal, siteAdmin) is { } forbidden) return forbidden;
+
+        var name = req?.HouseholdName?.Trim() ?? "";
+        var email = req?.OwnerEmail?.Trim() ?? "";
+        if (name.Length == 0 || email.Length == 0)
+        {
+            return Results.BadRequest(new { message = "Household name and owner email are required." });
+        }
+        if (name.Length > 200)
+        {
+            return Results.BadRequest(new { message = "Household name must be 200 characters or fewer." });
+        }
+        if (email.Length > 256)
+        {
+            return Results.BadRequest(new { message = "Owner email must be 256 characters or fewer." });
+        }
+        if (req?.OwnerDisplayName is { Length: > 200 })
+        {
+            return Results.BadRequest(new { message = "Owner display name must be 200 characters or fewer." });
+        }
+
+        var createdBy = principal.FindFirst(ClaimTypes.Email)?.Value ?? "";
+        var result = await requestService.CreateHouseholdAsync(name, email, req?.OwnerDisplayName, createdBy, ct);
+        return result.Outcome switch
+        {
+            CreateHouseholdOutcome.InvalidInput => Results.BadRequest(new { message = "Household name and owner email are required." }),
+            CreateHouseholdOutcome.EmailInUse => Results.Conflict(new { message = "That email already belongs to a household member." }),
+            // Member count is exactly 1 (the owner, just created in the transaction).
+            _ => Results.Created("/api/settings/households", new HouseholdSummaryDto(
+                result.Household!.Id, result.Household.Name, 1, ToIso(result.Household.CreatedAt))),
         };
     }
 
@@ -255,3 +307,9 @@ public static class SettingsAdminEndpoints
 
 /// <summary>Reject body — <see cref="Reason"/> is OPTIONAL (nullable; empty allowed, R-C7).</summary>
 public sealed record RejectReasonRequest(string? Reason);
+
+/// <summary>
+/// Admin create-household body: the household name + its owner's email (whitelisted so they drop straight in on
+/// first Google login), plus an OPTIONAL display name (defaults to the email local-part). Server-validated.
+/// </summary>
+public sealed record CreateHouseholdRequest(string? HouseholdName, string? OwnerEmail, string? OwnerDisplayName);

--- a/src/FamilyCoordinationApp/Services/HouseholdRequestService.cs
+++ b/src/FamilyCoordinationApp/Services/HouseholdRequestService.cs
@@ -145,4 +145,82 @@ public sealed class HouseholdRequestService(
 
         return ReviewOutcome.Ok;
     }
+
+    public async Task<CreateHouseholdResult> CreateHouseholdAsync(
+        string householdName, string ownerEmail, string? ownerDisplayName, string createdByEmail,
+        CancellationToken cancellationToken = default)
+    {
+        var name = householdName?.Trim() ?? "";
+        var email = ownerEmail?.Trim().ToLowerInvariant() ?? "";
+        if (name.Length == 0 || email.Length == 0)
+        {
+            return new CreateHouseholdResult(CreateHouseholdOutcome.InvalidInput, null);
+        }
+
+        await using var context = await dbFactory.CreateDbContextAsync(cancellationToken);
+
+        // The owner email must be free across ALL households (cross-tenant read, like AddMemberAsync's guard): an
+        // existing user already has a home, and the unique Users.Email constraint would reject the insert anyway.
+        // Cheap pre-check for a clean 409 before opening the transaction.
+        var emailTaken = await context.Users.AnyAsync(u => u.Email == email, cancellationToken);
+        if (emailTaken)
+        {
+            return new CreateHouseholdResult(CreateHouseholdOutcome.EmailInUse, null);
+        }
+
+        var now = DateTime.UtcNow;
+
+        // R-C2: household + owner + default categories commit atomically (same shape as ApproveAsync). The owner FK
+        // needs household.Id, so the household flushes first; a failure anywhere rolls the whole thing back — no
+        // orphan household, no household with no categories.
+        await using var transaction = await context.Database.BeginTransactionAsync(cancellationToken);
+
+        var household = new Household { Name = name, CreatedAt = now };
+        context.Households.Add(household);
+        await context.SaveChangesAsync(cancellationToken); // assign household.Id for the user FK below
+
+        context.Users.Add(new User
+        {
+            HouseholdId = household.Id,
+            Email = email,
+            // Fall back to the email local-part when no display name is given (parity AddMemberAsync).
+            DisplayName = string.IsNullOrWhiteSpace(ownerDisplayName) ? email.Split('@')[0] : ownerDisplayName!.Trim(),
+            GoogleId = null, // set when the owner first logs in with Google (parity AddMemberAsync)
+            IsWhitelisted = true,
+            CreatedAt = now,
+        });
+
+        SeedData.AddDefaultCategories(context, household.Id);
+
+        try
+        {
+            await context.SaveChangesAsync(cancellationToken);
+            await transaction.CommitAsync(cancellationToken);
+        }
+        catch (DbUpdateException ex) when (IsUniqueViolation(ex))
+        {
+            // A concurrent create/approve inserted the same email first. The transaction is NOT committed; returning
+            // disposes it → full rollback (no orphan household), so the caller gets a clean 409 (parity ApproveAsync).
+            logger.LogWarning(ex, "Create household blocked: email {Email} already in use — rolled back", email);
+            return new CreateHouseholdResult(CreateHouseholdOutcome.EmailInUse, null);
+        }
+
+        // Seed the curated chore/room library AFTER the commit (parity SetupService.CreateHouseholdAsync — the seeder
+        // opens its own factory context; idempotent per OQ3). Kept out of the transaction on purpose: a failure here
+        // leaves a usable household (owner + categories) with an empty chore library, not an orphan — logged, not fatal.
+        try
+        {
+            await SeedData.SeedChoresAndRoomsAsync(dbFactory, household.Id);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Household {HouseholdId} created but chore/room seeding failed", household.Id);
+        }
+
+        logger.LogInformation(
+            "Created household {HouseholdId} '{HouseholdName}' with owner {Email} by {Admin}",
+            household.Id, name, email, createdByEmail);
+
+        return new CreateHouseholdResult(CreateHouseholdOutcome.Ok, household);
+    }
 }

--- a/src/FamilyCoordinationApp/Services/Interfaces/IHouseholdRequestService.cs
+++ b/src/FamilyCoordinationApp/Services/Interfaces/IHouseholdRequestService.cs
@@ -39,6 +39,20 @@ public interface IHouseholdRequestService
     /// unknown id ⇒ <see cref="ReviewOutcome.NotFound"/>.
     /// </summary>
     Task<ReviewOutcome> RejectAsync(int requestId, string? reason, string reviewerEmail, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Admin-initiated household creation (the "push" invite — the mirror of the self-request→approve "pull"). A
+    /// site admin names a household and its owner's email; this creates the household + a whitelisted owner user
+    /// (GoogleId null until their first Google login — parity with <c>HouseholdMemberService.AddMemberAsync</c>) so
+    /// the owner lands straight in on first sign-in, no self-request. Household + owner + the nine default categories
+    /// commit in ONE transaction (R-C2, same shape as <see cref="ApproveAsync"/>); the curated chore/room library is
+    /// seeded post-commit (parity <c>SetupService.CreateHouseholdAsync</c>) so a pushed household is as complete as a
+    /// first-run one. If the email already belongs to any user ⇒ <see cref="CreateHouseholdOutcome.EmailInUse"/>
+    /// (they already have a household); blank name/email ⇒ <see cref="CreateHouseholdOutcome.InvalidInput"/>.
+    /// </summary>
+    Task<CreateHouseholdResult> CreateHouseholdAsync(
+        string householdName, string ownerEmail, string? ownerDisplayName, string createdByEmail,
+        CancellationToken cancellationToken = default);
 }
 
 /// <summary>The Household-requests view data (raw entities; the endpoint projects to DTOs).</summary>
@@ -64,3 +78,21 @@ public enum ReviewOutcome
 
 /// <summary>The result of an approve: the <see cref="Outcome"/> plus the created household (only when Ok).</summary>
 public sealed record ApproveResult(ReviewOutcome Outcome, Household? CreatedHousehold);
+
+/// <summary>Outcome of an admin-initiated household create — maps to HTTP (InvalidInput ⇒ 400, EmailInUse ⇒ 409).</summary>
+public enum CreateHouseholdOutcome
+{
+    Ok,
+
+    /// <summary>Household name or owner email was blank after trimming — a clean 400 (the endpoint also guards this).</summary>
+    InvalidInput,
+
+    /// <summary>
+    /// The owner email already belongs to a user (any household). Creating them would collide with the unique
+    /// <c>Users.Email</c> constraint and they already have a home — refuse with a clean 409, transaction rolled back.
+    /// </summary>
+    EmailInUse,
+}
+
+/// <summary>The result of a create: the <see cref="Outcome"/> plus the created household (only when Ok).</summary>
+public sealed record CreateHouseholdResult(CreateHouseholdOutcome Outcome, Household? Household);

--- a/tests/FamilyCoordinationApp.Tests/Services/HouseholdRequestServiceTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/HouseholdRequestServiceTests.cs
@@ -1,0 +1,136 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Moq;
+using FamilyCoordinationApp.Data;
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Services;
+using FamilyCoordinationApp.Services.Interfaces;
+
+namespace FamilyCoordinationApp.Tests.Services;
+
+/// <summary>
+/// Unit coverage for <see cref="HouseholdRequestService.CreateHouseholdAsync"/> — the admin-initiated "push" invite
+/// (the mirror of the self-request→approve "pull"). InMemory EF (mirrors <see cref="HouseholdMemberServiceTests"/>);
+/// the service opens a fresh context per call via the mocked factory over ONE in-memory DB, so state persists across
+/// calls. The service wraps the create in a transaction — InMemory can't do transactions, so the options ignore
+/// <see cref="InMemoryEventId.TransactionIgnoredWarning"/> (the transaction no-ops; the create logic still runs). The
+/// true unique-<c>Users.Email</c> race → 409 path is a real-Postgres concern (left to the integration suite); the
+/// pre-check covers the common case exercised here.
+/// </summary>
+public class HouseholdRequestServiceTests : IDisposable
+{
+    private const int ExistingHh = 1;
+    private readonly DbContextOptions<ApplicationDbContext> _options;
+    private readonly ApplicationDbContext _seedContext;
+    private readonly HouseholdRequestService _service;
+
+    public HouseholdRequestServiceTests()
+    {
+        _options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+
+        _seedContext = new ApplicationDbContext(_options);
+        var factory = new Mock<IDbContextFactory<ApplicationDbContext>>();
+        factory.Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new ApplicationDbContext(_options));
+        _service = new HouseholdRequestService(factory.Object, Mock.Of<ILogger<HouseholdRequestService>>());
+
+        // One existing household + member, so the email-collision guard has something to collide with.
+        _seedContext.Households.Add(new Household { Id = ExistingHh, Name = "The Firsts" });
+        _seedContext.Users.Add(new User
+        {
+            Id = 1,
+            HouseholdId = ExistingHh,
+            Email = "alice@a.test",
+            DisplayName = "Alice",
+            IsWhitelisted = true,
+            CreatedAt = DateTime.UtcNow,
+        });
+        _seedContext.SaveChanges();
+    }
+
+    public void Dispose() => _seedContext.Dispose();
+
+    private ApplicationDbContext NewContext() => new(_options);
+
+    [Fact]
+    public async Task CreateHousehold_NewOwner_CreatesHousehold_WithWhitelistedOwner_AndCategories()
+    {
+        var result = await _service.CreateHouseholdAsync("The Smiths", "bob@smith.test", "Bob Smith", "admin@site.test");
+
+        result.Outcome.Should().Be(CreateHouseholdOutcome.Ok);
+        result.Household.Should().NotBeNull();
+        result.Household!.Name.Should().Be("The Smiths");
+
+        await using var db = NewContext();
+        var owner = await db.Users.SingleAsync(u => u.Email == "bob@smith.test");
+        owner.HouseholdId.Should().Be(result.Household.Id);
+        owner.DisplayName.Should().Be("Bob Smith");
+        owner.IsWhitelisted.Should().BeTrue();
+        owner.GoogleId.Should().BeNull(); // set on the owner's first Google login
+
+        // Default categories were seeded for the NEW household inside the same operation.
+        var categories = await db.Categories.Where(c => c.HouseholdId == result.Household.Id).ToListAsync();
+        categories.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task CreateHousehold_NoDisplayName_DefaultsToEmailLocalPart()
+    {
+        var result = await _service.CreateHouseholdAsync("Household X", "charlie@x.test", null, "admin@site.test");
+
+        result.Outcome.Should().Be(CreateHouseholdOutcome.Ok);
+        await using var db = NewContext();
+        var owner = await db.Users.SingleAsync(u => u.Email == "charlie@x.test");
+        owner.DisplayName.Should().Be("charlie");
+    }
+
+    [Fact]
+    public async Task CreateHousehold_NormalizesEmail_TrimAndLowercase()
+    {
+        var result = await _service.CreateHouseholdAsync("Household Y", "  Dana@Y.TEST  ", "Dana", "admin@site.test");
+
+        result.Outcome.Should().Be(CreateHouseholdOutcome.Ok);
+        await using var db = NewContext();
+        (await db.Users.AnyAsync(u => u.Email == "dana@y.test")).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CreateHousehold_EmailAlreadyAMember_ReturnsEmailInUse_AndCreatesNoHousehold()
+    {
+        var before = await CountHouseholdsAsync();
+
+        // Same email as the seeded member, in mixed case — the guard normalizes and rejects.
+        var result = await _service.CreateHouseholdAsync("Dupe House", "ALICE@a.test", "Impostor", "admin@site.test");
+
+        result.Outcome.Should().Be(CreateHouseholdOutcome.EmailInUse);
+        result.Household.Should().BeNull();
+        (await CountHouseholdsAsync()).Should().Be(before); // no orphan household
+    }
+
+    [Theory]
+    [InlineData("", "owner@x.test")]
+    [InlineData("   ", "owner@x.test")]
+    [InlineData("Household", "")]
+    [InlineData("Household", "   ")]
+    public async Task CreateHousehold_BlankNameOrEmail_ReturnsInvalidInput(string name, string email)
+    {
+        var before = await CountHouseholdsAsync();
+
+        var result = await _service.CreateHouseholdAsync(name, email, "Owner", "admin@site.test");
+
+        result.Outcome.Should().Be(CreateHouseholdOutcome.InvalidInput);
+        result.Household.Should().BeNull();
+        (await CountHouseholdsAsync()).Should().Be(before);
+    }
+
+    private async Task<int> CountHouseholdsAsync()
+    {
+        await using var db = NewContext();
+        return await db.Households.CountAsync();
+    }
+}


### PR DESCRIPTION
## What & why

New-household creation was **pull-only**: a new person self-requests at `/household/request`, then a site admin approves. There was no way for an admin to *proactively* create a household and invite its owner — unlike member-invite (Settings → Family Members), which is **push**. This adds the push side, so an admin can onboard a new family without the self-request dance.

(Investigation that led here: the plumbing was fully intact — `HouseholdRequestService.ApproveAsync` already creates households — but had no admin entry point.)

## Backend
- **`IHouseholdRequestService.CreateHouseholdAsync`** + `CreateHouseholdResult`/`CreateHouseholdOutcome`. Creates the household + a **whitelisted owner** (`GoogleId` null until first Google login — parity with `HouseholdMemberService.AddMemberAsync`) so the owner lands straight in. Household + owner + the 9 default categories commit in **one transaction** (R-C2, same shape as `ApproveAsync`); the curated **chore/room library** seeds post-commit (parity `SetupService`) so a pushed household is as complete as a first-run one.
- Guards: email already a user anywhere ⇒ **409** (rolled back); blank ⇒ **400**; email normalized (trim + lowercase).
- **`POST /api/settings/households`** — **site-admin gated** (same `RequireSiteAdmin` 403), server-side length caps (200/256/200) → clean 400s, non-empty 4xx bodies.

## Frontend (Settings → Household Requests admin island)
- **"Invite a Household"** form (name + owner email + optional owner name) above the existing-households table; `api.createHousehold` + a `store.createHousehold` action (in-flight flag, success toast, list refresh).

## Tests
`HouseholdRequestServiceTests` (8): creates household + whitelisted owner + categories; defaults display name to the email local-part; normalizes email; rejects an existing-member email (`EmailInUse`, no orphan household); rejects blank name/email. **Suite 808/808.**

## ⚠ Note / follow-up (not changed here)
The **approve (pull)** path seeds default categories only, **not** the chore/room library — so request-approved households lack the seeded chores this push path gives them. Pre-existing and equal across all approve-created households; flagged rather than changed (it'd alter existing behavior). Worth a small follow-up to make both paths seed identically.

## Gates
dotnet build 0 err · tests 808/808 · svelte-check 0 err · build clean · dotnet format clean for changed files (39 pre-existing baseline whitespace errors untouched). Browser verification on :8080 to follow in a comment.

https://claude.ai/code/session_015Tu5FgtyXRfVMxqQ1qyLzL