### PR TITLE
fix(households): seed chore/room library on the approve path too

### DIFF
--- a/src/FamilyCoordinationApp/Services/HouseholdRequestService.cs
+++ b/src/FamilyCoordinationApp/Services/HouseholdRequestService.cs
@@ -105,6 +105,18 @@ public sealed class HouseholdRequestService(
             return new ApproveResult(ReviewOutcome.EmailInUse, null);
         }
 
+        // Seed the curated chore/room library AFTER the commit (parity CreateHouseholdAsync / SetupService — the seeder
+        // opens its own factory context; idempotent per OQ3). Kept out of the transaction on purpose: a failure here
+        // leaves a usable household (owner + categories) with an empty chore library, not an orphan — logged, not fatal.
+        try
+        {
+            await SeedData.SeedChoresAndRoomsAsync(dbFactory, household.Id);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Household {HouseholdId} approved but chore/room seeding failed", household.Id);
+        }
+
         logger.LogInformation(
             "Approved household request {RequestId}: {HouseholdName} for {Email} by {Admin}",
             requestId, request.HouseholdName, request.Email, reviewerEmail);

--- a/tests/FamilyCoordinationApp.Tests/Services/HouseholdRequestServiceTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/HouseholdRequestServiceTests.cs
@@ -12,7 +12,8 @@ namespace FamilyCoordinationApp.Tests.Services;
 
 /// <summary>
 /// Unit coverage for <see cref="HouseholdRequestService.CreateHouseholdAsync"/> — the admin-initiated "push" invite
-/// (the mirror of the self-request→approve "pull"). InMemory EF (mirrors <see cref="HouseholdMemberServiceTests"/>);
+/// (the mirror of the self-request→approve "pull") — plus the seeding parity of the "pull" side
+/// (<see cref="HouseholdRequestService.ApproveAsync"/>). InMemory EF (mirrors <see cref="HouseholdMemberServiceTests"/>);
 /// the service opens a fresh context per call via the mocked factory over ONE in-memory DB, so state persists across
 /// calls. The service wraps the create in a transaction — InMemory can't do transactions, so the options ignore
 /// <see cref="InMemoryEventId.TransactionIgnoredWarning"/> (the transaction no-ops; the create logic still runs). The
@@ -126,6 +127,38 @@ public class HouseholdRequestServiceTests : IDisposable
         result.Outcome.Should().Be(CreateHouseholdOutcome.InvalidInput);
         result.Household.Should().BeNull();
         (await CountHouseholdsAsync()).Should().Be(before);
+    }
+
+    [Fact]
+    public async Task Approve_PendingRequest_SeedsCategoriesChoresAndRooms()
+    {
+        // A pending self-service request awaiting admin review.
+        const int requestId = 42;
+        _seedContext.HouseholdRequests.Add(new HouseholdRequest
+        {
+            Id = requestId,
+            Email = "eve@new.test",
+            DisplayName = "Eve",
+            HouseholdName = "The Everetts",
+            Status = HouseholdRequestStatus.Pending,
+            RequestedAt = DateTime.UtcNow,
+        });
+        _seedContext.SaveChanges();
+
+        var result = await _service.ApproveAsync(requestId, "admin@site.test");
+
+        result.Outcome.Should().Be(ReviewOutcome.Ok);
+        result.CreatedHousehold.Should().NotBeNull();
+
+        await using var db = NewContext();
+        var hhId = result.CreatedHousehold!.Id;
+
+        // Parity with the push-invite / first-run paths: an approved household comes up with the full
+        // starter library — the nine categories PLUS the curated chore/room set. Regression guard: approve
+        // used to seed categories only, leaving a household with an empty Chores surface.
+        (await db.Categories.Where(c => c.HouseholdId == hhId).ToListAsync()).Should().NotBeEmpty();
+        (await db.Rooms.Where(r => r.HouseholdId == hhId).ToListAsync()).Should().NotBeEmpty();
+        (await db.Chores.Where(c => c.HouseholdId == hhId).ToListAsync()).Should().NotBeEmpty();
     }
 
     private async Task<int> CountHouseholdsAsync()


### PR DESCRIPTION
## What

`HouseholdRequestService.ApproveAsync` (the self-request → **approve** "pull" path) seeded the nine default categories but **not** the curated chore/room library — so a household created by approving a request came up with an empty Chores surface, while the two other creation paths seed the full starter set:

| Path | Method | Categories | Chores/Rooms |
|---|---|:---:|:---:|
| Push invite | `CreateHouseholdAsync` | ✅ | ✅ |
| First-run | `SetupService.CreateHouseholdAsync` | ✅ | ✅ |
| **Approve request** (before) | `ApproveAsync` | ✅ | ❌ |

This PR adds the missing seed to the approve path so all three produce identical households.

## How

Copies the post-commit block `CreateHouseholdAsync` already uses: `await SeedData.SeedChoresAndRoomsAsync(dbFactory, household.Id)`, placed **after** `transaction.CommitAsync` and wrapped in try/catch-log. Deliberately **out** of the approval transaction — the seeder opens its own factory context and is idempotent (OQ3); a seeding failure leaves a usable household (owner + categories), not a rolled-back approval.

Purely additive — the categories seeding and transaction shape are untouched.

## Scope

**Forward-only.** Seeds on *new* approvals. Existing already-approved households are unchanged; because `SeedChoresAndRoomsAsync` is idempotent, a one-off backfill is trivial if wanted (not done here).

## Verify

- Build clean. Tests **809/809** (baseline 808 + new `Approve_PendingRequest_SeedsCategoriesChoresAndRooms`). `dotnet format` clean on the changed file.
- **End-to-end on :8080** — inserted a pending request, approved it through Settings → Household Requests as a site admin, psql-confirmed the new household: **Categories=9, Chores=11, Rooms=5** (identical to the push path). Confirmed the pre-fix approve path produced 9 / **0 / 0**.

Follow-up to #67, where the divergence was found and flagged. Spine quest `c394440a`.

https://claude.ai/code/session_015Tu5FgtyXRfVMxqQ1qyLzL
