### PR TITLE
feat(chores): append-only ChoreSnoozeEvent log (Phase 15 history substrate)

### DIFF
--- a/src/FamilyCoordinationApp/Data/ApplicationDbContext.cs
+++ b/src/FamilyCoordinationApp/Data/ApplicationDbContext.cs
@@ -26,6 +26,7 @@ public class ApplicationDbContext : DbContext
     public DbSet<Chore> Chores => Set<Chore>();
     public DbSet<ChoreCompletion> ChoreCompletions => Set<ChoreCompletion>();
     public DbSet<ChoreEvent> ChoreEvents => Set<ChoreEvent>();
+    public DbSet<ChoreSnoozeEvent> ChoreSnoozeEvents => Set<ChoreSnoozeEvent>();
     public DbSet<ChoreParticipationEvent> ChoreParticipationEvents => Set<ChoreParticipationEvent>();
     public DbSet<ChoreSubtask> ChoreSubtasks => Set<ChoreSubtask>();
     public DbSet<HouseholdChoreDigestSettings> ChoreDigestSettings => Set<HouseholdChoreDigestSettings>();

--- a/src/FamilyCoordinationApp/Data/Configurations/ChoreSnoozeEventConfiguration.cs
+++ b/src/FamilyCoordinationApp/Data/Configurations/ChoreSnoozeEventConfiguration.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using FamilyCoordinationApp.Data.Entities;
+
+namespace FamilyCoordinationApp.Data.Configurations;
+
+public class ChoreSnoozeEventConfiguration : IEntityTypeConfiguration<ChoreSnoozeEvent>
+{
+    public void Configure(EntityTypeBuilder<ChoreSnoozeEvent> builder)
+    {
+        builder.ToTable("ChoreSnoozeEvents");
+
+        // Composite PK: HouseholdId + ChoreId + SnoozeEventId (mirrors ChoreCompletion / ChoreEvent).
+        builder.HasKey(se => new { se.HouseholdId, se.ChoreId, se.SnoozeEventId });
+        builder.Property(se => se.SnoozeEventId).ValueGeneratedOnAdd();
+
+        builder.Property(se => se.SetAt)
+            .IsRequired();
+
+        // SnoozedUntil: nullable `date` (null = a CLEAR event). No special config — Npgsql maps DateOnly? → date.
+
+        // FK to Chore (composite). Cascade on Chore delete (household-scoped teardown flows Household→Chore→here).
+        builder.HasOne(se => se.Chore)
+            .WithMany(c => c.SnoozeEvents)
+            .HasForeignKey(se => new { se.HouseholdId, se.ChoreId })
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // User FK => Restrict: a user delete must not wipe the snooze history (council M4).
+        builder.HasOne(se => se.SetBy)
+            .WithMany()
+            .HasForeignKey(se => se.SetByUserId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/FamilyCoordinationApp/Data/Entities/Chore.cs
+++ b/src/FamilyCoordinationApp/Data/Entities/Chore.cs
@@ -71,6 +71,7 @@ public class Chore
     public User? Assignee { get; set; }
     public ICollection<ChoreCompletion> Completions { get; set; } = new List<ChoreCompletion>();
     public ICollection<ChoreEvent> Events { get; set; } = new List<ChoreEvent>();
+    public ICollection<ChoreSnoozeEvent> SnoozeEvents { get; set; } = new List<ChoreSnoozeEvent>();
     public ICollection<ChoreParticipationEvent> ParticipationEvents { get; set; } = new List<ChoreParticipationEvent>();
     public ICollection<ChoreSubtask> Subtasks { get; set; } = new List<ChoreSubtask>();
 }

--- a/src/FamilyCoordinationApp/Data/Entities/ChoreSnoozeEvent.cs
+++ b/src/FamilyCoordinationApp/Data/Entities/ChoreSnoozeEvent.cs
@@ -1,0 +1,40 @@
+namespace FamilyCoordinationApp.Data.Entities;
+
+/// <summary>
+/// Append-only log of snooze-floor transitions for a chore (Phase 15 — the chore-history substrate). Each row
+/// is ONE snooze action: a SET (<see cref="SnoozedUntil"/> non-null = the floor that was applied) or a CLEAR
+/// (<see cref="SnoozedUntil"/> null = the floor was removed — an explicit un-snooze OR a satisfying completion,
+/// see <c>ChoreService</c> D9). Rows are written only on an actual state CHANGE (a no-op re-snooze to the same
+/// date, or a clear on an un-snoozed chore, writes nothing).
+/// <para>
+/// This ships now because snooze history is UNBACKFILLABLE — <see cref="Chore.SnoozedUntil"/> holds only the
+/// CURRENT floor, so without this stream a past snooze (and whether a historical missed beat was <i>snoozed</i>
+/// vs <i>slipped</i>) is unrecoverable. The read/UI use (richer "snoozed since March / re-snoozed 3×"
+/// narration) is a deliberate fast-follow; the write-path exists now so the history accrues.
+/// </para>
+/// Sibling to <see cref="ChoreCompletion"/> / <see cref="ChoreEvent"/>: same composite-key + DB-generated-id
+/// shape; a distinct entity (not a <see cref="ChoreEvent"/> type) because it carries the snooze-specific
+/// <see cref="SnoozedUntil"/> date payload the generic audit event has no place for.
+/// </summary>
+public class ChoreSnoozeEvent
+{
+    public int HouseholdId { get; set; }
+    public int ChoreId { get; set; }
+    public int SnoozeEventId { get; set; }
+
+    /// <summary>The user who performed the snooze action (for a completion-clear, the completer).</summary>
+    public int SetByUserId { get; set; }
+
+    /// <summary>UTC instant the action occurred.</summary>
+    public DateTime SetAt { get; set; }
+
+    /// <summary>
+    /// The snooze floor that was applied (household-tz local date), or <c>null</c> when this event CLEARED the
+    /// floor. Mirrors the semantics of <see cref="Chore.SnoozedUntil"/>.
+    /// </summary>
+    public DateOnly? SnoozedUntil { get; set; }
+
+    // Navigation
+    public Chore Chore { get; set; } = default!;
+    public User SetBy { get; set; } = default!;
+}

--- a/src/FamilyCoordinationApp/Endpoints/ChoresEndpoints.cs
+++ b/src/FamilyCoordinationApp/Endpoints/ChoresEndpoints.cs
@@ -331,7 +331,7 @@ public static class ChoresEndpoints
 
         try
         {
-            var chore = await svc.SnoozeAsync(user.HouseholdId, choreId, until, req.Version, ct);
+            var chore = await svc.SnoozeAsync(user.HouseholdId, choreId, user.UserId, until, req.Version, ct);
             return Results.Ok(Project(boardService, chore, timeProvider, timeZone));
         }
         catch (ChoreNotFoundException) { return Results.NotFound(); }

--- a/src/FamilyCoordinationApp/Migrations/20260705051559_AddChoreSnoozeEvent.Designer.cs
+++ b/src/FamilyCoordinationApp/Migrations/20260705051559_AddChoreSnoozeEvent.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FamilyCoordinationApp.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FamilyCoordinationApp.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260705051559_AddChoreSnoozeEvent")]
+    partial class AddChoreSnoozeEvent
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/FamilyCoordinationApp/Migrations/20260705051559_AddChoreSnoozeEvent.cs
+++ b/src/FamilyCoordinationApp/Migrations/20260705051559_AddChoreSnoozeEvent.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace FamilyCoordinationApp.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddChoreSnoozeEvent : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ChoreSnoozeEvents",
+                columns: table => new
+                {
+                    HouseholdId = table.Column<int>(type: "integer", nullable: false),
+                    ChoreId = table.Column<int>(type: "integer", nullable: false),
+                    SnoozeEventId = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    SetByUserId = table.Column<int>(type: "integer", nullable: false),
+                    SetAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    SnoozedUntil = table.Column<DateOnly>(type: "date", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ChoreSnoozeEvents", x => new { x.HouseholdId, x.ChoreId, x.SnoozeEventId });
+                    table.ForeignKey(
+                        name: "FK_ChoreSnoozeEvents_Chores_HouseholdId_ChoreId",
+                        columns: x => new { x.HouseholdId, x.ChoreId },
+                        principalTable: "Chores",
+                        principalColumns: new[] { "HouseholdId", "ChoreId" },
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ChoreSnoozeEvents_Users_SetByUserId",
+                        column: x => x.SetByUserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChoreSnoozeEvents_SetByUserId",
+                table: "ChoreSnoozeEvents",
+                column: "SetByUserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ChoreSnoozeEvents");
+        }
+    }
+}

--- a/src/FamilyCoordinationApp/Services/ChoreService.cs
+++ b/src/FamilyCoordinationApp/Services/ChoreService.cs
@@ -363,7 +363,12 @@ public class ChoreService(
 
             // Clear any snooze floor on a satisfying completion (D9) — BEFORE the OneOff-vs-recurring fork so it
             // applies to ALL modes (a OneOff completion clears it too). MN3: ONLY a satisfying completion clears
-            // it; snooze expiry never does.
+            // it; snooze expiry never does. Log the clear in the append-only snooze history (Phase 15), but ONLY
+            // when there was an actual floor to clear — else every satisfying completion would spam a no-op clear.
+            if (chore.SnoozedUntil is not null)
+            {
+                AppendSnoozeEvent(context, chore, actorUserId, snoozedUntil: null, now);
+            }
             chore.SnoozedUntil = null;
 
             if (chore.RecurrenceMode == RecurrenceMode.OneOff)
@@ -411,16 +416,25 @@ public class ChoreService(
         return chore;
     }
 
-    public async Task<Chore> SnoozeAsync(int householdId, int choreId, DateOnly? until, uint version, CancellationToken cancellationToken = default)
+    public async Task<Chore> SnoozeAsync(int householdId, int choreId, int actorUserId, DateOnly? until, uint version, CancellationToken cancellationToken = default)
     {
         await using var context = await dbFactory.CreateDbContextAsync(cancellationToken);
         var chore = await LoadChoreAsync(context, householdId, choreId, cancellationToken);
 
-        // Set or clear the snooze floor (until == null ⇒ un-snooze). The ONLY field changed: no assignment-trio
-        // touch (D11), no recurrence mutation (MN1), no ChoreCompletion written and LastCompletedAt untouched
-        // (M6). The scalar change drives the xmin UPDATE so SaveWithConcurrencyAsync surfaces a stale token as
-        // a 409 (mirrors the rest of the claim machine).
+        // Set or clear the snooze floor (until == null ⇒ un-snooze). The ONLY chore field changed: no
+        // assignment-trio touch (D11), no recurrence mutation (MN1), no ChoreCompletion written and
+        // LastCompletedAt untouched (M6). The scalar change drives the xmin UPDATE so SaveWithConcurrencyAsync
+        // surfaces a stale token as a 409 (mirrors the rest of the claim machine).
+        var previous = chore.SnoozedUntil;
         chore.SnoozedUntil = until;
+
+        // Append-only snooze log (Phase 15): record the transition so history can later label a missed beat
+        // snoozed-vs-slipped and narrate re-snoozes. Only on an ACTUAL change — a no-op re-snooze to the same
+        // date, or clearing an already-un-snoozed chore, writes nothing.
+        if (previous != until)
+        {
+            AppendSnoozeEvent(context, chore, actorUserId, until, UtcNow());
+        }
 
         await SaveWithConcurrencyAsync(context, chore, version, cancellationToken);
         logger.LogInformation("Chore {ChoreId} snooze {Action} (household {HouseholdId})",
@@ -556,6 +570,23 @@ public class ChoreService(
             ActorUserId = actorUserId,
             TargetUserId = targetUserId,
             At = now
+        });
+    }
+
+    /// <summary>
+    /// Append a snooze-floor transition to the append-only history (Phase 15). <c>SnoozeEventId</c> is
+    /// DB-generated; <paramref name="snoozedUntil"/> null ⇒ a CLEAR event. Callers append only on an actual
+    /// state change (<see cref="SnoozeAsync"/> and the satisfying-completion clear).
+    /// </summary>
+    private static void AppendSnoozeEvent(ApplicationDbContext context, Chore chore, int actorUserId, DateOnly? snoozedUntil, DateTime now)
+    {
+        context.ChoreSnoozeEvents.Add(new ChoreSnoozeEvent
+        {
+            HouseholdId = chore.HouseholdId,
+            ChoreId = chore.ChoreId,
+            SetByUserId = actorUserId,
+            SetAt = now,
+            SnoozedUntil = snoozedUntil
         });
     }
 

--- a/src/FamilyCoordinationApp/Services/Interfaces/IChoreService.cs
+++ b/src/FamilyCoordinationApp/Services/Interfaces/IChoreService.cs
@@ -120,7 +120,7 @@ public interface IChoreService
     /// </summary>
     /// <exception cref="ChoreNotFoundException">No such chore in the household.</exception>
     /// <exception cref="ChoreConflictException">The client <paramref name="version"/> is stale.</exception>
-    Task<Chore> SnoozeAsync(int householdId, int choreId, DateOnly? until, uint version, CancellationToken cancellationToken = default);
+    Task<Chore> SnoozeAsync(int householdId, int choreId, int actorUserId, DateOnly? until, uint version, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Adds a named member to a multi-person chore's roster as <b>Assigned</b> (a pre-opt-in by

--- a/tests/FamilyCoordinationApp.Tests/Integration/ChoreServiceSnoozeTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Integration/ChoreServiceSnoozeTests.cs
@@ -124,13 +124,13 @@ public sealed class ChoreServiceSnoozeTests(PostgresContainerFixture postgres) :
         var before = await ReloadAsync(FixedWeeklyChoreId);
         before.SnoozedUntil.Should().BeNull();
 
-        var snoozed = await _service.SnoozeAsync(HouseholdId, FixedWeeklyChoreId, new DateOnly(2026, 6, 20), before.Version);
+        var snoozed = await _service.SnoozeAsync(HouseholdId, FixedWeeklyChoreId, Alice, new DateOnly(2026, 6, 20), before.Version);
         snoozed.SnoozedUntil.Should().Be(new DateOnly(2026, 6, 20));
         snoozed.Version.Should().NotBe(before.Version, "the snooze write advances the xmin token");
         (await ReloadAsync(FixedWeeklyChoreId)).SnoozedUntil.Should().Be(new DateOnly(2026, 6, 20));
 
         // until: null clears the floor (un-snooze).
-        var cleared = await _service.SnoozeAsync(HouseholdId, FixedWeeklyChoreId, null, snoozed.Version);
+        var cleared = await _service.SnoozeAsync(HouseholdId, FixedWeeklyChoreId, Alice, null, snoozed.Version);
         cleared.SnoozedUntil.Should().BeNull();
         (await ReloadAsync(FixedWeeklyChoreId)).SnoozedUntil.Should().BeNull();
     }
@@ -141,10 +141,10 @@ public sealed class ChoreServiceSnoozeTests(PostgresContainerFixture postgres) :
         // V8. A stale xmin token must surface as ChoreConflictException (→ 409), never last-write-wins.
         var staleVersion = (await ReloadAsync(FixedWeeklyChoreId)).Version;
 
-        var first = await _service.SnoozeAsync(HouseholdId, FixedWeeklyChoreId, new DateOnly(2026, 6, 20), staleVersion);
+        var first = await _service.SnoozeAsync(HouseholdId, FixedWeeklyChoreId, Alice, new DateOnly(2026, 6, 20), staleVersion);
         first.Version.Should().NotBe(staleVersion);
 
-        var act = async () => await _service.SnoozeAsync(HouseholdId, FixedWeeklyChoreId, new DateOnly(2026, 6, 22), staleVersion);
+        var act = async () => await _service.SnoozeAsync(HouseholdId, FixedWeeklyChoreId, Alice, new DateOnly(2026, 6, 22), staleVersion);
         await act.Should().ThrowAsync<ChoreConflictException>();
     }
 
@@ -195,7 +195,7 @@ public sealed class ChoreServiceSnoozeTests(PostgresContainerFixture postgres) :
         // rows (equity totals unchanged) and never touches LastCompletedAt.
         var before = await ReloadAsync(FixedWeeklyChoreId);
 
-        await _service.SnoozeAsync(HouseholdId, FixedWeeklyChoreId, new DateOnly(2026, 6, 22), before.Version);
+        await _service.SnoozeAsync(HouseholdId, FixedWeeklyChoreId, Alice, new DateOnly(2026, 6, 22), before.Version);
 
         await using var ctx = _dbFactory.CreateDbContext();
         var completions = await ctx.ChoreCompletions
@@ -231,5 +231,95 @@ public sealed class ChoreServiceSnoozeTests(PostgresContainerFixture postgres) :
         var after = await ReloadAsync(OneOffChoreId);
         after.SnoozedUntil.Should().BeNull("a OneOff satisfying completion clears the floor too (D9)");
         after.Status.Should().Be(ChoreStatus.Done);
+    }
+
+    // ─── Append-only snooze log (Phase 15 — the chore-history substrate) ─────────────
+
+    private async Task<List<ChoreSnoozeEvent>> SnoozeEventsAsync(int choreId)
+    {
+        await using var ctx = _dbFactory.CreateDbContext();
+        return await ctx.ChoreSnoozeEvents.AsNoTracking()
+            .Where(e => e.HouseholdId == HouseholdId && e.ChoreId == choreId)
+            .OrderBy(e => e.SnoozeEventId)
+            .ToListAsync();
+    }
+
+    [Fact]
+    public async Task SnoozeAsync_LogsSetEvent_ThenClearEvent_OnRealPostgres()
+    {
+        // Phase 15. Each snooze transition appends one ChoreSnoozeEvent carrying the actor + floor (a null
+        // floor = a clear). The actor is per-action — Bob clears what Alice set.
+        var before = await ReloadAsync(FixedWeeklyChoreId);
+
+        var snoozed = await _service.SnoozeAsync(HouseholdId, FixedWeeklyChoreId, Alice, new DateOnly(2026, 6, 20), before.Version);
+
+        var afterSet = await SnoozeEventsAsync(FixedWeeklyChoreId);
+        afterSet.Should().ContainSingle();
+        afterSet[0].SetByUserId.Should().Be(Alice);
+        afterSet[0].SnoozedUntil.Should().Be(new DateOnly(2026, 6, 20));
+        afterSet[0].SetAt.Should().Be(Now);
+
+        await _service.SnoozeAsync(HouseholdId, FixedWeeklyChoreId, Bob, null, snoozed.Version);
+
+        var afterClear = await SnoozeEventsAsync(FixedWeeklyChoreId);
+        afterClear.Should().HaveCount(2);
+        afterClear[1].SetByUserId.Should().Be(Bob, "the clear records who un-snoozed, not who set it");
+        afterClear[1].SnoozedUntil.Should().BeNull("a clear event carries a null floor");
+    }
+
+    [Fact]
+    public async Task SnoozeAsync_NoOpReSnoozeToSameDate_LogsNoDuplicate_OnRealPostgres()
+    {
+        // Only an ACTUAL transition is logged — re-snoozing to the same date writes nothing.
+        var before = await ReloadAsync(FixedWeeklyChoreId);
+        await _service.SnoozeAsync(HouseholdId, FixedWeeklyChoreId, Alice, new DateOnly(2026, 6, 20), before.Version);
+
+        var reloaded = await ReloadAsync(FixedWeeklyChoreId);
+        await _service.SnoozeAsync(HouseholdId, FixedWeeklyChoreId, Alice, new DateOnly(2026, 6, 20), reloaded.Version);
+
+        (await SnoozeEventsAsync(FixedWeeklyChoreId)).Should().ContainSingle("a no-op re-snooze to the same date logs nothing");
+    }
+
+    [Fact]
+    public async Task SnoozeAsync_ReSnoozeToNewDate_LogsSecondEvent_OnRealPostgres()
+    {
+        // A re-snooze to a DIFFERENT date is a real transition — logged, so history can narrate a re-snooze.
+        var before = await ReloadAsync(FixedWeeklyChoreId);
+        await _service.SnoozeAsync(HouseholdId, FixedWeeklyChoreId, Alice, new DateOnly(2026, 6, 20), before.Version);
+
+        var reloaded = await ReloadAsync(FixedWeeklyChoreId);
+        await _service.SnoozeAsync(HouseholdId, FixedWeeklyChoreId, Alice, new DateOnly(2026, 6, 27), reloaded.Version);
+
+        var events = await SnoozeEventsAsync(FixedWeeklyChoreId);
+        events.Select(e => e.SnoozedUntil).Should().Equal(new DateOnly(2026, 6, 20), new DateOnly(2026, 6, 27));
+    }
+
+    [Fact]
+    public async Task SatisfyingCompletion_WhenSnoozed_LogsClearEvent_OnRealPostgres()
+    {
+        // D9 + Phase 15. Completing a snoozed chore clears the floor AND logs a clear event attributed to the
+        // completer — so history knows a missed beat AFTER this instant is slipped, not snoozed.
+        var chore = await ReloadAsync(FlexibleChoreId);   // seeded snoozed
+        chore.SnoozedUntil.Should().Be(Seeded);
+
+        await _service.CompleteAsync(HouseholdId, FlexibleChoreId, Bob, note: null, photoPath: null, participantUserIds: null, chore.Version);
+
+        var events = await SnoozeEventsAsync(FlexibleChoreId);
+        events.Should().ContainSingle("the completion cleared a real floor");
+        events[0].SnoozedUntil.Should().BeNull();
+        events[0].SetByUserId.Should().Be(Bob, "the completer is the clear actor");
+    }
+
+    [Fact]
+    public async Task SatisfyingCompletion_WhenNotSnoozed_LogsNoSnoozeEvent_OnRealPostgres()
+    {
+        // The anti-spam guard: a satisfying completion of an UN-snoozed chore must NOT write a clear event
+        // (else every completion would spam the log). FixedWeeklyChoreId starts un-snoozed.
+        var chore = await ReloadAsync(FixedWeeklyChoreId);
+        chore.SnoozedUntil.Should().BeNull();
+
+        await _service.CompleteAsync(HouseholdId, FixedWeeklyChoreId, Alice, note: null, photoPath: null, participantUserIds: null, chore.Version);
+
+        (await SnoozeEventsAsync(FixedWeeklyChoreId)).Should().BeEmpty("an un-snoozed completion writes no snooze event");
     }
 }


### PR DESCRIPTION
## What

Adds an **append-only `ChoreSnoozeEvent` log** — the data substrate for the Phase 15 chore-history surface. It records every transition of a chore's snooze floor (who, when, to what) so the history can later distinguish a *snoozed* gap from a *slipped* one and narrate re-snoozes.

## Why now (it's unbackfillable)

`Chore.SnoozedUntil` holds only the **current** floor. Without a log, a past snooze — and whether a historical missed beat was snoozed vs slipped — is **permanently unrecoverable**. So the write-path ships now even though the read/UI use (*"snoozed since March / re-snoozed 3×"*) is a deliberate fast-follow. Every day without it is lost history. (Decision ratified 2026-07-05.)

## Design

- **New entity `ChoreSnoozeEvent`**, sibling to `ChoreCompletion` / `ChoreEvent`: composite key `(HouseholdId, ChoreId, SnoozeEventId)`, DB-generated id, **Cascade** FK to `Chores` (household teardown), **Restrict** FK to `Users` (a user delete never wipes history — council M4).
- A **distinct entity, not a `ChoreEvent` type**, because it carries the snooze-specific `SnoozedUntil` date payload the generic audit event has no place for.
- **One row per transition**: `SnoozedUntil` non-null = a SET, `null` = a CLEAR.
- **Write points**: `SnoozeAsync` (threaded an actor `userId` in for `SetByUserId`) and the satisfying-completion clear (D9). Both log **only on an actual state change** — a no-op re-snooze to the same date, or completing an un-snoozed chore, writes nothing (**anti-spam guard**, so completions don't flood the log).

## Scope

Data-only; **no UI/read wiring** and no read endpoint yet — those come with the ledger/recap build (being specced next). `SnoozeAsync` gained an `actorUserId` parameter; the one caller (`PATCH /api/chores/{id}/snooze`) passes the resolved `user.UserId`. Create/edit floor-setting is intentionally **not** logged here (it's scheduling, not a snooze action) — flagged for the spec.

## Tests

New real-Postgres (Testcontainers) coverage in `ChoreServiceSnoozeTests`: set→clear event pair with per-action actor, no-op-same-date logs nothing, re-snooze to a new date logs a second event, completion-clear attributed to the completer, and the un-snoozed-completion anti-spam guard.

**Full suite: 814 passed, 0 failed.** Migration verified (`Up`/`Down`, snapshot); migration-idempotency guard green.

https://claude.ai/code/session_01BtdtjJ9iTub6q5DPXjpSNc
