### PR TITLE
feat(chores): chore-history surface — ledger + logbook (Phase 15)

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -237,10 +237,12 @@ Phases 8 and 9 were deprecated 2026-02-08. The identified gaps (attribution trac
   - **Island UI** — board snooze menu (Tomorrow / 3 days / 1 week / pick-a-date) + "Snoozed · due {resume}" chip + un-snooze; edit-sheet "Next due date"; add-sheet "First due".
 **Status**: Automated gates green — `dotnet build` + full suite (632 tests) + island `svelte-check`/`vite build`. V15 browser-verify (manual, `CHORES_USE_ISLAND=true` + dev seed) is the remaining review-needed step before merge.
 
-### Phase 15: Chores v1.5 — Equity rework / invisible labor (CAPTURED)
+### Phase 15: Chores v1.5 — Equity rework / invisible labor (CAPTURED) + chore-history surface (BUILT)
 **Goal**: Make the equity model measure the *real* distribution of household labor, including invisible/planning work, and actively help move toward equity.
 **Source**: prod feedback 2026-06-14 (split out of the Phase 14 discussion). KB: "Chores Equity Rework — invisible/planning labor".
-**Why it's a phase**: the current Equity lens counts only physical board completions (`EffortPoints`), which undercounts members whose contribution is planning/coordination/mental-load — invisible to the board. Rework needs (1) **new contribution dimensions** beyond physical completions and (2) **mechanisms that drive toward equity** (capacity-aware assignment, rebalancing nudges), not just a displayed distribution. Brushes `ChoreEquityCalculator` + the digest + possibly the work model. **Spec-first when prioritized** — not started.
+**Why it's a phase**: the current Equity lens counts only physical board completions (`EffortPoints`), which undercounts members whose contribution is planning/coordination/mental-load — invisible to the board. Rework needs (1) **new contribution dimensions** beyond physical completions and (2) **mechanisms that drive toward equity** (capacity-aware assignment, rebalancing nudges), not just a displayed distribution. Brushes `ChoreEquityCalculator` + the digest + possibly the work model. **Spec-first when prioritized** — the equity-measurement rungs (capacity-aware suggestion) are still open.
+
+**Chore-history surface — the TEMPORAL face of Phase 15 (BUILT 2026-07-05, PR #70, this branch)**: a distinct, second face alongside the equity-measurement rungs — the *temporal* record of household labor. A browsable completion **ledger** (C, leads: `GET /api/chores/ledger`) with schedule-vs-completion **ghost rows** + a **gone-quiet** band, plus an evolved **logbook** (A: the digest-mirror recap additively grown with per-week distribution + milestones + kept moments + what-got-tended + the shared gone-quiet band). Collective / non-punitive — the per-person "B" trajectory stays dropped; framing is honest/pride-forward, not nagging. Backed by ONE shared `ChoreHistoryService` (DateOnly-space DST-correct projection, HouseholdId-scoped, window-bounded) feeding both endpoints; the snoozed-vs-slipped ghost reason folds the `ChoreSnoozeEvent` log (Phase-15 substrate, PR #69). Built via the 9-WP council-hardened spec (`data/outputs/workshops/fca-chore-history/`, Spine quest `598a1d49`), commit-per-WP. Full suite **855 green** + full `:8080` browser-verify PASS. No new EF migration (DTO-only; #69 shipped the substrate).
 
 ## Progress
 
@@ -263,9 +265,10 @@ Phases execute in numeric order: 1 → 2 → 3 → 4 → 5 → 6 → 7 (8 & 9 de
 | 12. Chores v1.2 (Finish the Surface) | 6/6 items | Complete | PRs #13–15, #18–21 (2026-05-31) |
 | 13. Chores v1.3 (Multi-room chores) | - | Planned | from prod feedback #6 — needs a spec |
 | 14. Chores v1.4 (Board simplification + subtasks) | - | Complete | PRs #41–42 (2026-06-14) — Model A IA + subtask checklist |
-| 15. Chores v1.5 (Equity rework / invisible labor) | - | Captured | from prod feedback 2026-06-14 — spec-first when prioritized |
+| 15. Chores v1.5 (Equity rework / invisible labor) | - | Captured | equity rungs spec-first; **history surface BUILT — PR #70 (2026-07-05)** |
+| 15h. Chore-history surface (ledger + logbook) | 9 WPs | Built — pending merge | PR #70 (2026-07-05) — Spine `598a1d49`; 855 tests + browser-verify |
 | 16. Chores v1.6 (Snooze & set-next-due) | 6 WPs | Built — pending merge + V15 | 2026-06-22 (this branch) |
 
 ---
 *Created: 2026-01-22*
-*Last updated: 2026-06-22 (Phase 16 — Snooze & set-next-due — BUILT this branch via the 6-WP `chores-snooze-and-reschedule` spec; automated gates green / V15 browser-verify pending before merge)*
+*Last updated: 2026-07-05 (Phase 15 chore-history surface — ledger + logbook — BUILT this branch via the 9-WP `fca-chore-history` spec, PR #70; full suite 855 green + `:8080` browser-verify PASS. Trust the Spine campaign "Family Coordination App" / quest `598a1d49` over this snapshot for live work-state.)*

--- a/frontend/app/src/lib/chores/App.svelte
+++ b/frontend/app/src/lib/chores/App.svelte
@@ -10,6 +10,7 @@
   import RoomsDashboard from './lib/components/RoomsDashboard.svelte';
   import EquityBoard from './lib/components/EquityBoard.svelte';
   import RecapBoard from './lib/components/RecapBoard.svelte';
+  import LedgerBoard from './lib/components/LedgerBoard.svelte';
   import QuickAddSheet, { type QuickAddValue } from './lib/components/QuickAddSheet.svelte';
   import EditChoreSheet from './lib/components/EditChoreSheet.svelte';
   import HandOffPicker from './lib/components/HandOffPicker.svelte';
@@ -58,6 +59,12 @@
   let editOpen = $state(false);
   let editChore = $state<ChoreDto | null>(null);
   let digestSettingsOpen = $state(false);
+
+  // History lens ("Look back") sub-view. C-leads: default to the ledger; the logbook
+  // (the evolved recap) loads lazily on first toggle. COMPONENT-LOCAL state — not the
+  // store, and not a new lens id (the canonical lens stays `recap`; WP-09 relabels
+  // the display only, so ChoreLens.All is not churned).
+  let historySubview = $state<'ledger' | 'logbook'>('ledger');
 
   async function loadBoard() {
     try {
@@ -249,15 +256,32 @@
     }
   });
 
-  // ── Recap fetch-on-open (a second cached fetcher, like equity — M11) ──────
-  // Load the recap payload when the Recap lens is open and the cache is stale.
-  // A user who defaulted onto Recap lands here on mount and loads it the same way.
-  // The store guards re-entrancy; invalidation (completions/snooze/edit) reloads it.
-  // `!recapError` guard: don't auto-retry a failed load in a loop — the Retry button
-  // (which clears the error) is the re-attempt path.
+  // ── Ledger fetch-on-open (C-leads — the history lens's default sub-view) ──
+  // Load the ledger when the history lens ('recap') is open ON THE LEDGER sub-view
+  // and the cache is stale. Gated on `historySubview === 'ledger'` so opening the
+  // lens fetches ONLY the ledger (no double-fetch of the logbook). Same guarded
+  // shape as the equity/recap effects (re-entrancy + no auto-retry loop, MN10).
   $effect(() => {
     if (
       store.lens === 'recap' &&
+      historySubview === 'ledger' &&
+      !store.ledgerLoaded &&
+      !store.ledgerLoading &&
+      !store.ledgerError
+    ) {
+      store.loadLedger();
+    }
+  });
+
+  // ── Logbook (recap) fetch-on-open — now LAZY on the logbook sub-view ───────
+  // The evolved recap loads only when the user toggles to the logbook sub-view (was:
+  // on any 'recap' lens open, before C-leads). Guard expression copied verbatim from
+  // the equity effect + the sub-view gate (MN10 — no state read the effect also writes;
+  // it settles once loaded, and a FAILED load waits for the Retry button, not a loop).
+  $effect(() => {
+    if (
+      store.lens === 'recap' &&
+      historySubview === 'logbook' &&
       !store.recapLoaded &&
       !store.recapLoading &&
       !store.recapError
@@ -369,17 +393,52 @@
       />
     {:else if store.lens === 'recap'}
       <!--
-        Recap lens — the in-app weekly recap (GET /api/chores/recap). The $effect
-        above fetches it on open; completions/snooze/edit invalidate it (folded into
-        invalidateEquity). Shows the SAME content the Discord digest posts plus the
-        week-over-week trend. Server values only; NO client date math (MN9).
+        History lens ("Look back", Phase 15) — C-LEADS: opens on the LEDGER (the
+        browsable completion ledger, GET /api/chores/ledger) with a sub-toggle to the
+        LOGBOOK (the evolved recap, GET /api/chores/recap). Client-side switch only —
+        no route change, no SPA fallback (M11). Each sub-view has its own cached
+        payload + its own fetch-on-open $effect (above) + its own retry. The logbook
+        loads lazily on first toggle. Server values only; NO client date math (MN9).
       -->
-      <RecapBoard
-        recap={store.recap}
-        loading={store.recapLoading}
-        error={store.recapError}
-        onRetry={() => store.loadRecap()}
-      />
+      <div class="ch-history">
+        <div class="ch-history-toggle" role="tablist" aria-label="Look back view">
+          <button
+            type="button"
+            role="tab"
+            class="ch-history-tab"
+            class:on={historySubview === 'ledger'}
+            aria-selected={historySubview === 'ledger'}
+            onclick={() => (historySubview = 'ledger')}
+          >
+            Ledger
+          </button>
+          <button
+            type="button"
+            role="tab"
+            class="ch-history-tab"
+            class:on={historySubview === 'logbook'}
+            aria-selected={historySubview === 'logbook'}
+            onclick={() => (historySubview = 'logbook')}
+          >
+            Logbook
+          </button>
+        </div>
+        {#if historySubview === 'ledger'}
+          <LedgerBoard
+            ledger={store.ledger}
+            loading={store.ledgerLoading}
+            error={store.ledgerError}
+            onRetry={() => store.loadLedger()}
+          />
+        {:else}
+          <RecapBoard
+            recap={store.recap}
+            loading={store.recapLoading}
+            error={store.recapError}
+            onRetry={() => store.loadRecap()}
+          />
+        {/if}
+      </div>
     {/if}
   {:else if !store.loading}
     <div class="ch-empty">No chore board data.</div>
@@ -511,6 +570,50 @@
   }
   .ch-toolbar {
     margin-bottom: 24px;
+  }
+
+  /* ── History lens ("Look back") sub-toggle: Ledger | Logbook ─────────────── */
+  .ch-history {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+  .ch-history-toggle {
+    display: inline-flex;
+    align-self: center;
+    gap: 2px;
+    padding: 3px;
+    background: var(--color-action-hover);
+    border-radius: var(--radius-md);
+  }
+  .ch-history-tab {
+    font: inherit;
+    font-size: 0.875rem;
+    font-weight: 500;
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
+    padding: 8px 20px;
+    min-height: 38px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition:
+      background-color 0.15s,
+      color 0.15s;
+    -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation;
+  }
+  .ch-history-tab:hover:not(.on) {
+    color: var(--color-text);
+  }
+  .ch-history-tab.on {
+    background: var(--color-surface);
+    color: var(--color-text);
+    box-shadow: var(--shadow-1);
+  }
+  .ch-history-tab:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -2px;
   }
   .ch-loading,
   .ch-empty {

--- a/frontend/app/src/lib/chores/lib/api.ts
+++ b/frontend/app/src/lib/chores/lib/api.ts
@@ -4,6 +4,7 @@ import type {
   ChoreSubtaskDto,
   ChoreEquityDto,
   ChoreRecapDto,
+  ChoreLedgerDto,
   EquityWindow,
   CapacityTier,
   RoomDto,
@@ -206,6 +207,15 @@ export async function getEquity(
 
 export async function getRecap(weeks = 8): Promise<ChoreRecapDto> {
   return request<ChoreRecapDto>(`${CHORES_BASE}/recap?weeks=${weeks}`);
+}
+
+// ─── Ledger read (chore-history C surface — its own cached payload, like recap) ─
+// The browsable completion ledger: feed + weave scaffold + ghost rows + gone-quiet
+// band. Read-only; `weeks` is the weave length (default 12; server clamps 1..26).
+// Server is authoritative on clamping — no client date math (MN9).
+
+export async function getLedger(weeks = 12): Promise<ChoreLedgerDto> {
+  return request<ChoreLedgerDto>(`${CHORES_BASE}/ledger?weeks=${weeks}`);
 }
 
 // ─── Chore mutations (WP-11 wires these to optimistic UI + 409 retry) ───────

--- a/frontend/app/src/lib/chores/lib/components/LedgerBoard.svelte
+++ b/frontend/app/src/lib/chores/lib/components/LedgerBoard.svelte
@@ -1,0 +1,637 @@
+<script lang="ts">
+  import type { ChoreLedgerDto, LedgerEventDto, GhostDto } from '../types';
+
+  // ───────────────────────────────────────────────────────────────────────
+  // Ledger lens (C) — the browsable completion ledger. Three parts:
+  //   1. THE WEAVE — a mosaic of weeks × weekdays; one stitch per finished
+  //      chore, day by day. Thin days are thin, empty days are empty, and a
+  //      missed expected beat renders as a hollow mark. Gaps show as gaps.
+  //   2. GONE QUIET — chores that stopped appearing (≥2 trailing misses),
+  //      framed as a question for the house, never a verdict on a person.
+  //   3. THE RECORD — the completion feed, newest week first, grouped by day,
+  //      with ghost rows (expected-but-missing beats) sitting alongside.
+  //
+  // ⚠ Framing (load-bearing — honest/pride-forward, NOT nagging): a gap belongs
+  //   to the CHORE, never to a person. Ghosts read as gentle "this beat was
+  //   missed (snoozed/slipped)". displayName only — no ranking, no scoreboard.
+  // ⚠ MN9 — NO client date math on a date-only string. `localDate`/`weekStartLocal`
+  //   are "YYYY-MM-DD" already resolved in the household tz server-side. We format
+  //   by SPLITTING parts, and step days only via `Date.UTC(...)` on explicit numeric
+  //   components (never `new Date('YYYY-MM-DD')`, which shifts the day in US zones).
+  // ⚠ Pure render + loading/empty/error. The store owns fetch + cache invalidation.
+  // ───────────────────────────────────────────────────────────────────────
+
+  interface Props {
+    ledger: ChoreLedgerDto | null;
+    loading: boolean;
+    error: string | null;
+    /** Retry after an error (re-runs loadLedger). */
+    onRetry: () => void;
+  }
+
+  let { ledger, loading, error, onRetry }: Props = $props();
+
+  const MONTHS = [
+    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+  ];
+  const DOW = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
+  const MAX_CELL_DOTS = 5;
+
+  /** Format "YYYY-MM-DD" as "Mon D" (MN9-safe — split parts, never Date-parse a string). */
+  function dayLabel(iso: string): string {
+    const parts = iso.split('-');
+    const m = Number.parseInt(parts[1] ?? '', 10);
+    const d = Number.parseInt(parts[2] ?? '', 10);
+    if (!m || !d || m < 1 || m > 12) return iso;
+    return `${MONTHS[m - 1]} ${d}`;
+  }
+
+  /**
+   * Step a "YYYY-MM-DD" date by `days`, MN9-safe. Uses `Date.UTC` on the EXPLICIT
+   * numeric parts (not a string parse) so month/year rollover is correct and the
+   * result never shifts across a timezone — the sanctioned escape from the date footgun.
+   */
+  function addDaysIso(iso: string, days: number): string {
+    const parts = iso.split('-');
+    const y = Number.parseInt(parts[0] ?? '', 10);
+    const m = Number.parseInt(parts[1] ?? '', 10);
+    const d = Number.parseInt(parts[2] ?? '', 10);
+    const dt = new Date(Date.UTC(y, m - 1, d + days));
+    const yy = dt.getUTCFullYear();
+    const mm = String(dt.getUTCMonth() + 1).padStart(2, '0');
+    const dd = String(dt.getUTCDate()).padStart(2, '0');
+    return `${yy}-${mm}-${dd}`;
+  }
+
+  let events = $derived(ledger?.events ?? []);
+  let weeks = $derived(ledger?.weeks ?? []);
+  let ghosts = $derived(ledger?.ghosts ?? []);
+  let goneQuiet = $derived(ledger?.goneQuiet ?? []);
+  /** Server-stamped local "today" — the weave stops here; later cells are the unwritten future. */
+  let today = $derived(ledger?.windowEndLocal ?? '');
+
+  // Per-day indexes (grouped by the date STRING — never parsed). ISO dates sort lexicographically.
+  let eventsByDate = $derived.by(() => {
+    const map = new Map<string, LedgerEventDto[]>();
+    for (const e of events) {
+      const list = map.get(e.localDate);
+      if (list) list.push(e);
+      else map.set(e.localDate, [e]);
+    }
+    return map;
+  });
+  let ghostsByDate = $derived.by(() => {
+    const map = new Map<string, GhostDto[]>();
+    for (const g of ghosts) {
+      const list = map.get(g.expectedLocalDate);
+      if (list) list.push(g);
+      else map.set(g.expectedLocalDate, [g]);
+    }
+    return map;
+  });
+
+  interface DayCell {
+    date: string;
+    count: number;
+    hasGhost: boolean;
+    isFuture: boolean;
+    isToday: boolean;
+  }
+  interface WeaveWeek {
+    weekStartLocal: string;
+    completions: number;
+    cells: DayCell[];
+  }
+
+  // The weave: one column per week (oldest→newest), each a Mon→Sun stack of day cells.
+  let weaveWeeks = $derived.by((): WeaveWeek[] =>
+    weeks.map((w) => ({
+      weekStartLocal: w.weekStartLocal,
+      completions: w.completions,
+      cells: Array.from({ length: 7 }, (_, i): DayCell => {
+        const date = addDaysIso(w.weekStartLocal, i);
+        return {
+          date,
+          count: eventsByDate.get(date)?.length ?? 0,
+          hasGhost: ghostsByDate.has(date),
+          isFuture: today !== '' && date > today,
+          isToday: date === today,
+        };
+      }),
+    })),
+  );
+
+  interface FeedDay {
+    date: string;
+    events: LedgerEventDto[];
+    ghosts: GhostDto[];
+  }
+  interface FeedWeek {
+    weekStartLocal: string;
+    completions: number;
+    days: FeedDay[];
+  }
+
+  // The record feed: newest week first; within each, only days that carry an event or a ghost, newest first.
+  let feedWeeks = $derived.by((): FeedWeek[] => {
+    const out: FeedWeek[] = [];
+    for (let i = weeks.length - 1; i >= 0; i--) {
+      const w = weeks[i];
+      const days: FeedDay[] = [];
+      for (let r = 6; r >= 0; r--) {
+        const date = addDaysIso(w.weekStartLocal, r);
+        if (today !== '' && date > today) continue; // the unwritten future
+        const dayEvents = eventsByDate.get(date) ?? [];
+        const dayGhosts = ghostsByDate.get(date) ?? [];
+        if (dayEvents.length === 0 && dayGhosts.length === 0) continue;
+        days.push({ date, events: dayEvents, ghosts: dayGhosts });
+      }
+      if (days.length > 0) out.push({ weekStartLocal: w.weekStartLocal, completions: w.completions, days });
+    }
+    return out;
+  });
+
+  let totalEntries = $derived(events.length);
+  let hasAnyRecord = $derived(events.length > 0 || ghosts.length > 0 || goneQuiet.length > 0);
+</script>
+
+<div class="ch-ledger">
+  {#if error}
+    <div class="ch-ledger-error" role="alert">
+      <span>{error}</span>
+      <button type="button" class="ch-ledger-retry" onclick={onRetry}>Retry</button>
+    </div>
+  {:else if loading && ledger == null}
+    <div class="ch-ledger-state">Loading the ledger…</div>
+  {:else if ledger != null && hasAnyRecord}
+    <!-- ── Masthead ─────────────────────────────────────────────────────── -->
+    <header class="ch-ledger-masthead">
+      <span class="ch-ledger-hero-num">{totalEntries}</span>
+      <span class="ch-ledger-hero-lab">
+        {totalEntries === 1 ? 'chore written down' : 'chores written down'}
+      </span>
+      <p class="ch-ledger-sub">
+        Every chore in this house, the moment it happened — from {dayLabel(ledger.windowStartLocal)} through today.
+      </p>
+    </header>
+
+    <!-- ── The weave ────────────────────────────────────────────────────── -->
+    {#if weaveWeeks.length > 0}
+      <section class="ch-ledger-weave-wrap" aria-label="The weave — one mark per finished chore, day by day">
+        <h3 class="ch-ledger-sec-h">The weave</h3>
+        <p class="ch-ledger-sec-sub">
+          One stitch per finished chore. Thin days are thin; empty days are empty; a hollow ring is a beat that
+          was expected but missed.
+        </p>
+        <div class="ch-ledger-weave">
+          <div class="ch-ledger-dow" aria-hidden="true">
+            {#each DOW as label, i (i)}<span>{label}</span>{/each}
+          </div>
+          {#each weaveWeeks as week (week.weekStartLocal)}
+            <div
+              class="ch-ledger-wk"
+              title="Week of {dayLabel(week.weekStartLocal)} — {week.completions} {week.completions === 1
+                ? 'entry'
+                : 'entries'}"
+            >
+              {#each week.cells as cell (cell.date)}
+                <span
+                  class="ch-ledger-cell"
+                  class:future={cell.isFuture}
+                  class:empty={!cell.isFuture && cell.count === 0 && !cell.hasGhost}
+                  class:missed={!cell.isFuture && cell.count === 0 && cell.hasGhost}
+                  class:today={cell.isToday}
+                  aria-hidden="true"
+                >
+                  {#if cell.count > 0}
+                    {#each Array.from({ length: Math.min(cell.count, MAX_CELL_DOTS) }) as _, i (i)}<i></i>{/each}
+                  {/if}
+                </span>
+              {/each}
+            </div>
+          {/each}
+        </div>
+      </section>
+    {/if}
+
+    <!-- ── Gone quiet ───────────────────────────────────────────────────── -->
+    {#if goneQuiet.length > 0}
+      <section class="ch-ledger-quiet" aria-label="Gone quiet">
+        <h3 class="ch-ledger-sec-h">Gone quiet</h3>
+        <p class="ch-ledger-sec-sub">
+          Silences in the record — chores that stopped appearing. A gap belongs to the chore, never to a person.
+        </p>
+        <ul class="ch-ledger-quiet-list">
+          {#each goneQuiet as q (q.choreName)}
+            <li class="ch-ledger-qcard">
+              <div class="ch-ledger-qhead">
+                <span class="ch-ledger-qname">{q.choreName}</span>
+                <span class="ch-ledger-pill" class:soft={q.reason === 'slipped'}>{q.reason}</span>
+              </div>
+              <p class="ch-ledger-qmeta">
+                {q.cadenceLabel} ·
+                {#if q.lastCompletedLocalDate}
+                  last written {dayLabel(q.lastCompletedLocalDate)}
+                {:else}
+                  never written down yet
+                {/if}
+              </p>
+            </li>
+          {/each}
+        </ul>
+      </section>
+    {/if}
+
+    <!-- ── The record (feed) ────────────────────────────────────────────── -->
+    {#if feedWeeks.length > 0}
+      <section class="ch-ledger-record" aria-label="The record — newest first">
+        <h3 class="ch-ledger-sec-h">The record</h3>
+        {#each feedWeeks as week (week.weekStartLocal)}
+          <div class="ch-ledger-wksep">
+            <span class="ch-ledger-wl">Week of {dayLabel(week.weekStartLocal)}</span>
+            <span class="ch-ledger-wc">
+              {week.completions} {week.completions === 1 ? 'entry' : 'entries'}
+            </span>
+          </div>
+          {#each week.days as day (day.date)}
+            <div class="ch-ledger-day">
+              <div class="ch-ledger-dayh" class:is-today={day.date === today}>
+                <span class="ch-ledger-dl">{day.date === today ? 'Today' : dayLabel(day.date)}</span>
+              </div>
+              {#each day.events as event, i (i)}
+                <div class="ch-ledger-entry">
+                  <span class="ch-ledger-chore">{event.choreName}</span>
+                  <span class="ch-ledger-who">{event.doerDisplayName}</span>
+                  <span class="ch-ledger-pts">{event.points} {event.points === 1 ? 'pt' : 'pts'}</span>
+                  {#if event.hasPhoto}<span class="ch-ledger-photo" title="has a photo">📷</span>{/if}
+                  {#if event.note}<p class="ch-ledger-note">{event.note}</p>{/if}
+                </div>
+              {/each}
+              {#each day.ghosts as ghost, i (i)}
+                <div class="ch-ledger-ghost">
+                  <span class="ch-ledger-ghost-mark" aria-hidden="true">◌</span>
+                  <span class="ch-ledger-ghost-text">
+                    <b>{ghost.choreName}</b> was due around here —
+                    {ghost.reason === 'snoozed'
+                      ? "it's snoozed, so it isn't asking anyone"
+                      : 'this beat slipped by'}.
+                  </span>
+                </div>
+              {/each}
+            </div>
+          {/each}
+        {/each}
+        <p class="ch-ledger-colophon">
+          This ledger keeps deeds, not scores. Hollow marks are questions for the house — never verdicts on a
+          person.
+        </p>
+      </section>
+    {/if}
+  {:else}
+    <div class="ch-ledger-state">
+      <p class="ch-ledger-empty-head">The ledger is empty.</p>
+      <p>It fills in as chores get completed — every deed, the moment it happens.</p>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .ch-ledger {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  /* ── Masthead ───────────────────────────────────────────────────────────── */
+  .ch-ledger-masthead {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    padding: 20px 16px;
+    background: var(--color-action-hover);
+    border-radius: var(--radius-md);
+    text-align: center;
+  }
+  .ch-ledger-hero-num {
+    font-size: 2.75rem;
+    font-weight: 700;
+    line-height: 1;
+    color: var(--color-text);
+    font-variant-numeric: tabular-nums;
+  }
+  .ch-ledger-hero-lab {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-text-muted);
+  }
+  .ch-ledger-sub {
+    margin: 10px 0 0;
+    font-size: 0.8125rem;
+    font-style: italic;
+    color: var(--color-text-muted);
+    line-height: 1.5;
+    max-width: 34ch;
+  }
+
+  /* ── Section headers ────────────────────────────────────────────────────── */
+  .ch-ledger-sec-h {
+    margin: 0;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    color: var(--color-text);
+  }
+  .ch-ledger-sec-sub {
+    margin: 4px 0 0;
+    font-size: 0.75rem;
+    font-style: italic;
+    color: var(--color-text-muted);
+    line-height: 1.45;
+  }
+
+  /* ── The weave ──────────────────────────────────────────────────────────── */
+  .ch-ledger-weave-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 16px;
+    background: var(--color-action-hover);
+    border-radius: var(--radius-md);
+  }
+  .ch-ledger-weave {
+    display: flex;
+    gap: 4px;
+    margin-top: 12px;
+    align-items: stretch;
+  }
+  .ch-ledger-dow {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding-right: 2px;
+  }
+  .ch-ledger-dow span {
+    height: 16px;
+    line-height: 16px;
+    font-size: 0.5625rem;
+    color: var(--color-text-muted);
+    font-variant-numeric: tabular-nums;
+  }
+  .ch-ledger-wk {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    min-width: 0;
+  }
+  .ch-ledger-cell {
+    height: 16px;
+    border-radius: 3px;
+    background: var(--color-surface);
+    display: flex;
+    flex-wrap: wrap;
+    align-content: center;
+    justify-content: center;
+    gap: 1.5px;
+    padding: 1px;
+  }
+  .ch-ledger-cell.empty {
+    background: var(--color-surface);
+    opacity: 0.5;
+  }
+  .ch-ledger-cell.future {
+    visibility: hidden;
+  }
+  .ch-ledger-cell.missed {
+    background: transparent;
+    border: 1px dashed var(--color-line-strong);
+  }
+  .ch-ledger-cell.today {
+    box-shadow: 0 0 0 1.5px var(--color-primary);
+  }
+  .ch-ledger-cell i {
+    width: 3.5px;
+    height: 3.5px;
+    border-radius: 50%;
+    background: var(--color-primary);
+  }
+
+  /* ── Gone quiet ─────────────────────────────────────────────────────────── */
+  .ch-ledger-quiet {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 16px;
+    background: var(--color-action-hover);
+    border: 1px dashed var(--color-line-strong);
+    border-radius: var(--radius-md);
+  }
+  .ch-ledger-quiet-list {
+    list-style: none;
+    margin: 12px 0 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .ch-ledger-qcard {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding-bottom: 12px;
+    border-bottom: 1px dotted var(--color-line);
+  }
+  .ch-ledger-qcard:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+  }
+  .ch-ledger-qhead {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .ch-ledger-qname {
+    font-size: 0.9375rem;
+    font-weight: 500;
+    color: var(--color-text);
+  }
+  .ch-ledger-pill {
+    font-size: 0.625rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    border: 1px solid var(--color-primary);
+    color: var(--color-primary);
+    border-radius: 999px;
+    padding: 2px 8px;
+  }
+  .ch-ledger-pill.soft {
+    border-color: var(--color-line-strong);
+    color: var(--color-text-muted);
+  }
+  .ch-ledger-qmeta {
+    margin: 0;
+    font-size: 0.75rem;
+    font-style: italic;
+    color: var(--color-text-muted);
+    line-height: 1.5;
+  }
+
+  /* ── The record (feed) ──────────────────────────────────────────────────── */
+  .ch-ledger-record {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 16px;
+    background: var(--color-action-hover);
+    border-radius: var(--radius-md);
+  }
+  .ch-ledger-wksep {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 8px;
+    margin-top: 12px;
+    padding-top: 8px;
+    border-top: 2px solid var(--color-line-strong);
+  }
+  .ch-ledger-wksep:first-of-type {
+    margin-top: 4px;
+  }
+  .ch-ledger-wl {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-text);
+  }
+  .ch-ledger-wc {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    white-space: nowrap;
+  }
+  .ch-ledger-dayh {
+    padding: 10px 0 2px;
+  }
+  .ch-ledger-dl {
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-text-muted);
+  }
+  .ch-ledger-dayh.is-today .ch-ledger-dl {
+    color: var(--color-primary);
+    font-weight: 700;
+  }
+  .ch-ledger-entry {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 6px 0;
+    padding-left: 10px;
+    border-left: 2px solid var(--color-line);
+  }
+  .ch-ledger-chore {
+    font-size: 0.9375rem;
+    color: var(--color-text);
+  }
+  .ch-ledger-who {
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    background: var(--color-surface);
+    color: var(--color-text-muted);
+    border-radius: 999px;
+    padding: 2px 8px;
+  }
+  .ch-ledger-pts {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    font-variant-numeric: tabular-nums;
+  }
+  .ch-ledger-photo {
+    font-size: 0.75rem;
+  }
+  .ch-ledger-note {
+    flex-basis: 100%;
+    margin: 4px 0 0;
+    font-size: 0.8125rem;
+    font-style: italic;
+    color: var(--color-text-muted);
+    line-height: 1.5;
+  }
+  /* Ghost rows — visually distinct from real entries: they are absences, framed gently. */
+  .ch-ledger-ghost {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    padding: 6px 0 6px 10px;
+    margin-top: 2px;
+    border-left: 2px dashed var(--color-line-strong);
+  }
+  .ch-ledger-ghost-mark {
+    color: var(--color-text-muted);
+    font-size: 0.875rem;
+  }
+  .ch-ledger-ghost-text {
+    font-size: 0.8125rem;
+    font-style: italic;
+    color: var(--color-text-muted);
+    line-height: 1.45;
+  }
+  .ch-ledger-ghost-text b {
+    font-style: normal;
+    font-weight: 500;
+    color: var(--color-text);
+  }
+  .ch-ledger-colophon {
+    margin: 16px 0 0;
+    padding-top: 12px;
+    border-top: 2px solid var(--color-line-strong);
+    text-align: center;
+    font-size: 0.75rem;
+    font-style: italic;
+    color: var(--color-text-muted);
+    line-height: 1.6;
+  }
+
+  /* ── Loading / empty / error ────────────────────────────────────────────── */
+  .ch-ledger-state {
+    padding: 40px 16px;
+    text-align: center;
+    color: var(--color-text-muted);
+  }
+  .ch-ledger-empty-head {
+    font-size: 1.125rem;
+    font-weight: 500;
+    color: var(--color-text);
+    margin: 0 0 4px;
+  }
+  .ch-ledger-error {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 16px;
+    background: rgba(229, 57, 53, 0.08);
+    border-left: 4px solid var(--color-error);
+    border-radius: var(--radius-sm);
+    color: var(--color-error);
+    font-size: 0.875rem;
+  }
+  .ch-ledger-retry {
+    font: inherit;
+    border: none;
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+    padding: 4px 12px;
+    background: transparent;
+    color: var(--color-error);
+    font-weight: 500;
+  }
+  .ch-ledger-retry:hover {
+    background: rgba(229, 57, 53, 0.12);
+  }
+</style>

--- a/frontend/app/src/lib/chores/lib/components/RecapBoard.svelte
+++ b/frontend/app/src/lib/chores/lib/components/RecapBoard.svelte
@@ -67,6 +67,38 @@
   // Only worth drawing the trend if there's more than the current (partial) week,
   // or any past activity to compare against.
   let hasTrend = $derived(trend.length > 1);
+
+  // ── Phase 15 (logbook) additions ────────────────────────────────────────
+  //
+  // ⚠ MN2/E1 (load-bearing): the per-week distribution is a WITHIN-week breakdown
+  //   on ONE selected week — NEVER a single member's value drawn as a line across
+  //   weeks (that rebuilds the dropped "B" scoreboard). The week selection is
+  //   COMPONENT-LOCAL state (not the store); it defaults to the current week.
+
+  /** The selected week's `weekStartLocal`, or null ⇒ fall back to the current/latest week. */
+  let selectedWeek = $state<string | null>(null);
+
+  let selectedWeekLocal = $derived(
+    selectedWeek ??
+      trend.find((t) => t.isCurrent)?.weekStartLocal ??
+      trend.at(-1)?.weekStartLocal ??
+      null,
+  );
+  let selectedPoint = $derived(
+    trend.find((t) => t.weekStartLocal === selectedWeekLocal) ?? null,
+  );
+
+  function selectWeek(weekStartLocal: string): void {
+    selectedWeek = weekStartLocal;
+  }
+
+  let milestones = $derived(recap?.milestones ?? null);
+  let keptMoments = $derived(recap?.keptMoments ?? []);
+  let whatGotTended = $derived(recap?.whatGotTended ?? []);
+  let goneQuiet = $derived(recap?.goneQuiet ?? []);
+
+  // What-got-tended bar scaling (min 1 to avoid /0).
+  let maxTended = $derived(Math.max(1, ...whatGotTended.map((t) => t.completions)));
 </script>
 
 <div class="ch-recap">
@@ -154,20 +186,170 @@
         </header>
         <ol class="ch-recap-chart">
           {#each trend as week (week.weekStartLocal)}
-            <li class="ch-recap-col" class:is-current={week.isCurrent}>
-              <span class="ch-recap-col-num">{week.totalCompletions}</span>
-              <span class="ch-recap-col-track" aria-hidden="true">
-                <span
-                  class="ch-recap-col-bar"
-                  style="height: {(week.totalCompletions / maxCompletions) * 100}%;"
-                ></span>
-              </span>
-              <span class="ch-recap-col-label">
-                {week.isCurrent ? 'This week' : weekLabel(week.weekStartLocal)}
-              </span>
+            <li class="ch-recap-col" class:is-current={week.isCurrent} class:is-selected={week.weekStartLocal === selectedWeekLocal}>
+              <!-- The column doubles as the week selector for the breakdown below (Phase 15). A real
+                   <button> keeps click + keyboard (Enter/Space) native and accessible. -->
+              <button
+                type="button"
+                class="ch-recap-col-btn"
+                aria-pressed={week.weekStartLocal === selectedWeekLocal}
+                aria-label="Show {week.isCurrent ? 'this week' : weekLabel(week.weekStartLocal)}'s breakdown"
+                onclick={() => selectWeek(week.weekStartLocal)}
+              >
+                <span class="ch-recap-col-num">{week.totalCompletions}</span>
+                <span class="ch-recap-col-track" aria-hidden="true">
+                  <span
+                    class="ch-recap-col-bar"
+                    style="height: {(week.totalCompletions / maxCompletions) * 100}%;"
+                  ></span>
+                </span>
+                <span class="ch-recap-col-label">
+                  {week.isCurrent ? 'This week' : weekLabel(week.weekStartLocal)}
+                </span>
+              </button>
             </li>
           {/each}
         </ol>
+      </section>
+    {/if}
+
+    <!-- ══ Phase 15 logbook sections (APPENDED — the sections above are unchanged) ══ -->
+
+    <!-- ── Per-week breakdown (a WITHIN-week split on the selected week — never a
+            per-person line across weeks, MN2/E1) ──────────────────────────── -->
+    {#if hasTrend && selectedPoint != null}
+      <section class="ch-recap-breakdown" aria-label="Breakdown for the selected week">
+        <header class="ch-recap-trend-head">
+          <h3 class="ch-recap-trend-title">Who tended what</h3>
+          <p class="ch-recap-trend-sub">
+            {selectedPoint.isCurrent ? 'This week' : `Week of ${weekLabel(selectedPoint.weekStartLocal)}`} —
+            tap a bar above to look back.
+          </p>
+        </header>
+        {#if selectedPoint.distribution.length > 0 && selectedPoint.totalPoints > 0}
+          <ul class="ch-recap-rows" aria-label="Effort by person for the selected week">
+            {#each selectedPoint.distribution as member (member.displayName)}
+              <li class="ch-recap-row">
+                <span class="ch-recap-name">{member.displayName}</span>
+                <span class="ch-recap-track">
+                  <span class="ch-recap-bar" style="width: {member.sharePct}%;" aria-hidden="true"></span>
+                </span>
+                <span class="ch-recap-figures">
+                  <span class="ch-recap-share">{pct(member.sharePct)}%</span>
+                  <span class="ch-recap-points">{member.points} {member.points === 1 ? 'pt' : 'pts'}</span>
+                </span>
+              </li>
+            {/each}
+          </ul>
+        {:else}
+          <p class="ch-recap-empty-week">No completions this week — a quiet stretch.</p>
+        {/if}
+      </section>
+    {/if}
+
+    <!-- ── Milestones (collective — effort/count facts, no ranking) ────────── -->
+    {#if milestones != null && (milestones.bestWeek != null || milestones.seasonTotalCompletions > 0 || milestones.firstEvers.length > 0)}
+      <section class="ch-recap-milestones" aria-label="Milestones">
+        <h3 class="ch-recap-trend-title">Milestones</h3>
+        <div class="ch-recap-stat-grid">
+          <div class="ch-recap-stat">
+            <span class="ch-recap-stat-num">{milestones.seasonTotalCompletions}</span>
+            <span class="ch-recap-stat-label">chores this season</span>
+          </div>
+          <div class="ch-recap-stat">
+            <span class="ch-recap-stat-num">{milestones.seasonTotalPoints}</span>
+            <span class="ch-recap-stat-label">points this season</span>
+          </div>
+          <div class="ch-recap-stat">
+            <span class="ch-recap-stat-num">{milestones.longestActiveStreakWeeks}</span>
+            <span class="ch-recap-stat-label">
+              {milestones.longestActiveStreakWeeks === 1 ? 'week streak' : 'weeks streak'}
+            </span>
+          </div>
+          {#if milestones.bestWeek != null}
+            <div class="ch-recap-stat">
+              <span class="ch-recap-stat-num">{milestones.bestWeek.totalCompletions}</span>
+              <span class="ch-recap-stat-label">best week ({weekLabel(milestones.bestWeek.weekStartLocal)})</span>
+            </div>
+          {/if}
+        </div>
+        {#if milestones.firstEvers.length > 0}
+          <div class="ch-recap-firsts">
+            <span class="ch-recap-firsts-label">🌱 First time this season</span>
+            <ul class="ch-recap-chips">
+              {#each milestones.firstEvers as first (first.choreName + first.localDate)}
+                <li class="ch-recap-chip solid">{first.choreName}</li>
+              {/each}
+            </ul>
+          </div>
+        {/if}
+      </section>
+    {/if}
+
+    <!-- ── Kept moments (notes & photos — the pride-forward highlights) ────── -->
+    {#if keptMoments.length > 0}
+      <section class="ch-recap-moments" aria-label="Kept moments">
+        <h3 class="ch-recap-trend-title">Kept moments</h3>
+        <ul class="ch-recap-moment-list">
+          {#each keptMoments as moment, i (i)}
+            <li class="ch-recap-moment">
+              <div class="ch-recap-moment-head">
+                <span class="ch-recap-moment-chore">{moment.choreName}</span>
+                <span class="ch-recap-moment-date">{weekLabel(moment.localDate)}</span>
+                {#if moment.hasPhoto}<span class="ch-recap-moment-photo" title="has a photo">📷</span>{/if}
+              </div>
+              {#if moment.note}<p class="ch-recap-moment-note">{moment.note}</p>{/if}
+            </li>
+          {/each}
+        </ul>
+      </section>
+    {/if}
+
+    <!-- ── What got tended (per-room — roomless bucketed as "General") ─────── -->
+    {#if whatGotTended.length > 0}
+      <section class="ch-recap-tended" aria-label="What got tended">
+        <h3 class="ch-recap-trend-title">What got tended</h3>
+        <ul class="ch-recap-tended-list">
+          {#each whatGotTended as room (room.roomName)}
+            <li class="ch-recap-tended-row">
+              <span class="ch-recap-name">{room.roomName}</span>
+              <span class="ch-recap-track">
+                <span
+                  class="ch-recap-bar"
+                  style="width: {(room.completions / maxTended) * 100}%;"
+                  aria-hidden="true"
+                ></span>
+              </span>
+              <span class="ch-recap-points">{room.completions}</span>
+            </li>
+          {/each}
+        </ul>
+      </section>
+    {/if}
+
+    <!-- ── Quiet corners (the shared gone-quiet band — framed collectively) ── -->
+    {#if goneQuiet.length > 0}
+      <section class="ch-recap-quiet" aria-label="Quiet corners">
+        <h3 class="ch-recap-trend-title">Quiet corners</h3>
+        <p class="ch-recap-trend-sub">Chores that have gone quiet — a gap belongs to the chore, never a person.</p>
+        <ul class="ch-recap-quiet-list">
+          {#each goneQuiet as q (q.choreName)}
+            <li class="ch-recap-qcard">
+              <div class="ch-recap-qhead">
+                <span class="ch-recap-qname">{q.choreName}</span>
+                <span class="ch-recap-pill" class:soft={q.reason === 'slipped'}>{q.reason}</span>
+              </div>
+              <p class="ch-recap-qmeta">
+                {q.cadenceLabel} ·
+                {#if q.lastCompletedLocalDate}
+                  last done {weekLabel(q.lastCompletedLocalDate)}
+                {:else}
+                  never done yet
+                {/if}
+              </p>
+            </li>
+          {/each}
+        </ul>
       </section>
     {/if}
   {:else}
@@ -411,6 +593,208 @@
     overflow: hidden;
     text-overflow: ellipsis;
     max-width: 100%;
+  }
+
+  /* The column is a selector button (Phase 15) — reset chrome, keep the flex-column layout. */
+  .ch-recap-col-btn {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+    border: none;
+    background: none;
+    padding: 4px 0;
+    margin: 0;
+    font: inherit;
+    color: inherit;
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+  }
+  .ch-recap-col-btn:hover {
+    background: var(--color-surface);
+  }
+  .ch-recap-col.is-selected .ch-recap-col-btn {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -1px;
+  }
+  .ch-recap-col.is-selected .ch-recap-col-num,
+  .ch-recap-col.is-selected .ch-recap-col-label {
+    color: var(--color-text);
+    font-weight: 600;
+  }
+
+  /* ── Phase 15 logbook sections (all share the trend section's card styling) ── */
+  .ch-recap-breakdown,
+  .ch-recap-milestones,
+  .ch-recap-moments,
+  .ch-recap-tended,
+  .ch-recap-quiet {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 16px;
+    background: var(--color-action-hover);
+    border-radius: var(--radius-md);
+  }
+  .ch-recap-quiet {
+    border: 1px dashed var(--color-line-strong);
+  }
+
+  /* Milestones — a compact stat grid + first-time chips. */
+  .ch-recap-stat-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+  .ch-recap-stat {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    padding: 10px 16px;
+    background: var(--color-surface);
+    border-radius: var(--radius-sm);
+    min-width: 96px;
+    flex: 1 1 96px;
+    text-align: center;
+  }
+  .ch-recap-stat-num {
+    font-size: 1.375rem;
+    font-weight: 700;
+    color: var(--color-text);
+    font-variant-numeric: tabular-nums;
+    line-height: 1;
+  }
+  .ch-recap-stat-label {
+    font-size: 0.6875rem;
+    color: var(--color-text-muted);
+    line-height: 1.3;
+  }
+  .ch-recap-firsts {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .ch-recap-firsts-label {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: var(--color-text);
+  }
+  .ch-recap-chip.solid {
+    background: var(--color-action-hover);
+    border: 1px solid var(--color-line-strong);
+    border-style: solid;
+    color: var(--color-text);
+  }
+
+  /* Kept moments — note/photo highlights. */
+  .ch-recap-moment-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .ch-recap-moment {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding-left: 10px;
+    border-left: 2px solid var(--color-line);
+  }
+  .ch-recap-moment-head {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .ch-recap-moment-chore {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--color-text);
+  }
+  .ch-recap-moment-date {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .ch-recap-moment-photo {
+    font-size: 0.75rem;
+  }
+  .ch-recap-moment-note {
+    margin: 0;
+    font-size: 0.8125rem;
+    font-style: italic;
+    color: var(--color-text-muted);
+    line-height: 1.5;
+  }
+
+  /* What got tended — per-room tally rows (reuse .ch-recap-name/-track/-bar/-points). */
+  .ch-recap-tended-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .ch-recap-tended-row {
+    display: grid;
+    grid-template-columns: minmax(96px, 1fr) minmax(0, 2.4fr) minmax(36px, auto);
+    align-items: center;
+    gap: 12px;
+  }
+
+  /* Quiet corners — shared gone-quiet cards. */
+  .ch-recap-quiet-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .ch-recap-qcard {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding-bottom: 12px;
+    border-bottom: 1px dotted var(--color-line);
+  }
+  .ch-recap-qcard:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+  }
+  .ch-recap-qhead {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .ch-recap-qname {
+    font-size: 0.9375rem;
+    font-weight: 500;
+    color: var(--color-text);
+  }
+  .ch-recap-pill {
+    font-size: 0.625rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    border: 1px solid var(--color-primary);
+    color: var(--color-primary);
+    border-radius: 999px;
+    padding: 2px 8px;
+  }
+  .ch-recap-pill.soft {
+    border-color: var(--color-line-strong);
+    color: var(--color-text-muted);
+  }
+  .ch-recap-qmeta {
+    margin: 0;
+    font-size: 0.75rem;
+    font-style: italic;
+    color: var(--color-text-muted);
+    line-height: 1.5;
   }
 
   /* ── Loading / empty / error ────────────────────────────────────────────── */

--- a/frontend/app/src/lib/chores/lib/components/ViewSwitcher.svelte
+++ b/frontend/app/src/lib/chores/lib/components/ViewSwitcher.svelte
@@ -45,7 +45,9 @@
     mine: 'Mine',
     'needs-attention': 'All',
     rooms: 'Rooms',
-    recap: 'Recap',
+    // The history lens (Phase 15) — the canonical id stays `recap`; this is a
+    // DISPLAY relabel only (it now opens on the ledger with a logbook sub-toggle).
+    recap: 'Look back',
     equity: 'Board load',
   };
 

--- a/frontend/app/src/lib/chores/lib/state.svelte.ts
+++ b/frontend/app/src/lib/chores/lib/state.svelte.ts
@@ -22,6 +22,7 @@ import type {
   ChoreSubtaskDto,
   ChoreEquityDto,
   ChoreRecapDto,
+  ChoreLedgerDto,
   EquityWindow,
   CapacityTier,
   RoomRollupDto,
@@ -54,6 +55,7 @@ import {
   setCapacity,
   getEquity,
   getRecap,
+  getLedger,
   type CreateChoreRequest,
   type UpdateChoreRequest,
   type CompleteRequest,
@@ -180,6 +182,23 @@ class BoardStore {
   recapError = $state<string | null>(null);
   /** True once a recap fetch has resolved; invalidation flips it back so the App effect reloads. */
   recapLoaded = $state(false);
+
+  // ── Ledger lens (chore-history C surface — its own cached payload, like recap) ─
+  //
+  // GET /api/chores/ledger: the completion feed + weave scaffold + ghost rows +
+  // gone-quiet band. Same lifecycle as recap — fetch-on-open (App.svelte $effect,
+  // WP-09) + invalidated on the SAME completion/snooze/edit events (folded into
+  // `invalidateEquity`). `loadLedger()` never varies `weeks`, so a re-entrancy guard
+  // suffices — no loadSeq needed. All values are server-computed; NO client date math.
+
+  /** The cached ledger payload. null until first loaded (or after invalidation+reload). */
+  ledger = $state<ChoreLedgerDto | null>(null);
+  /** True while a `loadLedger()` fetch is in flight. */
+  ledgerLoading = $state(false);
+  /** Human-readable ledger error; null when healthy. */
+  ledgerError = $state<string | null>(null);
+  /** True once a ledger fetch has resolved; invalidation flips it back so the App effect reloads. */
+  ledgerLoaded = $state(false);
 
   /**
    * The board refetch hook, wired by App.svelte (`store.setRefresh(loadBoard)`).
@@ -418,9 +437,10 @@ class BoardStore {
     if (this.lens === 'equity') {
       void this.loadEquity();
     }
-    // The recap reads the same completion-derived data, so it goes stale on the
-    // exact same events — cascade the invalidation (reloads now if recap is open).
+    // The recap + ledger read the same completion-derived data, so they go stale on
+    // the exact same events — cascade the invalidation (each reloads now if open).
     this.invalidateRecap();
+    this.invalidateLedger();
   }
 
   // ── Recap lens fetch + invalidation (mirrors equity) ──────────────────────
@@ -452,6 +472,43 @@ class BoardStore {
     this.recapLoaded = false;
     if (this.lens === 'recap') {
       void this.loadRecap();
+    }
+  }
+
+  // ── Ledger lens fetch + invalidation (mirrors recap) ──────────────────────
+
+  /**
+   * Fetch the ledger payload (feed + weave + ghosts + gone-quiet). Called by
+   * App.svelte's $effect when the history lens is open on the ledger sub-view and
+   * the cache is stale (WP-09). Re-entrancy-guarded so the effect doesn't refetch
+   * every tick; `weeks` never varies at runtime, so no loadSeq guard is needed.
+   */
+  async loadLedger(): Promise<void> {
+    if (this.ledgerLoading) return;
+    this.ledgerLoading = true;
+    this.ledgerError = null;
+    try {
+      this.ledger = await getLedger();
+      this.ledgerLoaded = true;
+    } catch (e) {
+      this.ledgerError =
+        e instanceof ApiError
+          ? `Couldn't load the ledger (HTTP ${e.status}).`
+          : "Couldn't load the ledger right now.";
+    } finally {
+      this.ledgerLoading = false;
+    }
+  }
+
+  /**
+   * Drop the cached ledger; reload immediately if the history lens is open. The
+   * lens id stays `'recap'` (WP-09 relabels the DISPLAY only — the canonical id is
+   * unchanged so `ChoreLens.All` isn't churned).
+   */
+  invalidateLedger(): void {
+    this.ledgerLoaded = false;
+    if (this.lens === 'recap') {
+      void this.loadLedger();
     }
   }
 

--- a/frontend/app/src/lib/chores/lib/types.ts
+++ b/frontend/app/src/lib/chores/lib/types.ts
@@ -278,7 +278,11 @@ export interface RecapWeekDto {
   upForGrabsCount: number;
 }
 
-/** One week's totals in the week-over-week trend (totals only — no per-member split). */
+/**
+ * One week's totals in the week-over-week trend, plus its per-member `distribution` (Phase 15). The
+ * distribution is a WITHIN-week breakdown (displayName only) rendered on a SELECTED week — NEVER keyed as a
+ * single person's line across weeks (MN2: that rebuilds the dropped "B" scoreboard).
+ */
 export interface RecapTrendPointDto {
   /** Local Monday of the week, "YYYY-MM-DD" (household tz; MN9 — do not Date-parse). */
   weekStartLocal: string;
@@ -286,12 +290,120 @@ export interface RecapTrendPointDto {
   totalPoints: number;
   /** True for the in-progress current week (the last, partial bar). */
   isCurrent: boolean;
+  /** Per-member effort split for THIS week (displayName only; sums to the week total). */
+  distribution: RecapMemberLineDto[];
 }
 
-/** Full recap payload: the current week + the week-over-week trend (oldest→newest). */
+/** The highest-output week in the window (Phase 15). Uses total* names to match the sibling recap DTOs. */
+export interface BestWeekDto {
+  weekStartLocal: string;
+  totalCompletions: number;
+  totalPoints: number;
+}
+
+/** A chore whose ALL-TIME first-ever completion landed in the window ("first time!"). */
+export interface FirstEverDto {
+  choreName: string;
+  /** "YYYY-MM-DD" household-local (MN9 — do not Date-parse). */
+  localDate: string;
+}
+
+/** The collective milestones over the recap window (Phase 15 — effort/count facts, no per-person ranking). */
+export interface MilestonesDto {
+  /** null when the window had no activity. */
+  bestWeek: BestWeekDto | null;
+  longestActiveStreakWeeks: number;
+  firstEvers: FirstEverDto[];
+  seasonTotalCompletions: number;
+  seasonTotalPoints: number;
+}
+
+/** A completion that carried a note or photo — the logbook's "kept moments" (newest-first, cap 12). */
+export interface KeptMomentDto {
+  /** "YYYY-MM-DD" household-local (MN9 — do not Date-parse). */
+  localDate: string;
+  choreName: string;
+  note: string | null;
+  hasPhoto: boolean;
+}
+
+/** Per-room completion tally over the window. Roomless completions bucket into the virtual "General" group. */
+export interface WhatGotTendedDto {
+  roomName: string;
+  completions: number;
+}
+
+/**
+ * Full recap payload (Phase 15 — the evolved logbook): the digest-mirror current week + the week-over-week
+ * trend (each point now carrying a per-week distribution) + the additive logbook sections. Mirrors
+ * ChoreRecapDtos.cs EXACTLY (M5 lockstep with Fixtures/ChoreRecap/recap.json).
+ */
 export interface ChoreRecapDto {
   current: RecapWeekDto;
   trend: RecapTrendPointDto[];
+  milestones: MilestonesDto;
+  keptMoments: KeptMomentDto[];
+  whatGotTended: WhatGotTendedDto[];
+  /** The shared gone-quiet band (same shape + data as the ledger's). */
+  goneQuiet: GoneQuietDto[];
+}
+
+// ─── Chore-history ledger lens DTO (mirrors ChoreLedgerDtos.cs EXACTLY) ──────
+// Served at GET /api/chores/ledger?weeks=N (default 12). JSON keys are camelCase.
+// Source of truth: tests/FamilyCoordinationApp.Tests/Fixtures/ChoreHistory/ledger.json
+// (M5 lockstep tripwire). displayName ONLY — no userId/mention anywhere (D9/MN1).
+//
+// ⚠ MN9: every date is a "YYYY-MM-DD" household-local string already resolved
+//   server-side. NEVER `new Date('YYYY-MM-DD')` — group by the string (weekLabel()).
+
+/** One completion in the ledger feed (displayName only — neutral framing). */
+export interface LedgerEventDto {
+  choreName: string;
+  doerDisplayName: string;
+  /** "YYYY-MM-DD" household-local (MN9 — do not Date-parse). */
+  localDate: string;
+  points: number;
+  note: string | null;
+  hasPhoto: boolean;
+}
+
+/** One week of the weave scaffold (incl. empty weeks). Per-day density derives client-side from events/ghosts. */
+export interface LedgerWeekDto {
+  /** Local Monday of the week, "YYYY-MM-DD" (household tz; MN9). */
+  weekStartLocal: string;
+  completions: number;
+}
+
+/** An expected-but-missing beat. `reason` is 'snoozed' | 'slipped' (the server-internal ReasonFromLog is off-wire). */
+export interface GhostDto {
+  choreName: string;
+  /** "YYYY-MM-DD" household-local (MN9 — do not Date-parse). */
+  expectedLocalDate: string;
+  reason: 'snoozed' | 'slipped';
+}
+
+/**
+ * A chore that has gone quiet (≥2 trailing missed beats). SHARED by the ledger AND recap payloads — defined
+ * ONCE here (mirrors the C# single-owner `GoneQuietDto`). `lastCompletedLocalDate` is `null` when the chore
+ * was never completed (the key is always present).
+ */
+export interface GoneQuietDto {
+  choreName: string;
+  cadenceLabel: string;
+  /** "YYYY-MM-DD" household-local, or null = never completed (MN9 — do not Date-parse). */
+  lastCompletedLocalDate: string | null;
+  reason: 'snoozed' | 'slipped';
+}
+
+/** Full ledger payload: window bounds + completion feed + weave scaffold + ghost rows + gone-quiet band. */
+export interface ChoreLedgerDto {
+  /** "YYYY-MM-DD" household-local window bounds (the weave grid extent; MN9). */
+  windowStartLocal: string;
+  windowEndLocal: string;
+  events: LedgerEventDto[];
+  weeks: LedgerWeekDto[];
+  ghosts: GhostDto[];
+  goneQuiet: GoneQuietDto[];
 }
 
 // ─── Digest settings (WP-11 — mirrors WP-06 frozen contract EXACTLY) ─────────

--- a/src/FamilyCoordinationApp/Endpoints/ChoresEndpoints.cs
+++ b/src/FamilyCoordinationApp/Endpoints/ChoresEndpoints.cs
@@ -62,6 +62,9 @@ public static class ChoresEndpoints
         group.MapGet("/equity", GetEquity);
         // In-app weekly recap lens (digest content + week-over-week trend). Cookie-authed, household-scoped.
         group.MapGet("/recap", GetRecap);
+        // Chore-history ledger (C): completion feed + weave scaffold + ghost rows + gone-quiet band. Read-only,
+        // household-scoped. Its own cached payload, mirroring the /board /equity /recap lens idiom (D1).
+        group.MapGet("/ledger", GetLedger);
         group.MapGet("/digest-settings", GetDigestSettings);
         group.MapPut("/digest-settings", UpdateDigestSettings);
         group.MapPost("/seed-starter", SeedStarter);
@@ -857,6 +860,30 @@ public static class ChoresEndpoints
         // HouseholdId comes from the resolved caller, never the client (M1). weeks is clamped in the service.
         var dto = await recapService.GetRecapAsync(user.HouseholdId, weeks ?? 8, now: null, ct);
         return Results.Ok(dto);
+    }
+
+    // ─── Chore-history ledger lens (C — the browsable completion ledger) ──────────────────────────────
+
+    /// <summary>
+    /// GET /api/chores/ledger?weeks=N — the ledger read-model (M1, household-scoped): the completion feed, the
+    /// weave scaffold, ghost rows (expected-but-missing beats, snoozed/slipped), and the gone-quiet band. Read
+    /// only. <c>weeks</c> defaults to 12 (the weave is a 12×7 grid) and is clamped 1–26 by the service.
+    /// </summary>
+    private static async Task<IResult> GetLedger(
+        [FromQuery] int? weeks,
+        ClaimsPrincipal principal,
+        IChoreHistoryService historyService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        // Non-empty 401 body (M7/fca-empty-404) — a deliberate improvement over the sibling handlers' bare
+        // Results.Unauthorized(): an empty 4xx re-executes through the GET-only /not-found page.
+        if (user is null) return Results.Json(new { message = "Unauthorized" }, statusCode: 401);
+
+        // HouseholdId comes from the resolved caller, never the client (M1). weeks is clamped in the service.
+        var result = await historyService.GetHistoryAsync(user.HouseholdId, weeks ?? 12, now: null, ct);
+        return Results.Ok(ChoreLedgerProjection.ToLedger(result));
     }
 
     // ─── Digest settings (v1.1 WP-06) ────────────────────────────────────────────────

--- a/src/FamilyCoordinationApp/Program.cs
+++ b/src/FamilyCoordinationApp/Program.cs
@@ -127,6 +127,9 @@ builder.Services.AddScoped<IDigestSender, DiscordWebhookDigestSender>();
 // In-app weekly recap lens: read-only sibling of the digest (same DigestBuilder/equity/status pieces),
 // adds the week-over-week trend. No webhook, no send — just GET /api/chores/recap.
 builder.Services.AddScoped<IChoreRecapService, ChoreRecapService>();
+// Chore-history surface (Phase 15): shared read-only aggregation behind the ledger (GET /api/chores/ledger)
+// and the evolved recap. One computation, two projections (D3) — must NOT depend on IChoreRecapService.
+builder.Services.AddScoped<IChoreHistoryService, ChoreHistoryService>();
 
 // Chore/Room HTTP endpoints serialize enum DTOs (colorTier/dueState/assignmentKind/rollup status) as
 // camelCase strings so responses match the island TS unions + the WP-05 board.json fixture (council M5/M11).

--- a/src/FamilyCoordinationApp/Services/ChoreStatusCalculator.cs
+++ b/src/FamilyCoordinationApp/Services/ChoreStatusCalculator.cs
@@ -416,16 +416,20 @@ public class ChoreStatusCalculator
 
     // ---- Date helpers (all day-boundary math is timezone-aware) --------------------------------------
 
-    /// <summary>The local calendar date of a UTC instant in the injected timezone.</summary>
-    private static DateOnly LocalDate(DateTime utc, TimeZoneInfo tz)
+    /// <summary>The local calendar date of a UTC instant in the injected timezone.
+    /// <para><c>internal</c> (Phase 15 WP-01) so <c>ChoreHistoryService</c> reuses the single DST-correct
+    /// source for its projection math (M4) instead of re-deriving it. Visibility-only — no behavior change.</para></summary>
+    internal static DateOnly LocalDate(DateTime utc, TimeZoneInfo tz)
     {
         var asUtc = DateTime.SpecifyKind(utc, DateTimeKind.Utc);
         var local = TimeZoneInfo.ConvertTimeFromUtc(asUtc, tz);
         return DateOnly.FromDateTime(local);
     }
 
-    /// <summary>The UTC instant corresponding to local-midnight (00:00) of the given local date.</summary>
-    private static DateTime LocalMidnightUtc(DateOnly localDate, TimeZoneInfo tz)
+    /// <summary>The UTC instant corresponding to local-midnight (00:00) of the given local date.
+    /// <para><c>internal</c> (Phase 15 WP-01) — the projection converts each generated <c>DateOnly</c> beat to
+    /// UTC solely through this helper (M4). Visibility-only — no behavior change.</para></summary>
+    internal static DateTime LocalMidnightUtc(DateOnly localDate, TimeZoneInfo tz)
     {
         var localMidnight = localDate.ToDateTime(TimeOnly.MinValue, DateTimeKind.Unspecified);
         return TimeZoneInfo.ConvertTimeToUtc(localMidnight, tz);
@@ -442,8 +446,10 @@ public class ChoreStatusCalculator
         return naturalNextDue is { } nd && nd > resumeFloor ? nd : resumeFloor;
     }
 
-    /// <summary>Map a <see cref="System.DayOfWeek"/> to the project's custom <see cref="ChoreDaysOfWeek"/> flag.</summary>
-    private static ChoreDaysOfWeek ToChoreFlag(DayOfWeek day) => day switch
+    /// <summary>Map a <see cref="System.DayOfWeek"/> to the project's custom <see cref="ChoreDaysOfWeek"/> flag.
+    /// <para><c>internal</c> (Phase 15 WP-01) so the weekly-cadence beat generator flag-matches local dates via
+    /// the same map. Visibility-only — no behavior change.</para></summary>
+    internal static ChoreDaysOfWeek ToChoreFlag(DayOfWeek day) => day switch
     {
         DayOfWeek.Sunday => ChoreDaysOfWeek.Sunday,
         DayOfWeek.Monday => ChoreDaysOfWeek.Monday,

--- a/src/FamilyCoordinationApp/Services/Digest/ChoreHistoryService.cs
+++ b/src/FamilyCoordinationApp/Services/Digest/ChoreHistoryService.cs
@@ -210,6 +210,41 @@ public class ChoreHistoryService(
                 g => g.Key,
                 g => g.Select(r => ChoreStatusCalculator.LocalDate(r.CompletedAt, tz)).OrderBy(d => d).ToList());
 
+        // Snooze log (WP-03): the accurate snoozed-vs-slipped reason for each ghost/gone-quiet chore comes from
+        // the ChoreSnoozeEvent stream, not current state. Two bounded reads (M2 exception b):
+        //   (1) in-window events (SetAt >= windowStart);
+        //   (2) the SINGLE latest event before the window per chore (MAX(SetAt) GROUP BY ChoreId, re-fetched),
+        //       seeding the snooze state active AT windowStart so an early-window ghost inside a pre-window
+        //       snooze isn't mislabeled.
+        var snoozeEventRows = await context.ChoreSnoozeEvents
+            .AsNoTracking()
+            .Where(e => e.HouseholdId == householdId && e.SetAt >= oldestWeekStartUtc)
+            .Select(e => new SnoozeRow(e.ChoreId, e.SetAt, e.SnoozedUntil))
+            .ToListAsync(ct);
+
+        var seedMaxes = await context.ChoreSnoozeEvents
+            .AsNoTracking()
+            .Where(e => e.HouseholdId == householdId && e.SetAt < oldestWeekStartUtc)
+            .GroupBy(e => e.ChoreId)
+            .Select(g => new { ChoreId = g.Key, MaxSetAt = g.Max(e => e.SetAt) })
+            .ToListAsync(ct);
+
+        var seedRows = new List<SnoozeRow>();
+        if (seedMaxes.Count > 0)
+        {
+            var maxSetAts = seedMaxes.Select(s => s.MaxSetAt).Distinct().ToList();
+            var candidates = await context.ChoreSnoozeEvents
+                .AsNoTracking()
+                .Where(e => e.HouseholdId == householdId && e.SetAt < oldestWeekStartUtc && maxSetAts.Contains(e.SetAt))
+                .Select(e => new SnoozeRow(e.ChoreId, e.SetAt, e.SnoozedUntil))
+                .ToListAsync(ct);
+            // Keep exactly the (ChoreId, MaxSetAt) rows — guards against a rare cross-chore SetAt collision.
+            var seedKeys = seedMaxes.Select(s => (s.ChoreId, s.MaxSetAt)).ToHashSet();
+            seedRows = candidates.Where(c => seedKeys.Contains((c.ChoreId, c.SetAt))).ToList();
+        }
+
+        var snoozeByChore = BuildSnoozeStates(snoozeEventRows, seedRows);
+
         var memberNameById = members.ToDictionary(m => m.UserId, m => m.DisplayName);
 
         var events = BuildEvents(completions, choreById, memberNameById);
@@ -218,7 +253,7 @@ public class ChoreHistoryService(
         var milestones = BuildMilestones(weeksResult, firstEverByChore, choreById, oldestWeekStartUtc, asOf);
         var keptMoments = BuildKeptMoments(completions, choreById);
         var whatGotTended = BuildWhatGotTended(completions, choreById, roomNameById);
-        var (ghosts, goneQuiet) = BuildProjection(activeChores, doneDatesByChore, oldestWeekStartUtc, asOf);
+        var (ghosts, goneQuiet) = BuildProjection(activeChores, doneDatesByChore, snoozeByChore, oldestWeekStartUtc, asOf);
 
         return new ChoreHistoryResult(
             WindowStartLocal: LocalIsoDate(oldestWeekStartUtc),
@@ -244,6 +279,7 @@ public class ChoreHistoryService(
     private (IReadOnlyList<HistoryGhost> Ghosts, IReadOnlyList<HistoryGoneQuiet> GoneQuiet) BuildProjection(
         IReadOnlyList<Chore> activeChores,
         IReadOnlyDictionary<int, List<DateOnly>> doneDatesByChore,
+        IReadOnlyDictionary<int, ChoreSnoozeState> snoozeByChore,
         DateTime oldestWeekStartUtc,
         DateTime asOf)
     {
@@ -278,14 +314,19 @@ public class ChoreHistoryService(
             var (back, fwd) = ToleranceFor(snap);
             var (_, missed) = Match(beats, doneDates, back, fwd);
 
+            snoozeByChore.TryGetValue(chore.ChoreId, out var snoozeState);
+
             var missedSet = missed.ToHashSet();
             foreach (var beat in missed)
             {
+                // WP-03: the accurate reason comes from the ChoreSnoozeEvent log (ReasonFromLog=true); beats
+                // before the chore's earliest logged event fall back to current state (ReasonFromLog=false).
+                var (reason, fromLog) = ResolveReason(snap, beat, snoozeState);
                 ghosts.Add(new HistoryGhost(
                     ChoreName: chore.Name,
                     ExpectedLocalDate: Iso(beat),
-                    Reason: CurrentStateReason(snap, beat),
-                    ReasonFromLog: false)); // WP-03 overwrites both Reason and ReasonFromLog from the log.
+                    Reason: reason,
+                    ReasonFromLog: fromLog));
             }
 
             // Gone-quiet: the trailing run of consecutive misses at the newest end of the beat list.
@@ -293,7 +334,8 @@ public class ChoreHistoryService(
             if (trailing >= GoneQuietThreshold)
             {
                 var trailingBeats = beats.GetRange(beats.Count - trailing, trailing);
-                var allSnoozed = trailingBeats.All(b => CurrentStateReason(snap, b) == "snoozed");
+                // Snoozed iff EVERY trailing missed beat was snoozed (log-derived); else slipped (D5).
+                var allSnoozed = trailingBeats.All(b => ResolveReason(snap, b, snoozeState).Reason == "snoozed");
                 goneQuiet.Add(new HistoryGoneQuiet(
                     ChoreName: chore.Name,
                     CadenceLabel: CadenceLabel(snap),
@@ -503,6 +545,106 @@ public class ChoreHistoryService(
 
     /// <summary>Format a <see cref="DateOnly"/> beat as an ISO date string (already a local date — no tz conversion).</summary>
     private static string Iso(DateOnly d) => d.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+    // ── Snooze log fold (WP-03) ──────────────────────────────────────────────────────────────────────
+
+    /// <summary>A single snooze-log row (a SET when <c>SnoozedUntil</c> is non-null, a CLEAR when null).</summary>
+    private sealed record SnoozeRow(int ChoreId, DateTime SetAt, DateOnly? SnoozedUntil);
+
+    /// <summary>
+    /// A chore's folded snooze state: the active snooze intervals (UTC half-open <c>[start, end)</c>) plus the
+    /// local date of the earliest loaded event — the coverage boundary. A ghost on/after
+    /// <see cref="EarliestEventLocalDate"/> is labeled from the log; one before it falls back to current state.
+    /// </summary>
+    private sealed record ChoreSnoozeState(
+        IReadOnlyList<(DateTime StartUtc, DateTime EndUtc)> Intervals,
+        DateOnly? EarliestEventLocalDate);
+
+    /// <summary>Group the (seed + in-window) snooze rows per chore and fold each into snooze intervals.</summary>
+    private Dictionary<int, ChoreSnoozeState> BuildSnoozeStates(
+        IReadOnlyList<SnoozeRow> inWindow, IReadOnlyList<SnoozeRow> seeds)
+    {
+        var byChore = new Dictionary<int, List<SnoozeRow>>();
+        foreach (var r in seeds.Concat(inWindow))
+        {
+            if (!byChore.TryGetValue(r.ChoreId, out var list))
+            {
+                list = new List<SnoozeRow>();
+                byChore[r.ChoreId] = list;
+            }
+            list.Add(r);
+        }
+
+        var result = new Dictionary<int, ChoreSnoozeState>(byChore.Count);
+        foreach (var (choreId, rows) in byChore)
+        {
+            var ordered = rows.OrderBy(r => r.SetAt).ToList();
+            var intervals = FoldSnoozeIntervals(ordered);
+            var earliest = ChoreStatusCalculator.LocalDate(ordered[0].SetAt, tz);
+            result[choreId] = new ChoreSnoozeState(intervals, earliest);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Fold an ordered event stream into active snooze intervals (D5). A SET at <c>t0</c> with floor <c>X</c>
+    /// opens <c>[t0, min(LocalMidnightUtc(X), nextEventSetAt))</c> — the snooze expires at its own floor OR is
+    /// superseded by the next event (a CLEAR or a re-snooze), whichever is earlier. A CLEAR opens no interval;
+    /// it only bounds the preceding SET via <c>nextEventSetAt</c>. Using the next EVENT (not just the next
+    /// CLEAR) also cleanly handles a re-snooze that shortens the prior floor.
+    /// </summary>
+    private List<(DateTime StartUtc, DateTime EndUtc)> FoldSnoozeIntervals(IReadOnlyList<SnoozeRow> ordered)
+    {
+        var intervals = new List<(DateTime, DateTime)>();
+        for (var i = 0; i < ordered.Count; i++)
+        {
+            if (ordered[i].SnoozedUntil is not { } floor)
+            {
+                continue; // CLEAR — opens nothing.
+            }
+            var startUtc = DateTime.SpecifyKind(ordered[i].SetAt, DateTimeKind.Utc);
+            var floorUtc = ChoreStatusCalculator.LocalMidnightUtc(floor, tz);
+            var nextEventUtc = i + 1 < ordered.Count
+                ? DateTime.SpecifyKind(ordered[i + 1].SetAt, DateTimeKind.Utc)
+                : DateTime.MaxValue;
+            var endUtc = floorUtc < nextEventUtc ? floorUtc : nextEventUtc;
+            if (endUtc > startUtc)
+            {
+                intervals.Add((startUtc, endUtc));
+            }
+        }
+        return intervals;
+    }
+
+    /// <summary>Whether a beat's local day <c>[midnight(D), midnight(D+1))</c> intersects any snooze interval.</summary>
+    private bool WasSnoozedAt(DateOnly beat, IReadOnlyList<(DateTime StartUtc, DateTime EndUtc)> intervals)
+    {
+        var dayStart = ChoreStatusCalculator.LocalMidnightUtc(beat, tz);
+        var dayEnd = ChoreStatusCalculator.LocalMidnightUtc(beat.AddDays(1), tz);
+        foreach (var (startUtc, endUtc) in intervals)
+        {
+            if (startUtc < dayEnd && endUtc > dayStart)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Resolve a beat's reason. If the snooze log covers the beat (the chore has events AND the beat is on/after
+    /// the earliest loaded event), the answer is log-derived (<c>ReasonFromLog=true</c>). Otherwise it falls
+    /// back to the current-state placeholder (<c>ReasonFromLog=false</c>) — best-effort for pre-log beats (D5).
+    /// </summary>
+    private (string Reason, bool FromLog) ResolveReason(
+        ChoreRecurrenceSnapshot chore, DateOnly beat, ChoreSnoozeState? state)
+    {
+        if (state is { EarliestEventLocalDate: { } earliest } && beat >= earliest)
+        {
+            return (WasSnoozedAt(beat, state.Intervals) ? "snoozed" : "slipped", true);
+        }
+        return (CurrentStateReason(chore, beat), false);
+    }
 
     // ── Events — the completion feed (newest-first) ──────────────────────────────────────────────────
 

--- a/src/FamilyCoordinationApp/Services/Digest/ChoreHistoryService.cs
+++ b/src/FamilyCoordinationApp/Services/Digest/ChoreHistoryService.cs
@@ -1,0 +1,384 @@
+using System.Globalization;
+using Microsoft.EntityFrameworkCore;
+using FamilyCoordinationApp.Data;
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Services.Dtos;
+
+namespace FamilyCoordinationApp.Services.Digest;
+
+/// <summary>
+/// Read-only aggregation service behind the chore-history surface (Phase 15). It computes the collective,
+/// non-punitive history primitives over a bounded window — the completion feed, weekly aggregates + per-week
+/// distribution, the historical gap/ghost projection, the gone-quiet band, and milestones — and returns them
+/// in ONE explicit internal result record (<see cref="ChoreHistoryResult"/>). The ledger endpoint (WP-04) and
+/// the evolved recap (WP-05) each project a subset of that result; both surfaces read the SAME computation so
+/// a gone-quiet chore or a per-week share can never diverge between them (D3).
+/// <para>
+/// Construction + read idiom mirror <see cref="ChoreRecapService"/> exactly: a short-lived
+/// <see cref="IDbContextFactory{TContext}"/> context per call (M2), <c>AsNoTracking</c>, every query scoped to
+/// <c>householdId</c> from the resolved caller (M1 — a security boundary), and completions bounded to the
+/// oldest trend week (<c>CompletedAt &gt;= oldestWeekStartUtc</c>) so a long-lived household reads O(weeks),
+/// never O(all history). Two bounded exceptions push aggregation to Postgres instead of loading all rows: the
+/// first-ever detection runs a single <c>MIN(CompletedAt) GROUP BY ChoreId</c> (O(chores), D10), and WP-03's
+/// snooze fold seeds pre-window state per chore.
+/// </para>
+/// <para>
+/// This service must NOT depend on <see cref="IChoreRecapService"/>/<see cref="ChoreRecapService"/> — the
+/// dependency is one-way (WP-05 makes recap depend on history), so any shared code lives in pure static
+/// helpers (<see cref="ChoreEquityCalculator.WeekStartUtc"/>, <see cref="ChoreStatusCalculator.LocalDate"/>
+/// et al.), never a back-reference.
+/// </para>
+/// </summary>
+public interface IChoreHistoryService
+{
+    /// <summary>
+    /// Compute the full history result for <paramref name="householdId"/> over the trailing
+    /// <paramref name="weeks"/> weeks (clamped 1–26), oldest→newest and INCLUDING empty weeks.
+    /// </summary>
+    /// <param name="householdId">Resolved caller's household (M1 — never a client-supplied id).</param>
+    /// <param name="weeks">How many weeks of history to window (including the current week). Clamped 1–26.</param>
+    /// <param name="now">UTC instant to evaluate against; defaults to the injected <c>TimeProvider</c> now.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<ChoreHistoryResult> GetHistoryAsync(int householdId, int weeks, DateTime? now = null, CancellationToken ct = default);
+}
+
+// ── The frozen cross-wave contract (internal records, NOT wire DTOs) ─────────────────────────────────
+// WP-01 populates WindowStart/EndLocal, Events, Weeks, Milestones, KeptMoments, WhatGotTended.
+// WP-02 fills Ghosts + GoneQuiet (empty here). WP-03 overwrites their Reason from the snooze log.
+// WP-04/05 project subsets of this shape onto the wire DTOs. Do not reshape without re-freezing downstream.
+
+/// <summary>
+/// The complete history computation for a household over a window. <c>WindowStartLocal</c>/<c>WindowEndLocal</c>
+/// are <c>yyyy-MM-dd</c> household-tz strings (MN9). <c>Weeks</c> is oldest→newest and includes empty weeks.
+/// </summary>
+public sealed record ChoreHistoryResult(
+    string WindowStartLocal, string WindowEndLocal,
+    IReadOnlyList<HistoryEvent> Events,
+    IReadOnlyList<HistoryWeek> Weeks,
+    IReadOnlyList<HistoryGhost> Ghosts,          // EMPTY from WP-01 (WP-02 fills)
+    IReadOnlyList<HistoryGoneQuiet> GoneQuiet,   // EMPTY from WP-01 (WP-02/03 fill)
+    HistoryMilestones Milestones,
+    IReadOnlyList<HistoryKeptMoment> KeptMoments,
+    IReadOnlyList<HistoryRoomTally> WhatGotTended);
+
+/// <summary>One completion in the feed. displayName-only (no userId) — neutral framing (D9/MN1).</summary>
+public sealed record HistoryEvent(string ChoreName, string DoerDisplayName, string LocalDate, int Points, string? Note, bool HasPhoto);
+
+/// <summary>One week's totals + per-member distribution (displayName/points/sharePct — no userId).</summary>
+public sealed record HistoryWeek(string WeekStartLocal, int Completions, int Points, IReadOnlyList<RecapMemberLineDto> Distribution);
+
+/// <summary>An expected-but-unmatched beat. <c>ReasonFromLog</c> is server-internal telemetry (D5), off-wire.
+/// WP-02 sets a current-state Reason + ReasonFromLog=false; WP-03 overwrites both with the log-derived value.</summary>
+public sealed record HistoryGhost(string ChoreName, string ExpectedLocalDate, string Reason, bool ReasonFromLog);
+
+/// <summary>A chore with a trailing run of misses (the gone-quiet band). <c>LastCompletedLocalDate</c> NULL when never completed.</summary>
+public sealed record HistoryGoneQuiet(string ChoreName, string CadenceLabel, string? LastCompletedLocalDate, string Reason);
+
+/// <summary>The collective milestones over the window.</summary>
+public sealed record HistoryMilestones(BestWeek? BestWeek, int LongestActiveStreakWeeks, IReadOnlyList<FirstEver> FirstEvers, int SeasonTotalCompletions, int SeasonTotalPoints);
+
+/// <summary>The highest-output week in the window. Dedicated record — do NOT reuse a trend/week DTO.</summary>
+public sealed record BestWeek(string WeekStartLocal, int Completions, int Points);
+
+/// <summary>A chore whose all-time first-ever completion landed in the window.</summary>
+public sealed record FirstEver(string ChoreName, string LocalDate);
+
+/// <summary>A completion that carried a note or a photo (the "kept moments" highlight reel).</summary>
+public sealed record HistoryKeptMoment(string LocalDate, string ChoreName, string? Note, bool HasPhoto);
+
+/// <summary>Per-room completion tally over the window. Roomless completions bucket into the virtual "General" group.</summary>
+public sealed record HistoryRoomTally(string RoomName, int Completions);
+
+/// <inheritdoc cref="IChoreHistoryService"/>
+public class ChoreHistoryService(
+    IDbContextFactory<ApplicationDbContext> dbFactory,
+    ChoreEquityCalculator equity,
+    ChoreStatusCalculator status,
+    TimeZoneInfo tz,
+    TimeProvider timeProvider) : IChoreHistoryService
+{
+    private const int MinWeeks = 1;
+    private const int MaxWeeks = 26;
+
+    /// <summary>Fallback display name for a completion whose completer is no longer a household member.</summary>
+    private const string UnknownDoerName = "A household member";
+
+    /// <summary>The "kept moments" highlight reel is capped so the payload stays small (newest-first).</summary>
+    private const int KeptMomentsCap = 12;
+
+    /// <inheritdoc />
+    public async Task<ChoreHistoryResult> GetHistoryAsync(
+        int householdId, int weeks, DateTime? now = null, CancellationToken ct = default)
+    {
+        var asOf = DateTime.SpecifyKind(now ?? timeProvider.GetUtcNow().UtcDateTime, DateTimeKind.Utc);
+        weeks = Math.Clamp(weeks, MinWeeks, MaxWeeks);
+
+        // Window lower bound = the local Monday of the oldest trend week (mirrors ChoreRecapService). All reads
+        // are bounded to this so the scan is O(weeks of data), not O(all history) — M2.
+        var oldestWeekStartUtc = ChoreEquityCalculator.WeekStartUtc(asOf.AddDays(-7 * (weeks - 1)), tz);
+
+        await using var context = await dbFactory.CreateDbContextAsync(ct);
+
+        // Members — HouseholdId-scoped, alphabetical (M1), exactly as ChoreRecapService reads them.
+        var members = await context.Users
+            .AsNoTracking()
+            .Where(u => u.HouseholdId == householdId)
+            .OrderBy(u => u.DisplayName)
+            .Select(u => new MemberDto(u.Id, u.DisplayName, u.Initials, u.PictureUrl))
+            .ToListAsync(ct);
+
+        // In-window completions — the feed/weeks/distribution substrate. Window-bounded (M2), AsNoTracking.
+        var completions = await context.ChoreCompletions
+            .AsNoTracking()
+            .Where(c => c.HouseholdId == householdId && c.CompletedAt >= oldestWeekStartUtc)
+            .ToListAsync(ct);
+
+        // Chore name/room lookup for ALL household chores (O(chores)). An in-window completion always has a live
+        // chore row (delete cascades/restricts completions), so every referenced ChoreId resolves.
+        var choreLookup = await context.Chores
+            .AsNoTracking()
+            .Where(c => c.HouseholdId == householdId)
+            .Select(c => new { c.ChoreId, c.Name, c.RoomId })
+            .ToListAsync(ct);
+        var choreById = choreLookup.ToDictionary(c => c.ChoreId, c => (c.Name, c.RoomId));
+
+        // Room names for the what-got-tended tally (O(rooms)); roomless → the virtual "General" group.
+        var roomNameById = await context.Rooms
+            .AsNoTracking()
+            .Where(r => r.HouseholdId == householdId)
+            .ToDictionaryAsync(r => r.RoomId, r => r.Name, ct);
+
+        // First-ever detection (D10): a bounded DB-side MIN(CompletedAt) GROUP BY ChoreId — one row per chore
+        // (O(chores), indexed on HouseholdId+CompletedAt), NOT a full-history scan. A chore's first-ever is
+        // in-window iff its all-time earliest completion falls in [oldestWeekStartUtc, asOf]. Materialize the
+        // anonymous projection into concrete tuples so it crosses into the pure helper cleanly.
+        var firstEverRows = await context.ChoreCompletions
+            .AsNoTracking()
+            .Where(c => c.HouseholdId == householdId)
+            .GroupBy(c => c.ChoreId)
+            .Select(g => new { ChoreId = g.Key, FirstCompletedAt = g.Min(c => c.CompletedAt) })
+            .ToListAsync(ct);
+        var firstEverByChore = firstEverRows
+            .Select(r => (r.ChoreId, r.FirstCompletedAt))
+            .ToList();
+
+        var memberNameById = members.ToDictionary(m => m.UserId, m => m.DisplayName);
+
+        var events = BuildEvents(completions, choreById, memberNameById);
+        var weekBuckets = BucketByWeek(completions, asOf, weeks);
+        var weeksResult = BuildWeeks(weekBuckets, members, asOf);
+        var milestones = BuildMilestones(weeksResult, firstEverByChore, choreById, oldestWeekStartUtc, asOf);
+        var keptMoments = BuildKeptMoments(completions, choreById);
+        var whatGotTended = BuildWhatGotTended(completions, choreById, roomNameById);
+
+        return new ChoreHistoryResult(
+            WindowStartLocal: LocalIsoDate(oldestWeekStartUtc),
+            WindowEndLocal: LocalIsoDate(asOf),
+            Events: events,
+            Weeks: weeksResult,
+            Ghosts: Array.Empty<HistoryGhost>(),          // WP-02 fills
+            GoneQuiet: Array.Empty<HistoryGoneQuiet>(),    // WP-02/03 fill
+            Milestones: milestones,
+            KeptMoments: keptMoments,
+            WhatGotTended: whatGotTended);
+    }
+
+    // ── Events — the completion feed (newest-first) ──────────────────────────────────────────────────
+
+    private IReadOnlyList<HistoryEvent> BuildEvents(
+        IReadOnlyList<ChoreCompletion> completions,
+        IReadOnlyDictionary<int, (string Name, int? RoomId)> choreById,
+        IReadOnlyDictionary<int, string> memberNameById)
+    {
+        return completions
+            .OrderByDescending(c => c.CompletedAt)
+            .Select(c => new HistoryEvent(
+                ChoreName: choreById.TryGetValue(c.ChoreId, out var chore) ? chore.Name : string.Empty,
+                DoerDisplayName: memberNameById.TryGetValue(c.CompletedByUserId, out var name) ? name : UnknownDoerName,
+                LocalDate: LocalIsoDate(c.CompletedAt),
+                Points: c.EffortPointsSnapshot,
+                Note: string.IsNullOrWhiteSpace(c.Note) ? null : c.Note,
+                HasPhoto: !string.IsNullOrWhiteSpace(c.PhotoPath)))
+            .ToList();
+    }
+
+    // ── Weekly aggregates + per-week distribution ────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Bucket in-window completions by their local week-start (the SAME <see cref="ChoreEquityCalculator.WeekStartUtc"/>
+    /// key the recap trend uses, so the two never diverge — WP-01 test (a)), then emit one bucket per requested
+    /// week oldest→newest INCLUDING empty weeks (k = weeks−1 … 0; k = 0 is the in-progress current week).
+    /// </summary>
+    private (DateTime WeekStartUtc, List<ChoreCompletion> Completions)[] BucketByWeek(
+        IReadOnlyList<ChoreCompletion> completions, DateTime now, int weeks)
+    {
+        var byWeekStart = new Dictionary<DateTime, List<ChoreCompletion>>();
+        foreach (var c in completions)
+        {
+            var at = DateTime.SpecifyKind(c.CompletedAt, DateTimeKind.Utc);
+            var weekStart = ChoreEquityCalculator.WeekStartUtc(at, tz);
+            if (!byWeekStart.TryGetValue(weekStart, out var bucket))
+            {
+                bucket = new List<ChoreCompletion>();
+                byWeekStart[weekStart] = bucket;
+            }
+            bucket.Add(c);
+        }
+
+        var result = new (DateTime, List<ChoreCompletion>)[weeks];
+        // Oldest → newest; index 0 is the oldest week, the last index (k == 0) is the current week.
+        for (var k = weeks - 1; k >= 0; k--)
+        {
+            var weekStartUtc = ChoreEquityCalculator.WeekStartUtc(now.AddDays(-7 * k), tz);
+            byWeekStart.TryGetValue(weekStartUtc, out var bucket);
+            result[weeks - 1 - k] = (weekStartUtc, bucket ?? new List<ChoreCompletion>());
+        }
+        return result;
+    }
+
+    private IReadOnlyList<HistoryWeek> BuildWeeks(
+        (DateTime WeekStartUtc, List<ChoreCompletion> Completions)[] buckets,
+        IReadOnlyList<MemberDto> members,
+        DateTime now)
+    {
+        var weeks = new List<HistoryWeek>(buckets.Length);
+        foreach (var (weekStartUtc, bucket) in buckets)
+        {
+            var points = bucket.Sum(c => c.EffortPointsSnapshot);
+
+            // Per-week distribution: compute equity over JUST this week's bucket with EquityWindow.All (no lower
+            // bound — the bucket is already the week), so a member's per-week share sums to the week total. NOT
+            // EquityWindow.Week, whose lower-bound-only window would cumulatively over-count every week but the
+            // last. displayName-only (D6/MN1).
+            var equityResult = equity.Compute(bucket, members, EquityWindow.All, now, tz);
+            var distribution = equityResult.Members
+                .Select(m => new RecapMemberLineDto(m.DisplayName, m.Points, m.SharePct))
+                .ToList();
+
+            weeks.Add(new HistoryWeek(
+                WeekStartLocal: LocalIsoDate(weekStartUtc),
+                Completions: bucket.Count,
+                Points: points,
+                Distribution: distribution));
+        }
+        return weeks;
+    }
+
+    // ── Milestones — best week, streak, first-evers, season totals ───────────────────────────────────
+
+    private HistoryMilestones BuildMilestones(
+        IReadOnlyList<HistoryWeek> weeks,
+        IReadOnlyList<(int ChoreId, DateTime FirstCompletedAt)> firstEverByChore,
+        IReadOnlyDictionary<int, (string Name, int? RoomId)> choreById,
+        DateTime oldestWeekStartUtc,
+        DateTime asOf)
+    {
+        // Best week: rank by Points, tie-break Completions. Null when the window had no completions at all.
+        BestWeek? bestWeek = null;
+        foreach (var w in weeks)
+        {
+            if (w.Completions == 0)
+            {
+                continue;
+            }
+            if (bestWeek is null
+                || w.Points > bestWeek.Points
+                || (w.Points == bestWeek.Points && w.Completions > bestWeek.Completions))
+            {
+                bestWeek = new BestWeek(w.WeekStartLocal, w.Completions, w.Points);
+            }
+        }
+
+        // Longest run of consecutive non-empty weeks (oldest→newest order is already how weeks is built).
+        var longestStreak = 0;
+        var run = 0;
+        foreach (var w in weeks)
+        {
+            run = w.Completions > 0 ? run + 1 : 0;
+            longestStreak = Math.Max(longestStreak, run);
+        }
+
+        // First-evers: a chore whose all-time earliest completion (the bounded MIN aggregation) falls in the
+        // window. A chore completed BEFORE oldestWeekStartUtc is NOT a first-ever, even if it recurs in-window.
+        var firstEvers = new List<FirstEver>();
+        foreach (var (choreId, firstCompletedAt) in firstEverByChore)
+        {
+            var first = DateTime.SpecifyKind(firstCompletedAt, DateTimeKind.Utc);
+            if (first < oldestWeekStartUtc || first > asOf)
+            {
+                continue;
+            }
+            var name = choreById.TryGetValue(choreId, out var chore) ? chore.Name : string.Empty;
+            firstEvers.Add(new FirstEver(name, LocalIsoDate(first)));
+        }
+        // Deterministic order — newest first-ever first (a fresh "first time!" leads the list).
+        firstEvers = firstEvers
+            .OrderByDescending(f => f.LocalDate)
+            .ThenBy(f => f.ChoreName, StringComparer.Ordinal)
+            .ToList();
+
+        // Season totals = totals over the tiled window (sum of the week buckets), so they can never disagree
+        // with the per-week aggregates (D10).
+        var seasonCompletions = weeks.Sum(w => w.Completions);
+        var seasonPoints = weeks.Sum(w => w.Points);
+
+        return new HistoryMilestones(bestWeek, longestStreak, firstEvers, seasonCompletions, seasonPoints);
+    }
+
+    // ── Kept moments — completions carrying a note or photo (newest-first, capped) ───────────────────
+
+    private IReadOnlyList<HistoryKeptMoment> BuildKeptMoments(
+        IReadOnlyList<ChoreCompletion> completions,
+        IReadOnlyDictionary<int, (string Name, int? RoomId)> choreById)
+    {
+        return completions
+            .Where(c => !string.IsNullOrWhiteSpace(c.Note) || !string.IsNullOrWhiteSpace(c.PhotoPath))
+            .OrderByDescending(c => c.CompletedAt)
+            .Take(KeptMomentsCap)
+            .Select(c => new HistoryKeptMoment(
+                LocalDate: LocalIsoDate(c.CompletedAt),
+                ChoreName: choreById.TryGetValue(c.ChoreId, out var chore) ? chore.Name : string.Empty,
+                Note: string.IsNullOrWhiteSpace(c.Note) ? null : c.Note,
+                HasPhoto: !string.IsNullOrWhiteSpace(c.PhotoPath)))
+            .ToList();
+    }
+
+    // ── What got tended — per-room completion tally (roomless → "General") ───────────────────────────
+
+    private static IReadOnlyList<HistoryRoomTally> BuildWhatGotTended(
+        IReadOnlyList<ChoreCompletion> completions,
+        IReadOnlyDictionary<int, (string Name, int? RoomId)> choreById,
+        IReadOnlyDictionary<int, string> roomNameById)
+    {
+        var tally = new Dictionary<string, int>();
+        foreach (var c in completions)
+        {
+            var roomName = ChoreRollup.GeneralGroupName;
+            if (choreById.TryGetValue(c.ChoreId, out var chore)
+                && chore.RoomId is { } roomId
+                && roomNameById.TryGetValue(roomId, out var name))
+            {
+                roomName = name;
+            }
+            tally.TryGetValue(roomName, out var count);
+            tally[roomName] = count + 1;
+        }
+
+        // Most-tended first; tie-break by name for determinism (fixture-stable).
+        return tally
+            .OrderByDescending(kvp => kvp.Value)
+            .ThenBy(kvp => kvp.Key, StringComparer.Ordinal)
+            .Select(kvp => new HistoryRoomTally(kvp.Key, kvp.Value))
+            .ToList();
+    }
+
+    // ── Date helper (MN9 — server-stamped local ISO date) ────────────────────────────────────────────
+
+    /// <summary>Format a UTC instant as a household-local ISO date (<c>yyyy-MM-dd</c>) — server-side so the
+    /// island never builds a Date from a date-only string (MN9). Mirrors <c>ChoreRecapService.LocalIsoDate</c>.</summary>
+    private string LocalIsoDate(DateTime utc)
+    {
+        var local = TimeZoneInfo.ConvertTimeFromUtc(DateTime.SpecifyKind(utc, DateTimeKind.Utc), tz);
+        return local.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+    }
+}

--- a/src/FamilyCoordinationApp/Services/Digest/ChoreHistoryService.cs
+++ b/src/FamilyCoordinationApp/Services/Digest/ChoreHistoryService.cs
@@ -93,7 +93,6 @@ public sealed record HistoryRoomTally(string RoomName, int Completions);
 public class ChoreHistoryService(
     IDbContextFactory<ApplicationDbContext> dbFactory,
     ChoreEquityCalculator equity,
-    ChoreStatusCalculator status,
     TimeZoneInfo tz,
     TimeProvider timeProvider) : IChoreHistoryService
 {
@@ -105,6 +104,32 @@ public class ChoreHistoryService(
 
     /// <summary>The "kept moments" highlight reel is capped so the payload stays small (newest-first).</summary>
     private const int KeptMomentsCap = 12;
+
+    /// <summary>
+    /// A chore enters the gone-quiet band at ≥2 consecutive TRAILING missed beats (D10). One miss is a blip;
+    /// two-plus trailing is a pattern of silence. First-pass value, fixture-locked — tuning is cheap because
+    /// beat generation is separate from gone-quiet detection.
+    /// </summary>
+    private const int GoneQuietThreshold = 2;
+
+    /// <summary>
+    /// The projection read reaches this many days before the aggregation window so a beat at the window's
+    /// leading edge can still be "kept" by a completion that landed just before the window (the widest per-mode
+    /// back tolerance is 7 — <see cref="IntervalBackDays"/>'s clamp ceiling). Bounded (M2) — a small constant
+    /// margin, not O(all history).
+    /// </summary>
+    private const int MaxBackToleranceDays = 7;
+
+    // ── Per-mode match tolerances (D8) — named, fixture-locked. How many days a completion may land from a
+    //    beat and still "keep" it. Tuning is cheap because generation (ProjectBeats) is separate from matching.
+    private const int WeeklyBackDays = 1;
+    private const int WeeklyForwardDays = 3;
+    private const int OneOffBackDays = 1;
+    private const int OneOffForwardDays = 14;
+    private static int IntervalBackDays(int intervalDays) => Math.Clamp(intervalDays / 4, 1, 7);
+    private static int IntervalForwardDays(int intervalDays) => Math.Clamp(intervalDays / 2, 1, 14);
+    private const int FlexibleBackDays = 1;
+    private static int FlexibleForwardDays(int intervalDays) => Math.Clamp(intervalDays / 2, 1, 14);
 
     /// <inheritdoc />
     public async Task<ChoreHistoryResult> GetHistoryAsync(
@@ -162,6 +187,29 @@ public class ChoreHistoryService(
             .Select(r => (r.ChoreId, r.FirstCompletedAt))
             .ToList();
 
+        // Active chores drive the gap projection (WP-02). Read the full entities (recurrence fields +
+        // SnoozedUntil + CreatedAt + LastCompletedAt) — O(active chores), scoped to the household (M1).
+        var activeChores = await context.Chores
+            .AsNoTracking()
+            .Where(c => c.HouseholdId == householdId && c.Status == ChoreStatus.Active)
+            .ToListAsync(ct);
+
+        // Completion dates for matching. Read back a small margin before the window (MaxBackToleranceDays) so a
+        // beat at the window's leading edge can be kept by a completion just before it (no false leading-edge
+        // ghost). Bounded (M2). Lightweight projection ({ChoreId, CompletedAt}) — grouped into per-chore local
+        // dates for the greedy matcher.
+        var projectionReadStartUtc = oldestWeekStartUtc.AddDays(-MaxBackToleranceDays);
+        var projectionCompletionRows = await context.ChoreCompletions
+            .AsNoTracking()
+            .Where(c => c.HouseholdId == householdId && c.CompletedAt >= projectionReadStartUtc)
+            .Select(c => new { c.ChoreId, c.CompletedAt })
+            .ToListAsync(ct);
+        var doneDatesByChore = projectionCompletionRows
+            .GroupBy(r => r.ChoreId)
+            .ToDictionary(
+                g => g.Key,
+                g => g.Select(r => ChoreStatusCalculator.LocalDate(r.CompletedAt, tz)).OrderBy(d => d).ToList());
+
         var memberNameById = members.ToDictionary(m => m.UserId, m => m.DisplayName);
 
         var events = BuildEvents(completions, choreById, memberNameById);
@@ -170,18 +218,291 @@ public class ChoreHistoryService(
         var milestones = BuildMilestones(weeksResult, firstEverByChore, choreById, oldestWeekStartUtc, asOf);
         var keptMoments = BuildKeptMoments(completions, choreById);
         var whatGotTended = BuildWhatGotTended(completions, choreById, roomNameById);
+        var (ghosts, goneQuiet) = BuildProjection(activeChores, doneDatesByChore, oldestWeekStartUtc, asOf);
 
         return new ChoreHistoryResult(
             WindowStartLocal: LocalIsoDate(oldestWeekStartUtc),
             WindowEndLocal: LocalIsoDate(asOf),
             Events: events,
             Weeks: weeksResult,
-            Ghosts: Array.Empty<HistoryGhost>(),          // WP-02 fills
-            GoneQuiet: Array.Empty<HistoryGoneQuiet>(),    // WP-02/03 fill
+            Ghosts: ghosts,
+            GoneQuiet: goneQuiet,
             Milestones: milestones,
             KeptMoments: keptMoments,
             WhatGotTended: whatGotTended);
     }
+
+    // ── Historical gap/ghost projection (WP-02) ──────────────────────────────────────────────────────
+    //
+    // For each active recurring chore, project the NOMINAL expected beats across the window in DateOnly space
+    // (M4/MN4 — never UTC-tick arithmetic), greedily match them to completions within a per-mode tolerance, and
+    // emit each unmatched beat as a ghost. A chore with ≥2 consecutive trailing misses becomes gone-quiet.
+    // Snooze does NOT suppress generation (MN7) — it only labels the reason (a current-state placeholder here;
+    // WP-03 overwrites it from the ChoreSnoozeEvent log). Matching does NOT collapse the way the live board does
+    // (MN6) — every missed beat is surfaced.
+
+    private (IReadOnlyList<HistoryGhost> Ghosts, IReadOnlyList<HistoryGoneQuiet> GoneQuiet) BuildProjection(
+        IReadOnlyList<Chore> activeChores,
+        IReadOnlyDictionary<int, List<DateOnly>> doneDatesByChore,
+        DateTime oldestWeekStartUtc,
+        DateTime asOf)
+    {
+        var aggWindowStart = ChoreStatusCalculator.LocalDate(oldestWeekStartUtc, tz);
+        var today = ChoreStatusCalculator.LocalDate(asOf, tz);
+
+        var ghosts = new List<HistoryGhost>();
+        var goneQuiet = new List<HistoryGoneQuiet>();
+
+        foreach (var chore in activeChores)
+        {
+            var snap = ChoreRecurrenceSnapshot.FromChore(chore);
+
+            // Monthly (DayOfMonth-only) is rejected in v1 (MN5) — never project it. ProjectBeats also returns
+            // empty for it, but skip explicitly so intent is legible.
+            if (IsMonthlyOnly(snap))
+            {
+                continue;
+            }
+
+            // Never invent a beat before the chore existed: floor the window at the chore's creation date.
+            var choreCreated = ChoreStatusCalculator.LocalDate(chore.CreatedAt, tz);
+            var windowStart = choreCreated > aggWindowStart ? choreCreated : aggWindowStart;
+
+            var beats = ProjectBeats(snap, windowStart, today, tz);
+            if (beats.Count == 0)
+            {
+                continue;
+            }
+
+            var doneDates = doneDatesByChore.TryGetValue(chore.ChoreId, out var d) ? d : new List<DateOnly>();
+            var (back, fwd) = ToleranceFor(snap);
+            var (_, missed) = Match(beats, doneDates, back, fwd);
+
+            var missedSet = missed.ToHashSet();
+            foreach (var beat in missed)
+            {
+                ghosts.Add(new HistoryGhost(
+                    ChoreName: chore.Name,
+                    ExpectedLocalDate: Iso(beat),
+                    Reason: CurrentStateReason(snap, beat),
+                    ReasonFromLog: false)); // WP-03 overwrites both Reason and ReasonFromLog from the log.
+            }
+
+            // Gone-quiet: the trailing run of consecutive misses at the newest end of the beat list.
+            var trailing = TrailingMissCount(beats, missedSet);
+            if (trailing >= GoneQuietThreshold)
+            {
+                var trailingBeats = beats.GetRange(beats.Count - trailing, trailing);
+                var allSnoozed = trailingBeats.All(b => CurrentStateReason(snap, b) == "snoozed");
+                goneQuiet.Add(new HistoryGoneQuiet(
+                    ChoreName: chore.Name,
+                    CadenceLabel: CadenceLabel(snap),
+                    LastCompletedLocalDate: chore.LastCompletedAt is { } lc
+                        ? Iso(ChoreStatusCalculator.LocalDate(lc, tz))
+                        : null,
+                    Reason: allSnoozed ? "snoozed" : "slipped"));
+            }
+        }
+
+        // Deterministic order (fixture-stable): ghosts by date then chore; gone-quiet by chore.
+        ghosts = ghosts
+            .OrderBy(g => g.ExpectedLocalDate, StringComparer.Ordinal)
+            .ThenBy(g => g.ChoreName, StringComparer.Ordinal)
+            .ToList();
+        goneQuiet = goneQuiet
+            .OrderBy(g => g.ChoreName, StringComparer.Ordinal)
+            .ToList();
+
+        return (ghosts, goneQuiet);
+    }
+
+    /// <summary>
+    /// Project the NOMINAL expected beats for a chore across <c>[windowStart, today]</c>, generated entirely in
+    /// <see cref="DateOnly"/> (local-calendar) space so DST can never shift a beat off its weekday (M4 — the
+    /// load-bearing rule; UTC conversion happens only at the render edge). Mirrors the validated projection
+    /// spike verbatim. Snooze is ignored for GENERATION (MN7). <c>internal</c> for direct unit testing.
+    /// </summary>
+    internal static List<DateOnly> ProjectBeats(
+        ChoreRecurrenceSnapshot chore, DateOnly windowStart, DateOnly today, TimeZoneInfo tz)
+    {
+        var beats = new List<DateOnly>();
+        switch (chore.RecurrenceMode)
+        {
+            // Fixed weekly (DaysOfWeek): every flagged local weekday in the window is a calendar slot. Interior
+            // misses accumulate (unlike Flexible). Respect AnchorDate as a lower bound when set.
+            case RecurrenceMode.Fixed when chore.DaysOfWeek is { } days && days != ChoreDaysOfWeek.None:
+                for (var d = windowStart; d <= today; d = d.AddDays(1))
+                {
+                    if (days.HasFlag(ChoreStatusCalculator.ToChoreFlag(d.DayOfWeek))
+                        && (chore.AnchorDate is not { } a || d >= a))
+                    {
+                        beats.Add(d);
+                    }
+                }
+                break;
+
+            // Fixed interval-from-anchor: anchor + k·interval, stepped in DateOnly space (DST-immune).
+            case RecurrenceMode.Fixed when chore.AnchorDate is { } anchor && chore.IntervalDays is { } iv && iv > 0:
+                for (var k = 0; ; k++)
+                {
+                    var d = anchor.AddDays(k * iv);
+                    if (d > today)
+                    {
+                        break;
+                    }
+                    if (d >= windowStart)
+                    {
+                        beats.Add(d);
+                    }
+                }
+                break;
+
+            // Flexible is COMPLETION-anchored: the clock resets on every completion, so only the TRAILING run
+            // after the last completion accumulates missed beats. A late-but-done interior gap is a late
+            // completion, NOT a missed beat (fundamentally different from Fixed's calendar slots).
+            case RecurrenceMode.Flexible when chore.IntervalDays is { } iv && iv > 0:
+                var lastDone = chore.LastCompletedAt is { } last
+                    ? ChoreStatusCalculator.LocalDate(last, tz)
+                    : chore.AnchorDate; // never completed: pressure starts at the anchor
+                if (lastDone is { } baseDate)
+                {
+                    for (var d = baseDate.AddDays(iv); d <= today; d = d.AddDays(iv))
+                    {
+                        if (d >= windowStart)
+                        {
+                            beats.Add(d);
+                        }
+                    }
+                }
+                break;
+
+            // OneOff: HISTORY projects the ORIGINAL anchor, NOT the snooze-replaced due date — surfacing what
+            // snooze hid is the whole point (diverges from production OneOff dueness which reschedules).
+            case RecurrenceMode.OneOff:
+                if (chore.AnchorDate is { } due && due >= windowStart && due <= today && chore.LastCompletedAt is null)
+                {
+                    beats.Add(due);
+                }
+                break;
+        }
+        return beats;
+    }
+
+    /// <summary>
+    /// Greedily match beats to completions: each beat claims the NEAREST not-yet-consumed completion whose local
+    /// date is within <c>[beat − backTol, beat + fwdTol]</c> (ties → the earlier completion); a completion is
+    /// consumed by at most one beat. Unmatched beats are missed. Deliberately does NOT collapse the way the live
+    /// board does (MN6) — the history surface shows every missed beat. <c>internal</c> for direct unit testing.
+    /// </summary>
+    internal static (List<DateOnly> Kept, List<DateOnly> Missed) Match(
+        IReadOnlyList<DateOnly> beats, IReadOnlyList<DateOnly> doneDates, int backTol, int fwdTol)
+    {
+        var kept = new List<DateOnly>();
+        var missed = new List<DateOnly>();
+        var used = new bool[doneDates.Count];
+        foreach (var beat in beats)
+        {
+            var bestIdx = -1;
+            var bestDist = int.MaxValue;
+            for (var i = 0; i < doneDates.Count; i++)
+            {
+                if (used[i])
+                {
+                    continue;
+                }
+                var delta = doneDates[i].DayNumber - beat.DayNumber; // + = completed after the beat
+                if (delta < -backTol || delta > fwdTol)
+                {
+                    continue;
+                }
+                var dist = Math.Abs(delta);
+                // doneDates is ascending, so the FIRST minimal-distance hit is the earliest (tie → earlier).
+                if (dist < bestDist)
+                {
+                    bestDist = dist;
+                    bestIdx = i;
+                }
+            }
+            if (bestIdx >= 0)
+            {
+                used[bestIdx] = true;
+                kept.Add(beat);
+            }
+            else
+            {
+                missed.Add(beat);
+            }
+        }
+        return (kept, missed);
+    }
+
+    /// <summary>The count of consecutive missed beats at the NEWEST (trailing) end of the ordered beat list.</summary>
+    internal static int TrailingMissCount(IReadOnlyList<DateOnly> beats, ISet<DateOnly> missedSet)
+    {
+        var trailing = 0;
+        for (var i = beats.Count - 1; i >= 0; i--)
+        {
+            if (!missedSet.Contains(beats[i]))
+            {
+                break;
+            }
+            trailing++;
+        }
+        return trailing;
+    }
+
+    /// <summary>The per-mode match tolerance (D8), keyed off the recurrence shape.</summary>
+    private static (int Back, int Fwd) ToleranceFor(ChoreRecurrenceSnapshot chore)
+    {
+        var iv = chore.IntervalDays ?? 0;
+        return chore.RecurrenceMode switch
+        {
+            RecurrenceMode.Fixed when chore.DaysOfWeek is { } days && days != ChoreDaysOfWeek.None
+                => (WeeklyBackDays, WeeklyForwardDays),
+            RecurrenceMode.Fixed => (IntervalBackDays(iv), IntervalForwardDays(iv)),
+            RecurrenceMode.Flexible => (FlexibleBackDays, FlexibleForwardDays(iv)),
+            RecurrenceMode.OneOff => (OneOffBackDays, OneOffForwardDays),
+            _ => (WeeklyBackDays, WeeklyForwardDays),
+        };
+    }
+
+    /// <summary>A human cadence label for the gone-quiet card ("Mon/Thu" | "every N days" | "one-off").</summary>
+    private static string CadenceLabel(ChoreRecurrenceSnapshot chore)
+    {
+        if (chore.RecurrenceMode == RecurrenceMode.OneOff)
+        {
+            return "one-off";
+        }
+        if (chore.RecurrenceMode == RecurrenceMode.Fixed
+            && chore.DaysOfWeek is { } days && days != ChoreDaysOfWeek.None)
+        {
+            var abbr = new[]
+            {
+                (ChoreDaysOfWeek.Sunday, "Sun"), (ChoreDaysOfWeek.Monday, "Mon"), (ChoreDaysOfWeek.Tuesday, "Tue"),
+                (ChoreDaysOfWeek.Wednesday, "Wed"), (ChoreDaysOfWeek.Thursday, "Thu"), (ChoreDaysOfWeek.Friday, "Fri"),
+                (ChoreDaysOfWeek.Saturday, "Sat"),
+            };
+            return string.Join("/", abbr.Where(x => days.HasFlag(x.Item1)).Select(x => x.Item2));
+        }
+        return chore.IntervalDays is { } iv && iv > 0 ? $"every {iv} days" : "recurring";
+    }
+
+    /// <summary>Whether a chore is a monthly (<c>DayOfMonth</c>-only) recurrence — OUT OF SCOPE in v1 (MN5).</summary>
+    private static bool IsMonthlyOnly(ChoreRecurrenceSnapshot chore) =>
+        chore.DayOfMonth is not null
+        && (chore.DaysOfWeek is null || chore.DaysOfWeek == ChoreDaysOfWeek.None)
+        && !(chore.AnchorDate is not null && chore.IntervalDays is > 0);
+
+    /// <summary>
+    /// The CURRENT-STATE placeholder reason (WP-02): a beat is <c>snoozed</c> iff a snooze floor is set now and
+    /// the beat predates it, else <c>slipped</c>. Coarse — a slip-then-snooze paints the whole gap "snoozed"
+    /// (spike S8); WP-03 replaces this with the accurate log-derived reason.
+    /// </summary>
+    private static string CurrentStateReason(ChoreRecurrenceSnapshot chore, DateOnly beat) =>
+        chore.SnoozedUntil is { } s && beat < s ? "snoozed" : "slipped";
+
+    /// <summary>Format a <see cref="DateOnly"/> beat as an ISO date string (already a local date — no tz conversion).</summary>
+    private static string Iso(DateOnly d) => d.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
 
     // ── Events — the completion feed (newest-first) ──────────────────────────────────────────────────
 

--- a/src/FamilyCoordinationApp/Services/Digest/ChoreRecapService.cs
+++ b/src/FamilyCoordinationApp/Services/Digest/ChoreRecapService.cs
@@ -44,7 +44,8 @@ public class ChoreRecapService(
     ChoreStatusCalculator status,
     DigestBuilder builder,
     TimeZoneInfo tz,
-    TimeProvider timeProvider) : IChoreRecapService
+    TimeProvider timeProvider,
+    IChoreHistoryService historyService) : IChoreRecapService
 {
     private const int MinWeeks = 1;
     private const int MaxWeeks = 26;
@@ -87,11 +88,39 @@ public class ChoreRecapService(
             .Where(c => c.HouseholdId == householdId && c.Status == ChoreStatus.Active)
             .ToListAsync(ct);
 
-        var current = BuildCurrentWeek(householdName, members, completions, activeChores, asOf);
-        var trend = BuildTrend(completions, asOf, weeks);
+        // Phase 15 (D2/D3): project the shared history result for the additive logbook sections. Same instant
+        // + same weeks ⇒ its Weeks align to the trend by exact WeekStartLocal key. The digest-mirror Current
+        // path (BuildCurrentWeek) is UNTOUCHED — M6/E3.
+        var history = await historyService.GetHistoryAsync(householdId, weeks, now: asOf, ct);
+        var distributionByWeek = history.Weeks.ToDictionary(
+            w => w.WeekStartLocal, w => w.Distribution);
 
-        return new ChoreRecapDto(current, trend);
+        var current = BuildCurrentWeek(householdName, members, completions, activeChores, asOf);
+        var trend = BuildTrend(completions, asOf, weeks, distributionByWeek);
+
+        return new ChoreRecapDto(
+            current,
+            trend,
+            Milestones: ProjectMilestones(history.Milestones),
+            KeptMoments: history.KeptMoments
+                .Select(k => new KeptMomentDto(k.LocalDate, k.ChoreName, k.Note, k.HasPhoto))
+                .ToList(),
+            WhatGotTended: history.WhatGotTended
+                .Select(t => new WhatGotTendedDto(t.RoomName, t.Completions))
+                .ToList(),
+            GoneQuiet: history.GoneQuiet
+                .Select(q => new GoneQuietDto(q.ChoreName, q.CadenceLabel, q.LastCompletedLocalDate, q.Reason))
+                .ToList());
     }
+
+    /// <summary>Project the shared history milestones onto the wire DTO (renames Completions/Points →
+    /// TotalCompletions/TotalPoints to match the sibling recap DTO shapes).</summary>
+    private static MilestonesDto ProjectMilestones(HistoryMilestones m) => new(
+        BestWeek: m.BestWeek is { } bw ? new BestWeekDto(bw.WeekStartLocal, bw.Completions, bw.Points) : null,
+        LongestActiveStreakWeeks: m.LongestActiveStreakWeeks,
+        FirstEvers: m.FirstEvers.Select(f => new FirstEverDto(f.ChoreName, f.LocalDate)).ToList(),
+        SeasonTotalCompletions: m.SeasonTotalCompletions,
+        SeasonTotalPoints: m.SeasonTotalPoints);
 
     /// <summary>
     /// Assemble the current week EXACTLY as <see cref="DigestService.BuildModelAsync"/> does (same equity
@@ -150,7 +179,8 @@ public class ChoreRecapService(
     /// the following Monday-00:00 completion land in different weeks.
     /// </summary>
     private IReadOnlyList<RecapTrendPointDto> BuildTrend(
-        IReadOnlyList<ChoreCompletion> completions, DateTime now, int weeks)
+        IReadOnlyList<ChoreCompletion> completions, DateTime now, int weeks,
+        IReadOnlyDictionary<string, IReadOnlyList<RecapMemberLineDto>> distributionByWeek)
     {
         // Bucket every completion ONCE by its local week-start (O(completions)), then emit the requested
         // weeks from the buckets (O(weeks)) — instead of rescanning all completions per week. Both sides
@@ -172,11 +202,17 @@ public class ChoreRecapService(
             var weekStartUtc = ChoreEquityCalculator.WeekStartUtc(now.AddDays(-7 * k), tz);
             byWeekStart.TryGetValue(weekStartUtc, out var agg);
 
+            var weekStartLocal = LocalIsoDate(weekStartUtc);
             points.Add(new RecapTrendPointDto(
-                WeekStartLocal: LocalIsoDate(weekStartUtc),
+                WeekStartLocal: weekStartLocal,
                 TotalCompletions: agg.Completions,
                 TotalPoints: agg.Points,
-                IsCurrent: k == 0));
+                IsCurrent: k == 0,
+                // Merge the per-week distribution from the shared history result by exact WeekStartLocal key —
+                // both sides derive it from WeekStartUtc, so the keys align (D6). Never merge by index.
+                Distribution: distributionByWeek.TryGetValue(weekStartLocal, out var dist)
+                    ? dist
+                    : Array.Empty<RecapMemberLineDto>()));
         }
         return points;
     }

--- a/src/FamilyCoordinationApp/Services/Dtos/ChoreLedgerDtos.cs
+++ b/src/FamilyCoordinationApp/Services/Dtos/ChoreLedgerDtos.cs
@@ -1,0 +1,70 @@
+using FamilyCoordinationApp.Services.Digest;
+
+namespace FamilyCoordinationApp.Services.Dtos;
+
+/// <summary>
+/// The C (ledger) read-model for the chore-history surface (Phase 15). A completion <see cref="Events"/> feed,
+/// the week scaffold (<see cref="Weeks"/>, one per week oldest→newest INCLUDING empty weeks — the client
+/// derives per-day weave density by grouping <see cref="Events"/> by <c>localDate</c>), schedule-vs-completion
+/// <see cref="Ghosts"/> (expected-but-missing beats), and the <see cref="GoneQuiet"/> band.
+/// <para>
+/// Household-scoped (M1 — the id comes from the resolved caller, never the client). <b>displayName only — no
+/// userId / @mention field anywhere</b> (neutral framing, D9/MN1, contract-tested). Every date is a
+/// server-stamped <c>yyyy-MM-dd</c> household-local string (MN9); the client groups by the string and never
+/// builds a Date from it. Projected 1:1 from the shared <see cref="ChoreHistoryResult"/> (D3) — no recompute.
+/// </para>
+/// </summary>
+public sealed record ChoreLedgerDto(
+    string WindowStartLocal,
+    string WindowEndLocal,
+    IReadOnlyList<LedgerEventDto> Events,
+    IReadOnlyList<LedgerWeekDto> Weeks,
+    IReadOnlyList<GhostDto> Ghosts,
+    IReadOnlyList<GoneQuietDto> GoneQuiet);
+
+/// <summary>One completion in the feed. displayName only (no userId) — neutral framing (D9/MN1).</summary>
+/// <param name="LocalDate">Household-local completion date, <c>yyyy-MM-dd</c> (MN9). Time-of-day, if shown,
+/// derives client-side from the UTC instant — never parsed from this string.</param>
+public sealed record LedgerEventDto(
+    string ChoreName, string DoerDisplayName, string LocalDate, int Points, string? Note, bool HasPhoto);
+
+/// <summary>One week of the weave scaffold. Per-day completion + ghost density derives client-side from
+/// <see cref="ChoreLedgerDto.Events"/> / <see cref="ChoreLedgerDto.Ghosts"/> grouped within this week.</summary>
+public sealed record LedgerWeekDto(string WeekStartLocal, int Completions);
+
+/// <summary>An expected-but-missing beat. <c>Reason</c> is <c>"snoozed"</c> | <c>"slipped"</c>. The internal
+/// <c>ReasonFromLog</c> telemetry flag is NOT on the wire (server-side only, D5).</summary>
+public sealed record GhostDto(string ChoreName, string ExpectedLocalDate, string Reason);
+
+/// <summary>
+/// A chore that has gone quiet (≥2 trailing missed beats). <c>LastCompletedLocalDate</c> is JSON <c>null</c>
+/// when the chore was never completed (the key is always present). <c>Reason</c> is <c>"snoozed"</c> |
+/// <c>"slipped"</c>. <b>This is the single owner of the gone-quiet wire shape</b> — the recap payload (WP-05)
+/// references THIS type; it is not redefined there.
+/// </summary>
+public sealed record GoneQuietDto(
+    string ChoreName, string CadenceLabel, string? LastCompletedLocalDate, string Reason);
+
+/// <summary>
+/// Projects the shared <see cref="ChoreHistoryResult"/> onto the C (ledger) wire subset — dropping the
+/// internal <c>ReasonFromLog</c> telemetry and the recap-only per-week distribution/points. Pure mapping, no
+/// recompute (WP-04 boundary).
+/// </summary>
+public static class ChoreLedgerProjection
+{
+    public static ChoreLedgerDto ToLedger(ChoreHistoryResult r) => new(
+        WindowStartLocal: r.WindowStartLocal,
+        WindowEndLocal: r.WindowEndLocal,
+        Events: r.Events
+            .Select(e => new LedgerEventDto(e.ChoreName, e.DoerDisplayName, e.LocalDate, e.Points, e.Note, e.HasPhoto))
+            .ToList(),
+        Weeks: r.Weeks
+            .Select(w => new LedgerWeekDto(w.WeekStartLocal, w.Completions))
+            .ToList(),
+        Ghosts: r.Ghosts
+            .Select(g => new GhostDto(g.ChoreName, g.ExpectedLocalDate, g.Reason)) // ReasonFromLog dropped (D5)
+            .ToList(),
+        GoneQuiet: r.GoneQuiet
+            .Select(q => new GoneQuietDto(q.ChoreName, q.CadenceLabel, q.LastCompletedLocalDate, q.Reason))
+            .ToList());
+}

--- a/src/FamilyCoordinationApp/Services/Dtos/ChoreRecapDtos.cs
+++ b/src/FamilyCoordinationApp/Services/Dtos/ChoreRecapDtos.cs
@@ -1,18 +1,26 @@
 namespace FamilyCoordinationApp.Services.Dtos;
 
 /// <summary>
-/// The in-app weekly recap payload (read-only). The <see cref="Current"/> week mirrors EXACTLY what the
-/// Discord digest posts (same headline / distribution / falling-behind / up-for-grabs — built from the same
-/// <c>DigestBuilder</c>), so the app view and the channel post never diverge. <see cref="Trend"/> adds the
-/// week-over-week history the digest can't show: per-week completion + point totals, oldest→newest.
+/// The in-app weekly recap payload — evolved into the logbook (A) for the chore-history surface (Phase 15).
+/// The <see cref="Current"/> week mirrors EXACTLY what the Discord digest posts (same headline / distribution /
+/// falling-behind / up-for-grabs — built from the same <c>DigestBuilder</c>), so the app view and the channel
+/// post never diverge (M6 — byte-identical, contract-tested). <see cref="Trend"/> adds the week-over-week
+/// history; each point now also carries a per-week <see cref="RecapTrendPointDto.Distribution"/>. The Phase-15
+/// additions — <see cref="Milestones"/>, <see cref="KeptMoments"/>, <see cref="WhatGotTended"/>, and
+/// <see cref="GoneQuiet"/> (the shared band, same data as the ledger) — are ADDITIVE sibling fields projected
+/// from the shared <c>ChoreHistoryResult</c> (D2/D3); existing consumers ignore them.
 /// <para>
 /// Household-scoped (M1 — the household id comes from the resolved caller, never the client). No user ids and
-/// no @mention fields anywhere (mirrors the digest's neutral framing).
+/// no @mention fields anywhere (mirrors the digest's neutral framing, D6/MN1).
 /// </para>
 /// </summary>
 public sealed record ChoreRecapDto(
     RecapWeekDto Current,
-    IReadOnlyList<RecapTrendPointDto> Trend);
+    IReadOnlyList<RecapTrendPointDto> Trend,
+    MilestonesDto Milestones,
+    IReadOnlyList<KeptMomentDto> KeptMoments,
+    IReadOnlyList<WhatGotTendedDto> WhatGotTended,
+    IReadOnlyList<GoneQuietDto> GoneQuiet);
 
 /// <summary>
 /// The current week's assembled recap — the same content the weekly Discord digest sends.
@@ -44,15 +52,50 @@ public sealed record RecapMemberLineDto(
     double SharePct);
 
 /// <summary>
-/// One week's totals in the week-over-week trend. Totals only (no per-member split) — the trend answers
-/// "how did the house's output move week to week", not "who did what N weeks ago".
+/// One week's totals in the week-over-week trend, plus its per-member <see cref="Distribution"/> (Phase 15,
+/// D6). The distribution is a WITHIN-week breakdown (displayName-only, no userId) rendered on a selected week —
+/// it is NOT a per-person series across weeks (MN2: that would rebuild the dropped "B" scoreboard).
 /// </summary>
 /// <param name="WeekStartLocal">Local Monday of the week, ISO date string <c>yyyy-MM-dd</c> (household tz).</param>
 /// <param name="TotalCompletions">Chore completions in that week.</param>
 /// <param name="TotalPoints">Effort points in that week.</param>
 /// <param name="IsCurrent">True for the in-progress current week (the last, partial bar).</param>
+/// <param name="Distribution">Per-member effort split for THIS week (displayName only; sums to the week total).</param>
 public sealed record RecapTrendPointDto(
     string WeekStartLocal,
     int TotalCompletions,
     int TotalPoints,
-    bool IsCurrent);
+    bool IsCurrent,
+    IReadOnlyList<RecapMemberLineDto> Distribution);
+
+/// <summary>
+/// The collective milestones over the recap window (Phase 15 — the logbook's "moments" strip). All effort/
+/// count facts, no per-person ranking.
+/// </summary>
+/// <param name="BestWeek">The highest-output week in the window (<c>null</c> when the window had no activity).</param>
+/// <param name="LongestActiveStreakWeeks">Longest run of consecutive non-empty weeks.</param>
+/// <param name="FirstEvers">Chores whose ALL-TIME first completion landed in the window ("first time!").</param>
+/// <param name="SeasonTotalCompletions">Total completions over the window.</param>
+/// <param name="SeasonTotalPoints">Total effort points over the window.</param>
+public sealed record MilestonesDto(
+    BestWeekDto? BestWeek,
+    int LongestActiveStreakWeeks,
+    IReadOnlyList<FirstEverDto> FirstEvers,
+    int SeasonTotalCompletions,
+    int SeasonTotalPoints);
+
+/// <summary>
+/// The highest-output week. A DEDICATED record (NOT <see cref="RecapTrendPointDto"/>, which now carries a
+/// distribution): it uses <c>TotalCompletions</c>/<c>TotalPoints</c> to match the sibling recap wire DTOs.
+/// </summary>
+public sealed record BestWeekDto(string WeekStartLocal, int TotalCompletions, int TotalPoints);
+
+/// <summary>A chore whose all-time first-ever completion landed in the window.</summary>
+public sealed record FirstEverDto(string ChoreName, string LocalDate);
+
+/// <summary>A completion that carried a note or a photo — the logbook's "kept moments" highlight (newest-first, cap 12).</summary>
+/// <param name="LocalDate">Household-local completion date, <c>yyyy-MM-dd</c> (MN9).</param>
+public sealed record KeptMomentDto(string LocalDate, string ChoreName, string? Note, bool HasPhoto);
+
+/// <summary>Per-room completion tally over the window. Roomless completions bucket into the virtual "General" group.</summary>
+public sealed record WhatGotTendedDto(string RoomName, int Completions);

--- a/tests/FamilyCoordinationApp.Tests/Fixtures/ChoreHistory/ledger.json
+++ b/tests/FamilyCoordinationApp.Tests/Fixtures/ChoreHistory/ledger.json
@@ -1,0 +1,58 @@
+{
+  "windowStartLocal": "2026-04-06",
+  "windowEndLocal": "2026-06-24",
+  "events": [
+    {
+      "choreName": "Dishes",
+      "doerDisplayName": "Alice",
+      "localDate": "2026-06-22",
+      "points": 2,
+      "note": "Left them sparkling",
+      "hasPhoto": true
+    },
+    {
+      "choreName": "Take out trash",
+      "doerDisplayName": "Bob",
+      "localDate": "2026-06-21",
+      "points": 1,
+      "note": null,
+      "hasPhoto": false
+    }
+  ],
+  "weeks": [
+    {
+      "weekStartLocal": "2026-06-08",
+      "completions": 0
+    },
+    {
+      "weekStartLocal": "2026-06-15",
+      "completions": 2
+    }
+  ],
+  "ghosts": [
+    {
+      "choreName": "Water plants",
+      "expectedLocalDate": "2026-06-17",
+      "reason": "slipped"
+    },
+    {
+      "choreName": "Take out trash",
+      "expectedLocalDate": "2026-06-18",
+      "reason": "snoozed"
+    }
+  ],
+  "goneQuiet": [
+    {
+      "choreName": "Water plants",
+      "cadenceLabel": "every 7 days",
+      "lastCompletedLocalDate": null,
+      "reason": "slipped"
+    },
+    {
+      "choreName": "Deep clean",
+      "cadenceLabel": "Sun",
+      "lastCompletedLocalDate": "2026-03-15",
+      "reason": "snoozed"
+    }
+  ]
+}

--- a/tests/FamilyCoordinationApp.Tests/Fixtures/ChoreRecap/recap-current.json
+++ b/tests/FamilyCoordinationApp.Tests/Fixtures/ChoreRecap/recap-current.json
@@ -1,0 +1,22 @@
+{
+  "weekStartLocal": "2026-06-15",
+  "headline": "The Smith house knocked out 4 chores (10 pts) this week!",
+  "totalCompletions": 4,
+  "totalPoints": 10,
+  "distribution": [
+    {
+      "displayName": "Alice",
+      "points": 6,
+      "sharePct": 60
+    },
+    {
+      "displayName": "Bob",
+      "points": 4,
+      "sharePct": 40
+    }
+  ],
+  "fallingBehind": [
+    "Take out trash"
+  ],
+  "upForGrabsCount": 2
+}

--- a/tests/FamilyCoordinationApp.Tests/Fixtures/ChoreRecap/recap.json
+++ b/tests/FamilyCoordinationApp.Tests/Fixtures/ChoreRecap/recap.json
@@ -1,0 +1,104 @@
+{
+  "current": {
+    "weekStartLocal": "2026-06-15",
+    "headline": "The Smith house knocked out 4 chores (10 pts) this week!",
+    "totalCompletions": 4,
+    "totalPoints": 10,
+    "distribution": [
+      {
+        "displayName": "Alice",
+        "points": 6,
+        "sharePct": 60
+      },
+      {
+        "displayName": "Bob",
+        "points": 4,
+        "sharePct": 40
+      }
+    ],
+    "fallingBehind": [
+      "Take out trash"
+    ],
+    "upForGrabsCount": 2
+  },
+  "trend": [
+    {
+      "weekStartLocal": "2026-06-08",
+      "totalCompletions": 3,
+      "totalPoints": 7,
+      "isCurrent": false,
+      "distribution": [
+        {
+          "displayName": "Alice",
+          "points": 4,
+          "sharePct": 57.1
+        },
+        {
+          "displayName": "Bob",
+          "points": 3,
+          "sharePct": 42.9
+        }
+      ]
+    },
+    {
+      "weekStartLocal": "2026-06-15",
+      "totalCompletions": 4,
+      "totalPoints": 10,
+      "isCurrent": true,
+      "distribution": [
+        {
+          "displayName": "Alice",
+          "points": 6,
+          "sharePct": 60
+        },
+        {
+          "displayName": "Bob",
+          "points": 4,
+          "sharePct": 40
+        }
+      ]
+    }
+  ],
+  "milestones": {
+    "bestWeek": {
+      "weekStartLocal": "2026-06-15",
+      "totalCompletions": 4,
+      "totalPoints": 10
+    },
+    "longestActiveStreakWeeks": 2,
+    "firstEvers": [
+      {
+        "choreName": "Deep clean",
+        "localDate": "2026-06-10"
+      }
+    ],
+    "seasonTotalCompletions": 7,
+    "seasonTotalPoints": 17
+  },
+  "keptMoments": [
+    {
+      "localDate": "2026-06-14",
+      "choreName": "Dishes",
+      "note": "Left them sparkling",
+      "hasPhoto": true
+    }
+  ],
+  "whatGotTended": [
+    {
+      "roomName": "Kitchen",
+      "completions": 5
+    },
+    {
+      "roomName": "General",
+      "completions": 2
+    }
+  ],
+  "goneQuiet": [
+    {
+      "choreName": "Water plants",
+      "cadenceLabel": "every 7 days",
+      "lastCompletedLocalDate": null,
+      "reason": "slipped"
+    }
+  ]
+}

--- a/tests/FamilyCoordinationApp.Tests/Integration/ChoreLedgerEndpointIntegrationTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Integration/ChoreLedgerEndpointIntegrationTests.cs
@@ -1,0 +1,101 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+
+namespace FamilyCoordinationApp.Tests.Integration;
+
+/// <summary>
+/// The ledger endpoint (<c>GET /api/chores/ledger</c>) on real Postgres + the booted host. Proves household
+/// isolation (a caller sees only their OWN household's completions, M1), the <c>weeks</c> default (12), and
+/// that an anonymous caller is rejected with no data leak. This is also the first REAL-Postgres exercise of the
+/// WP-01 first-ever <c>MIN(CompletedAt) GROUP BY ChoreId</c> pushdown and the WP-03 snooze-seed aggregation
+/// (they must translate + execute, not just pass on the InMemory provider).
+/// <para>Aggregation runs against the factory's FIXED clock (local Sun 2026-06-07), whose Mon–Sun week the
+/// seeded mid-week completions fall in — so the feed is deterministic.</para>
+/// </summary>
+[Collection(IntegrationCollection.Name)]
+[Trait("kind", "integration")]
+public sealed class ChoreLedgerEndpointIntegrationTests(PostgresContainerFixture postgres) : IAsyncLifetime
+{
+    private readonly ChoresWebAppFactory _factory = new(postgres);
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    public async Task InitializeAsync() => await _factory.EnsureSeededAsync();
+
+    public async Task DisposeAsync() => await _factory.DisposeAsync();
+
+    private sealed record LedgerEvent(string choreName, string doerDisplayName, string localDate, int points, string? note, bool hasPhoto);
+    private sealed record LedgerWeek(string weekStartLocal, int completions);
+    private sealed record Ghost(string choreName, string expectedLocalDate, string reason);
+    private sealed record GoneQuiet(string choreName, string cadenceLabel, string? lastCompletedLocalDate, string reason);
+    private sealed record Ledger(
+        string windowStartLocal, string windowEndLocal,
+        List<LedgerEvent> events, List<LedgerWeek> weeks, List<Ghost> ghosts, List<GoneQuiet> goneQuiet);
+
+    [Fact]
+    public async Task Ledger_AsUserA_ReturnsHouseholdAOnly_NoLeak()
+    {
+        var client = _factory.CreateClientAs(ChoresWebAppFactory.UserAEmail);
+
+        var ledger = await client.GetFromJsonAsync<Ledger>("/api/chores/ledger?weeks=4", Json);
+
+        ledger.Should().NotBeNull();
+        ledger!.weeks.Should().HaveCount(4, "weeks=4 produces a 4-week scaffold including empty weeks");
+        ledger.events.Should().NotBeEmpty("household A has three in-week completions");
+        ledger.events.Should().OnlyContain(e => e.doerDisplayName == "Alice A" || e.doerDisplayName == "Amy A");
+        ledger.events.Should().NotContain(e => e.doerDisplayName == "Bob B", "household B's member must not appear");
+        // The wire is displayName-only — no userId anywhere in the raw payload (D9/MN1).
+        var raw = await client.GetStringAsync("/api/chores/ledger?weeks=4");
+        raw.Should().NotContain("userId", "the ledger carries no userId (neutral framing)");
+        raw.Should().NotContain("Household B private chore", "household B's chore name must not leak");
+    }
+
+    [Fact]
+    public async Task Ledger_DefaultWeeks_IsTwelve()
+    {
+        var client = _factory.CreateClientAs(ChoresWebAppFactory.UserAEmail);
+
+        var ledger = await client.GetFromJsonAsync<Ledger>("/api/chores/ledger", Json);
+
+        ledger.Should().NotBeNull();
+        ledger!.weeks.Should().HaveCount(12, "the ledger weave defaults to a 12-week grid");
+    }
+
+    [Fact]
+    public async Task Ledger_WeeksClampedToTwentySix()
+    {
+        var client = _factory.CreateClientAs(ChoresWebAppFactory.UserAEmail);
+
+        var ledger = await client.GetFromJsonAsync<Ledger>("/api/chores/ledger?weeks=99", Json);
+
+        ledger!.weeks.Should().HaveCount(26, "weeks is clamped to 26 by the service");
+    }
+
+    [Fact]
+    public async Task Ledger_AsUserB_SumsOnlyHouseholdB()
+    {
+        var client = _factory.CreateClientAs(ChoresWebAppFactory.UserBEmail);
+
+        var ledger = await client.GetFromJsonAsync<Ledger>("/api/chores/ledger?weeks=4", Json);
+
+        ledger.Should().NotBeNull();
+        ledger!.events.Should().OnlyContain(e => e.doerDisplayName == "Bob B", "only household B's completion");
+        ledger.events.Should().NotContain(e => e.doerDisplayName == "Alice A" || e.doerDisplayName == "Amy A");
+    }
+
+    [Fact]
+    public async Task Ledger_Anonymous_IsRejected_NoLeak()
+    {
+        var client = _factory.CreateAnonymousClient();
+
+        var resp = await client.GetAsync("/api/chores/ledger?weeks=4");
+
+        ((int)resp.StatusCode).Should().BeInRange(400, 499, "an anonymous caller must be rejected");
+        resp.StatusCode.Should().NotBe(HttpStatusCode.OK);
+
+        var body = await resp.Content.ReadAsStringAsync();
+        body.Should().NotContain("Alice A", "no ledger data may leak to an unauthenticated caller");
+        body.Should().NotContain("Bob B");
+    }
+}

--- a/tests/FamilyCoordinationApp.Tests/Services/ChoreHistoryServiceTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/ChoreHistoryServiceTests.cs
@@ -65,7 +65,6 @@ public class ChoreHistoryServiceTests
         return new ChoreHistoryService(
             dbFactory.Object,
             new ChoreEquityCalculator(),
-            new ChoreStatusCalculator(),
             tz,
             TimeProvider.System);
     }
@@ -387,18 +386,261 @@ public class ChoreHistoryServiceTests
         history.Milestones.SeasonTotalPoints.Should().Be(3, "household 2's 99 points must not leak");
     }
 
-    // ── Gap projection is WP-02 — empty here ─────────────────────────────────────────────────────────
+    // ═══════════════════════════════════════════════════════════════════════════════════════════════
+    // WP-02 — historical gap/ghost projection. The DST-heavy scenarios (S1/S2/S4/S6/S7/S-tol) test the
+    // pure ProjectBeats/Match functions directly (mirroring the validated spike); S-GQ + reason + monthly
+    // exercise the GetHistoryAsync integration. now = 2026-11-15 18:00 UTC (window crosses BOTH 2026 DST
+    // transitions: spring-fwd 2026-03-08, fall-back 2026-11-01).
+    // ═══════════════════════════════════════════════════════════════════════════════════════════════
+
+    // A completion stamped at local `hour` in Chicago, stored as the UTC instant (mirrors the spike's DoneAt).
+    private static DateTime DoneAtUtc(int y, int m, int d, int localHour = 10) =>
+        TimeZoneInfo.ConvertTimeToUtc(new DateTime(y, m, d, localHour, 0, 0, DateTimeKind.Unspecified), Chicago);
+
+    private static readonly DateOnly S1Today = ChoreStatusCalculator.LocalDate(Utc0(2026, 11, 15, 18), Chicago);
+
+    // ── S1 — snoozed-since-March Fixed weekly Mon+Thu: 72 missed, DST beats present + missed ──────────
 
     [Fact]
-    public async Task GhostsAndGoneQuiet_AreEmpty_InWp01()
+    public void S1_FixedWeekly_SnoozedSinceMarch_72MissedBeats_AcrossBothDst()
     {
+        var winStart = new DateOnly(2026, 2, 2); // Monday — the chore's history start
+        var snap = new ChoreRecurrenceSnapshot(
+            RecurrenceMode.Fixed, IntervalDays: null, AnchorDate: null,
+            DaysOfWeek: ChoreDaysOfWeek.Monday | ChoreDaysOfWeek.Thursday, DayOfMonth: null,
+            LastCompletedAt: DoneAtUtc(2026, 3, 5), SnoozedUntil: new DateOnly(2026, 12, 31));
+
+        var beats = ChoreHistoryService.ProjectBeats(snap, winStart, S1Today, Chicago);
+
+        // Completed regularly Feb..Mar 5 (the 10 Mon/Thu completions), then nothing.
+        var done = new List<DateOnly>
+        {
+            new(2026, 2, 2), new(2026, 2, 5), new(2026, 2, 9), new(2026, 2, 12),
+            new(2026, 2, 16), new(2026, 2, 19), new(2026, 2, 23), new(2026, 2, 26),
+            new(2026, 3, 2), new(2026, 3, 5),
+        };
+        var (kept, missed) = ChoreHistoryService.Match(beats, done, backTol: 1, fwdTol: 3);
+
+        kept.Should().HaveCount(10, "the 10 Feb..Mar completions each keep their beat, none mis-counted");
+        missed.Should().HaveCount(72, "every Mon/Thu after Mar 5 through today is a surfaced miss");
+
+        // DST spot-checks: the Monday AFTER spring-forward and the Monday AFTER fall-back are both real,
+        // correctly-dated beats and both missed (UTC-tick arithmetic would drift these off Monday — M4/MN4).
+        beats.Should().Contain(new DateOnly(2026, 3, 9));
+        missed.Should().Contain(new DateOnly(2026, 3, 9));
+        beats.Should().Contain(new DateOnly(2026, 11, 2));
+        missed.Should().Contain(new DateOnly(2026, 11, 2));
+    }
+
+    // ── S2 — kept-current control: ZERO false positives across both DST transitions ──────────────────
+
+    [Fact]
+    public void S2_FixedWeeklySunday_CompletedEverySunday_ZeroGhosts()
+    {
+        var winStart = new DateOnly(2026, 2, 1); // Sunday
+        var snap = new ChoreRecurrenceSnapshot(
+            RecurrenceMode.Fixed, null, null, ChoreDaysOfWeek.Sunday, null, LastCompletedAt: null);
+
+        var beats = ChoreHistoryService.ProjectBeats(snap, winStart, S1Today, Chicago);
+
+        var done = new List<DateOnly>();
+        for (var d = winStart; d <= S1Today; d = d.AddDays(7))
+        {
+            done.Add(d);
+        }
+        var (kept, missed) = ChoreHistoryService.Match(beats, done, 1, 3);
+
+        missed.Should().BeEmpty("a kept-current chore across BOTH DST transitions has NO false-positive ghosts");
+        kept.Should().HaveCount(beats.Count, "every Sunday beat matched exactly one completion");
+    }
+
+    // ── S4 — Flexible: trailing-only; interior late gap is not a missed beat ─────────────────────────
+
+    [Fact]
+    public void S4_Flexible_ProjectsFromLastCompletion_InteriorLateGapNotMissed()
+    {
+        var winStart = new DateOnly(2026, 6, 1);
+        var snap = new ChoreRecurrenceSnapshot(
+            RecurrenceMode.Flexible, IntervalDays: 7, AnchorDate: null, DaysOfWeek: null, DayOfMonth: null,
+            LastCompletedAt: DoneAtUtc(2026, 6, 25)); // done Jun 1 & Jun 25 (late); Jun 25 reset the clock
+
+        var beats = ChoreHistoryService.ProjectBeats(snap, winStart, S1Today, Chicago);
+
+        beats.Should().NotBeEmpty();
+        beats[0].Should().Be(new DateOnly(2026, 7, 2), "flexible projects from LAST completion (Jun 25 + 7), not Jun 8");
+        beats.Should().NotContain(new DateOnly(2026, 6, 8), "the interior late gap is a late completion, not a missed beat");
+
+        var done = new List<DateOnly> { new(2026, 6, 1), new(2026, 6, 25) };
+        var (_, missed) = ChoreHistoryService.Match(beats, done, 1, 3);
+        missed.Should().HaveCount(beats.Count, "all trailing beats after Jun 25 are missed");
+    }
+
+    // ── S6 — no-collapse: 3 missed Wednesdays + ONE Done → 2 missed + 1 kept (not 0) ─────────────────
+
+    [Fact]
+    public void S6_FixedWeekly_OneCompletionDoesNotCollapseBacklog()
+    {
+        var winStart = new DateOnly(2026, 6, 3); // Wednesday
+        var today = new DateOnly(2026, 6, 24);
+        var snap = new ChoreRecurrenceSnapshot(
+            RecurrenceMode.Fixed, null, null, ChoreDaysOfWeek.Wednesday, null, LastCompletedAt: DoneAtUtc(2026, 6, 24));
+
+        var beats = ChoreHistoryService.ProjectBeats(snap, winStart, today, Chicago); // Jun 3,10,17,24
+        var (kept, missed) = ChoreHistoryService.Match(beats, new List<DateOnly> { new(2026, 6, 24) }, 1, 3);
+
+        kept.Should().HaveCount(1, "one completion clears exactly one beat — history does NOT collapse like the board");
+        missed.Should().HaveCount(beats.Count - 1, "the earlier missed Wednesdays stay missed (honest history)");
+    }
+
+    // ── monthly (DayOfMonth) — OUT OF SCOPE: zero beats generated ────────────────────────────────────
+
+    [Fact]
+    public void Monthly_DayOfMonthChore_GeneratesNoBeats()
+    {
+        var snap = new ChoreRecurrenceSnapshot(
+            RecurrenceMode.Fixed, IntervalDays: null, AnchorDate: null, DaysOfWeek: null,
+            DayOfMonth: 15, LastCompletedAt: null);
+
+        var beats = ChoreHistoryService.ProjectBeats(snap, new DateOnly(2026, 1, 1), S1Today, Chicago);
+
+        beats.Should().BeEmpty("monthly-on-day recurrence is rejected in v1 — never project it (MN5)");
+    }
+
+    // ── naive-UTC control — documents why DateOnly generation is mandatory across the fall-back ──────
+
+    [Fact]
+    public void NaiveUtcTickStepping_DriftsAcrossFallBack_WhileDateOnlyStaysOnMonday()
+    {
+        var firstMon = new DateOnly(2026, 10, 19);
+        var correct = new List<DateOnly>();
+        for (var d = firstMon; d <= new DateOnly(2026, 11, 16); d = d.AddDays(7))
+        {
+            correct.Add(d);
+        }
+
+        // Naive: start at local-midnight-UTC, step fixed 7×24h ticks, convert back to local date.
+        var naive = new List<DateOnly>();
+        var utc = ChoreStatusCalculator.LocalMidnightUtc(firstMon, Chicago);
+        for (var i = 0; i < correct.Count; i++)
+        {
+            naive.Add(ChoreStatusCalculator.LocalDate(utc, Chicago));
+            utc = utc.AddDays(7);
+        }
+
+        correct.Should().OnlyContain(d => d.DayOfWeek == DayOfWeek.Monday, "DateOnly stepping stays on Monday");
+        naive.Should().Contain(d => d.DayOfWeek != DayOfWeek.Monday,
+            "naive UTC-tick stepping DRIFTS off Monday after the fall-back — the false-ghost trap M4/MN4 forbid");
+    }
+
+    // ── S-tol (D8) — on-time keeps; fwd+1 late leaves the beat missed ────────────────────────────────
+
+    [Fact]
+    public void STol_OnTimeKeeps_ButOneBeyondForwardToleranceMisses()
+    {
+        var beats = new List<DateOnly> { new(2026, 6, 10) };
+
+        // On-time (localDate == beat): kept.
+        ChoreHistoryService.Match(beats, new List<DateOnly> { new(2026, 6, 10) }, 1, 3)
+            .Kept.Should().ContainSingle();
+
+        // fwd+1 days late (weekly fwd = 3 ⇒ 4 days after): the beat stays missed.
+        ChoreHistoryService.Match(beats, new List<DateOnly> { new(2026, 6, 14) }, 1, 3)
+            .Missed.Should().ContainSingle();
+    }
+
+    // ── S-GQ (D10) — gone-quiet detection through the GetHistoryAsync integration ─────────────────────
+
+    // A Fixed weekly chore created before the window (so beats generate across it).
+    private static Chore WeeklyChore(
+        int id, string name, ChoreDaysOfWeek days, DateTime? lastCompletedAt = null, DateOnly? snoozedUntil = null) =>
+        new()
+        {
+            HouseholdId = H1,
+            ChoreId = id,
+            Name = name,
+            RecurrenceMode = RecurrenceMode.Fixed,
+            DaysOfWeek = days,
+            LastCompletedAt = lastCompletedAt,
+            SnoozedUntil = snoozedUntil,
+            EffortTier = EffortTier.Standard,
+            EffortPoints = 2,
+            Status = ChoreStatus.Active,
+            EnteredByUserId = Alice,
+            AssignmentKind = AssignmentKind.None,
+            CreatedAt = Utc0(2026, 1, 1),
+        };
+
+    [Fact]
+    public async Task GoneQuiet_NeverCompletedWeekly_AppearsWithCadenceAndNullLastCompleted()
+    {
+        // Fixed weekly Wed, never completed, created Jan. now = Wed 2026-06-24, weeks=4 ⇒ window Mon 06-01.
+        // Beats Jun 3/10/17/24 all missed (never done) ⇒ 4 trailing misses ⇒ gone quiet.
+        Seed(ctx => ctx.Chores.Add(WeeklyChore(1, "Water plants", ChoreDaysOfWeek.Wednesday)));
+
+        var history = await CreateService(Utc).GetHistoryAsync(H1, weeks: 4, now: Utc0(2026, 6, 24, 12));
+
+        history.GoneQuiet.Should().ContainSingle();
+        var gq = history.GoneQuiet[0];
+        gq.ChoreName.Should().Be("Water plants");
+        gq.CadenceLabel.Should().Be("Wed");
+        gq.LastCompletedLocalDate.Should().BeNull("a never-completed chore has no last-completed date");
+        gq.Reason.Should().Be("slipped", "no snooze floor ⇒ slipped, not snoozed");
+
+        history.Ghosts.Should().HaveCount(4, "every missed Wednesday in the window is a ghost");
+        history.Ghosts.Should().OnlyContain(g => g.ChoreName == "Water plants" && g.ReasonFromLog == false);
+    }
+
+    [Fact]
+    public async Task GoneQuiet_SingleTrailingMiss_DoesNotQualify()
+    {
+        // Completed on Jun 17 (keeps that beat); only Jun 24 is a trailing miss ⇒ 1 < threshold ⇒ NOT gone quiet.
         Seed(ctx =>
         {
-            ctx.Chores.Add(SimpleChore(1, "Dishes"));
-            ctx.ChoreCompletions.Add(Completion(1, Alice, Utc0(2026, 6, 16, 9), 3));
+            ctx.Chores.Add(WeeklyChore(1, "Vacuum", ChoreDaysOfWeek.Wednesday, lastCompletedAt: Utc0(2026, 6, 17, 12)));
+            ctx.ChoreCompletions.Add(Completion(1, Alice, Utc0(2026, 6, 17, 12), 2));
         });
 
-        var history = await CreateService(Utc).GetHistoryAsync(H1, weeks: 3, now: Utc0(2026, 6, 17, 12));
+        var history = await CreateService(Utc).GetHistoryAsync(H1, weeks: 4, now: Utc0(2026, 6, 24, 12));
+
+        history.GoneQuiet.Should().BeEmpty("a single trailing miss is a blip, not silence");
+        history.Ghosts.Should().Contain(g => g.ExpectedLocalDate == "2026-06-24", "the trailing miss is still a ghost");
+    }
+
+    [Fact]
+    public async Task Snooze_DoesNotSuppressGeneration_GhostsReadSnoozedPlaceholder()
+    {
+        // A snoozed-to-December chore STILL generates its nominal beats (MN7) — snooze only labels the reason.
+        // WP-02's reason is a current-state placeholder (ReasonFromLog=false); WP-03 overwrites from the log.
+        Seed(ctx => ctx.Chores.Add(
+            WeeklyChore(1, "Take out trash", ChoreDaysOfWeek.Wednesday, snoozedUntil: new DateOnly(2026, 12, 31))));
+
+        var history = await CreateService(Utc).GetHistoryAsync(H1, weeks: 4, now: Utc0(2026, 6, 24, 12));
+
+        history.Ghosts.Should().HaveCount(4, "snooze does NOT suppress beat generation (MN7)");
+        history.Ghosts.Should().OnlyContain(g => g.Reason == "snoozed" && g.ReasonFromLog == false);
+        history.GoneQuiet.Should().ContainSingle().Which.Reason.Should().Be("snoozed");
+    }
+
+    [Fact]
+    public async Task Monthly_ChoreProducesNoGhosts_Integration()
+    {
+        // A DayOfMonth-only Fixed chore is skipped entirely by the projection (MN5) — no ghosts, no gone-quiet.
+        Seed(ctx => ctx.Chores.Add(new Chore
+        {
+            HouseholdId = H1,
+            ChoreId = 1,
+            Name = "Pay rent",
+            RecurrenceMode = RecurrenceMode.Fixed,
+            DayOfMonth = 1,
+            EffortTier = EffortTier.Standard,
+            EffortPoints = 2,
+            Status = ChoreStatus.Active,
+            EnteredByUserId = Alice,
+            AssignmentKind = AssignmentKind.None,
+            CreatedAt = Utc0(2026, 1, 1),
+        }));
+
+        var history = await CreateService(Utc).GetHistoryAsync(H1, weeks: 4, now: Utc0(2026, 6, 24, 12));
 
         history.Ghosts.Should().BeEmpty();
         history.GoneQuiet.Should().BeEmpty();

--- a/tests/FamilyCoordinationApp.Tests/Services/ChoreHistoryServiceTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/ChoreHistoryServiceTests.cs
@@ -75,13 +75,17 @@ public class ChoreHistoryServiceTests
         dbFactory.Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(() => new ApplicationDbContext(_options));
 
+        var equity = new ChoreEquityCalculator();
+        var history = new ChoreHistoryService(dbFactory.Object, equity, tz, TimeProvider.System);
+
         return new ChoreRecapService(
             dbFactory.Object,
-            new ChoreEquityCalculator(),
+            equity,
             new ChoreStatusCalculator(),
             new DigestBuilder(),
             tz,
-            TimeProvider.System);
+            TimeProvider.System,
+            history);
     }
 
     private void Seed(Action<ApplicationDbContext> seed)

--- a/tests/FamilyCoordinationApp.Tests/Services/ChoreHistoryServiceTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/ChoreHistoryServiceTests.cs
@@ -1,0 +1,406 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using FamilyCoordinationApp.Data;
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Services;
+using FamilyCoordinationApp.Services.Digest;
+
+namespace FamilyCoordinationApp.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="ChoreHistoryService"/> — the shared history-aggregation service (Phase 15 WP-01).
+/// Every test injects an explicit <c>now</c> (UTC) + <see cref="TimeZoneInfo"/> so the window/bucketing math is
+/// deterministic. The load-bearing invariants pinned here: the weekly aggregates match the public recap
+/// <c>Trend</c> for the same completions (reuse of <see cref="ChoreEquityCalculator.WeekStartUtc"/>), the
+/// per-week distribution sums to the week total (displayName-only), first-ever is all-time (a pre-window
+/// completion is NOT a first-ever — the bounded MIN semantics), the window lower bound is honored behaviorally,
+/// and a second household's data never leaks (M1). Gap projection (Ghosts/GoneQuiet) is WP-02 — empty here.
+/// </summary>
+public class ChoreHistoryServiceTests
+{
+    private const int H1 = 1;
+    private const int H2 = 2;
+    private const int Alice = 100;
+    private const int Bob = 101;
+    private const int Carol = 200; // household 2
+
+    private static readonly TimeZoneInfo Chicago = ResolveTz("America/Chicago", "Central Standard Time");
+    private static readonly TimeZoneInfo Utc = TimeZoneInfo.Utc;
+
+    private static TimeZoneInfo ResolveTz(string ianaId, string windowsId)
+    {
+        try { return TimeZoneInfo.FindSystemTimeZoneById(ianaId); }
+        catch (TimeZoneNotFoundException) { return TimeZoneInfo.FindSystemTimeZoneById(windowsId); }
+    }
+
+    private static DateTime Utc0(int y, int m, int d, int h = 0, int min = 0) =>
+        new(y, m, d, h, min, 0, DateTimeKind.Utc);
+
+    private readonly DbContextOptions<ApplicationDbContext> _options;
+
+    public ChoreHistoryServiceTests()
+    {
+        _options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        using var ctx = new ApplicationDbContext(_options);
+        ctx.Households.AddRange(
+            new Household { Id = H1, Name = "Smith" },
+            new Household { Id = H2, Name = "Jones" });
+        ctx.Users.AddRange(
+            new User { Id = Alice, HouseholdId = H1, Email = "a@x.com", DisplayName = "Alice", Initials = "AL" },
+            new User { Id = Bob, HouseholdId = H1, Email = "b@x.com", DisplayName = "Bob", Initials = "BO" },
+            new User { Id = Carol, HouseholdId = H2, Email = "c@x.com", DisplayName = "Carol", Initials = "CA" });
+        ctx.SaveChanges();
+    }
+
+    private ChoreHistoryService CreateService(TimeZoneInfo tz)
+    {
+        var dbFactory = new Mock<IDbContextFactory<ApplicationDbContext>>();
+        dbFactory.Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new ApplicationDbContext(_options));
+
+        return new ChoreHistoryService(
+            dbFactory.Object,
+            new ChoreEquityCalculator(),
+            new ChoreStatusCalculator(),
+            tz,
+            TimeProvider.System);
+    }
+
+    private ChoreRecapService CreateRecapService(TimeZoneInfo tz)
+    {
+        var dbFactory = new Mock<IDbContextFactory<ApplicationDbContext>>();
+        dbFactory.Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new ApplicationDbContext(_options));
+
+        return new ChoreRecapService(
+            dbFactory.Object,
+            new ChoreEquityCalculator(),
+            new ChoreStatusCalculator(),
+            new DigestBuilder(),
+            tz,
+            TimeProvider.System);
+    }
+
+    private void Seed(Action<ApplicationDbContext> seed)
+    {
+        using var ctx = new ApplicationDbContext(_options);
+        seed(ctx);
+        ctx.SaveChanges();
+    }
+
+    private static ChoreCompletion Completion(
+        int id, int userId, DateTime at, int pts, int choreId = 1, int householdId = H1,
+        string? note = null, string? photo = null) =>
+        new()
+        {
+            HouseholdId = householdId,
+            ChoreId = choreId,
+            CompletionId = id,
+            CompletedByUserId = userId,
+            CompletedAt = at,
+            EffortPointsSnapshot = pts,
+            Note = note,
+            PhotoPath = photo,
+        };
+
+    private static Chore SimpleChore(int id, string name, int householdId = H1, int? roomId = null) =>
+        new()
+        {
+            HouseholdId = householdId,
+            ChoreId = id,
+            Name = name,
+            RoomId = roomId,
+            RecurrenceMode = RecurrenceMode.Flexible,
+            IntervalDays = 7,
+            EffortTier = EffortTier.Standard,
+            EffortPoints = 2,
+            Status = ChoreStatus.Active,
+            EnteredByUserId = Alice,
+            AssignmentKind = AssignmentKind.None,
+            CreatedAt = Utc0(2026, 1, 1),
+        };
+
+    // ── (a) Weeks match the public recap Trend; empty weeks appear as zeros ──────────────────────────
+
+    [Fact]
+    public async Task Weeks_MatchRecapTrend_ForSameCompletions_IncludingEmptyWeeks()
+    {
+        // now = Wed 2026-06-17 (week Mon 06-15). weeks=3 ⇒ [06-01 empty], [06-08], [06-15 current].
+        Seed(ctx =>
+        {
+            ctx.Chores.Add(SimpleChore(1, "Dishes"));
+            ctx.ChoreCompletions.AddRange(
+                Completion(1, Alice, Utc0(2026, 6, 16, 9), 3),   // week 06-15 (current)
+                Completion(2, Alice, Utc0(2026, 6, 9, 9), 2),    // week 06-08
+                Completion(3, Bob, Utc0(2026, 6, 11, 9), 4),     // week 06-08
+                Completion(4, Bob, Utc0(2026, 5, 20, 9), 9));    // < window ⇒ excluded
+        });
+
+        var history = await CreateService(Utc).GetHistoryAsync(H1, weeks: 3, now: Utc0(2026, 6, 17, 12));
+        var recap = await CreateRecapService(Utc).GetRecapAsync(H1, weeks: 3, now: Utc0(2026, 6, 17, 12));
+
+        history.Weeks.Should().HaveCount(3);
+        recap.Trend.Should().HaveCount(3);
+
+        // Element-wise: the history weekly aggregates must equal the recap trend totals (same WeekStartUtc key).
+        for (var i = 0; i < 3; i++)
+        {
+            history.Weeks[i].WeekStartLocal.Should().Be(recap.Trend[i].WeekStartLocal);
+            history.Weeks[i].Completions.Should().Be(recap.Trend[i].TotalCompletions);
+            history.Weeks[i].Points.Should().Be(recap.Trend[i].TotalPoints);
+        }
+
+        // The oldest week is empty and still present with zero counts.
+        history.Weeks[0].WeekStartLocal.Should().Be("2026-06-01");
+        history.Weeks[0].Completions.Should().Be(0);
+        history.Weeks[0].Points.Should().Be(0);
+
+        history.Weeks[1].Completions.Should().Be(2);
+        history.Weeks[1].Points.Should().Be(6);
+
+        // Window bounds are the oldest Monday → today (MN9 ISO strings).
+        history.WindowStartLocal.Should().Be("2026-06-01");
+        history.WindowEndLocal.Should().Be("2026-06-17");
+    }
+
+    [Fact]
+    public async Task Weeks_HalfOpenBoundary_MatchesRecap_Chicago()
+    {
+        // Chicago: Mon 06-15 00:00 local == 05:00 UTC. 04:59 UTC → prior week; 05:00 UTC → current week.
+        Seed(ctx =>
+        {
+            ctx.Chores.Add(SimpleChore(1, "Trash"));
+            ctx.ChoreCompletions.AddRange(
+                Completion(1, Alice, Utc0(2026, 6, 15, 4, 59), 2),  // → week 06-08
+                Completion(2, Bob, Utc0(2026, 6, 15, 5, 0), 5));    // → week 06-15 (current)
+        });
+
+        var history = await CreateService(Chicago).GetHistoryAsync(H1, weeks: 2, now: Utc0(2026, 6, 17, 12));
+
+        history.Weeks.Should().HaveCount(2);
+        history.Weeks[0].WeekStartLocal.Should().Be("2026-06-08");
+        history.Weeks[0].Completions.Should().Be(1);
+        history.Weeks[0].Points.Should().Be(2);
+        history.Weeks[1].WeekStartLocal.Should().Be("2026-06-15");
+        history.Weeks[1].Completions.Should().Be(1);
+        history.Weeks[1].Points.Should().Be(5);
+    }
+
+    // ── (b) Per-week distribution sums to the week total, displayName-only ────────────────────────────
+
+    [Fact]
+    public async Task WeekDistribution_SumsToWeekPoints_AndIsDisplayNameOnly()
+    {
+        Seed(ctx =>
+        {
+            ctx.Chores.Add(SimpleChore(1, "Dishes"));
+            ctx.ChoreCompletions.AddRange(
+                Completion(1, Alice, Utc0(2026, 6, 16, 9), 3),
+                Completion(2, Bob, Utc0(2026, 6, 16, 10), 1));
+        });
+
+        var history = await CreateService(Utc).GetHistoryAsync(H1, weeks: 1, now: Utc0(2026, 6, 17, 12));
+
+        var week = history.Weeks.Single();
+        week.Points.Should().Be(4);
+        week.Distribution.Sum(m => m.Points).Should().Be(week.Points,
+            "each week's distribution must sum to that week's points (equity over the week bucket)");
+
+        // Both members present, alphabetical, displayName-only (RecapMemberLineDto has no userId by shape).
+        week.Distribution.Should().HaveCount(2);
+        week.Distribution[0].DisplayName.Should().Be("Alice");
+        week.Distribution[0].Points.Should().Be(3);
+        week.Distribution[0].SharePct.Should().BeApproximately(75.0, 0.1);
+        week.Distribution[1].DisplayName.Should().Be("Bob");
+        week.Distribution[1].Points.Should().Be(1);
+    }
+
+    // ── (c) Milestones — first-ever is ALL-TIME; best week ranks by points ───────────────────────────
+
+    [Fact]
+    public async Task FirstEvers_ExcludePreWindowChore_IncludeInWindowFirst()
+    {
+        // Chore "Old" was first done in MARCH (before the 3-week window) → NOT a first-ever, even though it also
+        // recurs in-window. Chore "New" is first ever done in-window → IS a first-ever.
+        Seed(ctx =>
+        {
+            ctx.Chores.AddRange(SimpleChore(1, "Old"), SimpleChore(2, "New"));
+            ctx.ChoreCompletions.AddRange(
+                Completion(1, Alice, Utc0(2026, 3, 2, 9), 2, choreId: 1),    // Old — all-time MIN, pre-window
+                Completion(2, Alice, Utc0(2026, 6, 16, 9), 2, choreId: 1),   // Old — in-window recurrence
+                Completion(3, Bob, Utc0(2026, 6, 10, 9), 2, choreId: 2));    // New — all-time MIN, in-window
+        });
+
+        var history = await CreateService(Utc).GetHistoryAsync(H1, weeks: 3, now: Utc0(2026, 6, 17, 12));
+
+        history.Milestones.FirstEvers.Should().ContainSingle()
+            .Which.ChoreName.Should().Be("New", "only a chore whose ALL-TIME first completion is in-window counts");
+        history.Milestones.FirstEvers.Should().NotContain(f => f.ChoreName == "Old");
+    }
+
+    [Fact]
+    public async Task BestWeek_PicksHigherPointWeek_StreakAndSeasonTotals()
+    {
+        // weeks=3 [06-01],[06-08],[06-15]. 06-08 = 6 pts / 2 comp; 06-15 = 3 pts / 1 comp; 06-01 empty.
+        Seed(ctx =>
+        {
+            ctx.Chores.Add(SimpleChore(1, "Dishes"));
+            ctx.ChoreCompletions.AddRange(
+                Completion(1, Alice, Utc0(2026, 6, 9, 9), 2),
+                Completion(2, Bob, Utc0(2026, 6, 11, 9), 4),
+                Completion(3, Alice, Utc0(2026, 6, 16, 9), 3));
+        });
+
+        var history = await CreateService(Utc).GetHistoryAsync(H1, weeks: 3, now: Utc0(2026, 6, 17, 12));
+
+        history.Milestones.BestWeek.Should().NotBeNull();
+        history.Milestones.BestWeek!.WeekStartLocal.Should().Be("2026-06-08", "it has the most points (6)");
+        history.Milestones.BestWeek.Points.Should().Be(6);
+        history.Milestones.BestWeek.Completions.Should().Be(2);
+
+        // 06-08 and 06-15 are consecutive non-empty ⇒ streak 2 (the empty 06-01 breaks nothing before it).
+        history.Milestones.LongestActiveStreakWeeks.Should().Be(2);
+
+        // Season totals tile the window (sum of week buckets).
+        history.Milestones.SeasonTotalCompletions.Should().Be(3);
+        history.Milestones.SeasonTotalPoints.Should().Be(9);
+    }
+
+    [Fact]
+    public async Task BestWeek_IsNull_WhenWindowHasNoCompletions()
+    {
+        Seed(ctx => ctx.Chores.Add(SimpleChore(1, "Dishes")));
+
+        var history = await CreateService(Utc).GetHistoryAsync(H1, weeks: 4, now: Utc0(2026, 6, 17, 12));
+
+        history.Milestones.BestWeek.Should().BeNull();
+        history.Milestones.LongestActiveStreakWeeks.Should().Be(0);
+        history.Milestones.SeasonTotalCompletions.Should().Be(0);
+    }
+
+    // ── (d) Window lower bound is honored behaviorally ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task PreWindowCompletion_NeverAppearsInEventsOrWeeks()
+    {
+        Seed(ctx =>
+        {
+            ctx.Chores.Add(SimpleChore(1, "Dishes"));
+            ctx.ChoreCompletions.AddRange(
+                Completion(1, Alice, Utc0(2026, 6, 16, 9), 3),   // in-window
+                Completion(2, Bob, Utc0(2026, 5, 1, 9), 5));     // well before oldestWeekStartUtc (06-01)
+        });
+
+        var history = await CreateService(Utc).GetHistoryAsync(H1, weeks: 3, now: Utc0(2026, 6, 17, 12));
+
+        history.Events.Should().ContainSingle("only the in-window completion surfaces");
+        history.Events[0].ChoreName.Should().Be("Dishes");
+        history.Weeks.Sum(w => w.Completions).Should().Be(1);
+        history.Weeks.Sum(w => w.Points).Should().Be(3);
+    }
+
+    // ── (e) Kept moments cap; roomless → General; household isolation ────────────────────────────────
+
+    [Fact]
+    public async Task KeptMoments_CapAtTwelve_NewestFirst()
+    {
+        Seed(ctx =>
+        {
+            ctx.Chores.Add(SimpleChore(1, "Dishes"));
+            // 15 note-carrying completions across the current week, ascending in time.
+            for (var i = 0; i < 15; i++)
+            {
+                ctx.ChoreCompletions.Add(Completion(
+                    i + 1, Alice, Utc0(2026, 6, 15, 6).AddMinutes(i), 1, note: $"note {i}"));
+            }
+        });
+
+        var history = await CreateService(Utc).GetHistoryAsync(H1, weeks: 1, now: Utc0(2026, 6, 17, 12));
+
+        history.KeptMoments.Should().HaveCount(12, "the reel is capped at 12");
+        history.KeptMoments[0].Note.Should().Be("note 14", "newest first");
+        history.KeptMoments[11].Note.Should().Be("note 3");
+    }
+
+    [Fact]
+    public async Task KeptMoments_IncludePhotoOnlyCompletions()
+    {
+        Seed(ctx =>
+        {
+            ctx.Chores.Add(SimpleChore(1, "Dishes"));
+            ctx.ChoreCompletions.AddRange(
+                Completion(1, Alice, Utc0(2026, 6, 16, 9), 2, photo: "chores/p.jpg"),  // photo, no note
+                Completion(2, Bob, Utc0(2026, 6, 16, 10), 2));                         // neither ⇒ not a moment
+        });
+
+        var history = await CreateService(Utc).GetHistoryAsync(H1, weeks: 1, now: Utc0(2026, 6, 17, 12));
+
+        history.KeptMoments.Should().ContainSingle();
+        history.KeptMoments[0].HasPhoto.Should().BeTrue();
+        history.KeptMoments[0].Note.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task WhatGotTended_TalliesByRoom_RoomlessUnderGeneral()
+    {
+        Seed(ctx =>
+        {
+            ctx.Rooms.Add(new Room { HouseholdId = H1, RoomId = 1, Name = "Kitchen" });
+            ctx.Chores.AddRange(
+                SimpleChore(1, "Dishes", roomId: 1),   // Kitchen
+                SimpleChore(2, "Errand"));              // roomless ⇒ General
+            ctx.ChoreCompletions.AddRange(
+                Completion(1, Alice, Utc0(2026, 6, 16, 9), 2, choreId: 1),
+                Completion(2, Bob, Utc0(2026, 6, 16, 10), 2, choreId: 1),
+                Completion(3, Alice, Utc0(2026, 6, 16, 11), 2, choreId: 2));
+        });
+
+        var history = await CreateService(Utc).GetHistoryAsync(H1, weeks: 1, now: Utc0(2026, 6, 17, 12));
+
+        history.WhatGotTended.Should().HaveCount(2);
+        history.WhatGotTended[0].RoomName.Should().Be("Kitchen", "most-tended first (2 completions)");
+        history.WhatGotTended[0].Completions.Should().Be(2);
+        history.WhatGotTended.Should().Contain(t => t.RoomName == "General" && t.Completions == 1);
+    }
+
+    [Fact]
+    public async Task SecondHouseholdData_NeverAppears()
+    {
+        Seed(ctx =>
+        {
+            ctx.Chores.AddRange(
+                SimpleChore(1, "Smith dishes", householdId: H1),
+                SimpleChore(1, "Jones secret", householdId: H2));
+            ctx.ChoreCompletions.AddRange(
+                Completion(1, Alice, Utc0(2026, 6, 16, 9), 3, choreId: 1, householdId: H1),
+                Completion(2, Carol, Utc0(2026, 6, 16, 10), 99, choreId: 1, householdId: H2));
+        });
+
+        var history = await CreateService(Utc).GetHistoryAsync(H1, weeks: 1, now: Utc0(2026, 6, 17, 12));
+
+        history.Events.Should().ContainSingle().Which.ChoreName.Should().Be("Smith dishes");
+        history.Events.Should().NotContain(e => e.DoerDisplayName == "Carol");
+        history.Milestones.SeasonTotalPoints.Should().Be(3, "household 2's 99 points must not leak");
+    }
+
+    // ── Gap projection is WP-02 — empty here ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GhostsAndGoneQuiet_AreEmpty_InWp01()
+    {
+        Seed(ctx =>
+        {
+            ctx.Chores.Add(SimpleChore(1, "Dishes"));
+            ctx.ChoreCompletions.Add(Completion(1, Alice, Utc0(2026, 6, 16, 9), 3));
+        });
+
+        var history = await CreateService(Utc).GetHistoryAsync(H1, weeks: 3, now: Utc0(2026, 6, 17, 12));
+
+        history.Ghosts.Should().BeEmpty();
+        history.GoneQuiet.Should().BeEmpty();
+    }
+}

--- a/tests/FamilyCoordinationApp.Tests/Services/ChoreHistoryServiceTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/ChoreHistoryServiceTests.cs
@@ -645,4 +645,115 @@ public class ChoreHistoryServiceTests
         history.Ghosts.Should().BeEmpty();
         history.GoneQuiet.Should().BeEmpty();
     }
+
+    // ═══════════════════════════════════════════════════════════════════════════════════════════════
+    // WP-03 — fold the ChoreSnoozeEvent log into the accurate snoozed-vs-slipped reason. Seam-style tests
+    // through GetHistoryAsync with real ChoreSnoozeEvent rows (the new read-path). now = Wed 2026-06-24,
+    // Utc tz (a DateOnly snooze floor's LocalMidnightUtc = its own midnight — keeps interval math legible).
+    // ═══════════════════════════════════════════════════════════════════════════════════════════════
+
+    private static ChoreSnoozeEvent SnoozeEvent(int id, int choreId, DateTime setAtUtc, DateOnly? snoozedUntil) =>
+        new()
+        {
+            HouseholdId = H1,
+            ChoreId = choreId,
+            SnoozeEventId = id,
+            SetByUserId = Alice,
+            SetAt = setAtUtc,
+            SnoozedUntil = snoozedUntil,
+        };
+
+    private static HistoryGhost Ghost(ChoreHistoryResult h, string localDate) =>
+        h.Ghosts.Single(g => g.ExpectedLocalDate == localDate);
+
+    [Fact]
+    public async Task Reason_SetThenClear_SnoozedInsideInterval_SlippedAfterClear()
+    {
+        // Fixed weekly Wed, never completed. Beats Jun 3/10/17/24. SET(until Jun 20) at Jun 8, CLEAR at Jun 15.
+        // Interval [Jun 8, Jun 15) (cut short by the CLEAR before the floor). Current state = cleared (null).
+        Seed(ctx =>
+        {
+            ctx.Chores.Add(WeeklyChore(1, "Trash", ChoreDaysOfWeek.Wednesday, snoozedUntil: null));
+            ctx.ChoreSnoozeEvents.AddRange(
+                SnoozeEvent(1, 1, Utc0(2026, 6, 8, 9), new DateOnly(2026, 6, 20)),  // SET
+                SnoozeEvent(2, 1, Utc0(2026, 6, 15, 9), null));                     // CLEAR
+        });
+
+        var history = await CreateService(Utc).GetHistoryAsync(H1, weeks: 4, now: Utc0(2026, 6, 24, 12));
+
+        Ghost(history, "2026-06-10").Reason.Should().Be("snoozed", "Jun 10 is inside [Jun 8, Jun 15)");
+        Ghost(history, "2026-06-10").ReasonFromLog.Should().BeTrue();
+        Ghost(history, "2026-06-17").Reason.Should().Be("slipped", "the CLEAR cut the interval before Jun 17");
+        Ghost(history, "2026-06-17").ReasonFromLog.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Reason_SetNoClear_IntervalEndsAtFloor_NotOpenForever()
+    {
+        // SET(until Jun 12) at Jun 8, no CLEAR. Interval [Jun 8, Jun 12). A ghost after Jun 12 is 'slipped' —
+        // the interval expired at the floor, it did NOT stay open forever.
+        Seed(ctx =>
+        {
+            ctx.Chores.Add(WeeklyChore(1, "Trash", ChoreDaysOfWeek.Wednesday, snoozedUntil: new DateOnly(2026, 6, 12)));
+            ctx.ChoreSnoozeEvents.Add(SnoozeEvent(1, 1, Utc0(2026, 6, 8, 9), new DateOnly(2026, 6, 12)));
+        });
+
+        var history = await CreateService(Utc).GetHistoryAsync(H1, weeks: 4, now: Utc0(2026, 6, 24, 12));
+
+        Ghost(history, "2026-06-10").Reason.Should().Be("snoozed", "Jun 10 is inside [Jun 8, Jun 12)");
+        Ghost(history, "2026-06-17").Reason.Should().Be("slipped", "the interval ended at the Jun 12 floor");
+        Ghost(history, "2026-06-17").ReasonFromLog.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Reason_PreWindowSeed_SnoozeStartedBeforeWindow_LabelsEarlyGhostSnoozed()
+    {
+        // SET(until Jul 1) at May 20 — BEFORE the window (Mon Jun 1). Without the pre-window seed read, the
+        // early-window ghost Jun 3 would be mislabeled. The seed extends coverage: [May 20, Jul 1) covers Jun 3.
+        Seed(ctx =>
+        {
+            ctx.Chores.Add(WeeklyChore(1, "Trash", ChoreDaysOfWeek.Wednesday, snoozedUntil: new DateOnly(2026, 7, 1)));
+            ctx.ChoreSnoozeEvents.Add(SnoozeEvent(1, 1, Utc0(2026, 5, 20, 9), new DateOnly(2026, 7, 1)));
+        });
+
+        var history = await CreateService(Utc).GetHistoryAsync(H1, weeks: 4, now: Utc0(2026, 6, 24, 12));
+
+        Ghost(history, "2026-06-03").Reason.Should().Be("snoozed", "the pre-window snooze covers the early-window beat");
+        Ghost(history, "2026-06-03").ReasonFromLog.Should().BeTrue("the pre-window seed makes it log-derived, not fallback");
+    }
+
+    [Fact]
+    public async Task Reason_BeforeEarliestEvent_FallsBackToCurrentState_ReasonFromLogFalse()
+    {
+        // Only event is at Jun 15. A ghost on Jun 3 predates all log coverage ⇒ fallback to current
+        // Chore.SnoozedUntil, best-effort (ReasonFromLog=false). Current state here is cleared ⇒ 'slipped'.
+        Seed(ctx =>
+        {
+            ctx.Chores.Add(WeeklyChore(1, "Trash", ChoreDaysOfWeek.Wednesday, snoozedUntil: null));
+            ctx.ChoreSnoozeEvents.Add(SnoozeEvent(1, 1, Utc0(2026, 6, 15, 9), null)); // a CLEAR at Jun 15
+        });
+
+        var history = await CreateService(Utc).GetHistoryAsync(H1, weeks: 4, now: Utc0(2026, 6, 24, 12));
+
+        var g = Ghost(history, "2026-06-03");
+        g.ReasonFromLog.Should().BeFalse("Jun 3 is before the earliest logged event (Jun 15) — fallback path");
+        g.Reason.Should().Be("slipped", "current state is cleared");
+    }
+
+    [Fact]
+    public async Task GoneQuiet_AllTrailingMissesSnoozed_ReadsSnoozed()
+    {
+        // weeks=2 ⇒ window Mon Jun 15; beats Jun 17/24 (both missed ⇒ gone quiet). A pre-window SET(until Jul 1)
+        // at Jun 10 covers both trailing misses ⇒ GoneQuiet.Reason = 'snoozed'.
+        Seed(ctx =>
+        {
+            ctx.Chores.Add(WeeklyChore(1, "Trash", ChoreDaysOfWeek.Wednesday, snoozedUntil: new DateOnly(2026, 7, 1)));
+            ctx.ChoreSnoozeEvents.Add(SnoozeEvent(1, 1, Utc0(2026, 6, 10, 9), new DateOnly(2026, 7, 1)));
+        });
+
+        var history = await CreateService(Utc).GetHistoryAsync(H1, weeks: 2, now: Utc0(2026, 6, 24, 12));
+
+        history.GoneQuiet.Should().ContainSingle().Which.Reason.Should().Be("snoozed",
+            "every trailing missed beat is covered by the snooze log");
+    }
 }

--- a/tests/FamilyCoordinationApp.Tests/Services/ChoreLedgerDtoContractTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/ChoreLedgerDtoContractTests.cs
@@ -1,0 +1,160 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using FamilyCoordinationApp.Services.Dtos;
+
+namespace FamilyCoordinationApp.Tests.Services;
+
+/// <summary>
+/// Contract / consumer-audit tests for the ledger DTO (Phase 15 WP-04, M5). Serializes a representative
+/// <see cref="ChoreLedgerDto"/> with the SAME options WP-06 registers globally (camelCase +
+/// <see cref="JsonStringEnumConverter"/> camelCase) and asserts it matches the checked-in
+/// <c>Fixtures/ChoreHistory/ledger.json</c> EXACTLY. The island's <c>types.ts</c> mirrors this fixture; any
+/// shape/casing change breaks this test → forcing the island contract to update in lockstep. Also enforces
+/// the neutral-framing invariant: NO <c>userId</c>/<c>^id$</c>/mention key anywhere (D9/MN1).
+/// </summary>
+public class ChoreLedgerDtoContractTests
+{
+    public static readonly JsonSerializerOptions LedgerJsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+    };
+
+    private static readonly string FixturePath =
+        Path.Combine(AppContext.BaseDirectory, "Fixtures", "ChoreHistory", "ledger.json");
+
+    /// <summary>
+    /// A representative ledger covering: a note+photo event and a plain event; an EMPTY week alongside a
+    /// populated one (the weave scaffold includes empty weeks); a slipped and a snoozed ghost; a gone-quiet
+    /// entry with a <c>null</c> <c>lastCompletedLocalDate</c> (never completed) and one with a date. Static
+    /// values only — no clocks — so serialization is byte-deterministic.
+    /// </summary>
+    public static ChoreLedgerDto BuildRepresentativeLedger() => new(
+        WindowStartLocal: "2026-04-06",
+        WindowEndLocal: "2026-06-24",
+        Events: new List<LedgerEventDto>
+        {
+            new("Dishes", "Alice", "2026-06-22", 2, "Left them sparkling", true),
+            new("Take out trash", "Bob", "2026-06-21", 1, null, false),
+        },
+        Weeks: new List<LedgerWeekDto>
+        {
+            new("2026-06-08", 0), // empty week — still present in the scaffold
+            new("2026-06-15", 2),
+        },
+        Ghosts: new List<GhostDto>
+        {
+            new("Water plants", "2026-06-17", "slipped"),
+            new("Take out trash", "2026-06-18", "snoozed"),
+        },
+        GoneQuiet: new List<GoneQuietDto>
+        {
+            new("Water plants", "every 7 days", null, "slipped"),   // never completed → null
+            new("Deep clean", "Sun", "2026-03-15", "snoozed"),
+        });
+
+    [Fact]
+    public void SerializedLedger_MatchesContractFixture()
+    {
+        var ledger = BuildRepresentativeLedger();
+
+        var actualJson = JsonSerializer.Serialize(ledger, LedgerJsonOptions);
+
+        File.Exists(FixturePath).Should().BeTrue(
+            $"the ledger.json contract fixture must be checked in at {FixturePath}");
+        var expectedJson = File.ReadAllText(FixturePath);
+
+        Normalize(actualJson).Should().Be(Normalize(expectedJson),
+            "the serialized ledger DTO must match the checked-in contract fixture; if this fails after a "
+            + "deliberate DTO change, update ledger.json AND the island types.ts in lockstep (M5)");
+    }
+
+    [Fact]
+    public void SerializedLedger_UsesCamelCaseKeys()
+    {
+        var ledger = BuildRepresentativeLedger();
+        var json = JsonSerializer.Serialize(ledger, LedgerJsonOptions);
+        var root = JsonNode.Parse(json)!.AsObject();
+
+        root.Select(kvp => kvp.Key).Should().BeEquivalentTo(
+            "windowStartLocal", "windowEndLocal", "events", "weeks", "ghosts", "goneQuiet");
+
+        root["events"]!.AsArray()[0]!.AsObject().Select(kvp => kvp.Key).Should().BeEquivalentTo(
+            "choreName", "doerDisplayName", "localDate", "points", "note", "hasPhoto");
+        root["weeks"]!.AsArray()[0]!.AsObject().Select(kvp => kvp.Key).Should().BeEquivalentTo(
+            "weekStartLocal", "completions");
+        root["ghosts"]!.AsArray()[0]!.AsObject().Select(kvp => kvp.Key).Should().BeEquivalentTo(
+            "choreName", "expectedLocalDate", "reason");
+        root["goneQuiet"]!.AsArray()[0]!.AsObject().Select(kvp => kvp.Key).Should().BeEquivalentTo(
+            "choreName", "cadenceLabel", "lastCompletedLocalDate", "reason");
+    }
+
+    /// <summary>
+    /// The neutral-framing tripwire (D9/MN1): NO <c>userId</c>/<c>^id$</c>/mention key appears anywhere in the
+    /// serialized ledger. Asserted structurally so a future field addition can't silently reintroduce identity.
+    /// </summary>
+    [Fact]
+    public void SerializedLedger_HasNoUserIdOrMentionKeys()
+    {
+        var json = JsonSerializer.Serialize(BuildRepresentativeLedger(), LedgerJsonOptions);
+        var offending = new List<string>();
+        CollectOffendingKeys(JsonNode.Parse(json)!, offending);
+        offending.Should().BeEmpty("the ledger carries displayName only — no userId/id/mention (D9/MN1)");
+    }
+
+    [Fact]
+    public void GoneQuiet_NeverCompleted_SerializesNullLastCompletedDate()
+    {
+        var json = JsonSerializer.Serialize(BuildRepresentativeLedger(), LedgerJsonOptions);
+        var firstGoneQuiet = JsonNode.Parse(json)!["goneQuiet"]!.AsArray()[0]!.AsObject();
+
+        firstGoneQuiet.ContainsKey("lastCompletedLocalDate").Should().BeTrue("the key is always present");
+        firstGoneQuiet["lastCompletedLocalDate"].Should().BeNull("JSON null = never completed (not a sentinel)");
+    }
+
+    /// <summary>A deliberate rename of any contract field must break the fixture test (tripwire).</summary>
+    [Fact]
+    public void RenamingAField_BreaksTheFixture()
+    {
+        var json = JsonSerializer.Serialize(BuildRepresentativeLedger(), LedgerJsonOptions);
+        var drifted = json.Replace("\"expectedLocalDate\"", "\"expectedDate\"");
+        var expectedJson = File.ReadAllText(FixturePath);
+
+        Normalize(drifted).Should().NotBe(Normalize(expectedJson));
+    }
+
+    private static void CollectOffendingKeys(JsonNode node, List<string> offending)
+    {
+        switch (node)
+        {
+            case JsonObject obj:
+                foreach (var (key, value) in obj)
+                {
+                    var lower = key.ToLowerInvariant();
+                    if (lower is "userid" or "id" || lower.Contains("mention"))
+                    {
+                        offending.Add(key);
+                    }
+                    if (value is not null)
+                    {
+                        CollectOffendingKeys(value, offending);
+                    }
+                }
+                break;
+            case JsonArray arr:
+                foreach (var item in arr)
+                {
+                    if (item is not null)
+                    {
+                        CollectOffendingKeys(item, offending);
+                    }
+                }
+                break;
+        }
+    }
+
+    private static string Normalize(string json) =>
+        JsonNode.Parse(json)!.ToJsonString(new JsonSerializerOptions { WriteIndented = false });
+}

--- a/tests/FamilyCoordinationApp.Tests/Services/ChoreRecapDtoContractTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/ChoreRecapDtoContractTests.cs
@@ -1,0 +1,135 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using FamilyCoordinationApp.Services.Dtos;
+
+namespace FamilyCoordinationApp.Tests.Services;
+
+/// <summary>
+/// Contract / consumer-audit tests for the EVOLVED recap DTO (Phase 15 WP-05 — retrofitted; the recap payload
+/// had no contract test before). Serializes a representative <see cref="ChoreRecapDto"/> with the SAME options
+/// WP-06 registers globally and asserts it matches <c>Fixtures/ChoreRecap/recap.json</c>. Crucially, it also
+/// serializes <see cref="ChoreRecapDto.Current"/> ALONE and compares to a frozen <c>recap-current.json</c>
+/// baseline — so the digest-mirror block is pinned byte-for-byte INDEPENDENTLY of the outer recap shape (M6:
+/// the in-app "This week" must never diverge from the Discord digest).
+/// </summary>
+public class ChoreRecapDtoContractTests
+{
+    public static readonly JsonSerializerOptions RecapJsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+    };
+
+    private static readonly string FixtureDir =
+        Path.Combine(AppContext.BaseDirectory, "Fixtures", "ChoreRecap");
+    private static readonly string RecapFixturePath = Path.Combine(FixtureDir, "recap.json");
+    private static readonly string CurrentFixturePath = Path.Combine(FixtureDir, "recap-current.json");
+
+    /// <summary>
+    /// A representative evolved recap: a digest-mirror <c>Current</c>; a 2-point trend each carrying a per-week
+    /// <c>distribution</c> (displayName only); milestones (best week / streak / a first-ever / season totals);
+    /// a note+photo kept moment; a room + General what-got-tended; a never-completed gone-quiet entry (null
+    /// lastCompletedLocalDate). Static values only — byte-deterministic.
+    /// </summary>
+    public static ChoreRecapDto BuildRepresentativeRecap() => new(
+        Current: new RecapWeekDto(
+            WeekStartLocal: "2026-06-15",
+            Headline: "The Smith house knocked out 4 chores (10 pts) this week!",
+            TotalCompletions: 4,
+            TotalPoints: 10,
+            Distribution: new List<RecapMemberLineDto>
+            {
+                new("Alice", 6, 60.0),
+                new("Bob", 4, 40.0),
+            },
+            FallingBehind: new List<string> { "Take out trash" },
+            UpForGrabsCount: 2),
+        Trend: new List<RecapTrendPointDto>
+        {
+            new("2026-06-08", 3, 7, false, new List<RecapMemberLineDto> { new("Alice", 4, 57.1), new("Bob", 3, 42.9) }),
+            new("2026-06-15", 4, 10, true, new List<RecapMemberLineDto> { new("Alice", 6, 60.0), new("Bob", 4, 40.0) }),
+        },
+        Milestones: new MilestonesDto(
+            BestWeek: new BestWeekDto("2026-06-15", 4, 10),
+            LongestActiveStreakWeeks: 2,
+            FirstEvers: new List<FirstEverDto> { new("Deep clean", "2026-06-10") },
+            SeasonTotalCompletions: 7,
+            SeasonTotalPoints: 17),
+        KeptMoments: new List<KeptMomentDto>
+        {
+            new("2026-06-14", "Dishes", "Left them sparkling", true),
+        },
+        WhatGotTended: new List<WhatGotTendedDto>
+        {
+            new("Kitchen", 5),
+            new("General", 2),
+        },
+        GoneQuiet: new List<GoneQuietDto>
+        {
+            new("Water plants", "every 7 days", null, "slipped"),
+        });
+
+    [Fact]
+    public void SerializedRecap_MatchesContractFixture()
+    {
+        var actualJson = JsonSerializer.Serialize(BuildRepresentativeRecap(), RecapJsonOptions);
+
+        File.Exists(RecapFixturePath).Should().BeTrue(
+            $"the recap.json contract fixture must be checked in at {RecapFixturePath}");
+        Normalize(actualJson).Should().Be(Normalize(File.ReadAllText(RecapFixturePath)),
+            "the serialized recap DTO must match the checked-in fixture; on a deliberate change, update "
+            + "recap.json AND the island types.ts in lockstep (M5)");
+    }
+
+    /// <summary>
+    /// M6 — the digest-mirror <c>Current</c> block serializes byte-identical to a frozen baseline, verified by
+    /// serializing <c>dto.Current</c> ALONE (not a substring of the full recap) so outer shape shifts can't mask
+    /// a divergence. If this fails, the in-app "This week" has drifted from the Discord digest — STOP (E3).
+    /// </summary>
+    [Fact]
+    public void Current_SerializesByteIdenticalToFrozenBaseline()
+    {
+        var currentJson = JsonSerializer.Serialize(BuildRepresentativeRecap().Current, RecapJsonOptions);
+
+        File.Exists(CurrentFixturePath).Should().BeTrue(
+            $"the frozen current-block baseline must be checked in at {CurrentFixturePath}");
+        Normalize(currentJson).Should().Be(Normalize(File.ReadAllText(CurrentFixturePath)),
+            "the digest-mirror Current block must never change (M6/E3) — the in-app view must not diverge from the digest");
+    }
+
+    [Fact]
+    public void SerializedRecap_UsesCamelCaseKeys_AndDistributionHasNoUserId()
+    {
+        var root = JsonNode.Parse(JsonSerializer.Serialize(BuildRepresentativeRecap(), RecapJsonOptions))!.AsObject();
+
+        root.Select(kvp => kvp.Key).Should().BeEquivalentTo(
+            "current", "trend", "milestones", "keptMoments", "whatGotTended", "goneQuiet");
+
+        var firstTrend = root["trend"]!.AsArray()[0]!.AsObject();
+        firstTrend.Select(kvp => kvp.Key).Should().BeEquivalentTo(
+            "weekStartLocal", "totalCompletions", "totalPoints", "isCurrent", "distribution");
+
+        // Per-week distribution is displayName-only — NO userId (D6/MN1).
+        var firstDist = firstTrend["distribution"]!.AsArray()[0]!.AsObject();
+        firstDist.Select(kvp => kvp.Key).Should().BeEquivalentTo("displayName", "points", "sharePct");
+        firstDist.ContainsKey("userId").Should().BeFalse("the per-week distribution carries no userId (MN1)");
+
+        var milestones = root["milestones"]!.AsObject();
+        milestones.Select(kvp => kvp.Key).Should().BeEquivalentTo(
+            "bestWeek", "longestActiveStreakWeeks", "firstEvers", "seasonTotalCompletions", "seasonTotalPoints");
+    }
+
+    [Fact]
+    public void RenamingAField_BreaksTheFixture()
+    {
+        var json = JsonSerializer.Serialize(BuildRepresentativeRecap(), RecapJsonOptions);
+        var drifted = json.Replace("\"whatGotTended\"", "\"roomTallies\"");
+
+        Normalize(drifted).Should().NotBe(Normalize(File.ReadAllText(RecapFixturePath)));
+    }
+
+    private static string Normalize(string json) =>
+        JsonNode.Parse(json)!.ToJsonString(new JsonSerializerOptions { WriteIndented = false });
+}

--- a/tests/FamilyCoordinationApp.Tests/Services/ChoreRecapServiceTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/ChoreRecapServiceTests.cs
@@ -57,13 +57,17 @@ public class ChoreRecapServiceTests
         dbFactory.Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(() => new ApplicationDbContext(_options));
 
+        var equity = new ChoreEquityCalculator();
+        var history = new ChoreHistoryService(dbFactory.Object, equity, tz, TimeProvider.System);
+
         return new ChoreRecapService(
             dbFactory.Object,
-            new ChoreEquityCalculator(),
+            equity,
             new ChoreStatusCalculator(),
             new DigestBuilder(),
             tz,
-            TimeProvider.System);
+            TimeProvider.System,
+            history);
     }
 
     private void SeedCompletions(params ChoreCompletion[] completions)


### PR DESCRIPTION
The temporal face of Phase 15 (equity / invisible labor): a browsable completion **ledger** (C, leads) with schedule-vs-completion **ghost rows** + a **gone-quiet** band, plus an evolved **logbook** (A: digest-mirror + trend + per-week distribution + milestones). Collective / non-punitive — the per-person "B" trajectory stays dropped. Backed by one shared `ChoreHistoryService` feeding a new `GET /api/chores/ledger` and the additively-evolved `GET /api/chores/recap`.

Executes the 9-WP council-hardened spec (`data/outputs/workshops/fca-chore-history/`), commit-per-WP in wave order.

## What's here

**Backend (WP-01→05)**
- `ChoreHistoryService` — one shared read-only aggregation (window-bounded, HouseholdId-scoped, M1/M2): completion feed, weekly aggregates + displayName-only distribution, milestones (best week / streak / all-time first-evers via a bounded `MIN … GROUP BY` / season totals), kept moments, what-got-tended.
- Historical gap/ghost projection — beats generated in `DateOnly` space (DST-immune, M4/MN4), greedy per-mode-tolerance matching with no collapse (MN6), gone-quiet at ≥2 trailing misses; monthly skipped (MN5). The DST correctness (S1 = 72 missed / S2 = 0 false positives across both 2026 transitions) is unit-proven against the validated spike oracle.
- Snooze-vs-slip reason folded from the `ChoreSnoozeEvent` log (PR #69) with a bounded pre-window seed; internal `ReasonFromLog` telemetry stays off-wire (D5).
- `GET /api/chores/ledger` (`ChoreLedgerDto`, weeks default 12, non-empty 401) + contract fixture with a no-userId/mention tripwire; `/api/chores/recap` additively evolved with a **byte-identical `Current`** (digest-mirror, M6) + a retrofitted contract test.

**Frontend (WP-06→09)**
- `types.ts` mirrors both DTOs (`GoneQuietDto` shared, single-owner); `getLedger` + store `ledger` cache wired into the invalidation cascade.
- `LedgerBoard.svelte` (weave + gone-quiet + record feed with ghost rows) and the evolved `RecapBoard.svelte` (per-week within-week breakdown — never a cross-week per-person line, MN2/E1 — + milestones / kept moments / what-got-tended / quiet corners).
- C-leads toggle-in-lens: the `recap` lens becomes "Look back", opening on the ledger with a lazy logbook sub-toggle. No new route/fallback (M11); MN9-safe dates throughout.

## Verification
- **Backend: full suite 855 green** (814 baseline + 41 new), incl. Testcontainers integration (HouseholdId isolation + real-Postgres `MIN … GROUP BY` / snooze-seed pushdowns). Digest path untouched.
- **Frontend:** `npm run check` 0 errors + `npm run build` green.
- **:8080 browser-verify (the UI review gate) — full PASS** against the real container + Postgres: C-leads default; weave / gone-quiet / ghosts / entries render; logbook interactive week-breakdown sums to 100% (within-week, not a line); **0 refetches across 5 sub-toggles (M11)**; no fetch loop (MN10); no `userId` on the ledger wire (MN1); no console errors. Framing reads honest/pride-forward, not nagging.

No new EF migration (DTO-only backend work; #69 already shipped the substrate).

Spine quest `598a1d49`.

https://claude.ai/code/session_01WvHc4ijSBjiqyPkTejfpov