### PR TITLE
feat(chores): Phase 15 R4′ — capacity-fit (Quick wins + Fits me)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,35 @@ jobs:
         
       - name: Run tests
         run: dotnet test tests/FamilyCoordinationApp.Tests/FamilyCoordinationApp.Tests.csproj --configuration Release --verbosity normal
-        
+
+  frontend:
+    name: Frontend Check & Test
+    runs-on: ubuntu-latest  # GitHub-hosted, safe for untrusted code
+
+    defaults:
+      run:
+        working-directory: frontend/app
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'  # matches the SPA build stage in Dockerfile (node:20-alpine)
+          cache: 'npm'
+          cache-dependency-path: frontend/app/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check (svelte-check)
+        run: npm run check
+
+      - name: Unit tests (vitest)
+        run: npm test
+
   lint:
     name: Code Quality
     runs-on: ubuntu-latest

--- a/frontend/app/package-lock.json
+++ b/frontend/app/package-lock.json
@@ -17,7 +17,8 @@
         "svelte": "^5.19.0",
         "svelte-check": "^4.1.4",
         "typescript": "~5.7.2",
-        "vite": "^6.0.7"
+        "vite": "^6.0.7",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -984,10 +985,28 @@
         "vite": "^6.0.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1002,6 +1021,119 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/acorn": {
       "version": "8.17.0",
@@ -1025,6 +1157,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -1032,6 +1174,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chokidar": {
@@ -1058,6 +1210,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.6.0",
@@ -1101,6 +1260,13 @@
       "version": "5.8.1",
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
       "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/esbuild": {
@@ -1166,6 +1332,26 @@
         "@typescript-eslint/types": {
           "optional": true
         }
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -1280,6 +1466,27 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1410,6 +1617,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sirv": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
@@ -1434,6 +1648,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/svelte": {
       "version": "5.56.4",
@@ -1497,6 +1725,23 @@
         "svelte": ">=3.23.0 || ^5.0.0-next.0"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -1512,6 +1757,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/totalist": {
@@ -1633,6 +1888,113 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/zimmerframe": {

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -7,7 +7,8 @@
     "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview",
-    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"
+    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@sveltejs/adapter-static": "^3.0.8",
@@ -16,7 +17,8 @@
     "svelte": "^5.19.0",
     "svelte-check": "^4.1.4",
     "typescript": "~5.7.2",
-    "vite": "^6.0.7"
+    "vite": "^6.0.7",
+    "vitest": "^4.1.10"
   },
   "dependencies": {
     "svelte-dnd-action": "^0.9.69"

--- a/frontend/app/src/lib/chores/App.svelte
+++ b/frontend/app/src/lib/chores/App.svelte
@@ -6,6 +6,7 @@
   import { startLiveness, type LivenessHandle } from './lib/liveness';
   import { showToast } from '$lib/shared/toast-store.svelte';
   import ViewSwitcher from './lib/components/ViewSwitcher.svelte';
+  import PileControls from './lib/components/PileControls.svelte';
   import NeedsAttentionBoard from './lib/components/NeedsAttentionBoard.svelte';
   import RoomsDashboard from './lib/components/RoomsDashboard.svelte';
   import EquityBoard from './lib/components/EquityBoard.svelte';
@@ -340,6 +341,17 @@
       CLIENT-SIDE grouping of the ONE board payload — switching `store.lens` NEVER
       refetches (M11). All share the same optimistic card handlers.
     -->
+    <!--
+      Up-for-grabs pile controls (Phase 15 R4′). Pull-only + up-for-grabs-only:
+      the "Quick first" ordering toggle (WP-01; WP-03 adds "Fits me"). Gated on
+      the lens so it never shows on Mine / All; the store resets it on lens-switch.
+    -->
+    {#if store.lens === 'up-for-grabs'}
+      <PileControls
+        quickFirst={store.pileQuickFirst}
+        onToggleQuickFirst={() => store.togglePileQuickFirst()}
+      />
+    {/if}
     {#if store.lens === 'up-for-grabs' || store.lens === 'mine' || store.lens === 'needs-attention'}
       <NeedsAttentionBoard
         sections={store.boardSections}

--- a/frontend/app/src/lib/chores/App.svelte
+++ b/frontend/app/src/lib/chores/App.svelte
@@ -350,6 +350,9 @@
       <PileControls
         quickFirst={store.pileQuickFirst}
         onToggleQuickFirst={() => store.togglePileQuickFirst()}
+        fitsMe={store.pileFitsMe}
+        showFitsMe={store.showFitsMeChip}
+        onToggleFitsMe={() => store.togglePileFitsMe()}
       />
     {/if}
     {#if store.lens === 'up-for-grabs' || store.lens === 'mine' || store.lens === 'needs-attention'}
@@ -359,6 +362,9 @@
         currentUserId={store.currentUserId}
         totalChores={store.boardTotalCount}
         isPending={(id) => store.isPending(id)}
+        fitsMeActive={store.pileFitsMeActive}
+        setAsideCount={store.pileSetAsideCount}
+        onShowSetAside={() => store.togglePileFitsMe()}
         onClaim={handleClaim}
         onDrop={handleDrop}
         onComplete={handleComplete}

--- a/frontend/app/src/lib/chores/lib/capacity-fit.test.ts
+++ b/frontend/app/src/lib/chores/lib/capacity-fit.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { showsFitsMe, fitSetFor, fitsCapacity } from './capacity-fit';
+
+// ─────────────────────────────────────────────────────────────────────────
+// V1.6 — the ONE automatable proof of the R4′ founding-case guarantee. The
+// multi-identity visual proof (V1.3) stays a manual browser observation; this
+// pins the whitelist gate at the unit level so the forbidden `tier !== 'Full'`
+// regression can never leak the "Fits me" chip to a null-tier (Full/unset) user.
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('showsFitsMe — the whitelist chip gate (V1.6)', () => {
+  it('shows the chip ONLY for Reduced and Minimal', () => {
+    expect(showsFitsMe('Reduced')).toBe(true);
+    expect(showsFitsMe('Minimal')).toBe(true);
+  });
+
+  it('HIDES the chip for Full AND for null/undefined (the founding-case guarantee)', () => {
+    // Both must hide — a Full/unset viewer (e.g. Justin) is never shown a per-person affordance.
+    expect(showsFitsMe('Full')).toBe(false);
+    expect(showsFitsMe(null)).toBe(false);
+    expect(showsFitsMe(undefined)).toBe(false);
+  });
+});
+
+describe('fitSetFor — the per-tier fit sets', () => {
+  it('Minimal → Quick only; Reduced → Quick + Standard; Full/unset → everything', () => {
+    expect(fitSetFor('Minimal')).toEqual(['Quick']);
+    expect(fitSetFor('Reduced')).toEqual(['Quick', 'Standard']);
+    expect(fitSetFor('Full')).toEqual(['Quick', 'Standard', 'BigJob']);
+    expect(fitSetFor(null)).toEqual(['Quick', 'Standard', 'BigJob']);
+    expect(fitSetFor(undefined)).toEqual(['Quick', 'Standard', 'BigJob']);
+  });
+});
+
+describe('fitsCapacity — membership against the fit set', () => {
+  it('a Minimal viewer fits only Quick', () => {
+    expect(fitsCapacity('Quick', 'Minimal')).toBe(true);
+    expect(fitsCapacity('Standard', 'Minimal')).toBe(false);
+    expect(fitsCapacity('BigJob', 'Minimal')).toBe(false);
+  });
+
+  it('a Reduced viewer fits Quick + Standard, not BigJob', () => {
+    expect(fitsCapacity('Quick', 'Reduced')).toBe(true);
+    expect(fitsCapacity('Standard', 'Reduced')).toBe(true);
+    expect(fitsCapacity('BigJob', 'Reduced')).toBe(false);
+  });
+
+  it('a Full/unset viewer fits everything (filter is a no-op)', () => {
+    expect(fitsCapacity('BigJob', 'Full')).toBe(true);
+    expect(fitsCapacity('BigJob', null)).toBe(true);
+  });
+});

--- a/frontend/app/src/lib/chores/lib/capacity-fit.ts
+++ b/frontend/app/src/lib/chores/lib/capacity-fit.ts
@@ -1,0 +1,46 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Capacity-fit — the pure logic behind the up-for-grabs "Fits me" affordance
+// (Phase 15 R4′ WP-03). Deliberately RUNE-FREE and dependency-free (only type
+// imports) so it is trivially unit-testable in isolation (V1.6) and so the store
+// + components share ONE source of truth for the whitelist gate + the fit sets.
+//
+// The ONLY inputs anywhere here are the chore's declared weight (effortTier) and
+// the viewer's OWN self-set capacity tier. There is NO per-person share/history/
+// gap signal — that is the whole point (M1/M6/MN1).
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { CapacityTier, EffortTier } from './types';
+
+/**
+ * Does the "Fits me" chip render for this caller's capacity tier? WHITELIST gate (V1.3): the chip shows IFF
+ * the tier is `Reduced` or `Minimal`. Both `'Full'` AND `null`/`undefined` (unset ⇒ Full) hide it — that is
+ * the founding-case guarantee (a Full/unset viewer, e.g. Justin, is never shown a per-person affordance).
+ *
+ * NEVER express this as `tier !== 'Full'` — that would leak the chip to a null-tier user, breaking the one
+ * invariant the whole feature exists to protect.
+ */
+export function showsFitsMe(tier: CapacityTier | null | undefined): boolean {
+  return tier === 'Reduced' || tier === 'Minimal';
+}
+
+/**
+ * The effort tiers that FIT a given capacity tier. `Minimal` → Quick only; `Reduced` → Quick + Standard;
+ * `Full`/unset → everything (the chip is hidden for these, so this branch is a no-op safety net). Returned in
+ * ascending-weight order for readability; callers use it as a membership set.
+ */
+export function fitSetFor(tier: CapacityTier | null | undefined): readonly EffortTier[] {
+  switch (tier) {
+    case 'Minimal':
+      return ['Quick'];
+    case 'Reduced':
+      return ['Quick', 'Standard'];
+    default:
+      // Full / null / undefined — everything fits (no filtering).
+      return ['Quick', 'Standard', 'BigJob'];
+  }
+}
+
+/** Does a chore's declared effort tier fit the viewer's own capacity tier? */
+export function fitsCapacity(effortTier: EffortTier, tier: CapacityTier | null | undefined): boolean {
+  return fitSetFor(tier).includes(effortTier);
+}

--- a/frontend/app/src/lib/chores/lib/components/ChoreCard.svelte
+++ b/frontend/app/src/lib/chores/lib/components/ChoreCard.svelte
@@ -69,11 +69,20 @@
     onSnooze,
   }: Props = $props();
 
-  // ── Named effort tiers (P3 — never the raw points number as primary) ─────
+  // ── Named effort tiers (P3 — named tier leads; the raw points number is a
+  //    secondary cue). Phase 15 R4′ (WP-01): the chip also renders a 3-dot weight
+  //    gauge (filled = tier rank) so the chore's WEIGHT is legible at a glance —
+  //    the only signal R4′ reads is this declared weight, never anything personal.
   const EFFORT_LABEL: Record<EffortTier, string> = {
     Quick: 'Quick',
     Standard: 'Standard',
     BigJob: 'Big job',
+  };
+  /** Filled-dot count for the weight gauge (1..3). Rank of the chore's own tier. */
+  const EFFORT_DOTS: Record<EffortTier, number> = {
+    Quick: 1,
+    Standard: 2,
+    BigJob: 3,
   };
 
   // ── Dueness pill copy (server `dueState`) ────────────────────────────────
@@ -85,6 +94,8 @@
   };
 
   let effortLabel = $derived(EFFORT_LABEL[chore.effortTier]);
+  let effortDots = $derived(EFFORT_DOTS[chore.effortTier]);
+  let effortPointsLabel = $derived(`${chore.effortPoints} pt${chore.effortPoints === 1 ? '' : 's'}`);
   let dueLabel = $derived(DUE_LABEL[chore.dueState]);
 
   // colorTier (fresh|mid|due|overdue) is the decay accent — server-computed.
@@ -351,11 +362,22 @@
         {/each}
       {/if}
 
-      <span class="ch-tag ch-tag-effort" title="Effort: {effortLabel}">
-        <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true">
-          <path d="M13 2 3 14h7l-1 8 10-12h-7l1-8z" fill="currentColor" />
-        </svg>
-        {effortLabel}
+      <!--
+        Effort chip (Phase 15 R4′ WP-01) — the chore's declared WEIGHT made
+        legible: a 3-dot gauge (filled = tier rank) + the named tier + points.
+        Named tier leads (P3); the gauge + points are secondary cues. This reads
+        ONLY the chore's own effortTier/effortPoints — never a per-person signal.
+      -->
+      <span
+        class="ch-tag ch-tag-effort"
+        title="Effort: {effortLabel} · {effortPointsLabel}"
+      >
+        <span class="ch-effort-dots" aria-hidden="true">
+          {#each [1, 2, 3] as n (n)}
+            <i class:ch-effort-dot-on={n <= effortDots}></i>
+          {/each}
+        </span>
+        {effortLabel} · {effortPointsLabel}
       </span>
 
       <span class="ch-tag ch-tag-recurrence" title="{recurrenceHint}">
@@ -947,6 +969,27 @@
   }
   .ch-tag svg {
     flex-shrink: 0;
+  }
+  /* Effort chip (R4′ WP-01) — steady digit width for the points count. */
+  .ch-tag-effort {
+    font-variant-numeric: tabular-nums;
+  }
+  /* Weight gauge — three dots, filled up to the chore's tier rank. Inherits the
+     chip's muted text color via currentColor, so it works in light + dark. */
+  .ch-effort-dots {
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+  }
+  .ch-effort-dots i {
+    width: 5px;
+    height: 5px;
+    border-radius: 1.5px;
+    background: currentColor;
+    opacity: 0.3;
+  }
+  .ch-effort-dots i.ch-effort-dot-on {
+    opacity: 0.95;
   }
   /* Room locator chip — tinted distinct from the muted effort/recurrence tags
      so "which room" reads as the card's primary orientation cue. */

--- a/frontend/app/src/lib/chores/lib/components/NeedsAttentionBoard.svelte
+++ b/frontend/app/src/lib/chores/lib/components/NeedsAttentionBoard.svelte
@@ -26,6 +26,16 @@
     totalChores: number;
     /** True while a mutation for the given chore id is in flight. */
     isPending: (choreId: number) => boolean;
+    /**
+     * Phase 15 R4′ (WP-03) — the up-for-grabs "Fits me" filter is actively narrowing the pile. When true the
+     * board appends the provenance note, and (if any chores were hidden) the "N bigger lifts set aside" row.
+     * Defaults false so every other lens/board renders exactly as before.
+     */
+    fitsMeActive?: boolean;
+    /** Count of pile chores hidden by the active Fits-me filter (drives the set-aside row). */
+    setAsideCount?: number;
+    /** "Show them" — reveal the full pile (the store clears the Fits-me filter). */
+    onShowSetAside?: () => void;
     onClaim: (chore: ChoreDto) => void;
     onDrop: (chore: ChoreDto) => void;
     onComplete: (chore: ChoreDto) => void;
@@ -44,6 +54,9 @@
     currentUserId,
     totalChores,
     isPending,
+    fitsMeActive = false,
+    setAsideCount = 0,
+    onShowSetAside,
     onClaim,
     onDrop,
     onComplete,
@@ -109,6 +122,26 @@
       <p>{emptyCopy.body}</p>
     </div>
   {/if}
+
+  {#if fitsMeActive}
+    <!--
+      Phase 15 R4′ (WP-03) — the "Fits me" escape hatch + provenance. The filter is
+      never a wall: any bigger lifts it set aside stay one tap away. The subject of
+      every string here is the CHORE ("bigger lifts") and the viewer's OWN setting —
+      never "you can't do this" (VD.4). Rendered only while the filter is active.
+    -->
+    {#if setAsideCount > 0}
+      <div class="ch-set-aside">
+        <span>{setAsideCount} bigger lift{setAsideCount === 1 ? '' : 's'} set aside</span>
+        <button type="button" class="ch-set-aside-show" onclick={() => onShowSetAside?.()}>
+          Show {setAsideCount === 1 ? 'it' : 'them'}
+        </button>
+      </div>
+    {/if}
+    <p class="ch-fit-note">
+      Matched to each chore’s weight and your own capacity setting — never to history.
+    </p>
+  {/if}
 </div>
 
 <style>
@@ -165,5 +198,46 @@
     font-weight: 500;
     color: var(--color-text);
     margin: 0 0 4px;
+  }
+
+  /* ── Fits-me escape hatch + provenance (R4′ WP-03) ──────────────────────── */
+  .ch-set-aside {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 10px 14px;
+    border: 1px dashed var(--color-line-strong);
+    border-radius: var(--radius-md);
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+  }
+  .ch-set-aside-show {
+    font: inherit;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: var(--color-primary);
+    background: transparent;
+    border: none;
+    padding: 4px 6px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    white-space: nowrap;
+    -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation;
+  }
+  .ch-set-aside-show:hover {
+    background: var(--color-action-hover);
+  }
+  .ch-set-aside-show:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+  .ch-fit-note {
+    margin: 0;
+    padding: 4px 0 0;
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    text-align: center;
   }
 </style>

--- a/frontend/app/src/lib/chores/lib/components/PileControls.svelte
+++ b/frontend/app/src/lib/chores/lib/components/PileControls.svelte
@@ -4,12 +4,14 @@
   // Rendered ONLY on the up-for-grabs lens (App.svelte gates it) — pull-only:
   // every pixel here exists because the viewer opened that lens (M3).
   //
-  // WP-01 ships ONE control: "Quick first", a symmetric PRESENTATION toggle that
-  // orders the pile effort-ascending (the store owns the sort). It reads only the
-  // chore's declared weight — nothing personal, identical for every member (M6).
-  //
-  // WP-03 adds the self-only "Fits me" chip + set-aside row + provenance note
-  // beside it; this component is the seam that hosts them.
+  // Two controls, both up-for-grabs-only + pull-only:
+  //   "Quick first" (WP-01) — a symmetric PRESENTATION sort (effort-ascending). It
+  //   reads only the chore's declared weight; identical for every member (M6).
+  //   "Fits me" (WP-03) — a SELF-ONLY filter to the tiers that fit the viewer's own
+  //   capacity. It renders ONLY for a Reduced/Minimal caller (the store owns the
+  //   whitelist gate via `showFitsMe`); a Full/unset viewer never sees it. The
+  //   filter's subject is the chore's weight × the viewer's OWN tier — never a
+  //   per-person share/history (M1/M6/MN1).
   // ───────────────────────────────────────────────────────────────────────
 
   interface Props {
@@ -17,9 +19,15 @@
     quickFirst: boolean;
     /** Toggle "Quick first" — the store flips its session-only field. */
     onToggleQuickFirst: () => void;
+    /** Is "Fits me" filtering on? (store.pileFitsMe) */
+    fitsMe: boolean;
+    /** Render the "Fits me" chip at all? WHITELIST gate — Reduced/Minimal callers only (store.showFitsMeChip). */
+    showFitsMe: boolean;
+    /** Toggle "Fits me" — the store flips its session-only field. */
+    onToggleFitsMe: () => void;
   }
 
-  let { quickFirst, onToggleQuickFirst }: Props = $props();
+  let { quickFirst, onToggleQuickFirst, fitsMe, showFitsMe, onToggleFitsMe }: Props = $props();
 </script>
 
 <div class="ch-pile-controls" role="group" aria-label="Pile controls">
@@ -32,6 +40,23 @@
   >
     Quick first
   </button>
+  {#if showFitsMe}
+    <!--
+      Self-only "Fits me" filter. Shown ONLY for a Reduced/Minimal caller — a
+      Full/unset viewer never renders this chip, so the pile stays identical for
+      them (the founding-case guarantee). It matches the chore's weight to the
+      viewer's OWN capacity setting; never to anyone's share or history.
+    -->
+    <button
+      type="button"
+      class="ch-pile-chip"
+      aria-pressed={fitsMe}
+      onclick={onToggleFitsMe}
+      title="Show chores that fit your capacity setting"
+    >
+      Fits me
+    </button>
+  {/if}
 </div>
 
 <style>

--- a/frontend/app/src/lib/chores/lib/components/PileControls.svelte
+++ b/frontend/app/src/lib/chores/lib/components/PileControls.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+  // ───────────────────────────────────────────────────────────────────────
+  // Up-for-grabs pile controls (Phase 15 R4′ — the "capacity-fit" affordances).
+  // Rendered ONLY on the up-for-grabs lens (App.svelte gates it) — pull-only:
+  // every pixel here exists because the viewer opened that lens (M3).
+  //
+  // WP-01 ships ONE control: "Quick first", a symmetric PRESENTATION toggle that
+  // orders the pile effort-ascending (the store owns the sort). It reads only the
+  // chore's declared weight — nothing personal, identical for every member (M6).
+  //
+  // WP-03 adds the self-only "Fits me" chip + set-aside row + provenance note
+  // beside it; this component is the seam that hosts them.
+  // ───────────────────────────────────────────────────────────────────────
+
+  interface Props {
+    /** Is "Quick first" ordering on? (store.pileQuickFirst) */
+    quickFirst: boolean;
+    /** Toggle "Quick first" — the store flips its session-only field. */
+    onToggleQuickFirst: () => void;
+  }
+
+  let { quickFirst, onToggleQuickFirst }: Props = $props();
+</script>
+
+<div class="ch-pile-controls" role="group" aria-label="Pile controls">
+  <button
+    type="button"
+    class="ch-pile-chip"
+    aria-pressed={quickFirst}
+    onclick={onToggleQuickFirst}
+    title="Show quicker chores first"
+  >
+    Quick first
+  </button>
+</div>
+
+<style>
+  .ch-pile-controls {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 16px;
+  }
+
+  /* Pill toggle — mirrors the shipped chip idiom (set-as-default / meta tags):
+     bordered, rounded, muted until pressed; pressed borrows the primary accent. */
+  .ch-pile-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font: inherit;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: var(--color-text-muted);
+    background: var(--color-surface);
+    border: 1px solid var(--color-line-strong);
+    border-radius: 999px;
+    padding: 6px 14px;
+    min-height: 34px;
+    cursor: pointer;
+    white-space: nowrap;
+    transition:
+      color 0.15s,
+      border-color 0.15s,
+      background-color 0.15s;
+    -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation;
+  }
+  .ch-pile-chip:hover {
+    color: var(--color-text);
+    background: var(--color-action-hover);
+  }
+  .ch-pile-chip[aria-pressed='true'] {
+    color: var(--color-primary);
+    border-color: var(--color-primary);
+    background: color-mix(in srgb, var(--color-primary) 8%, var(--color-surface));
+  }
+  .ch-pile-chip:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+</style>

--- a/frontend/app/src/lib/chores/lib/state.svelte.ts
+++ b/frontend/app/src/lib/chores/lib/state.svelte.ts
@@ -29,6 +29,7 @@ import type {
   MemberDto,
   ChoreLensId,
   DueState,
+  EffortTier,
   RosterState,
 } from './types';
 import { CHORE_LENSES } from './types';
@@ -104,6 +105,32 @@ function sortDirtiestFirst(a: ChoreDto, b: ChoreDto): number {
   return a.id - b.id;
 }
 
+/**
+ * Effort-weight rank for the "Quick first" ordering (Phase 15 R4′ WP-01, D2). The
+ * ONLY chore input this feature reads — the chore's declared weight, already on
+ * every ChoreDto. Never a per-person signal (VD.1 / MN1).
+ */
+const EFFORT_RANK: Record<EffortTier, number> = {
+  Quick: 0,
+  Standard: 1,
+  BigJob: 2,
+};
+
+/**
+ * "Quick first" ordering: ascending effort weight (Quick → Standard → BigJob) as
+ * the PRIMARY key, then the shipped dirtiest-first as the tiebreak. Applied only
+ * to the up-for-grabs pile when the Quick-first toggle is on (WP-01 D2). It NEVER
+ * recomputes dueness — the tiebreak defers to `sortDirtiestFirst`, which keys on
+ * the server `dueState` (M5/M7). Bucketing into attention sections is a stable
+ * partition, so sorting the whole set with this composite comparator yields
+ * effort-primary order WITHIN each section without flattening the sections.
+ */
+function sortQuickFirst(a: ChoreDto, b: ChoreDto): number {
+  const r = EFFORT_RANK[a.effortTier] - EFFORT_RANK[b.effortTier];
+  if (r !== 0) return r;
+  return sortDirtiestFirst(a, b);
+}
+
 class BoardStore {
   /** The one fetched payload. null until the first load resolves. */
   board = $state<ChoreBoardDto | null>(null);
@@ -113,6 +140,22 @@ class BoardStore {
 
   /** The active lens (ViewSwitcher). Defaults to Up-for-grabs. */
   lens = $state<ChoreLensId>('up-for-grabs');
+
+  // ── Up-for-grabs pile controls (Phase 15 R4′ — WP-01 "Quick wins") ─────────
+  //
+  // "Quick first" is a self-only, session-only PRESENTATION toggle on the pile:
+  // it re-orders each attention section effort-ascending (D2). It is default-OFF,
+  // reset on lens-switch and first board load, and PERSISTS NOWHERE (D4/M4 — not
+  // server, not localStorage). It reads ONLY the chore's declared weight
+  // (effortTier), never any per-person / gap signal (M1/MN1). Reset is imperative
+  // (in setLens / first setBoard), NOT a $effect (M9 — no setup-effect loop).
+  //
+  // The state lives as a $state FIELD on this class instance, never an exported
+  // reassigned rune (M9 / rune-export rule). WP-03 adds the `pileFitsMe` filter
+  // beside it; the filter runs BEFORE sectioning, this sort runs within-section.
+
+  /** "Quick first" pile ordering toggle (up-for-grabs only). Default-off; session-only. */
+  pileQuickFirst = $state(false);
 
   /** This household member's userId — set once on init from the shell context. */
   currentUserId = $state(0);
@@ -337,13 +380,22 @@ class BoardStore {
   // fields it reads.
 
   boardSections = $derived.by<NeedsAttentionSection[]>(() => {
+    // 1. Pick the lens's chore set. This is the pre-section stage — WP-03's
+    //    "Fits me" filter narrows the up-for-grabs `set` HERE (filter-before-section,
+    //    D3), before the sort + bucketing below.
     const set =
       this.lens === 'up-for-grabs'
         ? this.upForGrabsChores
         : this.lens === 'mine'
           ? this.mineChores
           : this.chores; // 'needs-attention' ⇒ All
-    const ordered = [...set].sort(sortDirtiestFirst);
+    // 2. Order the set. On the up-for-grabs pile with "Quick first" ON, use the
+    //    effort-primary comparator (D2 — Quick→Standard→BigJob, dirtiest-first
+    //    tiebreak); everywhere else keep the shipped dirtiest-first. The bucketing
+    //    below is a stable partition, so this yields effort-primary order WITHIN
+    //    each attention section without recomputing dueness (M5/M7).
+    const quickFirst = this.lens === 'up-for-grabs' && this.pileQuickFirst;
+    const ordered = [...set].sort(quickFirst ? sortQuickFirst : sortDirtiestFirst);
     const fallingBehind: ChoreDto[] = [];
     const dueNow: ChoreDto[] = [];
     const comingUp: ChoreDto[] = [];
@@ -374,12 +426,21 @@ class BoardStore {
   );
 
   setBoard(next: ChoreBoardDto): void {
+    // Capture BEFORE initLensFromDefault flips the guard — true only on the very
+    // first board load of this store instance (a full page reload recreates the
+    // singleton, so this fires again then, satisfying "off after reload").
+    const firstLoad = !this.defaultViewInitialized;
     this.board = next;
     this.error = null;
     // Keep the local default mirror in sync with the authoritative payload, and
     // (on the FIRST load only) land on the user's roaming default lens.
     this.defaultView = coerceLens(next.userDefaultView);
     this.initLensFromDefault();
+    // Pile controls are default-off on first load (D4/M4). We reset ONLY on first
+    // load — never on the periodic liveness refetch, which also lands here and
+    // would otherwise stomp an active in-session toggle every ~20s. Lens-switches
+    // are handled separately in setLens().
+    if (firstLoad) this.pileQuickFirst = false;
     // The board refetch path (loadBoard / setRefresh / liveness) may have
     // included a completion from another user, so the cached equity payload is
     // potentially stale. Invalidate (and reload if the equity lens is active).
@@ -388,6 +449,14 @@ class BoardStore {
 
   setLens(next: ChoreLensId): void {
     this.lens = next;
+    // Default-off, no sticky personalization of the shared pile (D4/M4): a lens
+    // switch always resets the pile controls. Imperative reset, NOT a $effect (M9).
+    this.pileQuickFirst = false;
+  }
+
+  /** Toggle the up-for-grabs "Quick first" ordering (WP-01). Session-only, persists nowhere. */
+  togglePileQuickFirst(): void {
+    this.pileQuickFirst = !this.pileQuickFirst;
   }
 
   // ── Equity lens fetch + invalidation ──────────────────────────────────────

--- a/frontend/app/src/lib/chores/lib/state.svelte.ts
+++ b/frontend/app/src/lib/chores/lib/state.svelte.ts
@@ -33,6 +33,7 @@ import type {
   RosterState,
 } from './types';
 import { CHORE_LENSES } from './types';
+import { showsFitsMe, fitsCapacity } from './capacity-fit';
 import {
   ApiError,
   claimChore,
@@ -141,21 +142,28 @@ class BoardStore {
   /** The active lens (ViewSwitcher). Defaults to Up-for-grabs. */
   lens = $state<ChoreLensId>('up-for-grabs');
 
-  // ── Up-for-grabs pile controls (Phase 15 R4′ — WP-01 "Quick wins") ─────────
+  // ── Up-for-grabs pile controls (Phase 15 R4′ — capacity-fit) ───────────────
   //
-  // "Quick first" is a self-only, session-only PRESENTATION toggle on the pile:
-  // it re-orders each attention section effort-ascending (D2). It is default-OFF,
-  // reset on lens-switch and first board load, and PERSISTS NOWHERE (D4/M4 — not
-  // server, not localStorage). It reads ONLY the chore's declared weight
-  // (effortTier), never any per-person / gap signal (M1/MN1). Reset is imperative
-  // (in setLens / first setBoard), NOT a $effect (M9 — no setup-effect loop).
+  // Two self-only, session-only toggles on the up-for-grabs pile. BOTH are
+  // default-OFF, reset on lens-switch and first board load, and PERSIST NOWHERE
+  // (D4/M4 — not server, not localStorage). Both read ONLY the chore's declared
+  // weight (effortTier) × the viewer's OWN self-set tier — never any per-person
+  // share / history / gap signal (M1/M6/MN1). Reset is imperative (in setLens /
+  // first setBoard), NOT a $effect (M9 — no setup-effect loop). The state lives as
+  // $state FIELDS on this class instance, never an exported reassigned rune (M9).
   //
-  // The state lives as a $state FIELD on this class instance, never an exported
-  // reassigned rune (M9 / rune-export rule). WP-03 adds the `pileFitsMe` filter
-  // beside it; the filter runs BEFORE sectioning, this sort runs within-section.
+  //   "Quick first" (WP-01) — a PRESENTATION sort: orders each attention section
+  //   effort-ascending (D2). Symmetric — identical for every member.
+  //   "Fits me" (WP-03) — a self-only FILTER: narrows the pile to the tiers that
+  //   fit the viewer's own capacity (Minimal→Quick; Reduced→Quick+Standard). The
+  //   chip renders only for a Reduced/Minimal caller (whitelist gate). Runs
+  //   BEFORE sectioning (filter-before-section, D3); Quick-first sorts within.
 
   /** "Quick first" pile ordering toggle (up-for-grabs only). Default-off; session-only. */
   pileQuickFirst = $state(false);
+
+  /** "Fits me" pile filter toggle (up-for-grabs, Reduced/Minimal callers only). Default-off; session-only. */
+  pileFitsMe = $state(false);
 
   /** This household member's userId — set once on init from the shell context. */
   currentUserId = $state(0);
@@ -364,6 +372,29 @@ class BoardStore {
       .sort(sortDirtiestFirst);
   });
 
+  // ── Capacity-fit derived state (Phase 15 R4′ WP-03) ──────────────────────
+  //
+  // All derived from the board payload + the two toggles. Declared AFTER
+  // upForGrabsChores (pileSetAsideCount reads it) and BEFORE boardSections (which
+  // reads pileFitsMeActive + callerCapacityTier), per the class-$derived ordering
+  // rule already noted on boardSections.
+
+  /** The caller's OWN capacity tier off the board payload (null ⇒ Full). Drives the Fits-me chip + filter. */
+  callerCapacityTier = $derived<CapacityTier | null>(this.board?.callerCapacityTier ?? null);
+
+  /** Whether the "Fits me" chip renders — WHITELIST gate: Reduced/Minimal only (null/Full never — V1.3). */
+  showFitsMeChip = $derived(showsFitsMe(this.callerCapacityTier));
+
+  /** True when the Fits-me filter is actively narrowing the pile (up-for-grabs + toggle on + eligible tier). */
+  pileFitsMeActive = $derived(this.lens === 'up-for-grabs' && this.pileFitsMe && this.showFitsMeChip);
+
+  /** Count of up-for-grabs chores hidden by the active Fits-me filter — the "N bigger lifts set aside" row. */
+  pileSetAsideCount = $derived(
+    this.pileFitsMeActive
+      ? this.upForGrabsChores.filter((c) => !fitsCapacity(c.effortTier, this.callerCapacityTier)).length
+      : 0,
+  );
+
   // ── Unified attention-sectioned board (Phase 14 — Model A board IA) ──────
   //
   // The board ALWAYS sections by attention (Falling behind / Due now / Coming
@@ -380,15 +411,21 @@ class BoardStore {
   // fields it reads.
 
   boardSections = $derived.by<NeedsAttentionSection[]>(() => {
-    // 1. Pick the lens's chore set. This is the pre-section stage — WP-03's
-    //    "Fits me" filter narrows the up-for-grabs `set` HERE (filter-before-section,
-    //    D3), before the sort + bucketing below.
-    const set =
+    // 1. Pick the lens's chore set.
+    let set =
       this.lens === 'up-for-grabs'
         ? this.upForGrabsChores
         : this.lens === 'mine'
           ? this.mineChores
           : this.chores; // 'needs-attention' ⇒ All
+    // 1b. WP-03 "Fits me" — the pre-section FILTER (filter-before-section, D3): narrow the up-for-grabs pile
+    //     to the tiers that fit the viewer's OWN capacity (self-tier × chore-weight only; never a per-person
+    //     share/gap — M1/M6/MN1). Active only for a Reduced/Minimal caller with the toggle on. The hidden
+    //     ("set aside") chores stay one tap away via pileSetAsideCount + the board's escape-hatch row.
+    if (this.pileFitsMeActive) {
+      const tier = this.callerCapacityTier;
+      set = set.filter((c) => fitsCapacity(c.effortTier, tier));
+    }
     // 2. Order the set. On the up-for-grabs pile with "Quick first" ON, use the
     //    effort-primary comparator (D2 — Quick→Standard→BigJob, dirtiest-first
     //    tiebreak); everywhere else keep the shipped dirtiest-first. The bucketing
@@ -440,7 +477,10 @@ class BoardStore {
     // load — never on the periodic liveness refetch, which also lands here and
     // would otherwise stomp an active in-session toggle every ~20s. Lens-switches
     // are handled separately in setLens().
-    if (firstLoad) this.pileQuickFirst = false;
+    if (firstLoad) {
+      this.pileQuickFirst = false;
+      this.pileFitsMe = false;
+    }
     // The board refetch path (loadBoard / setRefresh / liveness) may have
     // included a completion from another user, so the cached equity payload is
     // potentially stale. Invalidate (and reload if the equity lens is active).
@@ -450,13 +490,19 @@ class BoardStore {
   setLens(next: ChoreLensId): void {
     this.lens = next;
     // Default-off, no sticky personalization of the shared pile (D4/M4): a lens
-    // switch always resets the pile controls. Imperative reset, NOT a $effect (M9).
+    // switch always resets BOTH pile controls. Imperative reset, NOT a $effect (M9).
     this.pileQuickFirst = false;
+    this.pileFitsMe = false;
   }
 
   /** Toggle the up-for-grabs "Quick first" ordering (WP-01). Session-only, persists nowhere. */
   togglePileQuickFirst(): void {
     this.pileQuickFirst = !this.pileQuickFirst;
+  }
+
+  /** Toggle the up-for-grabs "Fits me" filter (WP-03). Session-only, persists nowhere. */
+  togglePileFitsMe(): void {
+    this.pileFitsMe = !this.pileFitsMe;
   }
 
   // ── Equity lens fetch + invalidation ──────────────────────────────────────

--- a/frontend/app/src/lib/chores/lib/types.ts
+++ b/frontend/app/src/lib/chores/lib/types.ts
@@ -133,6 +133,12 @@ export interface ChoreBoardDto {
   needsAttentionChoreIds: number[];
   /** Persisted lens id; null ⇒ Up-for-grabs. One of ChoreLens (see below). */
   userDefaultView: string | null;
+  /**
+   * The REQUESTING user's OWN physical-capacity tier (Phase 15 R4′); `null` ⇒ Full (the pre-migration
+   * default). Rides the board payload so the up-for-grabs "Fits me" chip reads the caller's tier without the
+   * separately-cached equity fetch. Serializes AFTER `userDefaultView` (additive init-only body property).
+   */
+  callerCapacityTier: CapacityTier | null;
 }
 
 // ─── Rooms (admin surface, /api/rooms) ──────────────────────────────────────

--- a/frontend/app/vitest.config.ts
+++ b/frontend/app/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+// Standalone vitest config — deliberately does NOT load the SvelteKit vite plugin.
+// The only unit tests here cover rune-free, dependency-free pure modules (e.g.
+// src/lib/chores/lib/capacity-fit.ts — the R4′ founding-case gate, V1.6), so the
+// default `node` environment is sufficient and avoids the kit dev/build lifecycle.
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+    environment: 'node',
+  },
+});

--- a/src/FamilyCoordinationApp/Services/ChoreBoardService.cs
+++ b/src/FamilyCoordinationApp/Services/ChoreBoardService.cs
@@ -47,10 +47,16 @@ public class ChoreBoardService(
             .Select(u => new MemberDto(u.Id, u.DisplayName, u.Initials, u.PictureUrl))
             .ToListAsync(cancellationToken);
 
-        var userDefaultView = await context.Users
+        // The caller's own row carries BOTH the roaming default lens AND (Phase 15 R4′) the self-set
+        // physical-capacity tier the up-for-grabs "Fits me" chip reads. Widen the existing single-user
+        // projection to an anonymous type — STILL ONE query (E4), no new round-trip. A missing row (caller not
+        // found) ⇒ both null, preserving the prior FirstOrDefault-on-string behavior.
+        var caller = await context.Users
             .Where(u => u.HouseholdId == householdId && u.Id == userId)
-            .Select(u => u.ChoresDefaultView)
+            .Select(u => new { u.ChoresDefaultView, u.PhysicalCapacityTier })
             .FirstOrDefaultAsync(cancellationToken);
+        var userDefaultView = caller?.ChoresDefaultView;
+        var callerCapacityTier = caller?.PhysicalCapacityTier;
 
         // P5: Lazy progress query — only issued when the household has at least one multi-person chore.
         // Load completions in ONE query, group by ChoreId; single-person chores get an empty set.
@@ -157,7 +163,10 @@ public class ChoreBoardService(
             rollups,
             members,
             needsAttentionIds,
-            userDefaultView);
+            userDefaultView)
+        {
+            CallerCapacityTier = callerCapacityTier,
+        };
     }
 
     /// <inheritdoc />

--- a/src/FamilyCoordinationApp/Services/Dtos/ChoreDtos.cs
+++ b/src/FamilyCoordinationApp/Services/Dtos/ChoreDtos.cs
@@ -15,7 +15,21 @@ public sealed record ChoreBoardDto(
     IReadOnlyList<RoomRollupDto> Rooms,
     IReadOnlyList<MemberDto> Members,
     IReadOnlyList<int> NeedsAttentionChoreIds,
-    string? UserDefaultView);
+    string? UserDefaultView)
+{
+    /// <summary>
+    /// The REQUESTING user's own physical-capacity tier (<c>Full</c> / <c>Reduced</c> / <c>Minimal</c>;
+    /// <c>null</c> ⇒ Full, the pre-migration default). Phase 15 R4′: rides the board payload so the
+    /// up-for-grabs "Fits me" chip reads the caller's tier WITHOUT the separately-cached equity fetch (which
+    /// loads only on the equity lens, so on the default board surface it is null). Sourced from
+    /// <c>User.PhysicalCapacityTier</c> by widening the existing single-user caller projection in
+    /// <c>GetBoardAsync</c> — still ONE query (no new round-trip). Additive <c>init</c>-only property in the
+    /// record BODY (no primary-ctor arity change) so both positional <c>new ChoreBoardDto(...)</c> sites stay
+    /// valid — set via object initializer (mirrors <c>ChoreEquityDto.CallerCapacityTier</c>). Serializes
+    /// camelCase as <c>callerCapacityTier</c>, AFTER the positional keys.
+    /// </summary>
+    public string? CallerCapacityTier { get; init; }
+}
 
 /// <summary>
 /// A single chore with its <b>computed</b> dueness/freshness state (WP-02). The island renders

--- a/tests/FamilyCoordinationApp.Tests/Fixtures/ChoreBoard/board.json
+++ b/tests/FamilyCoordinationApp.Tests/Fixtures/ChoreBoard/board.json
@@ -255,5 +255,6 @@
     2,
     3
   ],
-  "userDefaultView": "rooms"
+  "userDefaultView": "rooms",
+  "callerCapacityTier": "Reduced"
 }

--- a/tests/FamilyCoordinationApp.Tests/Services/ChoreBoardDtoContractTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/ChoreBoardDtoContractTests.cs
@@ -253,7 +253,12 @@ public class ChoreBoardDtoContractTests
             rooms,
             members,
             needsAttention,
-            UserDefaultView: ChoreLens.Rooms);
+            UserDefaultView: ChoreLens.Rooms)
+        {
+            // Phase 15 R4′: the caller's own capacity tier rides the board payload (init-only body property).
+            // A non-null value ("Reduced" — the founding-case tier) exercises the added field in the contract.
+            CallerCapacityTier = "Reduced",
+        };
     }
 
     [Fact]
@@ -282,8 +287,9 @@ public class ChoreBoardDtoContractTests
         var root = JsonNode.Parse(json)!.AsObject();
 
         // Top-level camelCase property set is frozen (M9 — added/removed keys break this).
+        // Phase 15 R4′ added the 6th key `callerCapacityTier` (init-only body property, serializes last).
         root.Select(kvp => kvp.Key).Should().BeEquivalentTo(
-            "chores", "rooms", "members", "needsAttentionChoreIds", "userDefaultView");
+            "chores", "rooms", "members", "needsAttentionChoreIds", "userDefaultView", "callerCapacityTier");
 
         var firstChore = root["chores"]!.AsArray()[0]!.AsObject();
         firstChore.Select(kvp => kvp.Key).Should().BeEquivalentTo(

--- a/tests/FamilyCoordinationApp.Tests/Services/ChoreBoardServiceTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/ChoreBoardServiceTests.cs
@@ -348,6 +348,30 @@ public class ChoreBoardServiceTests
     }
 
     [Fact]
+    public async Task CallerCapacityTier_ReflectsTheCallerOnly_NullWhenUnset()
+    {
+        // Phase 15 R4′ (V1.2): the board carries the CALLER's own physical-capacity tier, sourced from
+        // User.PhysicalCapacityTier on the SAME single-user caller projection as the default view. Give Alice
+        // a Reduced tier; leave Bob's unset.
+        using (var ctx = new ApplicationDbContext(_options))
+        {
+            ctx.Users.Single(u => u.Id == Alice).PhysicalCapacityTier = "Reduced";
+            ctx.SaveChanges();
+        }
+        Seed(OneOff(1, H1, new DateOnly(2026, 5, 30)));
+
+        // The caller (Alice) sees her own tier.
+        var aliceBoard = await CreateService().GetBoardAsync(H1, Alice, Now);
+        aliceBoard.CallerCapacityTier.Should().Be("Reduced");
+
+        // Bob (same household, tier unset) sees null (⇒ Full). The field is CALLER-scoped — it is never
+        // leaked from another member's row, even though Alice in the same household is Reduced.
+        var bobBoard = await CreateService().GetBoardAsync(H1, Bob, Now);
+        bobBoard.CallerCapacityTier.Should().BeNull(
+            "the board carries only the caller's own tier, never another member's");
+    }
+
+    [Fact]
     public async Task IsClaimStale_True_ForClaimOlderThanThreshold_ButStillDisplayedClaimed()
     {
         // Claimed > 48h ago => stale on read; the chore is still surfaced as Claimed (no materialized release).


### PR DESCRIPTION
## Phase 15 R4′ — Chores capacity-fit ("Quick wins" + "Fits me")

Completes the open remainder of Phase 15 (the equity measurement slice R1–R3 shipped in #43). R4-as-conceived — a gap-driven suggestion (`SharePct − ExpectedSharePct`) — was killed by the framing grill because that router structurally targets the capacity-limited planner in every tier configuration (the forbidden "who's behind" ranking with a euphemism). What ships, reshaped, is **capacity-fit**: match the *chore's* declared weight to the *viewer's own* self-set capacity tier. **Chore-subject, self-only, pull-only, zero new data or math.**

Spec: `data/outputs/workshops/fca-phase15-r4-capacity-fit/spec.md` (lite, council-hardened, operator-approved 2026-07-06).

### What ships

**v0 "Quick wins" (WP-01, frontend-only)**
- Each up-for-grabs card's effort chip becomes a legible **weight gauge**: 3 dots filled to tier rank (Quick 1 / Standard 2 / Big job 3) + named tier + points.
- A **"Quick first"** toolbar toggle orders each attention section effort-ascending (dirtiest-first tiebreak) **within** the server-`dueState` sections — never flattens them. Symmetric: identical for every member (reads only `effortTier`).

**v1 "Fits me" (WP-02 backend + WP-03 frontend)**
- WP-02: `CallerCapacityTier` rides the board DTO as an additive `init`-only body property (mirrors `ChoreEquityDto.CallerCapacityTier`), sourced by widening the existing single-user caller projection in `GetBoardAsync` — **still one query, no N+1**.
- WP-03: a **self-only "Fits me" chip**, rendered only for a **Reduced/Minimal** caller (whitelist gate — `null` and `'Full'` both hide it; never `tier !== 'Full'`). It filters the pile to the tiers that fit the viewer's own capacity (Minimal→Quick; Reduced→Quick+Standard). Filter-before-section; the hidden lifts stay one tap away via a **"N bigger lifts set aside · Show them"** row + the provenance note *"Matched to each chore's weight and your own capacity setting — never to history."*

Both toggles are **default-off, session-only, reset on lens-switch + first load, persist nowhere**.

**WP-04** (equity "this week" heading nit) — **dropped**: the cartography lens confirmed no mislabel exists.

### Doctrine (the crux — this is what makes R4′ legitimate)

- **No gap signal** in the pile path (VD.1 grep of `sharePct`/`expectedSharePct`/`equalSharePct`/`fallingBehindCount` = zero).
- **No push** — no notification, digest line, home card, nav badge, toast, or timer (VD.2).
- **No memory** — no new entity/migration/column/localStorage; the board field is a *read* of an existing column (VD.3).
- **Chore-subject copy** — no second-person deficit phrasing (VD.4 grep = zero).
- **Founding case:** a Full/unset viewer (e.g. Justin) is *never* shown the per-person chip; a Reduced planner (Natalie) finds work that fits without ever being told she's behind.

### Verification

- **`dotnet test --filter Board` → 44 passed / 0 failed** — the M9 contract fixture (+ the 6th key `callerCapacityTier`) and a new service test (the board reflects the *caller's own* tier, `null` when unset, never leaked from another member's row).
- **`npm test` (vitest) → 6 passed** — `capacity-fit.test.ts` pins the whitelist gate so the forbidden `tier !== 'Full'` regression can never leak the chip to a null-tier user (V1.6, the automatable founding-case proof). *First frontend test harness — follow-up: wire `npm test` into CI.*
- **`npm run check` clean** (0 errors).
- **Browser-verified end-to-end at :8080, light + dark** (rebuilt image + swapped container): Quick-first reorders within sections + restores + hides on Mine + resets on return; as Justin (tier null) the board carries `callerCapacityTier:null` and shows **no** Fits-me chip; set his tier→Reduced and the chip appears, filters to Quick+Standard, sets aside 2 BigJobs, "Show them" reveals the full pile. Justin's tier restored to null after the test.

### Commits
- `9d1d449` WP-01 — Quick wins (weighted pile + quick-first sort)
- `3644663` WP-02 — CallerCapacityTier on the board DTO
- `59d527d` WP-03 — self-only "Fits me" capacity filter

https://claude.ai/code/session_01Pq4fvgiFFxLht9nSa4cqK3
