### PR TITLE
fix(fca): three user-facing SPA bugs (settings drag, meal-plan week race, SW icon staleness)

### DIFF
--- a/frontend/app/src/lib/meal-plan/lib/state.svelte.ts
+++ b/frontend/app/src/lib/meal-plan/lib/state.svelte.ts
@@ -97,11 +97,21 @@ class MealPlanStore {
    * the first load; liveness refreshes are silent.
    */
   async loadBoard(): Promise<void> {
+    // Capture the week this load targets. Two getBoard calls for different weeks can be in flight at
+    // once (a liveness reconcile racing changeWeek, or rapid prev/next); without this guard the OLDER
+    // response can land last and — because setBoard() adopts the response's weekStartDate — snap the
+    // board back to the wrong week. Mirror the targetWeek capture/compare addEntry already uses.
+    const targetWeek = this.weekStart;
     try {
       if (this.board == null) this.loading = true;
       this.error = null;
-      this.setBoard(await getBoard(this.weekStart));
+      const next = await getBoard(targetWeek);
+      // Discard a stale response: the user moved to another week while this GET was in flight.
+      if (this.weekStart !== targetWeek) return;
+      this.setBoard(next);
     } catch (e) {
+      // A stale week's failure is moot — only surface an error for the week still in view.
+      if (this.weekStart !== targetWeek) return;
       if (e instanceof ApiError) {
         this.error = `Failed to load the meal plan (HTTP ${e.status}).`;
       } else {

--- a/frontend/app/src/lib/settings/CategoriesApp.svelte
+++ b/frontend/app/src/lib/settings/CategoriesApp.svelte
@@ -42,16 +42,21 @@
 
   // Drag-reorder: a local copy svelte-dnd-action mutates during a drag, resynced
   // from the store whenever we're NOT dragging (the chores/recipes pattern).
-  let rows = $state<CategoryDto[]>([]);
+  // svelte-dnd-action requires every item to carry an `id`; CategoryDto keys on
+  // `categoryId`, so we drag over a lightweight row that ADDS `id` — without it,
+  // svelte-dnd-action (0.9.70) throws 'missing id property for item' on init and
+  // reorder is dead (same class as the shopping-list cross-category drag bug).
+  type DragRow = CategoryDto & { id: number };
+  let rows = $state<DragRow[]>([]);
   let dragging = $state(false);
   $effect(() => {
-    if (!dragging) rows = [...store.active];
+    if (!dragging) rows = store.active.map((c) => ({ ...c, id: c.categoryId }));
   });
-  function handleConsider(e: CustomEvent<DndEvent<CategoryDto>>) {
+  function handleConsider(e: CustomEvent<DndEvent<DragRow>>) {
     dragging = true;
     rows = e.detail.items;
   }
-  function handleFinalize(e: CustomEvent<DndEvent<CategoryDto>>) {
+  function handleFinalize(e: CustomEvent<DndEvent<DragRow>>) {
     rows = e.detail.items;
     dragging = false;
     void store.reorder(rows.map((c) => c.categoryId));
@@ -118,7 +123,7 @@
           onconsider={handleConsider}
           onfinalize={handleFinalize}
         >
-          {#each rows as cat (cat.categoryId)}
+          {#each rows as cat (cat.id)}
             <li class="set-row">
               <div class="set-row-main">
                 <span class="set-grip" aria-hidden="true">⠿</span>

--- a/frontend/app/static/service-worker.js
+++ b/frontend/app/static/service-worker.js
@@ -48,14 +48,9 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
-  // Cache-first ONLY for immutable/fingerprinted SPA assets (/_app/* is content-hashed
-  // per build) and the static icons. Everything else — including the server-rendered
-  // Razor pages (/account/*, /household/*, legal) and their assets — stays network-first
-  // so a deploy is picked up immediately.
-  if (
-    url.pathname.startsWith('/_app/') ||
-    (url.pathname.startsWith('/icons/') && /\.(png|svg|webp)$/.test(url.pathname))
-  ) {
+  // Immutable, content-hashed SPA assets (/_app/* is fingerprinted per build): cache-first
+  // FOREVER is correct — a new build changes the hash → new URL → cache miss → fetched fresh.
+  if (url.pathname.startsWith('/_app/')) {
     event.respondWith(
       caches.match(req).then(
         (cached) =>
@@ -66,6 +61,29 @@ self.addEventListener('fetch', (event) => {
             return res;
           }),
       ),
+    );
+    return;
+  }
+
+  // Stable-NAMED assets (PWA icons): STALE-WHILE-REVALIDATE — serve the cached copy for speed,
+  // but ALWAYS refetch in the background and update the cache so a deploy is picked up on the next
+  // load. This is the fix for the never-rotating CACHE_VERSION (its `?v=` is never passed by the
+  // registration, so the constant version means the activate purge never fires): a changed icon can
+  // no longer be pinned to its first-ever copy, WITHOUT relying on a cache-name rotation. Offline: the
+  // background refetch just fails and the cached copy stands. (Fingerprinted /_app/* above stays
+  // cache-first; only stable-named assets needed this.)
+  if (url.pathname.startsWith('/icons/') && /\.(png|svg|webp)$/.test(url.pathname)) {
+    event.respondWith(
+      caches.match(req).then((cached) => {
+        const revalidate = fetch(req)
+          .then((res) => {
+            const clone = res.clone();
+            caches.open(CACHE_NAME).then((c) => c.put(req, clone));
+            return res;
+          })
+          .catch(() => cached);
+        return cached || revalidate;
+      }),
     );
     return;
   }


### PR DESCRIPTION
Three pre-existing user-facing bugs surfaced during the post-R4′ campaign reconciliation (Spine quests `20955079`, `9a1f4e1c`, `c192e8dc`). None are de-Blazor regressions; the old island copies are gone, so only the live `$lib` copies are touched.

### 1. Settings → Categories reorder was dead
`svelte-dnd-action` 0.9.70 throws `'missing id property for item'` on init because `CategoryDto` keys on `categoryId`, not `id` — so the whole reorder never worked. Fix: drag over a lightweight row that adds `id: categoryId` (mapped back on finalize; `#each` keyed on `id`).
**Verified at :8080** — the dndzone now initialises cleanly (`role=list` / `listitem` / `tabindex=0` on every row, **zero console errors**; was throwing before).

### 2. Meal-plan board could snap to the wrong week
`loadBoard()` had no target-week guard, and `setBoard()` adopts the response's `weekStartDate`. With two `getBoard` calls in flight for different weeks (a liveness reconcile racing `changeWeek`, or rapid prev/next), the **older** response could land last and win — the board shows the wrong week. Fix: capture `targetWeek` before the GET and discard a stale response — the exact pattern `addEntry` already uses.

### 3. Service worker served PWA icons stale forever
`CACHE_VERSION` derives from a `?v=` param the registration never passes, so it's a constant → the `activate` purge never fires → stable-named cache-first assets (icons) serve their first-ever copy forever. Fix: switch stable-named `/icons/*` to **stale-while-revalidate** (serve cache, refetch in background, update cache) so freshness no longer depends on a cache-name rotation; fingerprinted `/_app/*` stays cache-first.

### Verification
- `npm run check` clean (0 errors) · `vitest` 6/6 · settings drag browser-verified at :8080.
- Diff is frontend-only (3 files). Bug 2 (a timing race) and Bug 3 (cross-deploy SW behaviour) aren't browser-automatable; they rest on the code fixes — Bug 2 mirrors the proven `addEntry` precedent.

https://claude.ai/code/session_01Pq4fvgiFFxLht9nSa4cqK3
