### PR TITLE
perf(dashboard): lean chore home-stats read instead of full board build

### DIFF
--- a/src/FamilyCoordinationApp/Services/ChoreBoardService.cs
+++ b/src/FamilyCoordinationApp/Services/ChoreBoardService.cs
@@ -170,6 +170,67 @@ public class ChoreBoardService(
     }
 
     /// <inheritdoc />
+    public async Task<ChoreHomeStatsDto> GetHomeStatsAsync(
+        int householdId,
+        DateTime? now = null,
+        CancellationToken cancellationToken = default)
+    {
+        var asOf = now ?? timeProvider.GetUtcNow().UtcDateTime;
+
+        await using var context = await dbFactory.CreateDbContextAsync(cancellationToken);
+
+        // EXACTLY GetBoardAsync's active set (M1 household filter + Status == Active), but projected down to
+        // the recurrence + assignment fields the two calculator calls read — no rooms, members, completions,
+        // participation, subtasks, or ChoreRoom memberships are touched. One row per chore: room fan-out is a
+        // rollup concern only, so a multi-room chore counts ONCE here, exactly like board.Chores (MN1).
+        var chores = await context.Chores
+            .Where(c => c.HouseholdId == householdId && c.Status == ChoreStatus.Active)
+            .Select(c => new
+            {
+                c.RecurrenceMode,
+                c.IntervalDays,
+                c.AnchorDate,
+                c.DaysOfWeek,
+                c.DayOfMonth,
+                c.LastCompletedAt,
+                c.SnoozedUntil,
+                c.AssignmentKind,
+                c.ClaimedAt,
+            })
+            .ToListAsync(cancellationToken);
+
+        // Same reduction as ChoreHomeStats.Compute over the board's ChoreDtos, applied to the same computed
+        // dueness inputs: a snoozed chore already reads Scheduled (auto-excluded from Overdue/DueToday); only
+        // UpForGrabs needs the explicit !IsSnoozed guard, or a snoozed unclaimed chore would still surface.
+        int overdue = 0, dueToday = 0, upForGrabs = 0;
+        foreach (var c in chores)
+        {
+            var snapshot = new ChoreRecurrenceSnapshot(
+                c.RecurrenceMode, c.IntervalDays, c.AnchorDate, c.DaysOfWeek, c.DayOfMonth,
+                c.LastCompletedAt, c.SnoozedUntil);
+            var dueness = calculator.Compute(snapshot, asOf, timeZone);
+
+            if (dueness.DueState == DueState.Overdue)
+            {
+                overdue++;
+            }
+            else if (dueness.DueState == DueState.DueToday)
+            {
+                dueToday++;
+            }
+
+            if (!dueness.IsSnoozed &&
+                (c.AssignmentKind == AssignmentKind.None ||
+                 calculator.IsClaimStale(c.AssignmentKind, c.ClaimedAt, asOf)))
+            {
+                upForGrabs++;
+            }
+        }
+
+        return new ChoreHomeStatsDto(chores.Count, overdue, dueToday, upForGrabs);
+    }
+
+    /// <inheritdoc />
     public ChoreDto ProjectChore(Chore chore, DateTime now, TimeZoneInfo timeZone, IReadOnlyList<int> roomIds)
     {
         var dueness = calculator.Compute(ChoreRecurrenceSnapshot.FromChore(chore), now, timeZone);

--- a/src/FamilyCoordinationApp/Services/DashboardService.cs
+++ b/src/FamilyCoordinationApp/Services/DashboardService.cs
@@ -9,8 +9,9 @@ namespace FamilyCoordinationApp.Services;
 /// <summary>
 /// Aggregates the dashboard island payload (strangler — mirrors <see cref="MealPlanBoardService"/>). Pure
 /// composition over the existing domain services + a focused today-meals query; adds NO new business logic so
-/// it rides those services' existing tests. The chore counts reuse the server-side, unit-tested
-/// <see cref="ChoreHomeStats"/> reducer directly (same assembly) rather than re-implementing the snooze guard.
+/// it rides those services' existing tests. The chore counts come from the lean
+/// <see cref="IChoreBoardService.GetHomeStatsAsync"/> read (equivalence-locked to the full board +
+/// <see cref="ChoreHomeStats"/> reducer) rather than building the whole board just to count.
 /// Read-only — never creates a plan/list/board row (an empty household yields zero counts / empty meals). All
 /// reads create short-lived contexts via the factory and filter by <c>HouseholdId</c> (M1).
 /// </summary>
@@ -28,12 +29,13 @@ public class DashboardService(
     {
         var householdName = await GetHouseholdNameAsync(userId, cancellationToken);
 
-        // Chores: reuse the board read + the SERVER-side, unit-tested ChoreHomeStats reducer (incl. the
-        // snooze guard on up-for-grabs). Parity with Home.razor's LoadChoreStats.
-        var board = await choreBoardService.GetBoardAsync(householdId, userId, cancellationToken: cancellationToken);
-        var choreStats = ChoreHomeStats.Compute(board.Chores);
+        // Chores: the lean count read (GetHomeStatsAsync) instead of the FULL board build — the dashboard only
+        // needs the four counts, not rooms/rollups/roster folds/subtasks. Counting semantics are locked to the
+        // board + ChoreHomeStats reducer by ChoreBoardHomeStatsTests' equivalence test (incl. the snooze guard
+        // on up-for-grabs and once-per-chore multi-room counting).
+        var choreStats = await choreBoardService.GetHomeStatsAsync(householdId, cancellationToken: cancellationToken);
         var chores = new DashboardChoreSummaryDto(
-            choreStats.Total, choreStats.Overdue, choreStats.DueToday, choreStats.UpForGrabs);
+            choreStats.ActiveTotal, choreStats.Overdue, choreStats.DueToday, choreStats.UpForGrabs);
 
         // Shopping: sum across ALL active (non-archived) lists — the household may have several going at once
         // and the card reflects everything still to buy (parity with Home.razor's LoadShoppingListStats).

--- a/src/FamilyCoordinationApp/Services/Dtos/ChoreDtos.cs
+++ b/src/FamilyCoordinationApp/Services/Dtos/ChoreDtos.cs
@@ -160,6 +160,21 @@ public enum RoomRollupStatus
 }
 
 /// <summary>
+/// The four Home/dashboard chore-card counts, computed server-side over the SAME active set
+/// <c>GetBoardAsync</c> projects (HouseholdId + <c>Status == Active</c>, one row per chore — multi-room
+/// membership never fans this out). Field-for-field mirror of <see cref="ChoreHomeStats.Result"/> /
+/// <c>DashboardChoreSummaryDto</c>: <see cref="Overdue"/>/<see cref="DueToday"/> read computed dueness
+/// (a snoozed chore reads <c>Scheduled</c>, so it is auto-excluded); <see cref="UpForGrabs"/> is
+/// <c>!IsSnoozed &amp;&amp; (AssignmentKind == None || claim-stale)</c>. Produced by the lean
+/// <c>ChoreBoardService.GetHomeStatsAsync</c> read (no rooms/rollups/roster/subtasks/equity work).
+/// </summary>
+public sealed record ChoreHomeStatsDto(
+    int ActiveTotal,
+    int Overdue,
+    int DueToday,
+    int UpForGrabs);
+
+/// <summary>
 /// Named rollup thresholds (P4) — the bucket boundaries for <see cref="RoomRollupStatus"/>, derived from
 /// the count of due-or-overdue chores in a room (D9). 0 ⇒ Clean; 1..<see cref="NeedsWorkThreshold"/>-1 ⇒
 /// Attention; &gt;= <see cref="NeedsWorkThreshold"/> ⇒ NeedsWork.

--- a/src/FamilyCoordinationApp/Services/Interfaces/IChoreBoardService.cs
+++ b/src/FamilyCoordinationApp/Services/Interfaces/IChoreBoardService.cs
@@ -28,6 +28,21 @@ public interface IChoreBoardService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Compute ONLY the four Home/dashboard chore counts (<see cref="ChoreHomeStatsDto"/>) for the
+    /// household — a lean read for aggregate surfaces (the dashboard) that must NOT pay for the full board
+    /// (rooms, rollups, roster folds, subtasks). Counting semantics are IDENTICAL to deriving them from
+    /// <see cref="GetBoardAsync"/>'s <c>Chores</c> via the <c>ChoreHomeStats</c> reducer: same active set
+    /// (strict <paramref name="householdId"/> filter, M1; stored Done/Archived excluded), same computed
+    /// dueness/snooze gate (<see cref="ChoreStatusCalculator"/>), one row per chore (multi-room membership
+    /// never multiplies a chore). <paramref name="now"/> may be supplied for deterministic tests; when null
+    /// the service uses <c>TimeProvider.GetUtcNow()</c>.
+    /// </summary>
+    Task<ChoreHomeStatsDto> GetHomeStatsAsync(
+        int householdId,
+        DateTime? now = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Project a single <see cref="Chore"/> entity into its per-chore <see cref="ChoreDto"/>, computing the
     /// chore's dueness (<see cref="ChoreStatusCalculator.Compute"/>) and claim-staleness
     /// (<see cref="ChoreStatusCalculator.IsClaimStale"/>) as of <paramref name="now"/> in the configured

--- a/src/FamilyCoordinationApp/Services/Interfaces/IDashboardService.cs
+++ b/src/FamilyCoordinationApp/Services/Interfaces/IDashboardService.cs
@@ -5,7 +5,7 @@ namespace FamilyCoordinationApp.Services.Interfaces;
 /// <summary>
 /// Read + projection for the dashboard island aggregate (strangler — mirrors <c>IMealPlanBoardService</c>).
 /// Assembles the single <see cref="DashboardDto"/> by composing the existing domain services — the chore
-/// summary via <c>ChoreHomeStats.Compute</c> over <see cref="IChoreBoardService"/>, the shopping summary via
+/// summary via the lean <see cref="IChoreBoardService.GetHomeStatsAsync"/> count read, the shopping summary via
 /// <see cref="IShoppingListService"/>, and today's meals via a focused household-scoped query. Read-only: no
 /// writes, no row creation (an empty household yields zero counts / empty lists). All reads filter by
 /// <c>HouseholdId</c> (M1, resolved server-side — never client-supplied).

--- a/tests/FamilyCoordinationApp.Tests/Services/ChoreBoardHomeStatsTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/ChoreBoardHomeStatsTests.cs
@@ -1,0 +1,247 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using FamilyCoordinationApp.Data;
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Services;
+using FamilyCoordinationApp.Services.Dtos;
+
+namespace FamilyCoordinationApp.Tests.Services;
+
+/// <summary>
+/// Semantics lock for the lean <see cref="ChoreBoardService.GetHomeStatsAsync"/> count read (the dashboard's
+/// chore summary). The keystone is the EQUIVALENCE test: on a representative seed (overdue / due-today /
+/// future / snoozed / stale-claim / fresh-claim / multi-room / Done / Archived / other-household), the lean
+/// method must return counts EQUAL to deriving them from <see cref="ChoreBoardService.GetBoardAsync"/>'s
+/// flat <c>Chores</c> list via the <see cref="ChoreHomeStats"/> reducer — the exact composition
+/// <c>DashboardService</c> used before the swap. Concrete literals are asserted too, so both paths can't
+/// silently drift together. (InMemory, frozen <c>now</c> + fixed UTC <see cref="TimeZoneInfo"/> — mirrors
+/// <see cref="ChoreBoardServiceTests"/>.)
+/// </summary>
+public class ChoreBoardHomeStatsTests
+{
+    private const int H1 = 1;   // primary household
+    private const int H2 = 2;   // other household (isolation)
+    private const int Alice = 100;
+    private const int Bob = 101;
+
+    // A fixed evaluation instant. Use UTC so local-day == UTC-day and dueness reasoning is direct.
+    private static readonly DateTime Now = new(2026, 5, 30, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly DateOnly Today = new(2026, 5, 30);
+    private static readonly TimeZoneInfo Utc = TimeZoneInfo.Utc;
+
+    private readonly DbContextOptions<ApplicationDbContext> _options;
+
+    public ChoreBoardHomeStatsTests()
+    {
+        _options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        using var ctx = new ApplicationDbContext(_options);
+        ctx.Households.AddRange(
+            new Household { Id = H1, Name = "Smith" },
+            new Household { Id = H2, Name = "Jones" });
+        ctx.Users.AddRange(
+            new User { Id = Alice, HouseholdId = H1, Email = "a@x.com", DisplayName = "Alice", Initials = "AL" },
+            new User { Id = Bob, HouseholdId = H1, Email = "b@x.com", DisplayName = "Bob", Initials = "BO" },
+            new User { Id = 200, HouseholdId = H2, Email = "c@x.com", DisplayName = "Carol", Initials = "CA" });
+        ctx.SaveChanges();
+    }
+
+    private ChoreBoardService CreateService()
+    {
+        var dbFactory = new Mock<IDbContextFactory<ApplicationDbContext>>();
+        dbFactory.Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new ApplicationDbContext(_options));
+
+        return new ChoreBoardService(
+            dbFactory.Object,
+            new ChoreStatusCalculator(),
+            Utc,
+            TimeProvider.System);
+    }
+
+    private void Seed(params Chore[] chores)
+    {
+        using var ctx = new ApplicationDbContext(_options);
+        ctx.Chores.AddRange(chores);
+        ctx.SaveChanges();
+    }
+
+    private void SeedMemberships(params ChoreRoom[] memberships)
+    {
+        using var ctx = new ApplicationDbContext(_options);
+        ctx.ChoreRooms.AddRange(memberships);
+        ctx.SaveChanges();
+    }
+
+    private void SeedRooms(params Room[] rooms)
+    {
+        using var ctx = new ApplicationDbContext(_options);
+        ctx.Rooms.AddRange(rooms);
+        ctx.SaveChanges();
+    }
+
+    // A OneOff chore due on the given local date (Overdue if date < today, DueToday if ==, NotDue if future).
+    private static Chore OneOff(
+        int id,
+        int householdId,
+        DateOnly due,
+        AssignmentKind kind = AssignmentKind.None,
+        int? assignee = null,
+        DateTime? claimedAt = null,
+        DateOnly? snoozedUntil = null,
+        ChoreStatus status = ChoreStatus.Active) => new()
+    {
+        HouseholdId = householdId,
+        ChoreId = id,
+        Name = $"Chore {id}",
+        RecurrenceMode = RecurrenceMode.OneOff,
+        AnchorDate = due,
+        EffortTier = EffortTier.Standard,
+        EffortPoints = 2,
+        Status = status,
+        EnteredByUserId = Alice,
+        AssignmentKind = kind,
+        AssigneeUserId = assignee,
+        ClaimedAt = claimedAt,
+        SnoozedUntil = snoozedUntil,
+        CreatedAt = Now,
+    };
+
+    /// <summary>
+    /// The representative seed the equivalence test runs on — one chore per counting concern (see the
+    /// inline notes), plus the exclusions (Done / Archived / other household).
+    /// </summary>
+    private void SeedRepresentativeScenario()
+    {
+        SeedRooms(
+            new Room { HouseholdId = H1, RoomId = 10, Name = "Kitchen", Icon = "🍳", SortOrder = 1, CreatedAt = Now },
+            new Room { HouseholdId = H1, RoomId = 11, Name = "Bathroom", Icon = "🛁", SortOrder = 2, CreatedAt = Now });
+
+        Seed(
+            // 1: overdue + unassigned            → Overdue, UpForGrabs
+            OneOff(1, H1, new DateOnly(2026, 5, 1)),
+            // 2: due today, deliberately assigned → DueToday only (Assigned ≠ up-for-grabs)
+            OneOff(2, H1, Today, AssignmentKind.Assigned, Bob),
+            // 3: future + unassigned              → UpForGrabs only (dueness-independent pile membership)
+            OneOff(3, H1, new DateOnly(2026, 6, 15)),
+            // 4: would-be-overdue but SNOOZED past today, unassigned → Total only. The snooze gate reads
+            //    Scheduled (drops it from Overdue) AND the !IsSnoozed guard drops it from UpForGrabs.
+            OneOff(4, H1, new DateOnly(2026, 5, 1), snoozedUntil: new DateOnly(2026, 6, 5)),
+            // 6: future, FRESH claim (1h old < 48h threshold) → not up-for-grabs
+            OneOff(6, H1, new DateOnly(2026, 6, 20), AssignmentKind.Claimed, Bob, claimedAt: Now.AddHours(-1)),
+            // 7: overdue + unassigned, member of BOTH rooms → must count ONCE in every bucket (MN1)
+            OneOff(7, H1, new DateOnly(2026, 5, 2)),
+            // 8: stored Done  → excluded from the active set entirely
+            OneOff(8, H1, new DateOnly(2026, 5, 1), status: ChoreStatus.Done),
+            // 9: stored Archived → excluded from the active set entirely
+            OneOff(9, H1, new DateOnly(2026, 5, 1), status: ChoreStatus.Archived),
+            // 20: other household's overdue unassigned chore → NEVER visible to H1 (M1)
+            OneOff(20, H2, new DateOnly(2026, 5, 1)));
+
+        // 5: recurring flexible, decayed way past its interval (Overdue) with a STALE claim (3 days > 48h)
+        //    → Overdue AND UpForGrabs (stale-claim arm of the pile predicate).
+        Seed(new Chore
+        {
+            HouseholdId = H1,
+            ChoreId = 5,
+            Name = "Decayed stale-claimed flexible",
+            RecurrenceMode = RecurrenceMode.Flexible,
+            IntervalDays = 7,
+            LastCompletedAt = Now.AddDays(-30),
+            EffortTier = EffortTier.Standard,
+            EffortPoints = 2,
+            Status = ChoreStatus.Active,
+            EnteredByUserId = Alice,
+            AssignmentKind = AssignmentKind.Claimed,
+            AssigneeUserId = Bob,
+            ClaimedAt = Now.AddDays(-3),
+            CreatedAt = Now,
+        });
+
+        SeedMemberships(
+            new ChoreRoom { HouseholdId = H1, ChoreId = 7, RoomId = 10 },
+            new ChoreRoom { HouseholdId = H1, ChoreId = 7, RoomId = 11 });
+    }
+
+    // ------------------------------------------------------------------ the equivalence lock
+
+    [Fact]
+    public async Task HomeStats_EqualBoardDerivedCounts_OnRepresentativeScenario()
+    {
+        SeedRepresentativeScenario();
+        var service = CreateService();
+
+        // The OLD dashboard composition: full board build → ChoreHomeStats reducer over the flat list.
+        var board = await service.GetBoardAsync(H1, Alice, Now);
+        var derived = ChoreHomeStats.Compute(board.Chores);
+
+        // The NEW lean read.
+        var stats = await service.GetHomeStatsAsync(H1, Now);
+
+        // Field-for-field equivalence — the point of the exercise.
+        stats.ActiveTotal.Should().Be(derived.Total);
+        stats.Overdue.Should().Be(derived.Overdue);
+        stats.DueToday.Should().Be(derived.DueToday);
+        stats.UpForGrabs.Should().Be(derived.UpForGrabs);
+
+        // Concrete literals too, so the two paths can't drift together unnoticed:
+        // active = {1,2,3,4,5,6,7} (Done 8 / Archived 9 / H2's 20 excluded); multi-room 7 counts ONCE.
+        stats.ActiveTotal.Should().Be(7, "snoozed chores stay in the active total; Done/Archived/H2 are out");
+        stats.Overdue.Should().Be(3, "chores 1, 5, 7 — the snoozed 4 reads Scheduled, not Overdue");
+        stats.DueToday.Should().Be(1, "chore 2 is due on the frozen today");
+        stats.UpForGrabs.Should().Be(4, "unassigned 1, 3, 7 + stale-claimed 5; snoozed 4 and fresh-claimed 6 are out");
+    }
+
+    // ------------------------------------------------------------------ per-concern guards
+
+    [Fact]
+    public async Task HomeStats_MultiRoomChore_CountsOnce()
+    {
+        SeedRooms(
+            new Room { HouseholdId = H1, RoomId = 10, Name = "Kitchen", SortOrder = 1, CreatedAt = Now },
+            new Room { HouseholdId = H1, RoomId = 11, Name = "Bathroom", SortOrder = 2, CreatedAt = Now });
+        Seed(OneOff(1, H1, new DateOnly(2026, 5, 1)));   // overdue + unassigned
+        SeedMemberships(
+            new ChoreRoom { HouseholdId = H1, ChoreId = 1, RoomId = 10 },
+            new ChoreRoom { HouseholdId = H1, ChoreId = 1, RoomId = 11 });
+
+        var stats = await CreateService().GetHomeStatsAsync(H1, Now);
+
+        stats.Should().Be(new ChoreHomeStatsDto(
+            ActiveTotal: 1, Overdue: 1, DueToday: 0, UpForGrabs: 1),
+            "a 2-room chore is one chore — room fan-out is a rollup concern, never a count multiplier (MN1)");
+    }
+
+    [Fact]
+    public async Task HomeStats_SnoozedChore_ExcludedFromOverdueAndUpForGrabs_ButInTotal()
+    {
+        // Would be Overdue + UpForGrabs if not snoozed.
+        Seed(OneOff(1, H1, new DateOnly(2026, 5, 1), snoozedUntil: new DateOnly(2026, 6, 5)));
+
+        var stats = await CreateService().GetHomeStatsAsync(H1, Now);
+
+        stats.Should().Be(new ChoreHomeStatsDto(ActiveTotal: 1, Overdue: 0, DueToday: 0, UpForGrabs: 0));
+    }
+
+    [Fact]
+    public async Task HomeStats_FiltersByHousehold()
+    {
+        SeedRepresentativeScenario();
+
+        var stats = await CreateService().GetHomeStatsAsync(H2, Now);
+
+        stats.Should().Be(new ChoreHomeStatsDto(ActiveTotal: 1, Overdue: 1, DueToday: 0, UpForGrabs: 1),
+            "H2 sees only its own chore 20 — never H1's board (M1)");
+    }
+
+    [Fact]
+    public async Task HomeStats_EmptyHousehold_ReturnsZeros()
+    {
+        var stats = await CreateService().GetHomeStatsAsync(H1, Now);
+
+        stats.Should().Be(new ChoreHomeStatsDto(0, 0, 0, 0));
+    }
+}


### PR DESCRIPTION
Burn-down run item (Spine quest `a8a14614` — "Leaner chore-count query for the dashboard aggregate").

`DashboardService` was calling `ChoreBoardService.GetBoardAsync` — rooms, rollups, roster folds, completions/participation/subtask batches — just to count overdue / dueToday / upForGrabs for the dashboard card.

### Change
- New `IChoreBoardService.GetHomeStatsAsync` + `ChoreHomeStatsDto`: ONE household-scoped `Chores` query (M1 filter + `Status == Active`, lean anonymous projection of only the recurrence + assignment fields) reduced with the **same `ChoreStatusCalculator` calls** the board uses. `ChoreRoom` is never joined, so a multi-room chore counts once by construction — matching `board.Chores`.
- `DashboardService` swaps the full board build + `ChoreHomeStats.Compute` for the lean read; wire DTO and counts unchanged.
- `GetBoardAsync` untouched.

### Semantics lock
`ChoreBoardHomeStatsTests` seeds a representative scenario (overdue, due-today-assigned, future-unassigned, snoozed-would-be-overdue, stale-claimed, fresh-claimed, 2-room overdue, Done, Archived, cross-household) and asserts `GetHomeStatsAsync` equals counts derived from `GetBoardAsync` + `ChoreHomeStats.Compute` on the same data, **plus concrete literals (7/3/1/4) so both paths can't drift together**. Per-concern guards: snooze gate on up-for-grabs, multi-room counts-once, M1 isolation, empty-household zeros.

### Verification
- `dotnet build` 0 errors; full `dotnet test` suite **874 passed / 0 failed** (the 2 known worktree-baseline ApiKeySecurityTests failures didn't occur this run).
- No UI change — dashboard payload shape is byte-identical.

https://claude.ai/code/session_01Nbc4zkiRDXrjBZ2vMnb9yU
