### PR TITLE
fix(auth): antiforgery-gate the Google OAuth challenge + lock in WP-11 antiforgery tests

### DIFF
--- a/src/FamilyCoordinationApp/Pages/Account/Login.cshtml
+++ b/src/FamilyCoordinationApp/Pages/Account/Login.cshtml
@@ -11,6 +11,7 @@
     </div>
 
     <form method="post" action="/account/login-google">
+        @Html.AntiForgeryToken()
         <input type="hidden" name="returnUrl" value="@Model.SafeReturnUrl" />
         <button type="submit" class="btn btn-google btn-block">
             <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true">

--- a/src/FamilyCoordinationApp/Pages/Household/Pending.cshtml
+++ b/src/FamilyCoordinationApp/Pages/Household/Pending.cshtml
@@ -11,6 +11,7 @@
         <h1>Please Sign In</h1>
         <p class="muted">Sign in to check your request status.</p>
         <form method="post" action="/account/login-google" asp-antiforgery="false" class="mt">
+            @Html.AntiForgeryToken()
             <input type="hidden" name="returnUrl" value="/household/pending" />
             <button type="submit" class="btn btn-outline btn-block">Sign in with Google</button>
         </form>

--- a/src/FamilyCoordinationApp/Pages/Household/Request.cshtml
+++ b/src/FamilyCoordinationApp/Pages/Household/Request.cshtml
@@ -14,6 +14,7 @@
     {
         <p class="center muted">First, sign in with Google to request a household.</p>
         <form method="post" action="/account/login-google" asp-antiforgery="false">
+            @Html.AntiForgeryToken()
             <input type="hidden" name="returnUrl" value="/household/request" />
             <button type="submit" class="btn btn-outline btn-block">Sign in with Google</button>
         </form>

--- a/src/FamilyCoordinationApp/Pages/Setup/FirstRunSetup.cshtml
+++ b/src/FamilyCoordinationApp/Pages/Setup/FirstRunSetup.cshtml
@@ -19,6 +19,7 @@
     {
         <p class="center muted">First, sign in with Google to create your household.</p>
         <form method="post" action="/account/login-google" asp-antiforgery="false">
+            @Html.AntiForgeryToken()
             <input type="hidden" name="returnUrl" value="/setup" />
             <button type="submit" class="btn btn-outline btn-block">Sign in with Google</button>
         </form>

--- a/src/FamilyCoordinationApp/Program.cs
+++ b/src/FamilyCoordinationApp/Program.cs
@@ -7,6 +7,7 @@ using FamilyCoordinationApp.Endpoints;
 using FamilyCoordinationApp.Services;
 using FamilyCoordinationApp.Services.Digest;
 using FamilyCoordinationApp.Services.Interfaces;
+using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.Google;
@@ -464,9 +465,24 @@ app.MapGet("/shoppinglists", () => Results.Redirect("/shopping-list", permanent:
 // Health check endpoint for Docker
 app.MapGet("/health", () => Results.Ok("healthy"));
 
-// Auth endpoints (minimal API) - wiring for Login.razor form POST
-app.MapPost("/account/login-google", async (HttpContext context) =>
+// Auth endpoint (minimal API) — the login/onboarding Razor Pages' sign-in forms POST here.
+// Login-CSRF hardening: initiating the OAuth challenge requires a valid antiforgery token (every sign-in
+// form embeds one via @Html.AntiForgeryToken()), so a cross-site page cannot silently log the victim's
+// browser into an attacker-chosen Google account. Validation is done in-handler via IAntiforgery — this
+// endpoint has no form-binding metadata, so the UseAntiforgery middleware never validates it implicitly.
+app.MapPost("/account/login-google", async (HttpContext context, IAntiforgery antiforgery) =>
 {
+    try
+    {
+        await antiforgery.ValidateRequestAsync(context);
+    }
+    catch (AntiforgeryValidationException)
+    {
+        // Non-empty body: an empty 4xx would re-execute through the GET-only /not-found page
+        // (CORRECTIONS fca-empty-404-surfaces-as-405-on-delete).
+        return Results.BadRequest(new { message = "Invalid or missing antiforgery token." });
+    }
+
     // Get returnUrl from form, default to home
     var form = await context.Request.ReadFormAsync();
     var returnUrl = form["returnUrl"].FirstOrDefault() ?? "/";
@@ -487,7 +503,8 @@ app.MapPost("/account/login-google", async (HttpContext context) =>
         RedirectUri = returnUrl,
         IsPersistent = true  // Remember me
     };
-    await context.ChallengeAsync(GoogleDefaults.AuthenticationScheme, properties);
+    // The Challenge redirect to Google (and the callback path) is unchanged — only the initiation is gated.
+    return Results.Challenge(properties, [GoogleDefaults.AuthenticationScheme]);
 });
 
 app.MapGet("/account/logout", async (HttpContext context) =>

--- a/tests/FamilyCoordinationApp.Tests/Integration/AntiforgeryEnforcementTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Integration/AntiforgeryEnforcementTests.cs
@@ -1,0 +1,110 @@
+using System.Net;
+using System.Text.RegularExpressions;
+using FluentAssertions;
+
+namespace FamilyCoordinationApp.Tests.Integration;
+
+/// <summary>
+/// Locks in the WP-11 antiforgery posture end-to-end against the real <see cref="Program"/> pipeline
+/// (previously only verified manually):
+/// <list type="bullet">
+/// <item>A token-less POST to the onboarding Razor Pages (<c>/household/request</c>, <c>/setup</c>) is
+/// rejected with 400 by the framework's automatic Razor Pages antiforgery validation — it must never reach
+/// the <c>OnPostAsync</c> handler (which would respond with a 302 redirect).</item>
+/// <item>Login-CSRF hardening: a token-less POST to <c>/account/login-google</c> is rejected with 400
+/// (a cross-site page must not be able to silently initiate the OAuth challenge and log the victim's
+/// browser into an attacker-chosen account), while a same-site form POST carrying the antiforgery token
+/// issued by <c>/account/login</c> still initiates the Google challenge (302 to accounts.google.com) —
+/// proving the hardening did not break the real sign-in flow.</item>
+/// </list>
+/// </summary>
+[Collection(IntegrationCollection.Name)]
+[Trait("kind", "integration")]
+public sealed class AntiforgeryEnforcementTests(PostgresContainerFixture postgres) : IAsyncLifetime
+{
+    private readonly ChoresWebAppFactory _factory = new(postgres);
+
+    public async Task InitializeAsync() => await _factory.EnsureSeededAsync();
+
+    public async Task DisposeAsync() => await _factory.DisposeAsync();
+
+    [Fact]
+    public async Task HouseholdRequest_TokenlessPost_IsRejectedWith400()
+    {
+        // Authenticated on purpose: if the antiforgery gate were missing, this request would reach
+        // OnPostAsync and come back as a 302 (redirect to /household/pending) — so a 400 here proves the
+        // request was rejected BEFORE the handler, by antiforgery validation specifically.
+        var client = _factory.CreateClientAs(ChoresWebAppFactory.UserAEmail);
+
+        var resp = await client.PostAsync("/household/request", new FormUrlEncodedContent(
+            new Dictionary<string, string> { ["HouseholdName"] = "CSRF Household" }));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest,
+            "a POST without an antiforgery token must be rejected by Razor Pages auto-validation");
+    }
+
+    [Fact]
+    public async Task FirstRunSetup_TokenlessPost_IsRejectedWith400()
+    {
+        // Same shape as above: a reached handler would 302 (setup is already complete in the seeded
+        // fixture → redirect to /dashboard), so 400 proves the antiforgery gate fired first.
+        var client = _factory.CreateClientAs(ChoresWebAppFactory.UserAEmail);
+
+        var resp = await client.PostAsync("/setup", new FormUrlEncodedContent(
+            new Dictionary<string, string> { ["HouseholdName"] = "CSRF Household" }));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest,
+            "a POST without an antiforgery token must be rejected by Razor Pages auto-validation");
+    }
+
+    [Fact]
+    public async Task LoginGoogle_TokenlessPost_IsRejectedWith400_WithNonEmptyBody()
+    {
+        // Login-CSRF: a bare cross-site form POST (no antiforgery token) must not initiate the OAuth
+        // challenge. If the gate were missing this would be a 302 to accounts.google.com.
+        var client = _factory.CreateAnonymousClient();
+
+        var resp = await client.PostAsync("/account/login-google", new FormUrlEncodedContent(
+            new Dictionary<string, string> { ["returnUrl"] = "/" }));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest,
+            "initiating the OAuth challenge without an antiforgery token must be rejected");
+
+        // Non-empty /error body invariant: an empty 4xx re-executes through the GET-only /not-found page
+        // and a non-GET call surfaces as a 405 (CORRECTIONS fca-empty-404-surfaces-as-405-on-delete).
+        var body = await resp.Content.ReadAsStringAsync();
+        body.Should().NotBeNullOrWhiteSpace("4xx responses must carry a body");
+    }
+
+    [Fact]
+    public async Task LoginGoogle_PostWithValidToken_StillChallengesGoogle()
+    {
+        // The real sign-in path: GET /account/login issues the antiforgery cookie + form token; posting
+        // both back must still initiate the Google OAuth challenge (302 to accounts.google.com). This
+        // pins the "don't break the actual OAuth flow" half of the hardening. The WebApplicationFactory
+        // client handles cookies, so the antiforgery cookie set by the GET flows into the POST.
+        var client = _factory.CreateAnonymousClient();
+
+        var loginPage = await client.GetAsync("/account/login");
+        loginPage.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var html = await loginPage.Content.ReadAsStringAsync();
+        var match = Regex.Match(html,
+            "name=\"__RequestVerificationToken\"[^>]*value=\"([^\"]+)\"");
+        match.Success.Should().BeTrue("the login page's sign-in form must embed an antiforgery token");
+        var token = match.Groups[1].Value;
+
+        var resp = await client.PostAsync("/account/login-google", new FormUrlEncodedContent(
+            new Dictionary<string, string>
+            {
+                ["__RequestVerificationToken"] = token,
+                ["returnUrl"] = "/dashboard"
+            }));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Found,
+            "a token-carrying form POST must still initiate the OAuth challenge");
+        resp.Headers.Location.Should().NotBeNull();
+        resp.Headers.Location!.Host.Should().Be("accounts.google.com",
+            "the challenge must redirect to Google's authorization endpoint");
+    }
+}


### PR DESCRIPTION
Burn-down run item (Spine quest `0c59e2f8` — "Auth hardening leftovers"). Both WP-11 security-review leftovers.

### Part 1 — antiforgery integration tests (test-only)
`AntiforgeryEnforcementTests` (existing `ChoresWebAppFactory` / Testcontainers-Postgres harness) locks in the posture that was previously only verified manually:
- token-less POST `/household/request` → 400
- token-less POST `/setup` → 400 (the setup page's actual route — not `/household/setup`)

### Part 2 — login-CSRF on `/account/login-google`
The endpoint was genuinely vulnerable: POST-only, but the handler read the form via bare `ReadFormAsync()` with no form-binding metadata, so antiforgery was **never validated** — and all four sign-in forms posted token-less. A cross-site page could auto-submit the form and silently log the victim's browser into an attacker-chosen Google account.

Fix:
- Handler now validates via in-handler `IAntiforgery.ValidateRequestAsync` before anything else → 400 with non-empty JSON body on failure (empty-4xx re-execute invariant). In-handler rather than endpoint metadata deliberately: `UseAntiforgery()` sits before `UseAuthentication` in this pipeline; in-handler validation avoids any ordering hazard.
- All four sign-in forms (Login, Household/Request, Household/Pending, Setup/FirstRunSetup) now embed `@Html.AntiForgeryToken()`.
- Challenge converted to `Results.Challenge(...)` — same 302, same properties; the redirect to Google and the callback path are unchanged. The existing local-only returnUrl guard kept as-is.
- New tests: token-less POST `/account/login-google` → 400 with body; valid-token POST → 302 to `accounts.google.com` (pins that OAuth initiation still works).

### Verification
- Build clean; full suite **873/873 passed** (869 baseline + 4 new), 0 failed.
- The real Google round-trip is untouched by the diff (initiation-gate only); worth one manual login after deploy as a smoke check.

https://claude.ai/code/session_01Nbc4zkiRDXrjBZ2vMnb9yU
