### PR TITLE
feat(recipes): optimistic concurrency (xmin) + inline ingredient edit

### DIFF
--- a/frontend/app/src/lib/recipes/EditApp.svelte
+++ b/frontend/app/src/lib/recipes/EditApp.svelte
@@ -69,6 +69,25 @@
   {#if store.loading}
     <div class="rc-loading-bar"><span></span></div>
   {:else}
+    {#if store.conflict}
+      <!-- Stale-version 409: NON-destructive — the form (and the user's typing) stays; Reload refetches
+           the latest (typed state is preserved as the draft first, see reloadAfterConflict). -->
+      <div class="rc-conflict-banner" role="alert">
+        <span class="rc-conflict-text">
+          This recipe changed — reload to get the latest. Your edits stay on screen until you reload (reloading
+          keeps them as a draft).
+        </span>
+        <button
+          type="button"
+          class="rc-btn-conflict"
+          onclick={() => store.reloadAfterConflict()}
+          disabled={store.reloading}
+        >
+          {store.reloading ? 'Reloading…' : 'Reload'}
+        </button>
+      </div>
+    {/if}
+
     {#if store.error}
       <div class="rc-inline-error" role="alert">{store.error}</div>
     {/if}
@@ -228,6 +247,41 @@
     border-radius: var(--radius-sm);
     color: var(--color-error);
     font-size: 0.875rem;
+  }
+  .rc-conflict-banner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+    padding: 10px 16px;
+    margin-bottom: 16px;
+    background: rgba(251, 140, 0, 0.1);
+    border-left: 4px solid var(--color-warning);
+    border-radius: var(--radius-sm);
+    color: var(--color-text);
+    font-size: 0.875rem;
+  }
+  .rc-conflict-text {
+    flex: 1 1 240px;
+  }
+  .rc-btn-conflict {
+    font: inherit;
+    font-weight: 500;
+    padding: 8px 16px;
+    border: 1px solid var(--color-warning);
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--color-text);
+    cursor: pointer;
+    min-height: 36px;
+  }
+  .rc-btn-conflict:hover:not(:disabled) {
+    background: var(--color-action-hover);
+  }
+  .rc-btn-conflict:disabled {
+    opacity: 0.6;
+    cursor: default;
   }
   .rc-footer {
     display: flex;

--- a/frontend/app/src/lib/recipes/EditApp.svelte
+++ b/frontend/app/src/lib/recipes/EditApp.svelte
@@ -105,8 +105,9 @@
       />
       <IngredientList
         ingredients={store.ingredients}
+        categories={store.categories}
         onReorder={(rows) => store.reorder(rows)}
-        onEdit={(id) => store.editIngredient(id)}
+        onUpdate={(id, patch) => store.updateIngredient(id, patch)}
         onRemove={(id) => store.removeIngredient(id)}
       />
     </section>

--- a/frontend/app/src/lib/recipes/lib/api.ts
+++ b/frontend/app/src/lib/recipes/lib/api.ts
@@ -20,7 +20,9 @@ const BASE = '/api/recipes';
  * arrive on the wire as an empty **400** (a bare DELETE 404 even surfaces as
  * 405). Every recipes endpoint therefore returns a NON-EMPTY body on not-found,
  * and the island treats ANY 4xx as a non-retryable client rejection → reconcile
- * (refetch the list) + a calm toast. There is no retry branch (versionless).
+ * (refetch the list) + a calm toast. Exception: a **409** on the full-form PUT
+ * is a stale xmin `version` token — the edit store shows a reload banner
+ * instead of navigating away (see recipeEditStore).
  */
 export class ApiError extends Error {
   constructor(
@@ -77,7 +79,7 @@ export async function createRecipe(body: RecipeWriteRequest): Promise<RecipeFull
   return request<RecipeFullDto>(`${BASE}`, { method: 'POST', ...jsonBody(body) });
 }
 
-/** #4 Update (replaces ingredients wholesale) → the re-fetched recipe. */
+/** #4 Update (replaces ingredients wholesale) → the re-fetched recipe. Stale `version` token ⇒ 409. */
 export async function updateRecipe(recipeId: number, body: RecipeWriteRequest): Promise<RecipeFullDto> {
   return request<RecipeFullDto>(`${BASE}/${recipeId}`, { method: 'PUT', ...jsonBody(body) });
 }

--- a/frontend/app/src/lib/recipes/lib/components/IngredientList.svelte
+++ b/frontend/app/src/lib/recipes/lib/components/IngredientList.svelte
@@ -1,20 +1,30 @@
 <script lang="ts">
   // Ingredient list (mirrors IngredientList.razor): drag-reorder via
-  // svelte-dnd-action (the chores pattern), edit (remove + re-add), and
+  // svelte-dnd-action (the chores pattern), INLINE edit (the row swaps to the
+  // same qty / unit / name / category / notes fields the add-entry collects,
+  // with save/cancel — replaces the old remove-and-re-add flow), and
   // delete-with-undo (the undo lives on the toast). Quantities use the EXACT
-  // formatter (formatExactQuantity — entered values are precise).
-  import type { IngredientRow } from '../recipeEditStore.svelte';
+  // formatter (formatExactQuantity — entered values are precise). Dragging is
+  // disabled while a row is being edited (typing in inputs must not start a drag).
+  import type { IngredientRow, IngredientUpdate } from '../recipeEditStore.svelte';
   import { formatExactQuantity } from '../quantity';
   import { dndzone, type DndEvent } from 'svelte-dnd-action';
 
   interface Props {
     ingredients: IngredientRow[];
+    categories: string[];
     onReorder: (rows: IngredientRow[]) => void;
-    onEdit: (id: number) => void;
+    onUpdate: (id: number, patch: IngredientUpdate) => void;
     onRemove: (id: number) => void;
   }
 
-  let { ingredients, onReorder, onEdit, onRemove }: Props = $props();
+  let { ingredients, categories, onReorder, onUpdate, onRemove }: Props = $props();
+
+  // Same static unit list as the add-entry (IngredientEntry).
+  const UNITS = [
+    'cup', 'cups', 'tbsp', 'tsp', 'oz', 'lb', 'lbs', 'g', 'kg', 'ml', 'l',
+    'clove', 'cloves', 'can', 'cans', 'bunch', 'slice', 'slices', 'piece', 'pieces',
+  ];
 
   // Local copy svelte-dnd-action mutates during a drag; resynced from the source
   // whenever we're NOT dragging (chores pattern — avoids fighting the library).
@@ -23,6 +33,50 @@
   $effect(() => {
     if (!dragging) rows = [...ingredients];
   });
+
+  // ── Inline edit state (one row at a time; fields are strings while editing) ──
+  let editingId = $state<number | null>(null);
+  let editQuantity = $state('');
+  let editUnit = $state('');
+  let editName = $state('');
+  let editCategory = $state('Pantry');
+  let editNotes = $state('');
+
+  function startEdit(ing: IngredientRow): void {
+    editingId = ing.id;
+    editQuantity = ing.quantity != null ? String(ing.quantity) : '';
+    editUnit = ing.unit ?? '';
+    editName = ing.name;
+    editCategory = ing.category;
+    editNotes = ing.notes ?? '';
+  }
+
+  function cancelEdit(): void {
+    editingId = null;
+  }
+
+  function saveEdit(): void {
+    if (editingId == null || !editName.trim()) return;
+    const q = editQuantity.trim() === '' ? null : Number(editQuantity);
+    onUpdate(editingId, {
+      name: editName.trim(),
+      quantity: q != null && !Number.isNaN(q) ? q : null,
+      unit: editUnit.trim() === '' ? null : editUnit.trim(),
+      category: editCategory,
+      notes: editNotes.trim() === '' ? null : editNotes.trim(),
+    });
+    editingId = null;
+  }
+
+  function handleEditKeydown(e: KeyboardEvent): void {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      saveEdit();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      cancelEdit();
+    }
+  }
 
   function handleConsider(e: CustomEvent<DndEvent<IngredientRow>>): void {
     dragging = true;
@@ -69,33 +123,88 @@
 {:else}
   <ul
     class="rc-ing-list"
-    use:dndzone={{ items: rows, flipDurationMs: 150, dropTargetStyle: {}, delayTouchStart: 250 }}
+    use:dndzone={{
+      items: rows,
+      flipDurationMs: 150,
+      dropTargetStyle: {},
+      delayTouchStart: 250,
+      dragDisabled: editingId != null,
+    }}
     onconsider={handleConsider}
     onfinalize={handleFinalize}
   >
     {#each rows as ing (ing.id)}
-      <li class="rc-ing-item">
-        <div class="rc-ing-main">
-          <span class="rc-ing-grip" aria-hidden="true">⠿</span>
-          <div class="rc-ing-text">
-            <span class="rc-ing-line">{formatLine(ing)}</span>
-            {#if ing.notes}
-              <span class="rc-ing-notes">{ing.notes}</span>
-            {/if}
+      <li class="rc-ing-item" class:rc-ing-editing={ing.id === editingId}>
+        {#if ing.id === editingId}
+          <div class="rc-ing-edit-grid">
+            <label class="rc-field rc-col-qty">
+              <span class="rc-field-label">Quantity</span>
+              <input type="text" class="rc-input" bind:value={editQuantity} onkeydown={handleEditKeydown} />
+            </label>
+            <label class="rc-field rc-col-unit">
+              <span class="rc-field-label">Unit</span>
+              <input
+                type="text"
+                class="rc-input"
+                list="rc-il-unit-list"
+                bind:value={editUnit}
+                onkeydown={handleEditKeydown}
+              />
+              <datalist id="rc-il-unit-list">
+                {#each UNITS as u (u)}
+                  <option value={u}></option>
+                {/each}
+              </datalist>
+            </label>
+            <label class="rc-field rc-col-name">
+              <span class="rc-field-label">Ingredient</span>
+              <input type="text" class="rc-input" bind:value={editName} onkeydown={handleEditKeydown} />
+            </label>
+            <label class="rc-field rc-col-cat">
+              <span class="rc-field-label">Category</span>
+              <select class="rc-input" bind:value={editCategory}>
+                {#each categories as cat (cat)}
+                  <option value={cat}>{cat}</option>
+                {/each}
+                {#if !categories.includes(editCategory)}
+                  <option value={editCategory}>{editCategory}</option>
+                {/if}
+              </select>
+            </label>
+            <label class="rc-field rc-col-notes">
+              <span class="rc-field-label">Notes (optional)</span>
+              <input type="text" class="rc-input" bind:value={editNotes} onkeydown={handleEditKeydown} />
+            </label>
+            <div class="rc-col-edit-actions">
+              <button type="button" class="rc-btn-ghost-sm" onclick={cancelEdit}>Cancel</button>
+              <button type="button" class="rc-btn-solid-sm" onclick={saveEdit} disabled={!editName.trim()}>
+                Save
+              </button>
+            </div>
           </div>
-        </div>
-        <div class="rc-ing-actions">
-          <span class="rc-cat-chip" style="--chip-color: {categoryColor(ing.category)}">{ing.category}</span>
-          <button type="button" class="rc-ing-btn" aria-label="Edit ingredient" onclick={() => onEdit(ing.id)}
-            >✎</button
-          >
-          <button
-            type="button"
-            class="rc-ing-btn rc-ing-del"
-            aria-label="Delete ingredient"
-            onclick={() => onRemove(ing.id)}>🗑</button
-          >
-        </div>
+        {:else}
+          <div class="rc-ing-main">
+            <span class="rc-ing-grip" aria-hidden="true">⠿</span>
+            <div class="rc-ing-text">
+              <span class="rc-ing-line">{formatLine(ing)}</span>
+              {#if ing.notes}
+                <span class="rc-ing-notes">{ing.notes}</span>
+              {/if}
+            </div>
+          </div>
+          <div class="rc-ing-actions">
+            <span class="rc-cat-chip" style="--chip-color: {categoryColor(ing.category)}">{ing.category}</span>
+            <button type="button" class="rc-ing-btn" aria-label="Edit ingredient" onclick={() => startEdit(ing)}
+              >✎</button
+            >
+            <button
+              type="button"
+              class="rc-ing-btn rc-ing-del"
+              aria-label="Delete ingredient"
+              onclick={() => onRemove(ing.id)}>🗑</button
+            >
+          </div>
+        {/if}
       </li>
     {/each}
   </ul>
@@ -138,6 +247,13 @@
   }
   .rc-ing-item:active {
     cursor: grabbing;
+  }
+  .rc-ing-editing {
+    cursor: default;
+    border-color: var(--color-primary);
+  }
+  .rc-ing-editing:active {
+    cursor: default;
   }
   .rc-ing-main {
     display: flex;
@@ -193,5 +309,97 @@
   }
   .rc-ing-del:hover {
     color: var(--color-error);
+  }
+
+  /* ── Inline edit grid (mirrors IngredientEntry's rc-parsed-grid) ── */
+  .rc-ing-edit-grid {
+    display: grid;
+    grid-template-columns: repeat(12, 1fr);
+    gap: 12px;
+    width: 100%;
+  }
+  .rc-field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .rc-field-label {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+  }
+  .rc-input {
+    font: inherit;
+    padding: 10px 12px;
+    border: 1px solid var(--color-line-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text);
+    width: 100%;
+  }
+  .rc-input:focus {
+    outline: none;
+    border-color: var(--color-primary);
+  }
+  .rc-col-qty {
+    grid-column: span 2;
+  }
+  .rc-col-unit {
+    grid-column: span 2;
+  }
+  .rc-col-name {
+    grid-column: span 5;
+  }
+  .rc-col-cat {
+    grid-column: span 3;
+  }
+  .rc-col-notes {
+    grid-column: span 8;
+  }
+  .rc-col-edit-actions {
+    grid-column: span 4;
+    display: flex;
+    align-items: flex-end;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+  @media (max-width: 700px) {
+    .rc-col-qty,
+    .rc-col-unit,
+    .rc-col-name,
+    .rc-col-cat,
+    .rc-col-notes,
+    .rc-col-edit-actions {
+      grid-column: span 12;
+    }
+  }
+  .rc-btn-ghost-sm,
+  .rc-btn-solid-sm {
+    font: inherit;
+    font-size: 0.875rem;
+    font-weight: 500;
+    padding: 8px 16px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    min-height: 40px;
+  }
+  .rc-btn-ghost-sm {
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
+  }
+  .rc-btn-ghost-sm:hover {
+    background: var(--color-action-hover);
+  }
+  .rc-btn-solid-sm {
+    border: none;
+    background: var(--color-primary);
+    color: #fff;
+  }
+  .rc-btn-solid-sm:hover:not(:disabled) {
+    background: var(--color-primary-hover);
+  }
+  .rc-btn-solid-sm:disabled {
+    opacity: 0.6;
+    cursor: default;
   }
 </style>

--- a/frontend/app/src/lib/recipes/lib/recipeEditStore.svelte.ts
+++ b/frontend/app/src/lib/recipes/lib/recipeEditStore.svelte.ts
@@ -6,9 +6,9 @@
 // ⚠ Svelte 5 rune rule: export the class INSTANCE, not reassigned $state.
 //
 // Mirrors RecipeEdit.razor: draft-first load (restore + toast, else recipe-or-
-// blank), 2s-debounce autosave drafts, ingredient add/bulk/remove(undo)/reorder,
-// image upload/remove/pick, and Save/Cancel/Delete. Single-user form ⇒ NO
-// liveness (autosave is the persistence path).
+// blank), 2s-debounce autosave drafts, ingredient add/bulk/remove(undo)/inline-
+// edit/reorder, image upload/remove/pick, and Save/Cancel/Delete. Single-user
+// form ⇒ NO liveness (autosave is the persistence path).
 //
 // Concurrency: the full-form save echoes the xmin token (`version` from GET);
 // a 409 means someone else saved since we loaded → non-destructive conflict
@@ -73,6 +73,15 @@ export interface NewIngredientInput {
   category: string;
   notes: string | null;
   groupName?: string | null;
+}
+
+/** The inline-editable fields of a row (mirrors what the add-entry collects). */
+export interface IngredientUpdate {
+  name: string;
+  quantity: number | null;
+  unit: string | null;
+  category: string;
+  notes: string | null;
 }
 
 type AutosaveStatus = 'none' | 'saving' | 'saved';
@@ -361,13 +370,13 @@ class RecipeEditStore {
   }
 
   /**
-   * "Edit" an ingredient — parity with Blazor's remove-and-re-add flow
-   * (IngredientList.razor:451-456). Inline editing is a harvested follow-up quest.
+   * Inline-edit an ingredient in place (replaces the old Blazor remove-and-re-add flow). Only the
+   * entry-form fields are editable; groupName / sortOrder / ingredientId are preserved. Persistence is
+   * unchanged: ingredients are client state, saved wholesale by the recipe PUT (and the draft autosave).
    */
-  editIngredient(id: number): void {
-    this.ingredients = this.resequence(this.ingredients.filter((r) => r.id !== id));
+  updateIngredient(id: number, patch: IngredientUpdate): void {
+    this.ingredients = this.ingredients.map((r) => (r.id === id ? { ...r, ...patch } : r));
     this.onEdit();
-    showToast({ message: 'Re-add the ingredient with your changes.', kind: 'info' });
   }
 
   /** Apply a drag-reorder (svelte-dnd-action finalize gives the new row order). */

--- a/frontend/app/src/lib/recipes/lib/recipeEditStore.svelte.ts
+++ b/frontend/app/src/lib/recipes/lib/recipeEditStore.svelte.ts
@@ -7,10 +7,13 @@
 //
 // Mirrors RecipeEdit.razor: draft-first load (restore + toast, else recipe-or-
 // blank), 2s-debounce autosave drafts, ingredient add/bulk/remove(undo)/reorder,
-// image upload/remove/pick, and Save/Cancel/Delete. Versionless / last-write-wins
-// (D5): on any 4xx during save/delete we surface a calm "this recipe changed"
-// and return to the list (§8). Single-user form ⇒ NO liveness (autosave is the
-// persistence path).
+// image upload/remove/pick, and Save/Cancel/Delete. Single-user form ⇒ NO
+// liveness (autosave is the persistence path).
+//
+// Concurrency: the full-form save echoes the xmin token (`version` from GET);
+// a 409 means someone else saved since we loaded → non-destructive conflict
+// banner + an explicit Reload action (reloadAfterConflict). Other 4xx during
+// save/delete keep the old calm "this recipe changed" → back-to-list path.
 // ─────────────────────────────────────────────────────────────────────────
 
 import type {
@@ -101,6 +104,10 @@ class RecipeEditStore {
   dirty = $state(false);
   autosaveStatus = $state<AutosaveStatus>('none');
   error = $state<string | null>(null);
+  /** A save hit a 409 (someone else changed the recipe) — show the reload banner, keep the form. */
+  conflict = $state(false);
+  /** Reload-after-conflict in progress (disables the banner button). */
+  reloading = $state(false);
 
   /** The recipe id (null = new). Set from the shell context. */
   recipeId = $state<number | null>(null);
@@ -108,6 +115,8 @@ class RecipeEditStore {
 
   isEdit = $derived(this.recipeId != null);
 
+  /** The xmin token from the last GET — echoed on the update PUT (null until a fresh load). */
+  private serverVersion: number | null = null;
   private uidSeq = 1;
   private autosaveTimer: ReturnType<typeof setTimeout> | null = null;
   private savedClearTimer: ReturnType<typeof setTimeout> | null = null;
@@ -129,11 +138,22 @@ class RecipeEditStore {
     this.recipeId = recipeId;
     this.loading = true;
     this.error = null;
+    this.conflict = false;
+    this.serverVersion = null;
     try {
       const draft = await getDraft(recipeId);
       if (draft) {
         this.applyDraft(draft);
         showToast({ message: 'Restored from draft', kind: 'info' });
+        if (recipeId != null) {
+          // Drafts carry no version token — best-effort fetch the current one so the eventual save is
+          // still concurrency-guarded. On failure (e.g. recipe deleted) keep null ⇒ last-write-wins as before.
+          try {
+            this.serverVersion = (await getRecipe(recipeId)).version;
+          } catch {
+            this.serverVersion = null;
+          }
+        }
       } else if (recipeId != null) {
         const full = await getRecipe(recipeId);
         this.applyFull(full);
@@ -185,6 +205,7 @@ class RecipeEditStore {
   }
 
   private applyFull(f: RecipeFullDto): void {
+    this.serverVersion = f.version;
     this.form = {
       name: f.name,
       description: f.description ?? '',
@@ -398,6 +419,7 @@ class RecipeEditStore {
     this.saving = true; // set first: a timer-fired autosave now bails on the saving guard
     await this.flushAutosave(); // wait out any in-flight draft save before we deleteDraft
     this.error = null;
+    this.conflict = false;
     try {
       const body = this.buildWriteRequest();
       if (this.recipeId != null) {
@@ -409,8 +431,12 @@ class RecipeEditStore {
       this.dirty = false; // suppress the beforeunload nav-lock before navigating
       this.navigateToList();
     } catch (e) {
-      if (e instanceof ApiError) {
-        // 4xx incl. the empty-400-from-404 quirk → concurrent delete / last-write-wins.
+      if (e instanceof ApiError && e.status === 409) {
+        // Stale xmin token — someone else saved since we loaded. NON-destructive: keep the form (and
+        // dirty, so the nav-lock still guards) and show the reload banner instead of navigating away.
+        this.conflict = true;
+      } else if (e instanceof ApiError) {
+        // Other 4xx incl. the empty-400-from-404 quirk → concurrent delete etc.
         this.error = 'This recipe changed since you opened it.';
         this.dirty = false;
         showToast({ message: 'This recipe changed — returning to the list.', kind: 'info' });
@@ -420,6 +446,43 @@ class RecipeEditStore {
       }
     } finally {
       this.saving = false;
+    }
+  }
+
+  /**
+   * Explicit conflict recovery: refetch the latest recipe and replace the form with it. The user's typed
+   * state is first persisted as the draft (best-effort) so it isn't silently discarded — reopening the
+   * editor restores it via the normal draft-first load. Deliberately NOT the draft-first load() (that
+   * would restore the very edits that just conflicted instead of showing the latest server state).
+   */
+  async reloadAfterConflict(): Promise<void> {
+    if (this.recipeId == null || this.reloading) return;
+    this.reloading = true;
+    try {
+      if (this.form.name.trim()) {
+        try {
+          await saveDraft(this.buildDraftBody()); // preserve what the user typed (draft needs a name)
+        } catch {
+          /* best-effort — reload anyway */
+        }
+      }
+      const full = await getRecipe(this.recipeId);
+      this.applyFull(full); // also refreshes serverVersion for the next save
+      this.conflict = false;
+      this.error = null;
+      this.dirty = false;
+      showToast({ message: 'Loaded the latest version. Your edits were kept as a draft.', kind: 'info' });
+    } catch (e) {
+      if (e instanceof ApiError) {
+        // The recipe was deleted meanwhile — nothing to reload into.
+        this.dirty = false;
+        showToast({ message: 'That recipe was removed — returning to the list.', kind: 'info' });
+        this.navigateToList();
+      } else {
+        showToast({ message: "Couldn't reload the recipe. Please try again.", kind: 'error' });
+      }
+    } finally {
+      this.reloading = false;
     }
   }
 
@@ -494,6 +557,8 @@ class RecipeEditStore {
         groupName: nullIfBlank(r.groupName),
         sortOrder: i,
       })),
+      // The xmin token echoed for the update PUT (null on create / when no fresh GET succeeded).
+      version: this.serverVersion,
     };
   }
 

--- a/frontend/app/src/lib/recipes/lib/types.ts
+++ b/frontend/app/src/lib/recipes/lib/types.ts
@@ -62,6 +62,8 @@ export interface RecipeIngredientFullDto {
 
 export interface RecipeFullDto {
   recipeId: number;
+  /** xmin concurrency token — echo it back on PUT; a stale token ⇒ 409. */
+  version: number;
   name: string;
   recipeType: RecipeType;
   description: string | null;
@@ -173,6 +175,8 @@ export interface RecipeWriteRequest {
   recipeType: RecipeType;
   imagePath: string | null;
   ingredients: RecipeIngredientWrite[];
+  /** xmin token from GET (PUT only; null ⇒ server skips the check — e.g. create). Stale ⇒ 409. */
+  version: number | null;
 }
 
 /** PUT /draft body — FLAT (recipeId + the draft fields). recipeId omitted ⇒ new-recipe draft. */

--- a/src/FamilyCoordinationApp/Endpoints/RecipesEndpoints.cs
+++ b/src/FamilyCoordinationApp/Endpoints/RecipesEndpoints.cs
@@ -18,7 +18,9 @@ namespace FamilyCoordinationApp.Endpoints;
 /// <see cref="IRecipeProjectionService"/> (no card/detail drift, M9). Kept SEPARATE from the meal-plan picker's
 /// <c>/api/meal-plan/recipes/*</c> (spec D11).
 ///
-/// <para>Parity-first ⇒ versionless / last-write-wins (no xmin token on the wire). Not-found responses carry a
+/// <para>Full-form edits are optimistic-concurrency guarded: GET carries the xmin token (<c>version</c>),
+/// PUT echoes it back, and a stale token → 409 with a non-empty body (<see cref="RecipeConflictException"/>).
+/// A null token skips the check (legacy last-write-wins). Not-found responses carry a
 /// NON-EMPTY body so the app-global <c>UseStatusCodePagesWithReExecute</c> leaves them as clean 404s (an empty
 /// 404 surfaces as an empty 400/405). <c>Recipe</c> has an EF global query filter on <c>IsDeleted</c>
 /// (<c>RecipeConfiguration</c>), so soft-deleted recipes are auto-excluded — no explicit filter here.</para>
@@ -162,12 +164,18 @@ public static class RecipesEndpoints
 
         try
         {
-            await recipeService.UpdateRecipeAsync(recipe, ct);
+            // req.Version is the xmin token echoed from GET (null ⇒ legacy client ⇒ last-write-wins).
+            await recipeService.UpdateRecipeAsync(recipe, req.Version, ct);
         }
         catch (InvalidOperationException)
         {
             // Household-scoped load missed (missing / cross-household id) → clean 404 (non-empty body, M1).
             return Results.NotFound(new { message = "Recipe not found." });
+        }
+        catch (RecipeConflictException)
+        {
+            // Stale xmin token — someone else saved since this client loaded the recipe. Non-empty body (M1).
+            return Results.Conflict(new { message = "This recipe was changed by someone else. Reload to see the latest." });
         }
 
         // Project from a FRESH load, NOT the UpdateRecipeAsync return — its Ingredients nav is stale after the
@@ -589,7 +597,11 @@ public static class RecipesEndpoints
 
     // ─── Request DTOs ─────────────────────────────────────────────────────────────
 
-    /// <summary>Create/update body. <see cref="ImagePath"/> is a path already returned by POST /images.</summary>
+    /// <summary>
+    /// Create/update body. <see cref="ImagePath"/> is a path already returned by POST /images.
+    /// <see cref="Version"/> is the xmin token from GET, enforced on PUT (stale ⇒ 409); ignored on POST and
+    /// skipped when null (a client without a token keeps last-write-wins).
+    /// </summary>
     public sealed record RecipeWriteRequest(
         string Name,
         string? Description,
@@ -600,7 +612,8 @@ public static class RecipesEndpoints
         int? CookTimeMinutes,
         RecipeType RecipeType,
         string? ImagePath,
-        IReadOnlyList<RecipeIngredientWrite> Ingredients);
+        IReadOnlyList<RecipeIngredientWrite> Ingredients,
+        uint? Version = null);
 
     public sealed record RecipeIngredientWrite(
         string Name,

--- a/src/FamilyCoordinationApp/Services/Dtos/RecipeDtos.cs
+++ b/src/FamilyCoordinationApp/Services/Dtos/RecipeDtos.cs
@@ -21,8 +21,8 @@ namespace FamilyCoordinationApp.Services.Dtos;
 // Drafts reuse DraftService's existing RecipeDraftData / IngredientDraftData records
 // directly (no draft DTO here) — they already serialize camelCase via the web defaults.
 //
-// Parity-first ⇒ versionless / last-write-wins: NO xmin token on the wire. Recipe.Version
-// exists on the entity but is unused here (a future quest may add 409 concurrency).
+// Optimistic concurrency: RecipeFullDto carries the xmin token (Version) so the
+// edit form can send it back on PUT; a stale token → 409 (RecipeConflictException).
 // ─────────────────────────────────────────────────────────────────────────
 
 // ── List ──────────────────────────────────────────────────────────────────
@@ -53,6 +53,7 @@ public sealed record RecipeListItemDto(
 /// </summary>
 public sealed record RecipeFullDto(
     int RecipeId,
+    uint Version,                     // xmin concurrency token — echoed back on PUT (stale ⇒ 409)
     string Name,
     RecipeType RecipeType,
     string? Description,

--- a/src/FamilyCoordinationApp/Services/Interfaces/IRecipeService.cs
+++ b/src/FamilyCoordinationApp/Services/Interfaces/IRecipeService.cs
@@ -7,7 +7,13 @@ public interface IRecipeService
     Task<List<Recipe>> GetRecipesAsync(int householdId, string? searchTerm = null, CancellationToken cancellationToken = default);
     Task<Recipe?> GetRecipeAsync(int householdId, int recipeId, CancellationToken cancellationToken = default);
     Task<Recipe> CreateRecipeAsync(Recipe recipe, CancellationToken cancellationToken = default);
-    Task<Recipe> UpdateRecipeAsync(Recipe recipe, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Full-form update (wholesale ingredient replace). When <paramref name="expectedVersion"/> is supplied it
+    /// is enforced as the xmin concurrency token — a stale value throws <see cref="RecipeConflictException"/>
+    /// (→ 409). <c>null</c> skips the check (legacy last-write-wins callers).
+    /// </summary>
+    /// <exception cref="RecipeConflictException">The client <paramref name="expectedVersion"/> is stale.</exception>
+    Task<Recipe> UpdateRecipeAsync(Recipe recipe, uint? expectedVersion = null, CancellationToken cancellationToken = default);
     Task DeleteRecipeAsync(int householdId, int recipeId, CancellationToken cancellationToken = default);
     Task<int> GetNextRecipeIdAsync(int householdId, CancellationToken cancellationToken = default);
     Task<List<string>> GetIngredientSuggestionsAsync(int householdId, string prefix, CancellationToken cancellationToken = default);

--- a/src/FamilyCoordinationApp/Services/RecipeExceptions.cs
+++ b/src/FamilyCoordinationApp/Services/RecipeExceptions.cs
@@ -1,0 +1,20 @@
+namespace FamilyCoordinationApp.Services;
+
+/// <summary>
+/// Thrown when an optimistic-concurrency conflict is detected on the <c>Recipe.Version</c> (xmin) token —
+/// another writer modified the row after the client read it. Mirrors <see cref="ChoreConflictException"/>:
+/// the service sets the client-supplied version as the EF <c>OriginalValue</c> before saving, so a stale token
+/// surfaces a <see cref="Microsoft.EntityFrameworkCore.DbUpdateConcurrencyException"/>, rethrown as this type.
+/// <para>The endpoint layer maps this to <c>409 Conflict</c> (with a non-empty body). The real stale-token
+/// behavior is verified against Postgres in the integration tests — the InMemory provider has no xmin.</para>
+/// </summary>
+public class RecipeConflictException : Exception
+{
+    public RecipeConflictException(string message) : base(message)
+    {
+    }
+
+    public RecipeConflictException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}

--- a/src/FamilyCoordinationApp/Services/RecipeProjectionService.cs
+++ b/src/FamilyCoordinationApp/Services/RecipeProjectionService.cs
@@ -25,6 +25,7 @@ public class RecipeProjectionService : IRecipeProjectionService
 
     public RecipeFullDto ToFull(Recipe recipe, bool includeAuthor = true) => new(
         recipe.RecipeId,
+        recipe.Version,
         recipe.Name,
         recipe.RecipeType,
         recipe.Description,

--- a/src/FamilyCoordinationApp/Services/RecipeService.cs
+++ b/src/FamilyCoordinationApp/Services/RecipeService.cs
@@ -77,7 +77,7 @@ public class RecipeService(
             "Recipe");
     }
 
-    public async Task<Recipe> UpdateRecipeAsync(Recipe recipe, CancellationToken cancellationToken = default)
+    public async Task<Recipe> UpdateRecipeAsync(Recipe recipe, uint? expectedVersion = null, CancellationToken cancellationToken = default)
     {
         await using var context = await dbFactory.CreateDbContextAsync(cancellationToken);
 
@@ -89,6 +89,16 @@ public class RecipeService(
         if (existing == null)
         {
             throw new InvalidOperationException($"Recipe {recipe.RecipeId} not found in household {recipe.HouseholdId}");
+        }
+
+        // Optimistic concurrency (mirrors ChoreService.SaveWithConcurrencyAsync): loading the row makes EF
+        // treat the LOADED Version as the original, so a stale client token would NOT conflict on its own.
+        // Setting the client token as the OriginalValue makes the UPDATE run WHERE xmin = <client version>,
+        // so a stale token surfaces as DbUpdateConcurrencyException → RecipeConflictException (→ 409).
+        // null ⇒ no token supplied ⇒ legacy last-write-wins (the check is skipped).
+        if (expectedVersion.HasValue)
+        {
+            context.Entry(existing).Property(r => r.Version).OriginalValue = expectedVersion.Value;
         }
 
         // Update scalar properties
@@ -126,7 +136,15 @@ public class RecipeService(
             context.RecipeIngredients.Add(newIngredient);
         }
 
-        await context.SaveChangesAsync(cancellationToken);
+        try
+        {
+            await context.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateConcurrencyException ex)
+        {
+            throw new RecipeConflictException(
+                $"Recipe {recipe.RecipeId} was modified by another user; the supplied version is stale.", ex);
+        }
 
         logger.LogInformation("Updated recipe {RecipeId} for household {HouseholdId}", recipe.RecipeId, recipe.HouseholdId);
 

--- a/tests/FamilyCoordinationApp.Tests/Fixtures/RecipeFull/recipe.json
+++ b/tests/FamilyCoordinationApp.Tests/Fixtures/RecipeFull/recipe.json
@@ -1,5 +1,6 @@
 {
   "recipeId": 10,
+  "version": 42,
   "name": "Overnight Oats",
   "recipeType": "breakfast",
   "description": "Creamy make-ahead oats.",

--- a/tests/FamilyCoordinationApp.Tests/Integration/RecipesEndpointTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Integration/RecipesEndpointTests.cs
@@ -15,8 +15,9 @@ namespace FamilyCoordinationApp.Tests.Integration;
 /// load), soft delete, favorite toggle + the 404-not-500 guards, ingredient suggestions + parse + bulk-parse,
 /// categories, image-upload validation, import duplicate detection, connected-household 403 + the connected
 /// list/detail/copy happy path, draft round-trip, the 401 gate, and the M1 cross-household no-leak invariant.
-/// Versionless — no token on the wire. Tests use DISTINCT recipe names + scoped searches so the class's shared
-/// database can't let them interfere; all 403 assertions use a never-connected household id.
+/// Full-form PUT is xmin-guarded: a stale <c>version</c> token → 409 with a non-empty body (real Postgres is
+/// what enforces the token — InMemory has no xmin). Tests use DISTINCT recipe names + scoped searches so the
+/// class's shared database can't let them interfere; all 403 assertions use a never-connected household id.
 /// </summary>
 [Collection(IntegrationCollection.Name)]
 [Trait("kind", "integration")]
@@ -38,7 +39,7 @@ public sealed class RecipesEndpointTests(PostgresContainerFixture postgres) : IA
         int ingredientId, decimal? quantity, string? unit, string name, string category,
         string? notes, string? groupName, int sortOrder);
     private sealed record RecipeFull(
-        int recipeId, string name, string recipeType, string? description, string? instructions,
+        int recipeId, uint version, string name, string recipeType, string? description, string? instructions,
         string instructionsHtml, string? imagePath, string? sourceUrl, int? prepTimeMinutes,
         int? cookTimeMinutes, int? servings, string? createdByName, string? createdByPictureUrl,
         string? sharedFromHouseholdName, List<IngredientFull> ingredients);
@@ -61,7 +62,8 @@ public sealed class RecipesEndpointTests(PostgresContainerFixture postgres) : IA
 
     private static object WriteBody(
         string name, string type = "main", string? sourceUrl = null,
-        IEnumerable<object>? ingredients = null, int? servings = 4, string? instructions = null) => new
+        IEnumerable<object>? ingredients = null, int? servings = 4, string? instructions = null,
+        uint? version = null) => new
     {
         name,
         description = (string?)null,
@@ -72,7 +74,8 @@ public sealed class RecipesEndpointTests(PostgresContainerFixture postgres) : IA
         cookTimeMinutes = (int?)null,
         recipeType = type,
         imagePath = (string?)null,
-        ingredients = ingredients ?? Array.Empty<object>()
+        ingredients = ingredients ?? Array.Empty<object>(),
+        version
     };
 
     private static object Ing(string name, double? qty = null, string? unit = null, string category = "Pantry",
@@ -187,6 +190,52 @@ public sealed class RecipesEndpointTests(PostgresContainerFixture postgres) : IA
     {
         var resp = await ClientA.PutAsJsonAsync("/api/recipes/999999", WriteBody("Nope"), Json);
         resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // ── Optimistic concurrency (xmin — real Postgres enforces the token) ─────────────
+
+    [Fact]
+    public async Task Update_WithStaleVersion_Returns409WithBody_AndDoesNotOverwrite()
+    {
+        var created = await CreateAsync(ClientA, WriteBody("Concurrency Target Dish"));
+        var staleVersion = created.version;
+        staleVersion.Should().NotBe(0u, "real Postgres assigns a non-zero xmin to a committed row");
+
+        // Writer 1 saves (advances xmin) — no token, legacy last-write-wins path still succeeds.
+        var first = await ClientA.PutAsJsonAsync($"/api/recipes/{created.recipeId}",
+            WriteBody("Concurrency Target Dish (writer 1)"), Json);
+        first.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Writer 2 echoes the ORIGINAL (now stale) token → 409 with a NON-EMPTY body (a bare 4xx would
+        // re-execute through the GET-only /not-found page and surface as a 405 on PUT).
+        var second = await ClientA.PutAsJsonAsync($"/api/recipes/{created.recipeId}",
+            WriteBody("Concurrency Target Dish (writer 2)", version: staleVersion), Json);
+        second.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        var body = await second.Content.ReadAsStringAsync();
+        body.Should().Contain("changed by someone else", "the 409 must carry a non-empty JSON message");
+
+        // The stale writer did NOT overwrite writer 1.
+        var detail = await ClientA.GetFromJsonAsync<RecipeFull>($"/api/recipes/{created.recipeId}", Json);
+        detail!.name.Should().Be("Concurrency Target Dish (writer 1)");
+    }
+
+    [Fact]
+    public async Task Update_WithCurrentVersion_Succeeds_AndAdvancesToken()
+    {
+        var created = await CreateAsync(ClientA, WriteBody("Concurrency Happy Dish"));
+
+        var resp = await ClientA.PutAsJsonAsync($"/api/recipes/{created.recipeId}",
+            WriteBody("Concurrency Happy Dish (edited)", version: created.version), Json);
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var updated = await resp.Content.ReadFromJsonAsync<RecipeFull>(Json);
+        updated!.name.Should().Be("Concurrency Happy Dish (edited)");
+        updated.version.Should().NotBe(created.version, "a successful save advances the xmin token");
+
+        // The advanced token is immediately usable for the next save (reload-and-retry flow).
+        var again = await ClientA.PutAsJsonAsync($"/api/recipes/{created.recipeId}",
+            WriteBody("Concurrency Happy Dish (edited twice)", version: updated.version), Json);
+        again.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
     [Fact]

--- a/tests/FamilyCoordinationApp.Tests/Services/RecipeFullDtoContractTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/RecipeFullDtoContractTests.cs
@@ -40,6 +40,7 @@ public class RecipeFullDtoContractTests
 
         return new RecipeFullDto(
             RecipeId: 10,
+            Version: 42,
             Name: "Overnight Oats",
             RecipeType: RecipeType.Breakfast,
             Description: "Creamy make-ahead oats.",
@@ -78,7 +79,7 @@ public class RecipeFullDtoContractTests
         var root = JsonNode.Parse(json)!.AsObject();
 
         root.Select(kvp => kvp.Key).Should().BeEquivalentTo(
-            "recipeId", "name", "recipeType", "description", "instructions", "instructionsHtml",
+            "recipeId", "version", "name", "recipeType", "description", "instructions", "instructionsHtml",
             "imagePath", "sourceUrl", "prepTimeMinutes", "cookTimeMinutes", "servings",
             "createdByName", "createdByPictureUrl", "sharedFromHouseholdName", "ingredients");
 


### PR DESCRIPTION
Burn-down run items (Spine quests `8721170d` — recipe xmin concurrency, `f7d4aa5d` — inline ingredient edit). Same surface, one PR, two commits.

### 1. Optimistic concurrency on full-form recipe edits (xmin)
Recipes shipped versionless/last-write-wins for parity (D5). The entity already had `[Timestamp] uint Version` — now it's wired through:
- `RecipeFullDto` carries `version`; `RecipeWriteRequest` accepts optional `version` (null = legacy last-write-wins, keeps existing clients/tests working).
- The **house pattern from `ChoreService.SaveWithConcurrencyAsync`**: client token set as EF `OriginalValue` so the UPDATE runs `WHERE xmin = <client version>` — race-free, not read-then-compare. `DbUpdateConcurrencyException` → 409 `{ message: "This recipe was changed by someone else. Reload to see the latest." }` (non-empty 4xx body invariant).
- Edit page: 409 → non-destructive warning banner + Reload (typed state saved best-effort as draft before refetch). M9 contract test updated in lockstep.
- Two new Postgres integration tests: stale version → 409 + no overwrite; current version → success + token advance.

### 2. Inline ingredient edit
Pencil on an ingredient row swaps it to inline qty/unit/name/category/notes inputs (mirrors the add grid), Save/Cancel + Enter/Escape, drag disabled while editing. Store's remove+re-add `editIngredient` replaced by `updateIngredient(id, patch)` preserving `groupName`/`sortOrder`/`ingredientId`.

**No per-ingredient endpoint added, deliberately**: ingredients are client form state persisted wholesale by the existing recipe PUT (same as add/bulk-paste); a row-level PUT would be dead code and would break cancel/draft semantics (new rows have `ingredientId: 0` until save).

### Verification
- `dotnet test` **871/871**; `npm run check` 0 errors; vitest 6/6; production SPA build clean.
- **Browser-verified end-to-end at :8080** (branch image): inline edit → row updates + persists; then with xmin bumped concurrently → UI save → 409 banner (form intact, stays on page) → Reload clears → re-edit + save succeeds, version advanced (4310468 → 4310513 observed).

Known UX note to watch in use: after a conflict Reload, the pre-conflict typing lives in the draft, so reopening the editor later offers "Restore from draft" — deliberate, slightly odd, revisit if the family hits it.

https://claude.ai/code/session_01Nbc4zkiRDXrjBZ2vMnb9yU
