### PR TITLE
feat(meal-plan): drag-to-assign — move entries between slots

### DIFF
--- a/frontend/app/src/lib/meal-plan/App.svelte
+++ b/frontend/app/src/lib/meal-plan/App.svelte
@@ -15,8 +15,8 @@
   // Root of the meal-plan island. Reads the ShellContext from #meal-plan-root
   // data-attrs, fetches the current week's board into the shared store, and
   // renders WeekNav + (CalendarGrid on md+ / DayList on sm-). Every slot is a
-  // client-side grouping of the one board payload (store.entriesByDayMeal).
-  // Versionless — add + remove only; on any 4xx/network the store reconciles.
+  // client-side grouping of the one board payload (the store's per-slot zones).
+  // Versionless — add + move + remove; on any 4xx the store reconciles.
   // No `new Date('YYYY-MM-DD')` anywhere — week stepping goes through dates.ts.
   // ───────────────────────────────────────────────────────────────────────
 
@@ -116,6 +116,18 @@
     confirmEntry = null;
     if (entry) await store.removeEntry(entry.mealPlanId, entry.entryId);
   }
+
+  // Rebuild the per-slot dnd zones whenever the board data or week changes —
+  // but NEVER mid-drag: while `dragActive`, the store's consider/finalize
+  // handlers own the zones, and a rebuild would re-bucket the dragged node and
+  // abort a cross-slot drop (the shopping-list lesson). On finalize the store
+  // applies the optimistic move to `board.entries` BEFORE releasing the gate,
+  // so this fires once and reconciles from the final state. $effect.pre so the
+  // zones exist in the same frame the board arrives (no empty flash).
+  $effect.pre(() => {
+    if (store.dragActive) return;
+    store.rebuildZones();
+  });
 
   $effect(() => {
     // One-time mount setup. MUST run exactly once — `loadBoard()` synchronously

--- a/frontend/app/src/lib/meal-plan/lib/api.ts
+++ b/frontend/app/src/lib/meal-plan/lib/api.ts
@@ -68,7 +68,7 @@ export async function getBoard(weekStart: string): Promise<MealPlanBoardDto> {
   return request<MealPlanBoardDto>(`${BASE}/board?weekStart=${encodeURIComponent(weekStart)}`);
 }
 
-// ─── Entries (add / remove — versionless) ────────────────────────────────────
+// ─── Entries (add / move / remove — versionless) ─────────────────────────────
 
 /** Body for POST /entries — supply EXACTLY one of recipeId / customMealName. */
 export interface AddEntryBody {
@@ -83,6 +83,28 @@ export interface AddEntryBody {
 /** Add a meal to a slot → the created entry (201). */
 export async function addEntry(body: AddEntryBody): Promise<MealPlanEntryDto> {
   return request<MealPlanEntryDto>(`${BASE}/entries`, { method: 'POST', ...jsonBody(body) });
+}
+
+/** Body for PATCH /entries/{mealPlanId}/{entryId} — the target slot (same week only). */
+export interface MoveEntryBody {
+  /** "YYYY-MM-DD" — must fall inside the entry's plan week (else a 400). */
+  date: string;
+  mealType: MealType;
+}
+
+/**
+ * Move an entry to another same-week slot (drag-to-assign) → the updated entry.
+ * Cross-week target / duplicate-in-slot → 400; a missing entry → 404/empty-400.
+ */
+export async function moveEntry(
+  mealPlanId: number,
+  entryId: number,
+  body: MoveEntryBody,
+): Promise<MealPlanEntryDto> {
+  return request<MealPlanEntryDto>(`${BASE}/entries/${mealPlanId}/${entryId}`, {
+    method: 'PATCH',
+    ...jsonBody(body),
+  });
 }
 
 /** Remove an entry. DELETE → 204 (no body); a missing entry → 404/empty-400. */

--- a/frontend/app/src/lib/meal-plan/lib/board-ops.test.ts
+++ b/frontend/app/src/lib/meal-plan/lib/board-ops.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import {
+  applyEntryMove,
+  buildZones,
+  dragId,
+  findCrossSlotEntry,
+  replaceEntry,
+  zoneKey,
+  type DragEntry,
+} from './board-ops';
+import type { MealPlanEntryDto, MealType } from './types';
+
+// ─────────────────────────────────────────────────────────────────────────
+// Drag-to-assign transforms. The store (state.svelte.ts) is a thin reactive
+// shell over these pure functions — the parts unit tests can pin down are the
+// optimistic move, the failure REVERT (the same transform aimed back at the
+// original slot), the server-echo merge, and the zone bucketing contract
+// svelte-dnd-action depends on (`id` on every row; every slot — empty ones
+// included — owning its own array).
+// ─────────────────────────────────────────────────────────────────────────
+
+const WEEK = ['2026-07-06', '2026-07-07', '2026-07-08', '2026-07-09', '2026-07-10', '2026-07-11', '2026-07-12'];
+const MEALS: MealType[] = ['breakfast', 'lunch', 'dinner'];
+
+function entry(overrides: Partial<MealPlanEntryDto> = {}): MealPlanEntryDto {
+  return {
+    mealPlanId: 1,
+    entryId: 1,
+    date: '2026-07-06',
+    mealType: 'dinner',
+    recipe: { recipeId: 10, name: 'Tacos', imagePath: null, recipeType: 'main' },
+    customMealName: null,
+    notes: null,
+    ...overrides,
+  };
+}
+
+describe('buildZones — the per-slot dnd source', () => {
+  it('seeds EVERY day × meal slot, empty ones included (empty slots must be live drop targets)', () => {
+    const zones = buildZones([], WEEK, MEALS);
+    expect(Object.keys(zones)).toHaveLength(21);
+    expect(zones[zoneKey('2026-07-08', 'lunch')]).toEqual([]);
+  });
+
+  it('buckets entries into their slot and augments each row with the dnd `id`', () => {
+    const a = entry({ entryId: 1 });
+    const b = entry({ entryId: 2, mealType: 'lunch' });
+    const zones = buildZones([a, b], WEEK, MEALS);
+
+    const dinner = zones[zoneKey('2026-07-06', 'dinner')];
+    expect(dinner).toHaveLength(1);
+    // svelte-dnd-action hard-requires `id` — entryId alone is not unique across
+    // plans, so the row id compounds both keys (the settings CategoriesApp fix).
+    expect(dinner[0].id).toBe('1:1');
+    expect(dragId(b)).toBe('1:2');
+    expect(zones[zoneKey('2026-07-06', 'lunch')][0].entryId).toBe(2);
+  });
+
+  it('keeps an off-row entry (e.g. a data-carried snack) by creating its key', () => {
+    const snack = entry({ mealType: 'snack' as MealType });
+    const zones = buildZones([snack], WEEK, MEALS);
+    expect(zones[zoneKey('2026-07-06', 'snack' as MealType)]).toHaveLength(1);
+  });
+});
+
+describe('findCrossSlotEntry — destination-drop detection at finalize', () => {
+  it('finds the dropped row by its still-original slot disagreeing with the zone', () => {
+    const dragged: DragEntry = { ...entry(), id: '1:1' }; // still says Mon|dinner
+    const resident: DragEntry = { ...entry({ entryId: 2, date: '2026-07-07', mealType: 'lunch' }), id: '1:2' };
+    expect(findCrossSlotEntry([resident, dragged], '2026-07-07', 'lunch')).toBe(dragged);
+  });
+
+  it('returns null for the source zone / a same-slot reorder (nothing to persist)', () => {
+    const a: DragEntry = { ...entry({ entryId: 1 }), id: '1:1' };
+    const b: DragEntry = { ...entry({ entryId: 2 }), id: '1:2' };
+    expect(findCrossSlotEntry([b, a], '2026-07-06', 'dinner')).toBeNull();
+    expect(findCrossSlotEntry([], '2026-07-06', 'dinner')).toBeNull();
+  });
+});
+
+describe('applyEntryMove — optimistic move + failure revert', () => {
+  const others = [entry({ entryId: 2 }), entry({ entryId: 3, mealType: 'breakfast' })];
+  const moving = entry({ entryId: 1 });
+
+  it('re-slots exactly the identified entry, immutably', () => {
+    const before = [...others, moving];
+    const after = applyEntryMove(before, 1, 1, '2026-07-09', 'lunch');
+
+    const movedEntry = after.find((e) => e.entryId === 1)!;
+    expect(movedEntry.date).toBe('2026-07-09');
+    expect(movedEntry.mealType).toBe('lunch');
+    // Untouched entries keep identity; the source array and object are not mutated.
+    expect(after.find((e) => e.entryId === 2)).toBe(others[0]);
+    expect(moving.date).toBe('2026-07-06');
+    expect(before).toHaveLength(3);
+  });
+
+  it('REVERT: aiming the transform back at the original slot restores the pre-move board', () => {
+    const before = [...others, moving];
+    const optimistic = applyEntryMove(before, 1, 1, '2026-07-09', 'lunch');
+    // Network/5xx failure path — the store replays the move toward the captured original slot.
+    const reverted = applyEntryMove(optimistic, 1, 1, moving.date, moving.mealType);
+    expect(reverted).toEqual(before);
+  });
+
+  it('is a no-op for an entry that vanished (removed by someone else mid-flight)', () => {
+    const after = applyEntryMove(others, 1, 99, '2026-07-09', 'lunch');
+    expect(after).toEqual(others);
+  });
+
+  it('matches on BOTH mealPlanId and entryId (entryId alone is not identity)', () => {
+    const foreign = entry({ mealPlanId: 2, entryId: 1 });
+    const after = applyEntryMove([foreign], 1, 1, '2026-07-09', 'lunch');
+    expect(after[0]).toBe(foreign);
+  });
+});
+
+describe('replaceEntry — merging the server echo after a successful move', () => {
+  it('swaps in the authoritative entry by identity, leaving the rest alone', () => {
+    const stale = entry({ entryId: 1, date: '2026-07-09', mealType: 'lunch' });
+    const other = entry({ entryId: 2 });
+    const echo = entry({ entryId: 1, date: '2026-07-09', mealType: 'lunch', notes: 'server-stamped' });
+
+    const after = replaceEntry([stale, other], echo);
+    expect(after.find((e) => e.entryId === 1)).toBe(echo);
+    expect(after.find((e) => e.entryId === 2)).toBe(other);
+  });
+
+  it('drops the echo when the entry is gone (a liveness refresh already removed it)', () => {
+    const other = entry({ entryId: 2 });
+    const echo = entry({ entryId: 1 });
+    expect(replaceEntry([other], echo)).toEqual([other]);
+  });
+});

--- a/frontend/app/src/lib/meal-plan/lib/board-ops.ts
+++ b/frontend/app/src/lib/meal-plan/lib/board-ops.ts
@@ -1,0 +1,96 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Pure board transforms for drag-to-assign. Rune-free on purpose — the vitest
+// harness (vitest.config.ts) runs plain `node` with no Svelte plugin, so the
+// dnd/move logic that needs unit coverage lives HERE and the store
+// (state.svelte.ts) stays a thin reactive shell over these functions.
+//
+// svelte-dnd-action contracts encoded here (all three have bitten this repo):
+//   • every dnd item MUST carry an `id` — MealPlanEntryDto keys on
+//     (mealPlanId, entryId), so we drag over a `DragEntry` row that ADDS
+//     `id: "<mealPlanId>:<entryId>"` (the settings CategoriesApp pattern).
+//   • every slot is its OWN zone with its OWN array — `buildZones` seeds ALL
+//     day × meal keys (empty arrays included) so an empty slot is a valid
+//     drop target, and the store only ever swaps ONE zone's array mid-drag.
+//   • the dragged row keeps its ORIGINAL date/mealType until finalize —
+//     `findCrossSlotEntry` uses exactly that mismatch to detect a cross-slot
+//     drop in the destination zone.
+// ─────────────────────────────────────────────────────────────────────────
+
+import type { MealPlanEntryDto, MealType } from './types';
+
+/** A board entry augmented with the `id` svelte-dnd-action requires. */
+export type DragEntry = MealPlanEntryDto & { id: string };
+
+/** The dnd id — entryId alone is only unique within a plan, so compound both keys. */
+export function dragId(e: Pick<MealPlanEntryDto, 'mealPlanId' | 'entryId'>): string {
+  return `${e.mealPlanId}:${e.entryId}`;
+}
+
+/** One slot's zone key (`"YYYY-MM-DD|mealType"`). */
+export function zoneKey(date: string, mealType: MealType): string {
+  return `${date}|${mealType}`;
+}
+
+/**
+ * Bucket the board's entries into per-slot drag rows. EVERY rendered slot
+ * (each day × each meal row) gets a key — an empty slot owns an empty array so
+ * it is a live drop target. Entries outside `mealRows` (e.g. a data-carried
+ * snack) still get their own key so they are never dropped from the map.
+ */
+export function buildZones(
+  entries: MealPlanEntryDto[],
+  days: string[],
+  mealRows: MealType[],
+): Record<string, DragEntry[]> {
+  const zones: Record<string, DragEntry[]> = {};
+  for (const day of days) {
+    for (const meal of mealRows) zones[zoneKey(day, meal)] = [];
+  }
+  for (const e of entries) {
+    const key = zoneKey(e.date, e.mealType);
+    (zones[key] ??= []).push({ ...e, id: dragId(e) });
+  }
+  return zones;
+}
+
+/**
+ * The entry a finalize event moved INTO this zone: its (still-original)
+ * date/mealType disagrees with the zone's slot. Only the destination zone's
+ * items can contain one — the source zone's finalize (and any same-slot
+ * reorder) yields null.
+ */
+export function findCrossSlotEntry(
+  items: DragEntry[],
+  date: string,
+  mealType: MealType,
+): DragEntry | null {
+  return items.find((e) => e.date !== date || e.mealType !== mealType) ?? null;
+}
+
+/**
+ * Re-slot one entry (optimistic move / failure revert — the revert is just the
+ * same transform aimed back at the original slot). Immutable: a new array with
+ * a new object for the moved entry; everything else is untouched. A missing
+ * entry (already removed by someone else) is a no-op.
+ */
+export function applyEntryMove(
+  entries: MealPlanEntryDto[],
+  mealPlanId: number,
+  entryId: number,
+  date: string,
+  mealType: MealType,
+): MealPlanEntryDto[] {
+  return entries.map((e) =>
+    e.mealPlanId === mealPlanId && e.entryId === entryId ? { ...e, date, mealType } : e,
+  );
+}
+
+/** Merge the server's authoritative echo over the optimistic entry (by identity). */
+export function replaceEntry(
+  entries: MealPlanEntryDto[],
+  updated: MealPlanEntryDto,
+): MealPlanEntryDto[] {
+  return entries.map((e) =>
+    e.mealPlanId === updated.mealPlanId && e.entryId === updated.entryId ? updated : e,
+  );
+}

--- a/frontend/app/src/lib/meal-plan/lib/components/CalendarGrid.svelte
+++ b/frontend/app/src/lib/meal-plan/lib/components/CalendarGrid.svelte
@@ -48,11 +48,15 @@
     {#each days as day (day)}
       <div class="mp-grid-cell">
         <MealSlot
-          entries={store.entriesFor(day, mealType)}
+          entries={store.zoneFor(day, mealType)}
           onAdd={() => onSlotAdd(day, mealType)}
           {onRemove}
           {onViewRecipe}
           {onViewCustom}
+          onDnd={(items, phase) =>
+            phase === 'consider'
+              ? store.zoneConsider(day, mealType, items)
+              : void store.zoneFinalize(day, mealType, items)}
         />
       </div>
     {/each}

--- a/frontend/app/src/lib/meal-plan/lib/components/DayList.svelte
+++ b/frontend/app/src/lib/meal-plan/lib/components/DayList.svelte
@@ -51,11 +51,15 @@
             <span class="mp-day-row-label">{MEAL_LABELS[mealType]}</span>
             <div class="mp-day-row-slot">
               <MealSlot
-                entries={store.entriesFor(day, mealType)}
+                entries={store.zoneFor(day, mealType)}
                 onAdd={() => onSlotAdd(day, mealType)}
                 {onRemove}
                 {onViewRecipe}
                 {onViewCustom}
+                onDnd={(items, phase) =>
+                  phase === 'consider'
+                    ? store.zoneConsider(day, mealType, items)
+                    : void store.zoneFinalize(day, mealType, items)}
               />
             </div>
           </div>

--- a/frontend/app/src/lib/meal-plan/lib/components/MealSlot.svelte
+++ b/frontend/app/src/lib/meal-plan/lib/components/MealSlot.svelte
@@ -10,12 +10,25 @@
   //         custom-meal notes view (RecipeDetailSheet's custom mode).
   //     each entry has a × remove; below the entries an "add side/dessert" row
   //     re-opens the picker for the same slot.
+  //
+  // Drag-to-assign: the entries list is a svelte-dnd-action zone (one zone per
+  // slot — the store owns the per-zone arrays; see state.svelte.ts). The zone
+  // wrapper contains ONLY item elements (the library's contract), so the add
+  // affordances live OUTSIDE it. An EMPTY slot still renders the zone (an
+  // empty per-zone array) stretched over the ＋ button, so it is a live drop
+  // target; the zone itself is pointer-transparent (drop detection is
+  // coordinate-based) while its item children stay interactive, so tap-to-add,
+  // tap-to-view, × remove all keep working. Whole-card drag; touch engages via
+  // long-press (delayTouchStart) so scrolling and taps stay natural on phones.
   // ───────────────────────────────────────────────────────────────────────
   import type { MealPlanEntryDto } from '../types';
+  import type { DragEntry } from '../board-ops';
   import { recipeTypeLabel } from '../recipeType';
+  import { dndzone, SHADOW_ITEM_MARKER_PROPERTY_NAME, type DndEvent } from 'svelte-dnd-action';
 
   interface Props {
-    entries: MealPlanEntryDto[];
+    /** The slot's drag rows (entry + the dnd `id`) — the store's per-zone array. */
+    entries: DragEntry[];
     /** Open the picker for this slot (＋ / add side-dessert). */
     onAdd: () => void;
     /** Remove an entry (confirms in the parent). */
@@ -24,25 +37,64 @@
     onViewRecipe: (entry: MealPlanEntryDto) => void;
     /** View a custom-meal entry's notes. */
     onViewCustom: (entry: MealPlanEntryDto) => void;
+    /** Forward this zone's dnd events to the store (App wires date/mealType). */
+    onDnd: (items: DragEntry[], phase: 'consider' | 'finalize') => void;
   }
 
-  let { entries, onAdd, onRemove, onViewRecipe, onViewCustom }: Props = $props();
+  let { entries, onAdd, onRemove, onViewRecipe, onViewCustom, onDnd }: Props = $props();
 
-  let hasEntries = $derived(entries.length > 0);
+  // REAL entries only: while a drag hovers an empty slot the zone briefly holds
+  // the library's shadow placeholder — that must NOT flip the slot to its
+  // "filled" layout mid-drag (the geometry change would jitter the drop).
+  let hasEntries = $derived(
+    entries.some((e) => !(e as unknown as Record<string, unknown>)[SHADOW_ITEM_MARKER_PROPERTY_NAME]),
+  );
+
+  function handleConsider(e: CustomEvent<DndEvent<DragEntry>>): void {
+    onDnd(e.detail.items, 'consider');
+  }
+  function handleFinalize(e: CustomEvent<DndEvent<DragEntry>>): void {
+    onDnd(e.detail.items, 'finalize');
+  }
 </script>
 
-{#if !hasEntries}
-  <button type="button" class="mp-slot mp-slot-empty" aria-label="Add a meal" onclick={onAdd}>
-    <svg viewBox="0 0 24 24" width="28" height="28" aria-hidden="true">
-      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" fill="currentColor" />
-    </svg>
-  </button>
-{:else}
-  <div class="mp-slot mp-slot-filled">
-    <div class="mp-slot-entries">
-      {#each entries as entry (entry.entryId)}
+<div class="mp-slot" class:mp-slot-filled={hasEntries}>
+  {#if !hasEntries}
+    <button type="button" class="mp-slot-empty" aria-label="Add a meal" onclick={onAdd}>
+      <svg viewBox="0 0 24 24" width="28" height="28" aria-hidden="true">
+        <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" fill="currentColor" />
+      </svg>
+    </button>
+  {/if}
+  <!-- The dnd zone. Always rendered (an empty slot is a live drop target); when
+       empty it overlays the ＋ button pointer-transparently — drop detection is
+       coordinate-based, so clicks pass through while drops still land. Only item
+       elements may live inside (svelte-dnd-action's contract). -->
+  <div
+    class="mp-slot-entries"
+    class:mp-slot-entries-overlay={!hasEntries}
+    use:dndzone={{
+      items: entries,
+      type: 'meal-plan-entries',
+      flipDurationMs: 150,
+      dropTargetStyle: {},
+      dropTargetClasses: ['mp-drop-active'],
+      delayTouchStart: 250,
+    }}
+    onconsider={handleConsider}
+    onfinalize={handleFinalize}
+  >
+    {#each entries as entry (entry.id)}
         {#if entry.recipe}
           <div class="mp-entry">
+            <span class="mp-entry-grip" aria-hidden="true">
+              <svg viewBox="0 0 24 24" width="12" height="16">
+                <path
+                  d="M9 5a2 2 0 1 1-4 0 2 2 0 0 1 4 0zm0 7a2 2 0 1 1-4 0 2 2 0 0 1 4 0zm0 7a2 2 0 1 1-4 0 2 2 0 0 1 4 0zm10-14a2 2 0 1 1-4 0 2 2 0 0 1 4 0zm0 7a2 2 0 1 1-4 0 2 2 0 0 1 4 0zm0 7a2 2 0 1 1-4 0 2 2 0 0 1 4 0z"
+                  fill="currentColor"
+                />
+              </svg>
+            </span>
             <button
               type="button"
               class="mp-entry-main"
@@ -84,6 +136,14 @@
           </div>
         {:else if entry.customMealName}
           <div class="mp-entry">
+            <span class="mp-entry-grip" aria-hidden="true">
+              <svg viewBox="0 0 24 24" width="12" height="16">
+                <path
+                  d="M9 5a2 2 0 1 1-4 0 2 2 0 0 1 4 0zm0 7a2 2 0 1 1-4 0 2 2 0 0 1 4 0zm0 7a2 2 0 1 1-4 0 2 2 0 0 1 4 0zm10-14a2 2 0 1 1-4 0 2 2 0 0 1 4 0zm0 7a2 2 0 1 1-4 0 2 2 0 0 1 4 0zm0 7a2 2 0 1 1-4 0 2 2 0 0 1 4 0z"
+                  fill="currentColor"
+                />
+              </svg>
+            </span>
             <button
               type="button"
               class="mp-entry-main"
@@ -120,20 +180,21 @@
             </button>
           </div>
         {/if}
-      {/each}
-
-      <button type="button" class="mp-slot-add-more" onclick={onAdd}>
-        <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
-          <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" fill="currentColor" />
-        </svg>
-        Add side/dessert
-      </button>
-    </div>
+    {/each}
   </div>
-{/if}
+  {#if hasEntries}
+    <button type="button" class="mp-slot-add-more" onclick={onAdd}>
+      <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
+        <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" fill="currentColor" />
+      </svg>
+      Add side/dessert
+    </button>
+  {/if}
+</div>
 
 <style>
   .mp-slot {
+    position: relative;
     min-height: 80px;
     width: 100%;
     border-radius: var(--radius-sm);
@@ -142,7 +203,10 @@
   .mp-slot-empty {
     display: grid;
     place-items: center;
+    width: 100%;
+    min-height: 80px;
     border: 2px dashed var(--color-line-strong);
+    border-radius: var(--radius-sm);
     background: transparent;
     color: var(--color-text-muted);
     cursor: pointer;
@@ -156,12 +220,29 @@
   .mp-slot-filled {
     background: var(--color-surface);
     box-shadow: var(--shadow-2);
+    padding: 8px;
   }
   .mp-slot-entries {
     display: flex;
     flex-direction: column;
     gap: 4px;
+    border-radius: var(--radius-sm);
+  }
+  /* An EMPTY slot's zone stretches over the ＋ button. Pointer-transparent so
+     tap-to-add still works — svelte-dnd-action's drop detection is
+     coordinate-based, not pointer-event-based, so drops still register. */
+  .mp-slot-entries-overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    pointer-events: none;
     padding: 8px;
+  }
+  /* Hovered-drop affordance (dropTargetClasses) — on both empty and filled zones. */
+  .mp-slot-entries:global(.mp-drop-active) {
+    outline: 2px dashed var(--color-primary);
+    outline-offset: 2px;
+    background: var(--color-action-hover);
   }
 
   .mp-entry {
@@ -174,6 +255,20 @@
   }
   .mp-entry:hover {
     background: var(--color-action-hover);
+  }
+
+  /* Drag affordance. The WHOLE card drags (mouse: press-drag; touch: long-press
+     ~250ms then drag) — the grip is the visual cue, kept always visible so
+     phones get the affordance without hover. */
+  .mp-entry-grip {
+    display: grid;
+    place-items: center;
+    width: 14px;
+    flex-shrink: 0;
+    margin-left: 2px;
+    color: var(--color-text-muted);
+    opacity: 0.45;
+    cursor: grab;
   }
 
   .mp-entry-main {

--- a/frontend/app/src/lib/meal-plan/lib/state.svelte.ts
+++ b/frontend/app/src/lib/meal-plan/lib/state.svelte.ts
@@ -3,22 +3,32 @@
 //
 // One `MealPlanBoardDto` (the current week) is fetched and held here. The
 // calendar grid + day list are CLIENT-SIDE groupings of that one payload via
-// `entriesByDayMeal`.
+// the per-slot `zones` (rebuilt from `board.entries` outside drags — see the
+// gated $effect.pre in App.svelte).
 //
 // ⚠ Svelte 5 rune rule (global CORRECTION): never `export` a reassigned
 // `$state`/`$derived` from a module. We wrap the mutable state in a class
 // instance and export the instance — the runes live as `$state`/`$derived`
 // fields on the object, which is the supported pattern.
 //
-// Parity-first ⇒ VERSIONLESS / last-write-wins. The only ops are add + remove;
-// there is no xmin token, no 409 branch. On any 4xx/network error we reconcile
-// (re-GET the current week) + surface a calm toast. NO `new Date('YYYY-MM-DD')`
-// anywhere — week stepping goes through lib/dates.ts (MN4).
+// Parity-first ⇒ VERSIONLESS / last-write-wins. The ops are add + remove +
+// move (drag-to-assign, same week); there is no xmin token, no 409 branch. On
+// any 4xx error we reconcile (re-GET the current week) + surface a calm toast.
+// NO `new Date('YYYY-MM-DD')` anywhere — week stepping goes through
+// lib/dates.ts (MN4).
 // ─────────────────────────────────────────────────────────────────────────
 
 import type { MealPlanBoardDto, MealPlanEntryDto, MealType, ShellContext } from './types';
-import { ApiError, addEntry, getBoard, removeEntry, type AddEntryBody } from './api';
-import { addWeeks, mondayOf, todayMonday } from './dates';
+import { ApiError, addEntry, getBoard, moveEntry, removeEntry, type AddEntryBody } from './api';
+import { addWeeks, mondayOf, todayMonday, weekDays } from './dates';
+import {
+  applyEntryMove,
+  buildZones,
+  findCrossSlotEntry,
+  replaceEntry,
+  zoneKey,
+  type DragEntry,
+} from './board-ops';
 import { showToast } from '$lib/shared/toast-store.svelte';
 
 /** The board's three rendered meal rows (Snack is implicit — only shown if data exists). */
@@ -42,24 +52,51 @@ class MealPlanStore {
    */
   private refresh: (() => Promise<void>) | null = null;
 
-  /**
-   * Slot lookup: `${date}|${mealType}` → the entries in that slot. Empty map
-   * until the board loads. A slot with no entries simply isn't a key.
-   */
-  entriesByDayMeal = $derived.by(() => {
-    const map = new Map<string, MealPlanEntryDto[]>();
-    for (const e of this.board?.entries ?? []) {
-      const key = `${e.date}|${e.mealType}`;
-      const bucket = map.get(key);
-      if (bucket) bucket.push(e);
-      else map.set(key, [e]);
-    }
-    return map;
-  });
+  // ── Per-slot zone state (drag-to-assign) ─────────────────────────────────
+  //
+  // svelte-dnd-action multi-zone rule (bit the shopping list): each slot's dnd
+  // zone must OWN a stable, mutable items array across a drag — NOT a $derived
+  // off `board.entries`. Any cross-zone rebuild mid-drag tears down the dragged
+  // DOM node and silently breaks between-slot drops. So `zones` is $state:
+  // App.svelte's gated $effect.pre rebuilds it from `board.entries` whenever
+  // data changes OUTSIDE a drag; during a drag the consider/finalize handlers
+  // below own it and only ever swap ONE zone's array.
+  zones = $state<Record<string, DragEntry[]>>({});
+  /** True from the first `consider` until `finalize` — gates the zone rebuild. */
+  dragActive = $state(false);
 
-  /** Entries for one slot (empty array when none). */
-  entriesFor(date: string, mealType: MealType): MealPlanEntryDto[] {
-    return this.entriesByDayMeal.get(`${date}|${mealType}`) ?? [];
+  /** One slot's drag rows (a stable empty array is seeded for empty slots). */
+  zoneFor(date: string, mealType: MealType): DragEntry[] {
+    return this.zones[zoneKey(date, mealType)] ?? [];
+  }
+
+  /** Re-derive all zones from the authoritative board. NEVER call mid-drag. */
+  rebuildZones(): void {
+    this.zones = buildZones(this.board?.entries ?? [], weekDays(this.weekStart), MEAL_ROWS);
+  }
+
+  /** Live drag: reflect the library's per-zone items in the zone that fired, nothing else. */
+  zoneConsider(date: string, mealType: MealType, items: DragEntry[]): void {
+    this.dragActive = true;
+    this.zones[zoneKey(date, mealType)] = items;
+  }
+
+  /**
+   * Drop: commit the fired zone's items, then — only in the DESTINATION zone,
+   * detected by a row still carrying its pre-drag slot — persist the move. The
+   * optimistic `board.entries` update happens synchronously inside `moveEntry`
+   * BEFORE the drag gate is released, so the rebuild reconciles to the moved
+   * state (no snap-back frame). The source zone's finalize (and a same-slot
+   * reorder, which has nothing to persist) just releases the gate.
+   */
+  zoneFinalize(date: string, mealType: MealType, items: DragEntry[]): Promise<void> {
+    this.zones[zoneKey(date, mealType)] = items;
+    const moved = findCrossSlotEntry(items, date, mealType);
+    const persist = moved
+      ? this.moveEntry(moved.mealPlanId, moved.entryId, date, mealType)
+      : Promise.resolve();
+    this.dragActive = false;
+    return persist;
   }
 
   /** Count of all entries on a given day (for the mobile day-list "N meals" label). */
@@ -162,6 +199,62 @@ class MealPlanStore {
           ? "Couldn't add that meal — the plan was refreshed."
           : "Couldn't add that meal right now.";
       showToast({ message: msg, kind: 'info' });
+    }
+  }
+
+  /**
+   * Move an entry to another slot in the SAME week (drag-to-assign). Optimistic
+   * re-slot, then PATCH; the server echo is merged back (authoritative
+   * UpdatedAt/UpdatedBy). Mirrors removeEntry's failure split: any 4xx (cross-
+   * week, duplicate-in-slot, entry gone — incl. the empty-400-from-404 quirk)
+   * → reconcile + calm toast; network/5xx → revert the optimistic move (the
+   * same transform aimed back at the original slot) + error toast. Same
+   * targetWeek stale-response guard as addEntry.
+   */
+  async moveEntry(
+    mealPlanId: number,
+    entryId: number,
+    date: string,
+    mealType: MealType,
+  ): Promise<void> {
+    if (!this.board) return;
+    const original = this.board.entries.find(
+      (e) => e.mealPlanId === mealPlanId && e.entryId === entryId,
+    );
+    if (!original) return;
+    const fromDate = original.date;
+    const fromMeal = original.mealType;
+    if (fromDate === date && fromMeal === mealType) return;
+
+    const targetWeek = this.weekStart;
+    // Optimistic re-slot (synchronous — zoneFinalize relies on this landing
+    // before the drag gate is released).
+    this.board.entries = applyEntryMove(this.board.entries, mealPlanId, entryId, date, mealType);
+    try {
+      const updated = await moveEntry(mealPlanId, entryId, { date, mealType });
+      // The user stepped to another week while the PATCH was in flight — this
+      // board is no longer the one we moved on; the new week's GET is truth.
+      if (!this.board || this.weekStart !== targetWeek) return;
+      this.board.entries = replaceEntry(this.board.entries, updated);
+    } catch (e) {
+      if (this.weekStart !== targetWeek) return;
+      if (e instanceof ApiError) {
+        // Any 4xx — the server rejected the move; resync to truth.
+        await this.reconcile();
+        showToast({ message: "Couldn't move that meal — the plan was refreshed.", kind: 'info' });
+      } else {
+        // Network/5xx: put the entry back in its original slot.
+        if (this.board) {
+          this.board.entries = applyEntryMove(
+            this.board.entries,
+            mealPlanId,
+            entryId,
+            fromDate,
+            fromMeal,
+          );
+        }
+        showToast({ message: 'Something went wrong. Please try again.', kind: 'error' });
+      }
     }
   }
 

--- a/src/FamilyCoordinationApp/Endpoints/MealPlanEndpoints.cs
+++ b/src/FamilyCoordinationApp/Endpoints/MealPlanEndpoints.cs
@@ -35,6 +35,7 @@ public static class MealPlanEndpoints
 
         group.MapGet("/board", GetBoard);
         group.MapPost("/entries", AddEntry);
+        group.MapPatch("/entries/{mealPlanId:int}/{entryId:int}", MoveEntry);
         group.MapDelete("/entries/{mealPlanId:int}/{entryId:int}", RemoveEntry);
 
         group.MapGet("/recipes", SearchRecipes);
@@ -119,6 +120,39 @@ public static class MealPlanEndpoints
 
         var dto = boardService.ProjectEntry(entry, recipe);
         return Results.Created($"/api/meal-plan/entries/{entry.MealPlanId}/{entry.EntryId}", dto);
+    }
+
+    private static async Task<IResult> MoveEntry(
+        int mealPlanId,
+        int entryId,
+        MoveEntryRequest req,
+        ClaimsPrincipal principal,
+        IMealPlanService mealPlanService,
+        IMealPlanBoardService boardService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        try
+        {
+            // Household-scoped move to another same-week slot (drag-to-assign). The service loads the
+            // Recipe nav, so the response reuses the ONE board projection (M9) with no extra query.
+            var entry = await mealPlanService.MoveMealAsync(
+                user.HouseholdId, mealPlanId, entryId, req.Date, req.MealType, user.UserId, ct);
+            return Results.Ok(boardService.ProjectEntry(entry, entry.Recipe));
+        }
+        catch (InvalidOperationException)
+        {
+            // Non-empty body — see RemoveEntry (an empty non-GET 4xx re-executes into a 405 on the wire).
+            return Results.NotFound(new { message = "Meal entry not found." });
+        }
+        catch (ArgumentException ex)
+        {
+            // Cross-week target / duplicate-in-slot — clean 400 with the reason (messages are ours).
+            return Results.BadRequest(new { message = ex.Message });
+        }
     }
 
     private static async Task<IResult> RemoveEntry(
@@ -225,6 +259,12 @@ public static class MealPlanEndpoints
         int? RecipeId,
         string? CustomMealName,
         string? Notes);
+
+    /// <summary>
+    /// Move an entry to another slot in the SAME week (drag-to-assign). <see cref="Date"/> must fall inside
+    /// the entry's plan week — a cross-week target is a 400 (a plan owns exactly one week).
+    /// </summary>
+    public sealed record MoveEntryRequest(DateOnly Date, MealType MealType);
 
     /// <summary>Quick-create a bare recipe from the picker's "New Recipe" tab (details added later).</summary>
     public sealed record QuickCreateRecipeRequest(string Name, RecipeType RecipeType);

--- a/src/FamilyCoordinationApp/Services/Interfaces/IMealPlanService.cs
+++ b/src/FamilyCoordinationApp/Services/Interfaces/IMealPlanService.cs
@@ -6,6 +6,16 @@ public interface IMealPlanService
 {
     Task<MealPlan> GetOrCreateMealPlanAsync(int householdId, DateOnly weekStart, CancellationToken cancellationToken = default);
     Task<MealPlanEntry> AddMealAsync(int householdId, DateOnly date, MealType mealType, int? recipeId, string? customMealName, string? notes = null, int? userId = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Move an existing entry to another slot (date × meal type) WITHIN its plan's week (drag-to-assign).
+    /// Household-scoped (M1). Returns the updated entry with its <c>Recipe</c> nav loaded (for projection).
+    /// Throws <see cref="InvalidOperationException"/> when the entry is not found and
+    /// <see cref="ArgumentException"/> when the target date falls outside the plan's week or the target
+    /// slot already holds the same meal (mirrors the AddMealAsync duplicate guard).
+    /// </summary>
+    Task<MealPlanEntry> MoveMealAsync(int householdId, int mealPlanId, int entryId, DateOnly newDate, MealType newMealType, int? userId = null, CancellationToken cancellationToken = default);
+
     Task RemoveMealAsync(int householdId, int mealPlanId, int entryId, CancellationToken cancellationToken = default);
     DateOnly GetWeekStartDate(DateOnly date);
     DateOnly[] GetWeekDays(DateOnly weekStart);

--- a/src/FamilyCoordinationApp/Services/MealPlanService.cs
+++ b/src/FamilyCoordinationApp/Services/MealPlanService.cs
@@ -147,6 +147,64 @@ public class MealPlanService(
             "MealPlanEntry");
     }
 
+    public async Task<MealPlanEntry> MoveMealAsync(int householdId, int mealPlanId, int entryId, DateOnly newDate, MealType newMealType, int? userId = null, CancellationToken cancellationToken = default)
+    {
+        await using var context = await dbFactory.CreateDbContextAsync(cancellationToken);
+
+        // Household-scoped — a cross-household id finds nothing ⇒ not found (M1). Recipe nav is loaded so
+        // the caller can project the response without a second query.
+        var entry = await context.MealPlanEntries
+            .Include(e => e.Recipe)
+            .FirstOrDefaultAsync(e =>
+                e.HouseholdId == householdId &&
+                e.MealPlanId == mealPlanId &&
+                e.EntryId == entryId, cancellationToken);
+
+        if (entry == null)
+        {
+            throw new InvalidOperationException($"Meal entry {entryId} not found in plan {mealPlanId} for household {householdId}");
+        }
+
+        // Same-week only: a MealPlan owns exactly one week, so a date in another week would need a
+        // cross-plan move (new EntryId under the other week's plan). The board UI only offers same-week
+        // drops; reject anything else cleanly instead of corrupting the plan's week invariant.
+        var mealPlan = await context.MealPlans
+            .FirstOrDefaultAsync(mp => mp.HouseholdId == householdId && mp.MealPlanId == mealPlanId, cancellationToken);
+        if (mealPlan == null || mealPlan.WeekStartDate != GetWeekStartDate(newDate))
+        {
+            throw new ArgumentException("The target date is outside this meal plan's week.");
+        }
+
+        // Mirror the AddMealAsync duplicate guard: the same recipe / custom meal can't sit twice in one slot.
+        var duplicateExists = await context.MealPlanEntries.AnyAsync(e =>
+            e.HouseholdId == householdId &&
+            e.MealPlanId == mealPlanId &&
+            e.EntryId != entryId &&
+            e.Date == newDate &&
+            e.MealType == newMealType &&
+            ((entry.RecipeId.HasValue && e.RecipeId == entry.RecipeId) ||
+             (entry.CustomMealName != null && e.CustomMealName == entry.CustomMealName)), cancellationToken);
+        if (duplicateExists)
+        {
+            throw new ArgumentException("That meal is already planned in the target slot.");
+        }
+
+        entry.Date = newDate;
+        entry.MealType = newMealType;
+        entry.UpdatedAt = DateTime.UtcNow;
+        entry.UpdatedByUserId = userId;
+
+        // Update parent MealPlan timestamp for polling
+        mealPlan.UpdatedAt = DateTime.UtcNow;
+
+        await context.SaveChangesAsync(cancellationToken);
+
+        logger.LogInformation("Moved meal entry {EntryId} in plan {MealPlanId} for household {HouseholdId} to {Date} {MealType}",
+            entryId, mealPlanId, householdId, newDate, newMealType);
+
+        return entry;
+    }
+
     public async Task RemoveMealAsync(int householdId, int mealPlanId, int entryId, CancellationToken cancellationToken = default)
     {
         await using var context = await dbFactory.CreateDbContextAsync(cancellationToken);

--- a/tests/FamilyCoordinationApp.Tests/Services/MealPlanServiceMoveTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Services/MealPlanServiceMoveTests.cs
@@ -1,0 +1,203 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using FamilyCoordinationApp.Data;
+using FamilyCoordinationApp.Data.Entities;
+using FamilyCoordinationApp.Services;
+
+namespace FamilyCoordinationApp.Tests.Services;
+
+/// <summary>
+/// MoveMealAsync (drag-to-assign): same-week slot move semantics — happy path, household isolation
+/// (M1), the same-week guard (a plan owns exactly one week), and the duplicate-in-target-slot guard
+/// (mirrors AddMealAsync's dedupe).
+/// </summary>
+public class MealPlanServiceMoveTests : IDisposable
+{
+    // Monday of the seeded week.
+    private static readonly DateOnly WeekStart = new(2026, 7, 6);
+
+    private readonly ApplicationDbContext _context;
+    private readonly DbContextOptions<ApplicationDbContext> _options;
+    private readonly MealPlanService _service;
+
+    public MealPlanServiceMoveTests()
+    {
+        _options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        _context = new ApplicationDbContext(_options);
+
+        var dbFactoryMock = new Mock<IDbContextFactory<ApplicationDbContext>>();
+        dbFactoryMock.Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new ApplicationDbContext(_options));
+
+        _service = new MealPlanService(dbFactoryMock.Object, new Mock<ILogger<MealPlanService>>().Object);
+
+        SeedTestData();
+    }
+
+    private void SeedTestData()
+    {
+        _context.Households.AddRange(
+            new Household { Id = 1, Name = "Smith Family" },
+            new Household { Id = 2, Name = "Jones Family" });
+
+        _context.Users.Add(new User { Id = 1, HouseholdId = 1, Email = "a@b.com", DisplayName = "Alice" });
+
+        _context.Recipes.Add(new Recipe
+        {
+            HouseholdId = 1,
+            RecipeId = 1,
+            Name = "Tacos",
+            RecipeType = RecipeType.Main,
+            CreatedAt = DateTime.UtcNow,
+        });
+
+        _context.MealPlans.Add(new MealPlan
+        {
+            HouseholdId = 1,
+            MealPlanId = 1,
+            WeekStartDate = WeekStart,
+            CreatedAt = DateTime.UtcNow,
+        });
+
+        _context.MealPlanEntries.AddRange(
+            // The entry the tests move: Monday dinner, recipe meal.
+            new MealPlanEntry
+            {
+                HouseholdId = 1,
+                MealPlanId = 1,
+                EntryId = 1,
+                Date = WeekStart,
+                MealType = MealType.Dinner,
+                RecipeId = 1,
+            },
+            // Same recipe already sits in Wednesday dinner — the duplicate-guard target.
+            new MealPlanEntry
+            {
+                HouseholdId = 1,
+                MealPlanId = 1,
+                EntryId = 2,
+                Date = WeekStart.AddDays(2),
+                MealType = MealType.Dinner,
+                RecipeId = 1,
+            },
+            // A custom meal on Monday lunch (custom-name dedupe check).
+            new MealPlanEntry
+            {
+                HouseholdId = 1,
+                MealPlanId = 1,
+                EntryId = 3,
+                Date = WeekStart,
+                MealType = MealType.Lunch,
+                CustomMealName = "Leftovers",
+            });
+
+        _context.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task MoveMeal_ToAnotherSameWeekSlot_UpdatesDateAndMealType()
+    {
+        var newDate = WeekStart.AddDays(3); // Thursday
+        var moved = await _service.MoveMealAsync(1, 1, 1, newDate, MealType.Lunch, userId: 1);
+
+        moved.Date.Should().Be(newDate);
+        moved.MealType.Should().Be(MealType.Lunch);
+        moved.UpdatedByUserId.Should().Be(1);
+        moved.UpdatedAt.Should().NotBeNull();
+        moved.Recipe.Should().NotBeNull("the Recipe nav must be loaded for the response projection");
+
+        await using var verify = new ApplicationDbContext(_options);
+        var persisted = await verify.MealPlanEntries
+            .SingleAsync(e => e.HouseholdId == 1 && e.MealPlanId == 1 && e.EntryId == 1);
+        persisted.Date.Should().Be(newDate);
+        persisted.MealType.Should().Be(MealType.Lunch);
+
+        var plan = await verify.MealPlans.SingleAsync(mp => mp.HouseholdId == 1 && mp.MealPlanId == 1);
+        plan.UpdatedAt.Should().NotBeNull("the move must bump the plan timestamp for polling");
+    }
+
+    [Fact]
+    public async Task MoveMeal_MissingEntry_Throws()
+    {
+        var act = () => _service.MoveMealAsync(1, 1, 999, WeekStart, MealType.Breakfast);
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task MoveMeal_CrossHousehold_IsNotFound()
+    {
+        // Household 2 asking for household 1's entry — the scoped lookup must not see it (M1).
+        var act = () => _service.MoveMealAsync(2, 1, 1, WeekStart, MealType.Breakfast);
+        await act.Should().ThrowAsync<InvalidOperationException>();
+
+        await using var verify = new ApplicationDbContext(_options);
+        var untouched = await verify.MealPlanEntries
+            .SingleAsync(e => e.HouseholdId == 1 && e.MealPlanId == 1 && e.EntryId == 1);
+        untouched.Date.Should().Be(WeekStart);
+        untouched.MealType.Should().Be(MealType.Dinner);
+    }
+
+    [Fact]
+    public async Task MoveMeal_DateOutsideThePlansWeek_Throws()
+    {
+        var nextMonday = WeekStart.AddDays(7);
+        var act = () => _service.MoveMealAsync(1, 1, 1, nextMonday, MealType.Dinner);
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*outside this meal plan's week*");
+    }
+
+    [Fact]
+    public async Task MoveMeal_SameRecipeAlreadyInTargetSlot_Throws()
+    {
+        // Entry 1 (Tacos) → Wednesday dinner, where entry 2 already plans Tacos.
+        var act = () => _service.MoveMealAsync(1, 1, 1, WeekStart.AddDays(2), MealType.Dinner);
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*already planned*");
+    }
+
+    [Fact]
+    public async Task MoveMeal_SameCustomMealAlreadyInTargetSlot_Throws()
+    {
+        // A second "Leftovers" on Tuesday dinner, then move Monday-lunch "Leftovers" onto it.
+        _context.MealPlanEntries.Add(new MealPlanEntry
+        {
+            HouseholdId = 1,
+            MealPlanId = 1,
+            EntryId = 4,
+            Date = WeekStart.AddDays(1),
+            MealType = MealType.Dinner,
+            CustomMealName = "Leftovers",
+        });
+        _context.SaveChanges();
+
+        var act = () => _service.MoveMealAsync(1, 1, 3, WeekStart.AddDays(1), MealType.Dinner);
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*already planned*");
+    }
+
+    [Fact]
+    public async Task MoveMeal_DifferentMealInTargetSlot_IsAllowed()
+    {
+        // Moving the custom meal onto Monday dinner (which holds a RECIPE meal) is fine —
+        // the dedupe only blocks the SAME recipe/custom name, not co-located different meals.
+        var moved = await _service.MoveMealAsync(1, 1, 3, WeekStart, MealType.Dinner);
+
+        moved.MealType.Should().Be(MealType.Dinner);
+        await using var verify = new ApplicationDbContext(_options);
+        var slotEntries = await verify.MealPlanEntries
+            .Where(e => e.HouseholdId == 1 && e.Date == WeekStart && e.MealType == MealType.Dinner)
+            .CountAsync();
+        slotEntries.Should().Be(2);
+    }
+}


### PR DESCRIPTION
Burn-down run item (Spine quest `1656427f` — "Meal Plan island: drag-to-assign"). The deferred-from-parity enhancement, now additive on the SPA board.

### What it does
Drag an assigned meal card between slots (same week) with `svelte-dnd-action` — desktop grip-drag, mobile long-press (250ms). Click flows unchanged (empty-slot + → picker, card → detail sheet). **Recipe-source drag was deliberately skipped**: assigning is exclusively via the modal picker, so there's no natural drag source alongside the grid — click-to-pick remains the assign path.

### Backend
No move endpoint existed (only add + delete). Added `PATCH /api/meal-plan/entries/{mealPlanId}/{entryId}` with `{ date, mealType }` → 200 updated `MealPlanEntryDto` (shared M9 projection). Household-scoped (M1); 404/400 all carry message bodies (entry-not-found, cross-week target, duplicate-same-meal-in-slot — mirrors AddMealAsync's dedupe). `MoveMealAsync` stamps `UpdatedAt/UpdatedByUserId` and bumps the plan timestamp for the liveness poller. 7 new service tests.

### Frontend
All three in-repo svelte-dnd-action landmines pre-empted:
- id-augmented drag rows (`id: "planId:entryId"`) — the PR #76 CategoriesApp pattern
- per-zone `$state` arrays (21 day×meal zones, seeded so **empty slots are drop targets**), zone rebuilds gated to never run mid-drag — the shopping-list pattern
- authoritative state change deferred to finalize; optimistic move with revert-on-network-failure and refetch+calm-toast on 4xx reconcile (mirrors removeEntry), targetWeek stale-guard like addEntry

Move/revert logic extracted into rune-free `board-ops.ts` (the vitest harness runs plain node) — 11 new vitest cases; the store is a thin reactive shell.

### Verification
- Gates: `dotnet test` **876/876**; svelte-check 0 errors; vitest **17/17**; production SPA build clean; no new format findings.
- **Verified at :8080 (branch image)**: board renders with grips, dnd zones initialize with zero console errors (the settings-drag failure mode was an init throw); move endpoint exercised through the real stack — happy 200 + updated DTO, duplicate → 400 with body, cross-week → 400 with body.
- **Manual drag verification by operator pending** (drags aren't browser-automatable): desktop slot→slot, empty-slot drop, mobile long-press, offline revert. Do not merge until that's done.

https://claude.ai/code/session_01Nbc4zkiRDXrjBZ2vMnb9yU
