### PR TITLE
feat(recipes): import preview — scrape → preview → confirm

### DIFF
--- a/frontend/app/src/lib/recipes/lib/api.ts
+++ b/frontend/app/src/lib/recipes/lib/api.ts
@@ -5,7 +5,7 @@ import type {
   ParsedIngredientDto,
   CategoryDto,
   ConnectedHouseholdDto,
-  RecipeImportResultDto,
+  RecipeImportPreviewDto,
   RecipeDraftData,
   SaveDraftRequest,
 } from './types';
@@ -135,13 +135,15 @@ export async function listImages(): Promise<string[]> {
 // ─── Import ─────────────────────────────────────────────────────────────────
 
 /**
- * #13 Scrape→create. On success returns the SAVED recipe id (then nav to edit).
+ * #13 Scrape→preview. Parses the URL WITHOUT persisting — on success returns the
+ * parsed recipe payload (create-compatible: confirm by POSTing it to createRecipe).
  * On a duplicate returns existingRecipeId/Name (unless `force`). On failure,
- * errorType + partialData for the "Add Manually" fallback. May take ≤60s (Polly)
- * — do NOT add a shorter client timeout.
+ * errorType + partialData (still previewable). May take ≤60s (Polly) — do NOT add
+ * a shorter client timeout. (The legacy scrape-and-create POST /import still
+ * exists server-side but the SPA no longer calls it.)
  */
-export async function importRecipe(url: string, force = false): Promise<RecipeImportResultDto> {
-  return request<RecipeImportResultDto>(`${BASE}/import`, { method: 'POST', ...jsonBody({ url, force }) });
+export async function previewImport(url: string, force = false): Promise<RecipeImportPreviewDto> {
+  return request<RecipeImportPreviewDto>(`${BASE}/import/preview`, { method: 'POST', ...jsonBody({ url, force }) });
 }
 
 // ─── Connected households ─────────────────────────────────────────────────────

--- a/frontend/app/src/lib/recipes/lib/components/ImportDialog.svelte
+++ b/frontend/app/src/lib/recipes/lib/components/ImportDialog.svelte
@@ -1,11 +1,17 @@
 <script lang="ts">
-  // Import-from-URL dialog (mirrors ImportRecipeDialog.razor): URL field, a
-  // supported-sites note, a spinner (YouTube variant warns it's slower), duplicate
-  // detection ("View Existing" / "Import Anyway"=force), and an error → "Add
-  // Manually" fallback. On success the parent navigates to /recipes/edit/{id}.
+  // Import-from-URL dialog — scrape → PREVIEW → confirm (nothing is persisted until
+  // the user confirms). Phase 'url': URL field, supported-sites note, a spinner
+  // (YouTube variant warns it's slower), duplicate detection ("View Existing" /
+  // "Import Anyway"=force), and an error → "Add Manually" fallback. Phase 'preview':
+  // the parsed result (title, image, meta, ingredients, steps, source) — a PARTIAL
+  // parse still previews (with a warning; confirm needs at least a title). Confirm
+  // POSTs the payload to the plain create endpoint, then the parent navigates to
+  // /recipes/edit/{id}; Back/Cancel persist nothing.
   import { base } from '$app/paths';
   import { goto } from '$app/navigation';
-  import { importRecipe, ApiError } from '../api';
+  import { previewImport, createRecipe, ApiError } from '../api';
+  import type { PartialRecipeDataDto, RecipePreviewDto, RecipeWriteRequest } from '../types';
+  import { formatExactQuantity } from '../quantity';
 
   interface Props {
     open: boolean;
@@ -22,7 +28,52 @@
   let existingId = $state<number | null>(null);
   let showManual = $state(false);
 
+  // Preview phase state. `preview` = full parse; `partial` = degraded parse (still shown).
+  let phase = $state<'url' | 'preview'>('url');
+  let preview = $state<RecipePreviewDto | null>(null);
+  let partial = $state<PartialRecipeDataDto | null>(null);
+  let previewWarning = $state<string | null>(null);
+  let confirming = $state(false);
+  let confirmError = $state<string | null>(null);
+
   let isYouTube = $derived(/youtube\.com|youtu\.be/i.test(url));
+
+  // One render model for both full and partial previews.
+  let view = $derived.by(() => {
+    if (preview) {
+      return {
+        name: preview.name as string | null,
+        description: preview.description,
+        instructions: preview.instructions,
+        imageUrl: preview.imagePath,
+        sourceUrl: preview.sourceUrl ?? url.trim(),
+        servings: preview.servings,
+        prepTimeMinutes: preview.prepTimeMinutes,
+        cookTimeMinutes: preview.cookTimeMinutes,
+        ingredients: preview.ingredients.map((i) => {
+          const qty = i.quantity != null ? formatExactQuantity(i.quantity) : null;
+          const line = [qty, i.unit, i.name].filter(Boolean).join(' ');
+          return i.notes ? `${line} (${i.notes})` : line;
+        }),
+      };
+    }
+    if (partial) {
+      return {
+        name: partial.name,
+        description: partial.description,
+        instructions: partial.instructions,
+        imageUrl: partial.imageUrl,
+        sourceUrl: url.trim(),
+        servings: partial.servings,
+        prepTimeMinutes: partial.prepTimeMinutes,
+        cookTimeMinutes: partial.cookTimeMinutes,
+        ingredients: partial.ingredientStrings ?? [],
+      };
+    }
+    return null;
+  });
+
+  let canConfirm = $derived(!confirming && (preview != null || !!partial?.name?.trim()));
 
   $effect(() => {
     if (!dialogEl) return;
@@ -39,6 +90,12 @@
     error = null;
     existingId = null;
     showManual = false;
+    phase = 'url';
+    preview = null;
+    partial = null;
+    previewWarning = null;
+    confirming = false;
+    confirmError = null;
   }
 
   function handleClose(): void {
@@ -46,21 +103,42 @@
     onClose();
   }
 
-  async function doImport(force = false): Promise<void> {
+  /** Back to the URL step — discards the preview (nothing was persisted). */
+  function backToUrl(): void {
+    phase = 'url';
+    preview = null;
+    partial = null;
+    previewWarning = null;
+    confirmError = null;
+    error = null;
+  }
+
+  async function doPreview(force = false): Promise<void> {
     if (!url.trim() || importing) return;
     importing = true;
     error = null;
     showManual = false;
     existingId = null;
     try {
-      const res = await importRecipe(url.trim(), force);
-      if (res.success && res.recipeId != null) {
-        onImported(res.recipeId);
+      const res = await previewImport(url.trim(), force);
+      if (res.success && res.recipe != null) {
+        preview = res.recipe;
+        partial = null;
+        previewWarning = null;
+        phase = 'preview';
         return;
       }
       if (res.existingRecipeId != null) {
         existingId = res.existingRecipeId;
         error = res.errorMessage ?? 'This recipe has already been imported.';
+        return;
+      }
+      if (res.partialData != null) {
+        // Failure honesty: show what DID come back before the user decides.
+        preview = null;
+        partial = res.partialData;
+        previewWarning = res.errorMessage ?? 'Only part of the recipe could be extracted.';
+        phase = 'preview';
         return;
       }
       error = res.errorMessage ?? 'Import failed for unknown reason.';
@@ -77,12 +155,55 @@
     }
   }
 
+  /** Confirm: create the previewed recipe via the plain create endpoint, then navigate. */
+  async function confirmImport(): Promise<void> {
+    if (!canConfirm) return;
+    const body: RecipeWriteRequest | null = preview
+      ? { ...preview }
+      : partial?.name?.trim()
+        ? {
+            name: partial.name.trim(),
+            description: partial.description,
+            instructions: partial.instructions,
+            sourceUrl: url.trim(),
+            servings: partial.servings,
+            prepTimeMinutes: partial.prepTimeMinutes,
+            cookTimeMinutes: partial.cookTimeMinutes,
+            recipeType: 'main',
+            imagePath: partial.imageUrl,
+            ingredients: (partial.ingredientStrings ?? []).map((s, i) => ({
+              name: s,
+              quantity: null,
+              unit: null,
+              category: 'Pantry',
+              notes: null,
+              groupName: null,
+              sortOrder: i,
+            })),
+          }
+        : null;
+    if (!body) return;
+
+    confirming = true;
+    confirmError = null;
+    try {
+      const created = await createRecipe(body);
+      onImported(created.recipeId);
+    } catch (e) {
+      confirmError =
+        e instanceof ApiError
+          ? `Could not save the recipe (HTTP ${e.status}).`
+          : 'An error occurred while saving the recipe.';
+      confirming = false;
+    }
+  }
+
   function viewExisting(): void {
     if (existingId != null) void goto(`${base}/recipes/edit/${existingId}`);
   }
 
   function importAnyway(): void {
-    void doImport(true);
+    void doPreview(true);
   }
 
   function addManually(): void {
@@ -93,62 +214,146 @@
 <dialog bind:this={dialogEl} onclose={handleClose} class="rc-dialog">
   {#if open}
     <header class="rc-dialog-head">
-      <h2>Import Recipe</h2>
+      <h2>{phase === 'preview' ? 'Preview Recipe' : 'Import Recipe'}</h2>
       <button type="button" class="rc-dialog-x" aria-label="Close" onclick={handleClose}>×</button>
     </header>
 
-    <div class="rc-dialog-body">
-      <p class="rc-import-intro">Paste a recipe URL to import. Tested and working with:</p>
-      <p class="rc-import-sites">✓ AllRecipes • BBC Good Food • NYT Cooking • Serious Eats • YouTube</p>
+    {#if phase === 'url'}
+      <div class="rc-dialog-body">
+        <p class="rc-import-intro">Paste a recipe URL to import. Tested and working with:</p>
+        <p class="rc-import-sites">✓ AllRecipes • BBC Good Food • NYT Cooking • Serious Eats • YouTube</p>
 
-      <label class="rc-field">
-        <span class="rc-field-label">Recipe URL</span>
-        <input
-          type="url"
-          class="rc-input"
-          placeholder="https://www.allrecipes.com/recipe/..."
-          bind:value={url}
-          disabled={importing}
-        />
-      </label>
+        <label class="rc-field">
+          <span class="rc-field-label">Recipe URL</span>
+          <input
+            type="url"
+            class="rc-input"
+            placeholder="https://www.allrecipes.com/recipe/..."
+            bind:value={url}
+            disabled={importing}
+          />
+        </label>
 
-      {#if importing}
-        <div class="rc-import-progress">
-          <span class="rc-spinner" aria-hidden="true"></span>
-          <span>
-            {isYouTube
-              ? 'Extracting recipe from video… This may take a moment.'
-              : 'Importing recipe…'}
-          </span>
-        </div>
-      {/if}
+        {#if importing}
+          <div class="rc-import-progress">
+            <span class="rc-spinner" aria-hidden="true"></span>
+            <span>
+              {isYouTube
+                ? 'Extracting recipe from video… This may take a moment.'
+                : 'Fetching recipe…'}
+            </span>
+          </div>
+        {/if}
 
-      {#if error}
-        <div class="rc-import-alert" class:rc-alert-info={existingId != null}>
-          <p class="rc-alert-msg">{error}</p>
-          {#if existingId != null}
-            <div class="rc-alert-actions">
-              <button type="button" class="rc-text-btn" onclick={viewExisting}>View Existing</button>
-              <button type="button" class="rc-text-btn" onclick={importAnyway}>Import Anyway</button>
-            </div>
-          {:else if showManual}
-            <button type="button" class="rc-text-btn" onclick={addManually}>Add Recipe Manually</button>
-          {/if}
-        </div>
-      {/if}
-    </div>
+        {#if error}
+          <div class="rc-import-alert" class:rc-alert-info={existingId != null}>
+            <p class="rc-alert-msg">{error}</p>
+            {#if existingId != null}
+              <div class="rc-alert-actions">
+                <button type="button" class="rc-text-btn" onclick={viewExisting}>View Existing</button>
+                <button type="button" class="rc-text-btn" onclick={importAnyway}>Import Anyway</button>
+              </div>
+            {:else if showManual}
+              <button type="button" class="rc-text-btn" onclick={addManually}>Add Recipe Manually</button>
+            {/if}
+          </div>
+        {/if}
+      </div>
 
-    <footer class="rc-dialog-actions">
-      <button type="button" class="rc-btn-ghost" onclick={handleClose} disabled={importing}>Cancel</button>
-      <button
-        type="button"
-        class="rc-btn-solid"
-        onclick={() => doImport(false)}
-        disabled={importing || !url.trim()}
-      >
-        Import
-      </button>
-    </footer>
+      <footer class="rc-dialog-actions">
+        <button type="button" class="rc-btn-ghost" onclick={handleClose} disabled={importing}>Cancel</button>
+        <button
+          type="button"
+          class="rc-btn-solid"
+          onclick={() => doPreview(false)}
+          disabled={importing || !url.trim()}
+        >
+          Import
+        </button>
+      </footer>
+    {:else if view}
+      <div class="rc-dialog-body">
+        {#if previewWarning}
+          <div class="rc-import-alert rc-preview-warning">
+            <p class="rc-alert-msg">{previewWarning}</p>
+            {#if !canConfirm}
+              <button type="button" class="rc-text-btn" onclick={addManually}>Add Recipe Manually</button>
+            {/if}
+          </div>
+        {/if}
+
+        <p class="rc-preview-hint">Nothing is saved yet — review what was found, then add it.</p>
+
+        {#if view.imageUrl}
+          <img
+            class="rc-preview-img"
+            src={view.imageUrl}
+            alt=""
+            loading="lazy"
+            onerror={(e) => ((e.currentTarget as HTMLImageElement).style.display = 'none')}
+          />
+        {/if}
+
+        <h3 class="rc-preview-name" class:rc-preview-missing={!view.name?.trim()}>
+          {view.name?.trim() || 'No title found'}
+        </h3>
+
+        {#if view.description}
+          <p class="rc-preview-desc">{view.description}</p>
+        {/if}
+
+        {#if view.servings != null || view.prepTimeMinutes != null || view.cookTimeMinutes != null}
+          <p class="rc-preview-meta">
+            {#if view.servings != null}<span>Serves {view.servings}</span>{/if}
+            {#if view.prepTimeMinutes != null}<span>Prep {view.prepTimeMinutes} min</span>{/if}
+            {#if view.cookTimeMinutes != null}<span>Cook {view.cookTimeMinutes} min</span>{/if}
+          </p>
+        {/if}
+
+        <h4 class="rc-preview-heading">Ingredients ({view.ingredients.length})</h4>
+        {#if view.ingredients.length > 0}
+          <ul class="rc-preview-ingredients">
+            {#each view.ingredients as line, i (i)}
+              <li>{line}</li>
+            {/each}
+          </ul>
+        {:else}
+          <p class="rc-preview-missing">No ingredients found — you can add them after saving.</p>
+        {/if}
+
+        <h4 class="rc-preview-heading">Instructions</h4>
+        {#if view.instructions?.trim()}
+          <p class="rc-preview-steps">{view.instructions}</p>
+        {:else}
+          <p class="rc-preview-missing">No instructions found.</p>
+        {/if}
+
+        <p class="rc-preview-source">Source: <span class="rc-preview-url">{view.sourceUrl}</span></p>
+
+        {#if confirming}
+          <div class="rc-import-progress">
+            <span class="rc-spinner" aria-hidden="true"></span>
+            <span>Saving recipe…</span>
+          </div>
+        {/if}
+
+        {#if confirmError}
+          <div class="rc-import-alert">
+            <p class="rc-alert-msg">{confirmError}</p>
+          </div>
+        {/if}
+      </div>
+
+      <footer class="rc-dialog-actions">
+        <button type="button" class="rc-btn-ghost rc-btn-back" onclick={backToUrl} disabled={confirming}>
+          Back
+        </button>
+        <button type="button" class="rc-btn-ghost" onclick={handleClose} disabled={confirming}>Cancel</button>
+        <button type="button" class="rc-btn-solid" onclick={confirmImport} disabled={!canConfirm}>
+          Add Recipe
+        </button>
+      </footer>
+    {/if}
   {/if}
 </dialog>
 
@@ -295,6 +500,77 @@
   .rc-text-btn:hover {
     text-decoration: underline;
   }
+  /* ── Preview phase ── */
+  .rc-preview-hint {
+    margin: 0 0 12px;
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+  }
+  .rc-preview-warning {
+    margin: 0 0 16px; /* it leads the body — cancel rc-import-alert's margin-top */
+  }
+  .rc-preview-img {
+    display: block;
+    width: 100%;
+    max-height: 220px;
+    object-fit: cover;
+    border-radius: var(--radius-sm);
+    margin-bottom: 12px;
+  }
+  .rc-preview-name {
+    margin: 0 0 4px;
+    font-size: 1.125rem;
+    font-weight: 600;
+  }
+  .rc-preview-desc {
+    margin: 0 0 8px;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+  .rc-preview-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px 16px;
+    margin: 0 0 8px;
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+  }
+  .rc-preview-heading {
+    margin: 16px 0 6px;
+    font-size: 0.875rem;
+    font-weight: 600;
+  }
+  .rc-preview-ingredients {
+    margin: 0;
+    padding-left: 20px;
+    font-size: 0.875rem;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .rc-preview-steps {
+    margin: 0;
+    font-size: 0.875rem;
+    white-space: pre-line;
+  }
+  .rc-preview-missing {
+    margin: 0;
+    font-size: 0.875rem;
+    font-style: italic;
+    color: var(--color-text-muted);
+  }
+  .rc-preview-source {
+    margin: 16px 0 0;
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+  }
+  .rc-preview-url {
+    word-break: break-all;
+  }
+  .rc-btn-back {
+    margin-right: auto;
+  }
+
   .rc-dialog-actions {
     display: flex;
     justify-content: flex-end;

--- a/frontend/app/src/lib/recipes/lib/components/ImportDialog.svelte
+++ b/frontend/app/src/lib/recipes/lib/components/ImportDialog.svelte
@@ -158,10 +158,12 @@
   /** Confirm: create the previewed recipe via the plain create endpoint, then navigate. */
   async function confirmImport(): Promise<void> {
     if (!canConfirm) return;
+    // version: null — this is a CREATE; the xmin concurrency token only applies to edits (PUT).
     const body: RecipeWriteRequest | null = preview
-      ? { ...preview }
+      ? { ...preview, version: null }
       : partial?.name?.trim()
         ? {
+            version: null,
             name: partial.name.trim(),
             description: partial.description,
             instructions: partial.instructions,

--- a/frontend/app/src/lib/recipes/lib/types.ts
+++ b/frontend/app/src/lib/recipes/lib/types.ts
@@ -113,12 +113,52 @@ export interface PartialRecipeDataDto {
   servings: number | null;
 }
 
+/** Legacy scrape-AND-create result (POST /import — endpoint kept; the SPA now uses /import/preview). */
 export interface RecipeImportResultDto {
   success: boolean;
   /** The SAVED recipe id on success. */
   recipeId: number | null;
   errorMessage: string | null;
   /** The RecipeImportErrorType name (e.g. "NetworkError"). */
+  errorType: string | null;
+  existingRecipeId: number | null;
+  existingRecipeName: string | null;
+  partialData: PartialRecipeDataDto | null;
+}
+
+/** One parsed ingredient of a preview — SAME shape as RecipeIngredientWrite (create-compatible). */
+export interface RecipePreviewIngredientDto {
+  name: string;
+  quantity: number | null;
+  unit: string | null;
+  category: string;
+  notes: string | null;
+  groupName: string | null;
+  sortOrder: number;
+}
+
+/** The parsed-but-UNSAVED recipe — field-compatible with RecipeWriteRequest (send verbatim on confirm). */
+export interface RecipePreviewDto {
+  name: string;
+  description: string | null;
+  instructions: string | null;
+  sourceUrl: string | null;
+  servings: number | null;
+  prepTimeMinutes: number | null;
+  cookTimeMinutes: number | null;
+  recipeType: RecipeType;
+  imagePath: string | null;
+  ingredients: RecipePreviewIngredientDto[];
+}
+
+/**
+ * POST /import/preview result — scrape + parse WITHOUT persisting. Mirrors RecipeImportResultDto's
+ * duplicate/failure surface; success carries `recipe` (the preview payload) instead of a saved id.
+ */
+export interface RecipeImportPreviewDto {
+  success: boolean;
+  recipe: RecipePreviewDto | null;
+  errorMessage: string | null;
   errorType: string | null;
   existingRecipeId: number | null;
   existingRecipeName: string | null;

--- a/src/FamilyCoordinationApp/Endpoints/RecipesEndpoints.cs
+++ b/src/FamilyCoordinationApp/Endpoints/RecipesEndpoints.cs
@@ -52,8 +52,11 @@ public static class RecipesEndpoints
         group.MapPost("/images", UploadImage);
         group.MapGet("/images", ListImages);
 
-        // Import (literal)
+        // Import (literal). /import/preview scrapes + parses WITHOUT persisting (the SPA previews the
+        // result and confirms via the plain create endpoint); /import is the legacy scrape-and-create
+        // (kept working — a stale service-worker-cached SPA may still call it during rollout).
         group.MapPost("/import", ImportRecipe);
+        group.MapPost("/import/preview", PreviewImport);
 
         // Connected households (literal prefix)
         group.MapGet("/connections", GetConnections);
@@ -357,21 +360,16 @@ public static class RecipesEndpoints
         // bypasses ONLY this check (ImportFromUrlAsync has no force param) — mirrors ImportRecipeDialog.
         if (!req.Force)
         {
-            await using var ctx = await dbFactory.CreateDbContextAsync(ct);
-            var existing = await ctx.Recipes
-                .Where(r => r.HouseholdId == user.HouseholdId && r.SourceUrl == req.Url)
-                .Select(r => new { r.RecipeId, r.Name })
-                .FirstOrDefaultAsync(ct);
-
+            var existing = await FindExistingBySourceUrlAsync(dbFactory, user.HouseholdId, req.Url, ct);
             if (existing is not null)
             {
                 return Results.Ok(new RecipeImportResultDto(
                     Success: false,
                     RecipeId: null,
-                    ErrorMessage: $"This recipe has already been imported as \"{existing.Name}\".",
+                    ErrorMessage: $"This recipe has already been imported as \"{existing.Value.Name}\".",
                     ErrorType: null,
-                    ExistingRecipeId: existing.RecipeId,
-                    ExistingRecipeName: existing.Name,
+                    ExistingRecipeId: existing.Value.RecipeId,
+                    ExistingRecipeName: existing.Value.Name,
                     PartialData: null));
             }
         }
@@ -390,6 +388,70 @@ public static class RecipesEndpoints
         return Results.Ok(new RecipeImportResultDto(
             Success: false,
             RecipeId: null,
+            ErrorMessage: result.ErrorMessage,
+            ErrorType: result.ErrorType.ToString(),
+            ExistingRecipeId: null,
+            ExistingRecipeName: null,
+            PartialData: MapPartial(result.PartialData)));
+    }
+
+    /// <summary>
+    /// Scrape + parse a URL and return the result WITHOUT persisting anything (the preview step of the
+    /// scrape → preview → confirm flow; confirm is the plain create endpoint). Same duplicate detection /
+    /// force semantics and the same 200-envelope failure contract as <see cref="ImportRecipe"/> — a scrape
+    /// failure is <c>success:false</c> + errorMessage (+ partialData when extraction got that far), so the
+    /// SPA can still preview a partial parse.
+    /// </summary>
+    private static async Task<IResult> PreviewImport(
+        ImportRequest req,
+        ClaimsPrincipal principal,
+        IRecipeImportService importService,
+        IDbContextFactory<ApplicationDbContext> dbFactory,
+        CancellationToken ct)
+    {
+        var user = await UserContextResolver.ResolveUserAsync(principal, dbFactory, ct);
+        if (user is null) return Results.Unauthorized();
+
+        if (string.IsNullOrWhiteSpace(req.Url))
+        {
+            return Results.BadRequest(new { message = "A recipe URL is required." });
+        }
+
+        if (!req.Force)
+        {
+            var existing = await FindExistingBySourceUrlAsync(dbFactory, user.HouseholdId, req.Url, ct);
+            if (existing is not null)
+            {
+                return Results.Ok(new RecipeImportPreviewDto(
+                    Success: false,
+                    Recipe: null,
+                    ErrorMessage: $"This recipe has already been imported as \"{existing.Value.Name}\".",
+                    ErrorType: null,
+                    ExistingRecipeId: existing.Value.RecipeId,
+                    ExistingRecipeName: existing.Value.Name,
+                    PartialData: null));
+            }
+        }
+
+        // ImportFromUrlAsync returns an UNSAVED entity — here it is mapped to the preview DTO and
+        // deliberately NEVER persisted (that is the whole point of this endpoint).
+        var result = await importService.ImportFromUrlAsync(req.Url, user.HouseholdId, user.UserId, ct);
+
+        if (result.Success && result.Recipe is not null)
+        {
+            return Results.Ok(new RecipeImportPreviewDto(
+                Success: true,
+                Recipe: MapPreview(result.Recipe),
+                ErrorMessage: null,
+                ErrorType: null,
+                ExistingRecipeId: null,
+                ExistingRecipeName: null,
+                PartialData: null));
+        }
+
+        return Results.Ok(new RecipeImportPreviewDto(
+            Success: false,
+            Recipe: null,
             ErrorMessage: result.ErrorMessage,
             ErrorType: result.ErrorType.ToString(),
             ExistingRecipeId: null,
@@ -584,6 +646,38 @@ public static class RecipesEndpoints
     private static PartialRecipeDataDto? MapPartial(PartialRecipeData? p) => p is null ? null : new(
         p.Name, p.Description, p.Instructions, p.IngredientStrings, p.ImageUrl,
         p.PrepTimeMinutes, p.CookTimeMinutes, p.Servings);
+
+    /// <summary>Map the import service's unsaved <see cref="Recipe"/> to the create-compatible preview shape.</summary>
+    private static RecipePreviewDto MapPreview(Recipe recipe) => new(
+        recipe.Name,
+        recipe.Description,
+        recipe.Instructions,
+        recipe.SourceUrl,
+        recipe.Servings,
+        recipe.PrepTimeMinutes,
+        recipe.CookTimeMinutes,
+        recipe.RecipeType,
+        recipe.ImagePath,
+        recipe.Ingredients
+            .OrderBy(i => i.SortOrder)
+            .Select(i => new RecipePreviewIngredientDto(
+                i.Name, i.Quantity, i.Unit, i.Category, i.Notes, i.GroupName, i.SortOrder))
+            .ToList());
+
+    /// <summary>
+    /// Household-scoped exact-SourceUrl duplicate lookup (shared by import + import/preview; the EF global
+    /// filter excludes soft-deleted rows).
+    /// </summary>
+    private static async Task<(int RecipeId, string Name)?> FindExistingBySourceUrlAsync(
+        IDbContextFactory<ApplicationDbContext> dbFactory, int householdId, string url, CancellationToken ct)
+    {
+        await using var ctx = await dbFactory.CreateDbContextAsync(ct);
+        var existing = await ctx.Recipes
+            .Where(r => r.HouseholdId == householdId && r.SourceUrl == url)
+            .Select(r => new { r.RecipeId, r.Name })
+            .FirstOrDefaultAsync(ct);
+        return existing is null ? null : (existing.RecipeId, existing.Name);
+    }
 
     private static string? NullIfBlank(string? s) => string.IsNullOrWhiteSpace(s) ? null : s.Trim();
 

--- a/src/FamilyCoordinationApp/Services/Dtos/RecipeDtos.cs
+++ b/src/FamilyCoordinationApp/Services/Dtos/RecipeDtos.cs
@@ -120,3 +120,44 @@ public sealed record PartialRecipeDataDto(
     int? PrepTimeMinutes,
     int? CookTimeMinutes,
     int? Servings);
+
+/// <summary>
+/// Result of <c>POST /import/preview</c> — the scrape + parse WITHOUT persisting anything. Mirrors
+/// <see cref="RecipeImportResultDto"/>'s duplicate/failure surface, but success carries the parsed
+/// recipe (<see cref="RecipePreviewDto"/>, create-request shaped) instead of a saved id: the SPA
+/// previews it and, on confirm, POSTs the payload to the existing create endpoint.
+/// </summary>
+public sealed record RecipeImportPreviewDto(
+    bool Success,
+    RecipePreviewDto? Recipe,
+    string? ErrorMessage,
+    string? ErrorType,
+    int? ExistingRecipeId,
+    string? ExistingRecipeName,
+    PartialRecipeDataDto? PartialData);
+
+/// <summary>
+/// The parsed-but-UNSAVED recipe. Field-compatible with the create body
+/// (<c>RecipesEndpoints.RecipeWriteRequest</c>) so the client can send it back verbatim on confirm.
+/// </summary>
+public sealed record RecipePreviewDto(
+    string Name,
+    string? Description,
+    string? Instructions,
+    string? SourceUrl,
+    int? Servings,
+    int? PrepTimeMinutes,
+    int? CookTimeMinutes,
+    RecipeType RecipeType,
+    string? ImagePath,
+    IReadOnlyList<RecipePreviewIngredientDto> Ingredients);
+
+/// <summary>One parsed ingredient line — same shape as <c>RecipeIngredientWrite</c> (create-compatible).</summary>
+public sealed record RecipePreviewIngredientDto(
+    string Name,
+    decimal? Quantity,
+    string? Unit,
+    string Category,
+    string? Notes,
+    string? GroupName,
+    int SortOrder);

--- a/tests/FamilyCoordinationApp.Tests/Integration/RecipeImportPreviewEndpointTests.cs
+++ b/tests/FamilyCoordinationApp.Tests/Integration/RecipeImportPreviewEndpointTests.cs
@@ -1,0 +1,245 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FamilyCoordinationApp.Data;
+using FamilyCoordinationApp.Models.SchemaOrg;
+using FamilyCoordinationApp.Services;
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FamilyCoordinationApp.Tests.Integration;
+
+/// <summary>
+/// End-to-end coverage of <c>POST /api/recipes/import/preview</c> through the real HTTP pipeline against real
+/// Postgres. The SCRAPE is stubbed (per the existing scraper-test pattern — <c>RecipeImportServiceTests</c>
+/// mocks <c>IRecipeScraperService</c>); everything downstream is real: <c>RecipeImportService</c>,
+/// <c>IngredientParser</c>, <c>CategoryInferenceService</c>, and the endpoint's duplicate detection. The
+/// <c>IUrlValidator</c> is also stubbed valid so no test does live DNS. Proves the preview endpoint returns
+/// the parse (create-request shaped) and — the whole point — PERSISTS NOTHING (raw-row assertion). Failure
+/// paths keep the import family's 200-envelope contract (success:false + non-empty errorMessage), and a
+/// partial parse still returns partialData so the SPA can preview it.
+/// </summary>
+[Collection(IntegrationCollection.Name)]
+[Trait("kind", "integration")]
+public sealed class RecipeImportPreviewEndpointTests(PostgresContainerFixture postgres) : IAsyncLifetime
+{
+    private readonly PreviewWebAppFactory _factory = new(postgres);
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    public async Task InitializeAsync() => await _factory.EnsureSeededAsync();
+
+    public async Task DisposeAsync() => await _factory.DisposeAsync();
+
+    private HttpClient ClientA => _factory.CreateClientAs(ChoresWebAppFactory.UserAEmail);
+
+    // ── Wire shapes (camelCase via JsonSerializerDefaults.Web) ──────────────────────
+    private sealed record PreviewIngredient(
+        string name, decimal? quantity, string? unit, string category, string? notes, string? groupName, int sortOrder);
+    private sealed record PreviewRecipe(
+        string name, string? description, string? instructions, string? sourceUrl, int? servings,
+        int? prepTimeMinutes, int? cookTimeMinutes, string recipeType, string? imagePath,
+        List<PreviewIngredient> ingredients);
+    private sealed record PartialData(
+        string? name, string? description, string? instructions, List<string>? ingredientStrings,
+        string? imageUrl, int? prepTimeMinutes, int? cookTimeMinutes, int? servings);
+    private sealed record PreviewResult(
+        bool success, PreviewRecipe? recipe, string? errorMessage, string? errorType,
+        int? existingRecipeId, string? existingRecipeName, PartialData? partialData);
+
+    private static RecipeSchema FullSchema(string name = "Preview Pancakes") => new()
+    {
+        Name = name,
+        Description = "Fluffy preview pancakes",
+        RecipeIngredient = new[] { "2 cups flour", "1 egg" },
+        RecipeInstructions = JsonSerializer.Deserialize<JsonElement>(
+            "[{\"@type\":\"HowToStep\",\"text\":\"Mix\"},{\"@type\":\"HowToStep\",\"text\":\"Cook\"}]"),
+        RecipeYield = JsonSerializer.Deserialize<JsonElement>("\"4 servings\""),
+        PrepTime = "PT10M",
+        CookTime = "PT20M",
+        Image = JsonSerializer.Deserialize<JsonElement>("\"https://example.com/pancakes.jpg\"")
+    };
+
+    private async Task<int> CountRecipesBySourceUrlAsync(string url)
+    {
+        var dbFactory = _factory.Services.GetRequiredService<IDbContextFactory<ApplicationDbContext>>();
+        await using var ctx = await dbFactory.CreateDbContextAsync();
+        // IgnoreQueryFilters so even a soft-deleted accidental write would be caught.
+        return await ctx.Recipes.IgnoreQueryFilters().CountAsync(r => r.SourceUrl == url);
+    }
+
+    [Fact]
+    public async Task Preview_Success_ReturnsParse_AndPersistsNothing()
+    {
+        const string url = "https://preview.test/pancakes";
+        _factory.Scraper.Next = FullSchema();
+
+        var resp = await ClientA.PostAsJsonAsync("/api/recipes/import/preview", new { url, force = false }, Json);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await resp.Content.ReadFromJsonAsync<PreviewResult>(Json);
+        result.Should().NotBeNull();
+        result!.success.Should().BeTrue();
+        result.errorMessage.Should().BeNull();
+        result.recipe.Should().NotBeNull();
+
+        var recipe = result.recipe!;
+        recipe.name.Should().Be("Preview Pancakes");
+        recipe.description.Should().Be("Fluffy preview pancakes");
+        recipe.sourceUrl.Should().Be(url);
+        recipe.imagePath.Should().Be("https://example.com/pancakes.jpg");
+        recipe.servings.Should().Be(4);
+        recipe.prepTimeMinutes.Should().Be(10);
+        recipe.cookTimeMinutes.Should().Be(20);
+        recipe.recipeType.Should().Be("main"); // default(RecipeType) — camelCase enum string on the wire
+        recipe.instructions.Should().Contain("Mix").And.Contain("Cook");
+
+        // The real IngredientParser ran ("2 cups flour" → 2 / "cups" / "flour").
+        recipe.ingredients.Should().HaveCount(2);
+        recipe.ingredients[0].quantity.Should().Be(2m);
+        recipe.ingredients[0].unit.Should().Be("cups");
+        recipe.ingredients[0].name.Should().Be("flour");
+        recipe.ingredients[0].category.Should().NotBeNullOrWhiteSpace();
+        recipe.ingredients.Select(i => i.sortOrder).Should().BeInAscendingOrder();
+
+        // THE invariant: preview persisted nothing (raw-row check, query filters ignored).
+        (await CountRecipesBySourceUrlAsync(url)).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Preview_NoRecipeMarkup_ReturnsFailureEnvelope_AndPersistsNothing()
+    {
+        const string url = "https://preview.test/no-jsonld";
+        _factory.Scraper.Next = null; // scraper found no JSON-LD Recipe
+
+        var resp = await ClientA.PostAsJsonAsync("/api/recipes/import/preview", new { url, force = false }, Json);
+
+        // Import-family convention: scrape failures are a 200 envelope with success:false + a message.
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await resp.Content.ReadFromJsonAsync<PreviewResult>(Json);
+        result!.success.Should().BeFalse();
+        result.recipe.Should().BeNull();
+        result.errorType.Should().Be("ParsingFailed");
+        result.errorMessage.Should().NotBeNullOrWhiteSpace();
+
+        (await CountRecipesBySourceUrlAsync(url)).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Preview_PartialParse_MissingIngredients_ReturnsPartialData_AndPersistsNothing()
+    {
+        const string url = "https://preview.test/partial";
+        _factory.Scraper.Next = new RecipeSchema
+        {
+            Name = "Partial Soup",
+            Description = "Only metadata, no ingredients",
+            RecipeIngredient = null // → ValidationFailed with partial data
+        };
+
+        var resp = await ClientA.PostAsJsonAsync("/api/recipes/import/preview", new { url, force = false }, Json);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await resp.Content.ReadFromJsonAsync<PreviewResult>(Json);
+        result!.success.Should().BeFalse();
+        result.recipe.Should().BeNull();
+        result.errorType.Should().Be("ValidationFailed");
+        result.errorMessage.Should().NotBeNullOrWhiteSpace();
+        result.partialData.Should().NotBeNull();
+        result.partialData!.name.Should().Be("Partial Soup");
+        result.partialData.description.Should().Be("Only metadata, no ingredients");
+
+        (await CountRecipesBySourceUrlAsync(url)).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Preview_DuplicateUrl_ReturnsExisting_AndForceBypasses()
+    {
+        const string url = "https://preview.test/duplicate";
+
+        // Seed a persisted recipe with that SourceUrl through the real create endpoint.
+        var createResp = await ClientA.PostAsJsonAsync("/api/recipes", new
+        {
+            name = "Preview Dup Source",
+            description = (string?)null,
+            instructions = (string?)null,
+            sourceUrl = url,
+            servings = (int?)null,
+            prepTimeMinutes = (int?)null,
+            cookTimeMinutes = (int?)null,
+            recipeType = "main",
+            imagePath = (string?)null,
+            ingredients = Array.Empty<object>()
+        }, Json);
+        createResp.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var resp = await ClientA.PostAsJsonAsync("/api/recipes/import/preview", new { url, force = false }, Json);
+        var result = await resp.Content.ReadFromJsonAsync<PreviewResult>(Json);
+        result!.success.Should().BeFalse();
+        result.existingRecipeId.Should().NotBeNull();
+        result.existingRecipeName.Should().Be("Preview Dup Source");
+        result.recipe.Should().BeNull();
+
+        // force=true bypasses the duplicate check and previews — still without persisting a second row.
+        _factory.Scraper.Next = FullSchema("Forced Preview");
+        var forced = await ClientA.PostAsJsonAsync("/api/recipes/import/preview", new { url, force = true }, Json);
+        var forcedResult = await forced.Content.ReadFromJsonAsync<PreviewResult>(Json);
+        forcedResult!.success.Should().BeTrue();
+        forcedResult.recipe!.name.Should().Be("Forced Preview");
+
+        (await CountRecipesBySourceUrlAsync(url)).Should().Be(1); // only the seeded create
+    }
+
+    [Fact]
+    public async Task Preview_EmptyUrl_Returns400_WithNonEmptyBody()
+    {
+        var resp = await ClientA.PostAsJsonAsync("/api/recipes/import/preview", new { url = "", force = false }, Json);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await resp.Content.ReadAsStringAsync();
+        body.Should().NotBeNullOrWhiteSpace(); // /api 4xx must carry a body (re-execute quirk)
+        body.Should().Contain("URL");
+    }
+}
+
+/// <summary>
+/// <see cref="ChoresWebAppFactory"/> variant for the import-preview tests: replaces
+/// <see cref="IRecipeScraperService"/> with a configurable stub (no real network) and
+/// <see cref="IUrlValidator"/> with an always-valid stub (no live DNS). Everything else — the real
+/// <c>RecipeImportService</c> pipeline, endpoints, auth, Postgres — is the production wiring.
+/// </summary>
+public sealed class PreviewWebAppFactory(PostgresContainerFixture postgres) : ChoresWebAppFactory(postgres)
+{
+    public StubRecipeScraper Scraper { get; } = new();
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        base.ConfigureWebHost(builder);
+        builder.ConfigureServices(services =>
+        {
+            services.AddSingleton<IRecipeScraperService>(Scraper);
+            services.AddSingleton<IUrlValidator>(new AlwaysValidUrlValidator());
+        });
+    }
+
+    /// <summary>Returns whatever a test placed in <see cref="Next"/> (null ⇒ "no JSON-LD found").</summary>
+    public sealed class StubRecipeScraper : IRecipeScraperService
+    {
+        public RecipeSchema? Next { get; set; }
+
+        public Task<RecipeSchema?> ScrapeRecipeAsync(string url, CancellationToken cancellationToken = default)
+            => Task.FromResult(Next);
+
+        public Task<string> FetchHtmlAsync(string url, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("Not exercised by the import pipeline under test.");
+
+        public Task<RecipeSchema?> ExtractJsonLdAsync(string html, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("Not exercised by the import pipeline under test.");
+    }
+
+    private sealed class AlwaysValidUrlValidator : IUrlValidator
+    {
+        public bool IsUrlSafe(string url) => true;
+        public (bool IsValid, string? ErrorMessage) ValidateUrl(string url) => (true, null);
+    }
+}


### PR DESCRIPTION
Burn-down run item (Spine quest `c39ee0ef` — "Recipe import: scrape→preview-in-island"). Deferred-from-parity UX, harvested from recipes-island spec §14.

### What changes
Import was scrape → **create immediately** → navigate-to-edit. Now: URL → scrape → **preview in the dialog** (title, image, servings/prep/cook, ingredients, steps, source + "Nothing is saved yet…") → **Add Recipe** creates and navigates to edit; Back/Cancel persist nothing.

### Backend
- New `POST /api/recipes/import/preview`: scrapes + parses and returns `RecipeImportPreviewDto` **without persisting** — `ImportFromUrlAsync` already returns an unsaved entity; it's mapped to a create-request-compatible shape. Same duplicate/force semantics and 200-envelope failure contract as `/import`; empty URL → 400 with body.
- **Confirm reuses the existing create endpoint** (`POST /api/recipes`) — the preview payload is `RecipeWriteRequest`-shaped, so no confirm endpoint.
- Legacy `POST /api/recipes/import` **kept working unchanged** — a stale service-worker-cached SPA may still call it during rollout (this repo's known SW history). Shared duplicate-lookup helper extracted.

### Frontend
`ImportDialog` becomes two-phase. Partial parses still preview with a warning (confirm allowed when at least a title parsed, else "Add Manually" fallback). Duplicate → info alert with View Existing / Import Anyway (force), which re-previews and only creates on confirm.

### Verification
- `dotnet test` **874/874** (5 new `RecipeImportPreviewEndpointTests` — parse round-trip, persists-nothing raw-row invariant, failure/partial envelopes, duplicate + force, non-empty 400 body); svelte-check 0 errors; vitest 6/6.
- :8080 browser verify (live allrecipes.com scrape → preview → cancel-persists-nothing → confirm → duplicate path): **pending — will run before merge** (the local stack is currently holding the meal-plan branch for its manual drag verification).

https://claude.ai/code/session_01Nbc4zkiRDXrjBZ2vMnb9yU
