### PR TITLE
feat(infra): nightly offsite Postgres backup → Cloudflare R2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
 
 # Use bd merge for beads JSONL files
 .beads/issues.jsonl merge=beads
+
+# Shell scripts run on Linux (thedarktower) — keep LF so the shebang never sees CRLF
+*.sh text eol=lf

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,6 @@ Deployment + environment configuration detail auto-loads via `.claude/rules/depl
 ## Corrections
 <!-- Also see global corrections: D:\Development\data\memory\CORRECTIONS.md -->
 
-- [2026-04-16 UTC] PREPEND `sudo` to docker commands on the production host over SSH. Reason: docker socket not in user group.
+- [2026-04-16 UTC] PREPEND `sudo` to docker commands on the production host over SSH. Reason: docker socket not in user group. **Update 2026-07-09:** `sirm` was added to the `docker` group (for the offsite `pg_dump`→R2 backup cron), so plain `docker` now works for `sirm` over a *fresh* SSH login (a new session picks up the group); `sudo docker` still works, and `deploy.sh` is unaffected. Prod Postgres is reachable only via `docker exec` (5432 is not host-published) — dump uses local-socket `trust` auth, no password. See `infra/backup/`.
 
 <!-- /reflect completed 2026-04-16 UTC -->

--- a/infra/backup/README.md
+++ b/infra/backup/README.md
@@ -1,0 +1,93 @@
+# Offsite Postgres backups → Cloudflare R2
+
+Nightly `pg_dump` of the production `familyapp` database, age-encrypted and shipped
+offsite to a Cloudflare R2 bucket. This closes the one unrecoverable failure mode of
+the self-hosted setup: **the family's data dying with the single home server.**
+
+- **What runs:** [`pg-backup-r2.sh`](./pg-backup-r2.sh) as a **`sirm` user-cron** on thedarktower, nightly **03:30 local**.
+- **Why user-cron (not root):** `sirm` is in the `docker` group, so the dump runs via `docker exec` with no sudo. pg auth is local-socket `trust` (see `docker/postgres/pg_hba.conf`), so no DB password is handled.
+- **Cost:** ~$0 — dumps are ~125 KB; R2 free tier is 10 GB + generous ops.
+- **Not** point-in-time / RPO-minutes. It's a nightly durability net. PITR would come from a managed Postgres if the app ever migrates off the home server (separate, parked decision).
+
+## Where things live (on thedarktower)
+
+| Path | What |
+|---|---|
+| `~/familyapp-backup/pg-backup-r2.sh` | the script (canonical source: repo `infra/backup/`) |
+| `~/familyapp-backup/backup.env` | config + secrets, mode `600` (R2 keys, `AGE_RECIPIENT`, retention, heartbeat URL) |
+| `~/familyapp-backup/backup.log` | run log (appended by cron) |
+| user crontab (`crontab -l`) | the `30 3 * * *` entry |
+
+R2 object layout (bucket `familyapp-backups`, account `157bf441cc44ecffbcb46b0d42339157`):
+
+| key | what |
+|---|---|
+| `daily/familyapp_<UTC-ISO>.dump.age`   | every night, newest `RETAIN_DAILY` (14) kept |
+| `monthly/familyapp_<UTC-ISO>.dump.age` | copy taken on the 1st, newest `RETAIN_MONTHLY` (6) kept |
+
+`.age` = age-encrypted (asymmetric). The host holds only the **public** recipient
+(`AGE_RECIPIENT` in `backup.env`). The **private** key is off-host — Bitwarden Secrets
+`FAMILYAPP_BACKUP_AGE_KEY` — and is required only at restore time.
+
+## Encryption keys
+
+- **Public** (`age1…`): in `backup.env` as `AGE_RECIPIENT`. Encrypt-only; safe on the host.
+- **Private** (`AGE-SECRET-KEY-1…`): Bitwarden Secrets `FAMILYAPP_BACKUP_AGE_KEY` (+ keep an offline copy). **Losing it makes every backup unreadable.** It must NOT live on the host — if `~/familyapp-backup/age-key.txt` exists, move it into bws and `shred -u` it.
+
+## Restore / recovery procedure
+
+A backup that has never been restored is a hope. This exact procedure was run green at
+install (restored counts matched prod). Run it to recover, or to re-verify anytime.
+
+```bash
+ssh thedarktower
+set -a; . ~/familyapp-backup/backup.env; set +a
+export RCLONE_CONFIG=/dev/null RCLONE_CONFIG_R2_TYPE=s3 RCLONE_CONFIG_R2_PROVIDER=Cloudflare \
+  RCLONE_CONFIG_R2_ACCESS_KEY_ID=$R2_ACCESS_KEY_ID RCLONE_CONFIG_R2_SECRET_ACCESS_KEY=$R2_SECRET_ACCESS_KEY \
+  RCLONE_CONFIG_R2_ENDPOINT=https://$R2_ACCOUNT_ID.r2.cloudflarestorage.com \
+  RCLONE_CONFIG_R2_REGION=auto RCLONE_CONFIG_R2_NO_CHECK_BUCKET=true
+
+# 1. pull the latest daily object
+LATEST=$(rclone lsf R2:familyapp-backups/daily/ | sort | tail -1); echo "$LATEST"
+rclone copyto "R2:familyapp-backups/daily/$LATEST" "/tmp/$LATEST"
+
+# 2. decrypt (needs the private key from bws — write it to a temp file first)
+#    bws secret get <id-of-FAMILYAPP_BACKUP_AGE_KEY> ... > /tmp/age.key
+age -d -i /tmp/age.key -o /tmp/restore.dump "/tmp/$LATEST"
+
+# 3. restore into a throwaway container and sanity-check row counts
+docker run -d --name fa-restore-test -e POSTGRES_USER=familyapp -e POSTGRES_DB=familyapp \
+  -e POSTGRES_PASSWORD=restoretest postgres:17
+sleep 8
+docker cp /tmp/restore.dump fa-restore-test:/tmp/restore.dump
+docker exec fa-restore-test pg_restore -U familyapp -d familyapp --no-owner --no-privileges /tmp/restore.dump
+docker exec fa-restore-test psql -U familyapp -d familyapp -c \
+  'SELECT (SELECT count(*) FROM "Recipes") recipes,(SELECT count(*) FROM "Households") households;'
+docker exec familyapp-postgres  psql -U familyapp -d familyapp -c \
+  'SELECT (SELECT count(*) FROM "Recipes") recipes,(SELECT count(*) FROM "Households") households;'   # compare
+
+# 4. cleanup
+docker rm -f fa-restore-test; rm -f /tmp/restore.dump /tmp/age.key "/tmp/$LATEST"
+```
+
+**Real recovery** into prod restores into a freshly-recreated `familyapp` database on the
+live container (drop + create empty first — the app rebuilds schema on boot, so restoring
+over a live DB throws "already exists"). See `data/memory/INFRASTRUCTURE.md` for the
+drop-recreate-restore shape used for the observatory DB.
+
+## Operations
+
+- **Logs:** `~/familyapp-backup/backup.log`. Each run appends ~6 lines.
+- **Manual run:** `~/familyapp-backup/pg-backup-r2.sh` (or via cron env: `env -i HOME=/home/sirm PATH=/usr/bin:/bin ~/familyapp-backup/pg-backup-r2.sh`).
+- **Health / dead-man alert:** healthchecks.io. Set `HEALTHCHECK_URL` in `backup.env` to a check's ping URL; the script pings `/start`, `/fail` on error, and success. A missed nightly run → healthchecks nags. If it goes red, read the log. Common causes: R2 token rotated, `familyapp-postgres` renamed, disk full in `/tmp`.
+- **Update the script:** edit repo `infra/backup/pg-backup-r2.sh`, then
+  `scp infra/backup/pg-backup-r2.sh thedarktower:~/familyapp-backup/ && ssh thedarktower chmod 755 ~/familyapp-backup/pg-backup-r2.sh`.
+- **Disable:** `crontab -e` and remove the `pg-backup-r2.sh` line.
+
+## Rebuild-from-scratch (if the host is replaced)
+
+1. `sudo usermod -aG docker sirm` (backup runs as a docker-group user cron).
+2. `brew install rclone age`.
+3. Recreate `~/familyapp-backup/backup.env` from [`familyapp-backup.env.example`](./familyapp-backup.env.example): R2 keys (bws `R2_S3_Access_Key_ID` / `R2_S3_Secret_Access_Key`), account id `157bf441cc44ecffbcb46b0d42339157`, bucket `familyapp-backups`, `AGE_RECIPIENT` = the public key paired with bws `FAMILYAPP_BACKUP_AGE_KEY`, `HEALTHCHECK_URL`.
+4. `scp` the script into `~/familyapp-backup/`, `chmod 755`, add the `30 3 * * *` crontab line.
+5. Run once, then the restore test above.

--- a/infra/backup/familyapp-backup.env.example
+++ b/infra/backup/familyapp-backup.env.example
@@ -1,0 +1,30 @@
+# familyapp-backup.env — config for pg-backup-r2.sh
+# Deployed on thedarktower at ~/familyapp-backup/backup.env (mode 0600 — holds R2 creds).
+# Copy this file, fill in the real values, do NOT commit the filled-in copy.
+
+# --- Cloudflare R2 (S3-compatible) ---
+# From the R2 dashboard: create a bucket, then an R2 API token scoped to it
+# (Object Read & Write). The token screen gives you the Access Key ID + Secret.
+# R2_ACCOUNT_ID is your Cloudflare account id (also on the R2 overview page).
+R2_ACCOUNT_ID=
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+R2_BUCKET=familyapp-backups
+
+# --- Retention (objects kept per prefix; names sort chronologically) ---
+RETAIN_DAILY=14
+RETAIN_MONTHLY=6
+
+# --- Encryption (optional but recommended) ---
+# Asymmetric age: put ONLY the PUBLIC recipient here. The private key stays off
+# this host (password manager + a printed copy). Generate with:  age-keygen
+# Leave blank to upload unencrypted (relies on R2 being private + a scoped token).
+AGE_RECIPIENT=
+
+# --- Dead-man's-switch heartbeat (optional but recommended) ---
+# healthchecks.io check URL. The script pings <url>/start, <url>/fail on error,
+# and <url> on success; a missed nightly run makes healthchecks nag you.
+HEALTHCHECK_URL=
+
+# --- Overrides (defaults are correct for the current prod compose) ---
+# PG_CONTAINER=familyapp-postgres

--- a/infra/backup/pg-backup-r2.sh
+++ b/infra/backup/pg-backup-r2.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# pg-backup-r2.sh — nightly offsite Postgres backup for family-coordination-app.
+#
+# Dumps the production Postgres DB (custom format, version-matched pg_dump run
+# INSIDE the container via `docker exec`; local-socket trust auth, no password),
+# optionally encrypts it with age (asymmetric — the host holds only the public
+# recipient; the private key lives off-host in Bitwarden Secrets), uploads it to
+# a Cloudflare R2 bucket, prunes old objects, and pings a healthchecks.io
+# dead-man's-switch so a silently-failed run gets noticed.
+#
+# Runs as the `sirm` user (member of the docker group) from a user crontab.
+# Config lives in an env file (default ~/familyapp-backup/backup.env, mode 600).
+# See infra/backup/README.md for install + restore.
+#
+set -euo pipefail
+
+# cron runs with a minimal PATH — make brew tools (rclone, age) + docker reachable.
+export PATH="/home/linuxbrew/.linuxbrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
+
+# --------------------------------------------------------------------------
+# Config
+# --------------------------------------------------------------------------
+ENV_FILE="${FAMILYAPP_BACKUP_ENV:-$HOME/familyapp-backup/backup.env}"
+if [ ! -r "$ENV_FILE" ]; then
+  echo "[familyapp-backup] FATAL: env file not readable: $ENV_FILE" >&2
+  exit 1
+fi
+# shellcheck disable=SC1090
+set -a; . "$ENV_FILE"; set +a
+
+PG_CONTAINER="${PG_CONTAINER:-familyapp-postgres}"
+PG_USER="${PG_USER:-familyapp}"
+PG_DB="${PG_DB:-familyapp}"
+R2_BUCKET="${R2_BUCKET:?R2_BUCKET is required in $ENV_FILE}"
+: "${R2_ACCOUNT_ID:?R2_ACCOUNT_ID is required in $ENV_FILE}"
+: "${R2_ACCESS_KEY_ID:?R2_ACCESS_KEY_ID is required in $ENV_FILE}"
+: "${R2_SECRET_ACCESS_KEY:?R2_SECRET_ACCESS_KEY is required in $ENV_FILE}"
+RETAIN_DAILY="${RETAIN_DAILY:-14}"
+RETAIN_MONTHLY="${RETAIN_MONTHLY:-6}"
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/familyapp-backup.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# --------------------------------------------------------------------------
+# Heartbeat helpers (healthchecks.io-compatible; no-op if HEALTHCHECK_URL unset)
+# --------------------------------------------------------------------------
+hc() {  # hc [suffix]   e.g. hc /start | hc /fail | hc (success)
+  [ -n "${HEALTHCHECK_URL:-}" ] || return 0
+  curl -fsS -m 10 --retry 3 -o /dev/null "${HEALTHCHECK_URL}${1:-}" || true
+}
+fail() { echo "[familyapp-backup] ERROR: $*" >&2; hc /fail; exit 1; }
+log()  { echo "[familyapp-backup] $(date -u +%FT%TZ) $*"; }
+
+hc /start
+log "starting backup (container=$PG_CONTAINER bucket=$R2_BUCKET)"
+
+# --------------------------------------------------------------------------
+# 1. Dump — custom format, compressed. pg_dump runs inside the container so it
+#    version-matches the server exactly; local-socket auth is 'trust' (pg_hba),
+#    so no password is needed. Streams to the host over stdout.
+# --------------------------------------------------------------------------
+ts="$(date -u +%Y-%m-%dT%H%M%SZ)"   # UTC; sorts chronologically as a string
+dom="$(date -u +%d)"                # day-of-month (monthly snapshot on the 1st)
+base="familyapp_${ts}.dump"
+dumpfile="$WORKDIR/$base"
+
+if ! docker exec "$PG_CONTAINER" pg_dump -U "$PG_USER" -d "$PG_DB" -Fc --no-owner --no-privileges \
+      > "$dumpfile" 2> "$WORKDIR/pg_dump.err"; then
+  sed 's/^/[pg_dump] /' "$WORKDIR/pg_dump.err" >&2 || true
+  fail "pg_dump failed"
+fi
+
+sz="$(stat -c%s "$dumpfile")"
+[ "$sz" -ge 1000 ] || fail "dump suspiciously small ($sz bytes) — refusing to upload"
+log "dump ok: $base ($sz bytes)"
+
+# --------------------------------------------------------------------------
+# 2. Optional encryption (asymmetric age). AGE_RECIPIENT is the PUBLIC key; the
+#    private key is NOT on this host (Bitwarden Secrets FAMILYAPP_BACKUP_AGE_KEY).
+# --------------------------------------------------------------------------
+upload="$dumpfile"; suffix=""
+if [ -n "${AGE_RECIPIENT:-}" ]; then
+  age -r "$AGE_RECIPIENT" -o "$dumpfile.age" "$dumpfile" || fail "age encryption failed"
+  upload="$dumpfile.age"; suffix=".age"
+  log "encrypted to age recipient ${AGE_RECIPIENT:0:16}…"
+fi
+
+# --------------------------------------------------------------------------
+# 3. Upload to R2 (rclone on-the-fly s3 remote from env — no rclone.conf needed)
+# --------------------------------------------------------------------------
+export RCLONE_CONFIG=/dev/null                 # no rclone.conf — remote is fully env-defined
+export RCLONE_CONFIG_R2_TYPE=s3
+export RCLONE_CONFIG_R2_PROVIDER=Cloudflare
+export RCLONE_CONFIG_R2_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+export RCLONE_CONFIG_R2_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+export RCLONE_CONFIG_R2_ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+export RCLONE_CONFIG_R2_REGION=auto
+export RCLONE_CONFIG_R2_NO_CHECK_BUCKET=true   # scoped token may lack bucket-create perms
+
+obj="${base}${suffix}"
+rclone copyto "$upload" "R2:${R2_BUCKET}/daily/${obj}" || fail "R2 upload (daily) failed"
+log "uploaded daily/${obj}"
+
+if [ "$dom" = "01" ]; then
+  rclone copyto "$upload" "R2:${R2_BUCKET}/monthly/${obj}" || fail "R2 upload (monthly) failed"
+  log "uploaded monthly/${obj}"
+fi
+
+# --------------------------------------------------------------------------
+# 4. Prune — keep the newest N objects per prefix (names sort chronologically)
+# --------------------------------------------------------------------------
+prune() {  # prune <prefix> <keep>
+  local prefix="$1" keep="$2" objs total del i
+  mapfile -t objs < <(rclone lsf "R2:${R2_BUCKET}/${prefix}/" 2>/dev/null | grep -v '/$' | sort)
+  total="${#objs[@]}"
+  [ "$total" -gt "$keep" ] || return 0
+  del=$(( total - keep ))
+  for (( i=0; i<del; i++ )); do
+    if rclone deletefile "R2:${R2_BUCKET}/${prefix}/${objs[$i]}"; then
+      log "pruned ${prefix}/${objs[$i]}"
+    else
+      echo "[familyapp-backup] WARN: prune failed for ${prefix}/${objs[$i]}" >&2
+    fi
+  done
+}
+prune daily   "$RETAIN_DAILY"
+prune monthly "$RETAIN_MONTHLY"
+
+log "backup complete"
+hc   # success ping


### PR DESCRIPTION
## What

Nightly offsite Postgres backup for the production `familyapp` DB → Cloudflare R2.
Closes the one unrecoverable failure mode of the self-hosted setup (the family's data
dying with the single home server). This is **step 1 of the hosting-resilience verdict**;
the managed-host migration stays parked with the operator.

## How it works

`infra/backup/pg-backup-r2.sh` runs as a `sirm` user-cron at **03:30 local**:

- `docker exec` version-matched `pg_dump -Fc` (local-socket `trust` auth — no DB password)
- → asymmetric **age** encrypt → **rclone** upload to R2 (`daily/`, plus `monthly/` on the 1st)
- → count-based prune (14 daily / 6 monthly) → **healthchecks.io** heartbeat.

Encryption is asymmetric: the host holds only the public recipient; the private key is
off-host (bws `FAMILYAPP_BACKUP_AGE_KEY`), needed only at restore. No sudo — `sirm` is in
the `docker` group; secrets live in `~/familyapp-backup/backup.env` (0600), never committed.

## Verified on thedarktower

- Full run: dump 125 KB → encrypt → R2 object present; **exit 0 under a simulated cron env** (minimal PATH).
- **Restore test**: pulled the R2 object → age-decrypt → `pg_restore` into a throwaway
  `postgres:17` → row counts match prod exactly (recipes 33, households 3, users 6, chores 76).

## Not in this PR (operational follow-ups, non-code)

- Move the age private key off-host into bws (it's on the host at `~/familyapp-backup/age-key.txt`;
  my bws token is read-only, so the operator places it, then we `shred` the host copy).
- Wire `HEALTHCHECK_URL` once the healthchecks check exists (dead-man alerting).

https://claude.ai/code/session_01Xg2RrioZKPsgiQY13udmrS
