### PR TITLE
docs(rules): deployment.md matches the de-sudo'd prod docker model (quest f3e39200)

### DIFF
--- a/.claude/rules/deployment.md
+++ b/.claude/rules/deployment.md
@@ -32,14 +32,16 @@ Push to `master` triggers GitHub Actions:
 1. **CI** (`ci.yml`): Build, test, format check, Docker build validation (GitHub-hosted runners)
 2. **Deploy** (`deploy.yml`): Self-hosted runner pulls code, builds Docker image, deploys via `docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d`
 
+This push-to-master pipeline is the **normal** deploy path. `deploy.sh` (and its Windows wrapper) is the manual/emergency path — don't run both concurrently against the same host.
+
 Production traffic flow: `Internet → Cloudflare → <server-hostname> (host nginx) → app container`
 
-(On the production host over SSH, prepend `sudo` to docker commands — see CLAUDE.md `## Corrections`. Note the NOPASSWD sudoers whitelist covers `docker build/compose/ps/inspect/exec/logs/rm/image prune/network` but NOT `docker tag/images/rmi` — non-interactive scripts must not call those bare.)
+(On the production host over SSH: the deploy user is in the `docker` group — added 2026-07-09 — so docker commands work **without sudo** on a fresh login; the host's agent-guidance doc was de-sudo'd 2026-08-05 with live receipts. If sudo is used anyway, the NOPASSWD whitelist covers `docker build/compose/ps/inspect/exec/logs/rm/image prune/network` but NOT `docker tag/images/rmi` — under sudo those prompt for a password, which is why the rollback below runs bare docker.)
 
 **Rollback (de-Blazor C-c):** every deployed image is also tagged `familyapp:<git-sha>` by the build (`deploy.sh`). To roll back (interactive):
 ```bash
-sudo docker tag familyapp:<sha> familyapp:latest
-sudo docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --force-recreate app
+docker tag familyapp:<sha> familyapp:latest
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --force-recreate app
 ```
 
 ## Environment Configuration


### PR DESCRIPTION
docs(rules): deployment.md matches the de-sudo'd prod docker model + names the normal deploy path (quest f3e39200)

Two contradictions found by the cross-surface sweep (burn-down item 9):

- "prepend sudo to docker commands" contradicted the docker-group grant
  (2026-07-09) and the host guidance doc that was de-sudo'd 2026-08-05 with
  live receipts. Rewritten to the bare-docker model; the NOPASSWD whitelist
  detail is kept with its real consequence spelled out (docker tag/images/rmi
  are NOT whitelisted, so under sudo they password-prompt - which is why the
  rollback recipe now runs bare docker).
- The CI push-to-master pipeline and INFRASTRUCTURE.md's manual deploy.sh
  path each presented as canonical without acknowledging the other; the rule
  now names CI as the normal path and deploy.sh as manual/emergency.

Claude-Session: https://claude.ai/code/session_01N3v6fWTuXgpaEQFQF1W3qt
